### PR TITLE
revert(MathBlock): the commit 14b4e98 caused KaTeX math formulas to fail to render

### DIFF
--- a/playground/src/const/markdown.ts
+++ b/playground/src/const/markdown.ts
@@ -4,7 +4,63 @@ const streamContent = `>>>I'll create a simple Electron + Vue chat application d
 [Star on GitHub](https://github.com/Simon-He95/vue-markdown-render)
 
 ![Vue Markdown Icon](/vue-markdown-icon.svg "Vue Markdown Icon")
+好的，我将为您输出泰勒公式的一般形式及其常见展开式。
 
+---
+
+## 1. 泰勒公式（Taylor's Formula）
+
+### 一般形式（在点 \\(x = a\\) 处展开）：
+\\[
+f(x) = f(a) + f'(a)(x-a) + \\frac{f''(a)}{2!}(x-a)^2 + \\frac{f'''(a)}{3!}(x-a)^3 + \\cdots + \\frac{f^{(n)}(a)}{n!}(x-a)^n + R_n(x)
+\\]
+
+其中：
+- \\(f^{(k)}(a)\\) 是 \\(f(x)\\) 在 \\(x=a\\) 处的 \\(k\\) 阶导数
+- \\(R_n(x)\\) 是余项，常见形式有拉格朗日余项：
+\\[
+R_n(x) = \\frac{f^{(n+1)}(\\xi)}{(n+1)!}(x-a)^{n+1}, \\quad \\xi \\text{ 在 } a \\text{ 和 } x \\text{ 之间}
+\\]
+
+---
+
+## 2. 麦克劳林公式（Maclaurin's Formula，即 \\(a=0\\) 时的泰勒公式）：
+\\[
+f(x) = f(0) + f'(0)x + \\frac{f''(0)}{2!}x^2 + \\frac{f'''(0)}{3!}x^3 + \\cdots + \\frac{f^{(n)}(0)}{n!}x^n + R_n(x)
+\\]
+
+---
+
+## 3. 常见函数的麦克劳林展开（前几项）
+
+- **指数函数**：
+\\[
+e^x = 1 + x + \\frac{x^2}{2!} + \\frac{x^3}{3!} + \\cdots + \\frac{x^n}{n!} + \\cdots, \\quad x \\in \\mathbb{R}
+\\]
+
+- **正弦函数**：
+\\[
+\\sin x = x - \\frac{x^3}{3!} + \\frac{x^5}{5!} - \\frac{x^7}{7!} + \\cdots + (-1)^n \\frac{x^{2n+1}}{(2n+1)!} + \\cdots
+\\]
+
+- **余弦函数**：
+\\[
+\\cos x = 1 - \\frac{x^2}{2!} + \\frac{x^4}{4!} - \\frac{x^6}{6!} + \\cdots + (-1)^n \\frac{x^{2n}}{(2n)!} + \\cdots
+\\]
+
+- **自然对数**（在 \\(x=0\\) 附近）：
+\\[
+\\ln(1+x) = x - \\frac{x^2}{2} + \\frac{x^3}{3} - \\frac{x^4}{4} + \\cdots + (-1)^{n-1} \\frac{x^n}{n} + \\cdots, \\quad -1 < x \\le 1
+\\]
+
+- **二项式展开**（\\( (1+x)^m \\)，\\(m\\) 为实数）：
+\\[
+(1+x)^m = 1 + mx + \\frac{m(m-1)}{2!}x^2 + \\frac{m(m-1)(m-2)}{3!}x^3 + \\cdots, \\quad |x| < 1
+\\]
+
+---
+
+如果您需要某个特定函数在特定点的泰勒展开，请告诉我，我可以为您详细写出。
 *Figure: Vue Markdown Icon (served from /vue-markdown-icon.svg)*
 
 ::: warning

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import katex from 'katex'
-import { onUnmounted, ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
 const props = defineProps<{
   node: {
@@ -13,42 +13,32 @@ const props = defineProps<{
 const mathElement = ref<HTMLElement | null>(null)
 
 function renderMath() {
-  const el = mathElement.value
-  const content = props.node?.content ?? ''
-
-  if (!el)
+  if (!mathElement.value || !props.node.content)
     return
-
-  if (!content) {
-    el.textContent = props.node?.raw ?? ''
-    return
-  }
 
   try {
-    const html = katex.renderToString(content, {
+    katex.render(props.node.content, mathElement.value, {
       throwOnError: false,
       displayMode: false,
-      output: 'htmlAndMathml',
+      output: 'html',
       strict: 'ignore',
     })
-
-    el.innerHTML = html
   }
   catch (error) {
     console.error('KaTeX rendering error:', error)
-    el.textContent = props.node?.raw ?? ''
+    mathElement.value.textContent = props.node.raw
   }
 }
 
 watch(
   () => props.node.content,
-  renderMath,
-  { immediate: true, flush: 'post' },
+  () => {
+    renderMath()
+  },
 )
 
-onUnmounted(() => {
-  if (mathElement.value)
-    mathElement.value.innerHTML = ''
+onMounted(() => {
+  renderMath()
 })
 </script>
 


### PR DESCRIPTION
- The commit 14b4e98 caused KaTeX math formulas to fail to render properly. Temporarily revert the mathnode-related changes in this commit.
- add more katex related examples