### PR TITLE
fix: only match double tildes for strikethrough syntax

### DIFF
--- a/src/utils/markdown-parser/inline-parsers/index.ts
+++ b/src/utils/markdown-parser/inline-parsers/index.ts
@@ -71,9 +71,9 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
           i++
           break
         }
-        if (/[^~]*~+[^~]+/.test(content)) {
+        if (/[^~]*~~+[^~]+/.test(content)) {
           // 处理成 parseStrikethroughToken
-          const index = content.indexOf('~') || 0
+          const index = content.indexOf('~~') || 0
           const _text = content.slice(0, index)
           if (_text) {
             if (currentTextNode) {

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -292,17 +292,48 @@ exports[`markdownRender node e2e coverage > renders mermaid block node 1`] = `
         <!-- 左侧语言标签 -->
         <div data-v-a77e0552="" class="flex items-center space-x-2"><img data-v-a77e0552="" src="data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20width='16'%20height='16'%3e%3cpath%20fill='none'%20stroke='%23ca9ee6'%20stroke-linecap='round'%20stroke-linejoin='round'%20d='M1.5%202.5c0%206%202.25%205.75%204%207%20.83.67%201.17%202%201%204h3c-.17-2%20.17-3.33%201-4%201.75-1.25%204-1%204-7C12%202.5%2010%203%208%207%206%203%204%202.5%201.5%202.5'%20/%3e%3c/svg%3e" class="w-4 h-4 my-0" alt="Mermaid"><span data-v-a77e0552="" class="text-sm font-medium text-gray-600 dark:text-gray-400 font-mono">Mermaid</span></div><!-- 中间切换按钮 -->
         <div data-v-a77e0552="" class="flex items-center space-x-1 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5"><button data-v-a77e0552="" class="px-2.5 py-1 text-xs rounded transition-colors bg-white dark:bg-gray-600 text-gray-700 dark:text-gray-200 shadow-sm">
-            <div data-v-a77e0552="" class="flex items-center space-x-1"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:eye"></span><span data-v-a77e0552="">Preview</span></div>
+            <div data-v-a77e0552="" class="flex items-center space-x-1"><svg data-v-a77e0552="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+                <g data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+                  <path data-v-a77e0552="" d="M2.062 12.348a1 1 0 0 1 0-.696a10.75 10.75 0 0 1 19.876 0a1 1 0 0 1 0 .696a10.75 10.75 0 0 1-19.876 0"></path>
+                  <circle data-v-a77e0552="" cx="12" cy="12" r="3"></circle>
+                </g>
+              </svg><span data-v-a77e0552="">Preview</span></div>
           </button><button data-v-a77e0552="" class="px-2.5 py-1 text-xs rounded transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
-            <div data-v-a77e0552="" class="flex items-center space-x-1"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:code"></span><span data-v-a77e0552="">Source</span></div>
+            <div data-v-a77e0552="" class="flex items-center space-x-1"><svg data-v-a77e0552="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+                <path data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m16 18l6-6l-6-6M8 6l-6 6l6 6"></path>
+              </svg><span data-v-a77e0552="">Source</span></div>
           </button></div><!-- 右侧操作按钮 -->
-        <div data-v-a77e0552="" class="flex items-center space-x-1"><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors" aria-pressed="false"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:chevron-right" style="rotate: 90deg;"></span></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:copy"></span></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:download"></span></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:maximize-2"></span></button></div>
+        <div data-v-a77e0552="" class="flex items-center space-x-1"><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors" aria-pressed="false"><svg data-v-a77e0552="" style="rotate: 90deg;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+              <path data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path>
+            </svg></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><svg data-v-a77e0552="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+              <g data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+                <rect data-v-a77e0552="" width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+                <path data-v-a77e0552="" d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+              </g>
+            </svg></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><svg data-v-a77e0552="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+              <g data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+                <path data-v-a77e0552="" d="M12 15V3m9 12v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <path data-v-a77e0552="" d="m7 10l5 5l5-5"></path>
+              </g>
+            </svg></button><button data-v-a77e0552="" class="mermaid-action-btn p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><svg data-v-a77e0552="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="0.75rem" height="0.75rem" viewBox="0 0 24 24">
+              <path data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 3h6v6m0-6l-7 7M3 21l7-7m-1 7H3v-6"></path>
+            </svg></button></div>
       </div><!-- 内容区域（带高度过渡的容器） -->
       <div data-v-a77e0552="">
         <div data-v-a77e0552="" class="relative">
           <!-- ...existing preview content... -->
           <div data-v-a77e0552="" class="absolute top-2 right-2 z-10 rounded-lg">
-            <div data-v-a77e0552="" class="flex items-center gap-2 backdrop-blur rounded-lg"><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:zoom-in"></span></button><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><span data-v-a77e0552="" class="icon-stub w-3 h-3" data-icon="lucide:zoom-out"></span></button><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">100% </button></div>
+            <div data-v-a77e0552="" class="flex items-center gap-2 backdrop-blur rounded-lg"><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><svg data-v-a77e0552="" data-v-3d59cc65="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+                  <g data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+                    <circle data-v-a77e0552="" cx="11" cy="11" r="8"></circle>
+                    <path data-v-a77e0552="" d="m21 21l-4.35-4.35M11 8v6m-3-3h6"></path>
+                  </g>
+                </svg></button><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"><svg data-v-a77e0552="" data-v-3d59cc65="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="w-3 h-3">
+                  <g data-v-a77e0552="" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+                    <circle data-v-a77e0552="" cx="11" cy="11" r="8"></circle>
+                    <path data-v-a77e0552="" d="m21 21l-4.35-4.35M8 11h6"></path>
+                  </g>
+                </svg></button><button data-v-a77e0552="" class="p-2 text-xs rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">100% </button></div>
           </div>
           <div data-v-a77e0552="" class="min-h-[360px] bg-gray-50 dark:bg-gray-900 relative transition-all duration-100 overflow-hidden block" style="height: 360px;">
             <div data-v-a77e0552="" data-mermaid-wrapper="" class="absolute inset-0 cursor-grab" style="transform: translate(0px, 0px) scale(1);">


### PR DESCRIPTION
close #80 
<img width="1300" height="1556" alt="Google Chrome 2025-10-17 15 03 27" src="https://github.com/user-attachments/assets/a1563a93-087e-4645-a06d-63b7aa809505" />
