### PR TITLE
refactor(markdown-parser): hoist/cached RegExp and add bounded LRUCache

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,6 +1,6 @@
 import type { LinkNode, MarkdownToken, ParsedNode, TextNode } from '../../types'
-import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { LRUCache } from '../../utils/lru'
+import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
 import { parseFenceToken } from './fence-parser'

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,5 +1,6 @@
 import type { LinkNode, MarkdownToken, ParsedNode, TextNode } from '../../types'
 import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
+import { LRUCache } from '../../utils/lru'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
 import { parseFenceToken } from './fence-parser'
@@ -29,6 +30,18 @@ export function isLikelyUrl(href?: string) {
     return false
   return AUTOLINK_PROTOCOL_RE.test(href) || AUTOLINK_GENERIC_RE.test(href)
 }
+
+// Small helpers and caches for dynamic RegExp construction used by inline parsers.
+// Hoisting these avoids repeatedly allocating identical RegExp instances.
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Use shared LRU implementation to bound memory usage for dynamically generated RegExp
+
+const bracketRegexCache = new LRUCache<string, RegExp>(500)
+const parenHrefRegexCache = new LRUCache<string, RegExp>(500)
+const linkMatchRegexCache = new LRUCache<string, RegExp>(500)
 
 // Process inline tokens (for text inside paragraphs, headings, etc.)
 export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreToken?: MarkdownToken): ParsedNode[] {
@@ -527,15 +540,12 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
     // mirror logic previously in the switch-case for 'link_open'
     resetCurrentTextNode()
     const href = token.attrs?.find(([name]) => name === 'href')?.[1]
-    // 如果 text 不在[]里说明，它不是一个link， 当 text 处理
-    function escapeRegExp(str: string) {
-      return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    }
+    // local escapeRegExp removed; using hoisted helper and regex caches
 
     if (raw && tokens[i + 1].type === 'text') {
       const text = String(tokens[i + 1]?.content ?? '')
       const escText = escapeRegExp(text)
-      const reg = new RegExp(`\\[${escText}\\s*\\]`)
+      const reg = bracketRegexCache.getOrCreate(escText, () => new RegExp(`\\[${escText}\\s*\\]`))
       if (!reg.test(raw)) {
         // If this link_open comes from an autolinkified URL (e.g. http://...)
         // treat it as a real link node rather than plain text. Otherwise
@@ -567,7 +577,11 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
       }
     }
     if (raw && href) {
-      const loadingMath = new RegExp(`\\(\\s*${escapeRegExp(href)}\\s*\\)`)
+      const hrefStrLocal = String(href)
+      const loadingMath = parenHrefRegexCache.getOrCreate(hrefStrLocal, () => {
+        const escHref = escapeRegExp(hrefStrLocal)
+        return new RegExp(`\\(\\s*${escHref}\\s*\\)`)
+      })
       const pre = result.length > 0 ? result[result.length - 1] : undefined as ParsedNode | undefined
       const loading = !loadingMath.test(raw)
       if (loading && pre) {
@@ -580,7 +594,7 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
           else if (((pre as { content?: unknown }).content) && typeof (pre as { content?: unknown }).content === 'string')
             preText = String((pre as { content?: string }).content ?? '').slice(1, -1)
         }
-        const isLinkMatch = new RegExp(`\\[${escapeRegExp(preText)}\\s*\\]\\(`)
+        const isLinkMatch = linkMatchRegexCache.getOrCreate(preText, () => new RegExp(`\\[${escapeRegExp(preText)}\\s*\\]\\(`))
         if (isLinkMatch.test(raw)) {
           const text = String(preText ?? '')
           resetCurrentTextNode()

--- a/packages/markdown-parser/src/parser/node-parsers/container-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/container-parser.ts
@@ -1,7 +1,7 @@
 import type { AdmonitionNode, MarkdownToken, ParsedNode, TextNode } from '../../types'
+import { LRUCache } from '../../utils/lru'
 import { parseInlineTokens } from '../inline-parsers'
 import { parseList } from './list-parser'
-import { LRUCache } from '../../utils/lru'
 
 // Cache regexes for container close types by kind to avoid reallocating
 const containerCloseTypeCache = new LRUCache<string, RegExp>(50)

--- a/packages/markdown-parser/src/parser/node-parsers/html-block-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/html-block-parser.ts
@@ -55,11 +55,7 @@ export function parseHtmlBlock(token: MarkdownToken): HtmlBlockNode {
   const isVoid = VOID_TAGS.has(tag)
 
   // Already closed somewhere in the block (case-insensitive)
-  let closeTagRe = htmlCloseTagRegexCache.get(tag)
-  if (!closeTagRe) {
-    closeTagRe = new RegExp(`<\\/\\s*${tag}\\b`, 'i')
-    htmlCloseTagRegexCache.set(tag, closeTagRe)
-  }
+  const closeTagRe = htmlCloseTagRegexCache.getOrCreate(tag, () => new RegExp(`<\\/\\s*${tag}\\b`, 'i'))
   const hasClosing = closeTagRe.test(raw)
 
   const loading = !(isVoid || selfClosing || hasClosing)

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -3,6 +3,7 @@ import type { MathOptions } from '../config'
 
 import findMatchingClose from '../findMatchingClose'
 import { ESCAPED_TEX_BRACE_COMMANDS, isMathLike } from './isMathLike'
+import { LRUCache } from '../utils/lru'
 
 // Heuristic to decide whether a piece of text is likely math.
 // Matches common TeX commands, math operators, function-call patterns like f(x),
@@ -94,6 +95,25 @@ const CONTROL_MAP: Record<string, string> = {
   '\v': 'v',
 }
 
+// Precompile default regexes and caches to avoid recreating them on every call.
+// These depend only on module-level constants and are safe to reuse.
+const DEFAULT_STANDALONE_BACKSLASH_T_RE = new RegExp(
+  `${CONTROL_CHARS_CLASS}|(?<!\\\\|\\w)(${ESCAPED_KATEX_COMMANDS})\\b`,
+  'g',
+)
+
+// Default brace-taking command regex (uses both TEX brace commands and KaTeX commands).
+const DEFAULT_BRACE_CMD_RE = (() => {
+  const combined = [ESCAPED_TEX_BRACE_COMMANDS, ESCAPED_KATEX_COMMANDS].filter(Boolean).join('|')
+  return combined ? new RegExp(`(^|[^\\\\\\w])(${combined})\\s*\\{`, 'g') : null
+})()
+
+// Use shared LRU implementation from ../utils/lru to bound memory for dynamic RegExp
+
+// Cache compiled RegExp objects for user-supplied command lists.
+const commandsRegexCache = new LRUCache<string, RegExp>(500)
+const braceCmdRegexCache = new LRUCache<string, RegExp>(500)
+
 function countUnescapedStrong(s: string) {
   const re = /(^|[^\\])(__|\*\*)/g
   let m: RegExpExecArray | null
@@ -114,12 +134,23 @@ export function normalizeStandaloneBackslashT(s: string, opts?: MathOptions) {
   // Build or reuse regex: match control chars or unescaped command words.
   let re: RegExp
   if (useDefault) {
-    re = new RegExp(`${CONTROL_CHARS_CLASS}|(?<!\\\\|\\w)(${ESCAPED_KATEX_COMMANDS})\\b`, 'g')
+    re = DEFAULT_STANDALONE_BACKSLASH_T_RE
   }
   else {
-    const commandPattern = `(?:${commands.slice().sort((a, b) => b.length - a.length).map(c => c.replace(/[.*+?^${}()|[\\]\\"\]/g, '\\$&')).join('|')})`
-    re = new RegExp(`${CONTROL_CHARS_CLASS}|(?<!\\\\|\\w)(${commandPattern})\\b`, 'g')
+    const key = commands.slice().sort((a, b) => b.length - a.length).join('|')
+    re = commandsRegexCache.getOrCreate(key, () => {
+      const commandPattern = `(?:${commands
+        .slice()
+        .sort((a, b) => b.length - a.length)
+        .map(c => c.replace(/[.*+?^${}()|[\\]\\"\\]/g, '\\$&'))
+        .join('|')})`
+      return new RegExp(`${CONTROL_CHARS_CLASS}|(?<!\\\\|\\w)(${commandPattern})\\b`, 'g')
+    })
   }
+
+  // Reset lastIndex in case the regex is reused elsewhere (global regexes are stateful).
+  if (re && 'lastIndex' in re)
+    (re as RegExp).lastIndex = 0
 
   let out = s.replace(re, (m: string, cmd?: string) => {
     if (CONTROL_MAP[m] !== undefined)
@@ -145,8 +176,29 @@ export function normalizeStandaloneBackslashT(s: string, opts?: MathOptions) {
     : [commands.map(c => c.replace(/[.*+?^${}()|[\\]\\\]/g, '\\$&')).join('|'), ESCAPED_TEX_BRACE_COMMANDS].filter(Boolean).join('|')
   let result = out
   if (braceEscaped) {
-    const braceCmdRe = new RegExp(`(^|[^\\\\\\w])(${braceEscaped})\\s*\\{`, 'g')
-    result = result.replace(braceCmdRe, (_m: string, p1: string, p2: string) => `${p1}\\${p2}{`)
+    // Use default precompiled regex when possible, otherwise compile and cache a
+    // regex for this specific `commands` set.
+    let braceCmdRe: RegExp | null = null
+    if (useDefault && DEFAULT_BRACE_CMD_RE)
+      braceCmdRe = DEFAULT_BRACE_CMD_RE
+    else {
+      const key = commands.slice().sort((a, b) => b.length - a.length).join('|')
+      const cmdPart = commands
+        .map(c => c.replace(/[.*+?^${}()|[\\]\\\"]/g, '\\$&'))
+        .join('|')
+      const combined = [cmdPart, ESCAPED_TEX_BRACE_COMMANDS].filter(Boolean).join('|')
+      if (combined) {
+        braceCmdRe = braceCmdRegexCache.getOrCreate(key, () => new RegExp(`(^|[^\\\\\\w])(${combined})\\s*\\{`, 'g'))
+      }
+      else {
+        braceCmdRe = null
+      }
+    }
+    if (braceCmdRe) {
+      if ('lastIndex' in braceCmdRe)
+        braceCmdRe.lastIndex = 0
+      result = result.replace(braceCmdRe, (_m: string, p1: string, p2: string) => `${p1}\\${p2}{`)
+    }
   }
   result = result.replace(/span\{([^}]+)\}/, 'span\\{$1\\}')
     .replace(/\\operatorname\{span\}\{((?:[^{}]|\{[^}]*\})+)\}/, '\\operatorname{span}\\{$1\\}')

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -2,8 +2,8 @@ import type { MarkdownIt } from 'markdown-it-ts'
 import type { MathOptions } from '../config'
 
 import findMatchingClose from '../findMatchingClose'
-import { ESCAPED_TEX_BRACE_COMMANDS, isMathLike } from './isMathLike'
 import { LRUCache } from '../utils/lru'
+import { ESCAPED_TEX_BRACE_COMMANDS, isMathLike } from './isMathLike'
 
 // Heuristic to decide whether a piece of text is likely math.
 // Matches common TeX commands, math operators, function-call patterns like f(x),
@@ -142,7 +142,7 @@ export function normalizeStandaloneBackslashT(s: string, opts?: MathOptions) {
       const commandPattern = `(?:${commands
         .slice()
         .sort((a, b) => b.length - a.length)
-        .map(c => c.replace(/[.*+?^${}()|[\\]\\"\\]/g, '\\$&'))
+        .map(c => c.replace(/[.*+?^${}()|[\\]\\"\\\]/g, '\\$&'))
         .join('|')})`
       return new RegExp(`${CONTROL_CHARS_CLASS}|(?<!\\\\|\\w)(${commandPattern})\\b`, 'g')
     })
@@ -179,12 +179,13 @@ export function normalizeStandaloneBackslashT(s: string, opts?: MathOptions) {
     // Use default precompiled regex when possible, otherwise compile and cache a
     // regex for this specific `commands` set.
     let braceCmdRe: RegExp | null = null
-    if (useDefault && DEFAULT_BRACE_CMD_RE)
+    if (useDefault && DEFAULT_BRACE_CMD_RE) {
       braceCmdRe = DEFAULT_BRACE_CMD_RE
+    }
     else {
       const key = commands.slice().sort((a, b) => b.length - a.length).join('|')
       const cmdPart = commands
-        .map(c => c.replace(/[.*+?^${}()|[\\]\\\"]/g, '\\$&'))
+        .map(c => c.replace(/[.*+?^${}()|[\\]\\"\]/g, '\\$&'))
         .join('|')
       const combined = [cmdPart, ESCAPED_TEX_BRACE_COMMANDS].filter(Boolean).join('|')
       if (combined) {

--- a/packages/markdown-parser/src/utils/lru.ts
+++ b/packages/markdown-parser/src/utils/lru.ts
@@ -1,0 +1,40 @@
+// Lightweight LRU cache used by parser modules to bound memory for
+// dynamically-created RegExp and other small cached objects.
+export class LRUCache<K, V> {
+  private max: number
+  private map: Map<K, V>
+
+  constructor(max = 500) {
+    this.max = max
+    this.map = new Map()
+  }
+
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) return undefined
+    const val = this.map.get(key) as V
+    // mark as recently used
+    this.map.delete(key)
+    this.map.set(key, val)
+    return val
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) this.map.delete(key)
+    this.map.set(key, value)
+    if (this.map.size > this.max) {
+      const iter = this.map.keys()
+      const firstKey = iter.next().value
+      if (firstKey !== undefined)
+        this.map.delete(firstKey as K)
+    }
+  }
+
+  // convenience: get or create via factory
+  getOrCreate(key: K, factory: () => V): V {
+    const existing = this.get(key)
+    if (existing !== undefined) return existing
+    const v = factory()
+    this.set(key, v)
+    return v
+  }
+}

--- a/packages/markdown-parser/src/utils/lru.ts
+++ b/packages/markdown-parser/src/utils/lru.ts
@@ -10,7 +10,8 @@ export class LRUCache<K, V> {
   }
 
   get(key: K): V | undefined {
-    if (!this.map.has(key)) return undefined
+    if (!this.map.has(key))
+      return undefined
     const val = this.map.get(key) as V
     // mark as recently used
     this.map.delete(key)
@@ -19,7 +20,8 @@ export class LRUCache<K, V> {
   }
 
   set(key: K, value: V): void {
-    if (this.map.has(key)) this.map.delete(key)
+    if (this.map.has(key))
+      this.map.delete(key)
     this.map.set(key, value)
     if (this.map.size > this.max) {
       const iter = this.map.keys()
@@ -32,7 +34,8 @@ export class LRUCache<K, V> {
   // convenience: get or create via factory
   getOrCreate(key: K, factory: () => V): V {
     const existing = this.get(key)
-    if (existing !== undefined) return existing
+    if (existing !== undefined)
+      return existing
     const v = factory()
     this.set(key, v)
     return v

--- a/packages/markdown-parser/test/setup/vitest.setup.ts
+++ b/packages/markdown-parser/test/setup/vitest.setup.ts
@@ -1,0 +1,2 @@
+// Reuse the repository-level Vitest setup so package tests have the same environment.
+import '../../../../test/setup/vitest.setup'

--- a/packages/markdown-parser/test/utils/lru.test.ts
+++ b/packages/markdown-parser/test/utils/lru.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { LRUCache } from '../../src/utils/lru'
+
+describe('lRUCache', () => {
+  it('stores and retrieves and updates recency', () => {
+    const c = new LRUCache<string, number>(2)
+    c.set('a', 1)
+    c.set('b', 2)
+    // access 'a' to make 'b' the oldest
+    expect(c.get('a')).toBe(1)
+    c.set('c', 3)
+    // 'b' should have been evicted
+    expect(c.get('b')).toBe(undefined)
+    expect(c.get('a')).toBe(1)
+    expect(c.get('c')).toBe(3)
+  })
+
+  it('getOrCreate creates and caches value', () => {
+    const c = new LRUCache<string, number>(2)
+    let calls = 0
+    const v1 = c.getOrCreate('x', () => {
+      calls++
+      return 42
+    })
+    const v2 = c.getOrCreate('x', () => {
+      calls++
+      return 43
+    })
+    expect(v1).toBe(42)
+    expect(v2).toBe(42)
+    expect(calls).toBe(1)
+  })
+
+  it('evicts oldest when size exceeded', () => {
+    const c = new LRUCache<string, number>(1)
+    c.set('a', 1)
+    c.set('b', 2)
+    expect(c.get('a')).toBe(undefined)
+    expect(c.get('b')).toBe(2)
+  })
+})

--- a/src/components/AdmonitionNode/AdmonitionNode.vue
+++ b/src/components/AdmonitionNode/AdmonitionNode.vue
@@ -80,7 +80,7 @@ const headerId = `admonition-${Math.random().toString(36).slice(2, 9)}`
       class="admonition-content"
       :aria-labelledby="headerId"
     >
-  <NodeRenderer :index-key="`admonition-${indexKey}`" :nodes="props.node.children" :typewriter="props.typewriter" @copy="emit('copy', $event)" />
+      <NodeRenderer :index-key="`admonition-${indexKey}`" :nodes="props.node.children" :typewriter="props.typewriter" @copy="emit('copy', $event)" />
     </div>
   </div>
 </template>

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -30,7 +30,7 @@ defineEmits<{
 
 <template>
   <blockquote class="blockquote" dir="auto" :cite="node.cite">
-  <NodeRenderer :index-key="`blockquote-${indexKey}`" :nodes="node.children || []" :typewriter="typewriter" @copy="$emit('copy', $event)" />
+    <NodeRenderer :index-key="`blockquote-${indexKey}`" :nodes="node.children || []" :typewriter="typewriter" @copy="$emit('copy', $event)" />
   </blockquote>
 </template>
 

--- a/src/components/DefinitionListNode/DefinitionListNode.vue
+++ b/src/components/DefinitionListNode/DefinitionListNode.vue
@@ -31,10 +31,10 @@ defineEmits(['copy'])
   <dl class="definition-list">
     <template v-for="(item, index) in node.items" :key="index">
       <dt class="definition-term">
-  <NodeRenderer :index-key="`definition-term-${indexKey}-${index}`" :nodes="item.term" :typewriter="typewriter" @copy="$emit('copy', $event)" />
+        <NodeRenderer :index-key="`definition-term-${indexKey}-${index}`" :nodes="item.term" :typewriter="typewriter" @copy="$emit('copy', $event)" />
       </dt>
       <dd class="definition-desc">
-  <NodeRenderer :index-key="`definition-desc-${indexKey}-${index}`" :nodes="item.definition" :typewriter="typewriter" @copy="$emit('copy', $event)" />
+        <NodeRenderer :index-key="`definition-desc-${indexKey}-${index}`" :nodes="item.definition" :typewriter="typewriter" @copy="$emit('copy', $event)" />
       </dd>
     </template>
   </dl>

--- a/src/components/FootnoteNode/FootnoteNode.vue
+++ b/src/components/FootnoteNode/FootnoteNode.vue
@@ -27,7 +27,7 @@ defineEmits(['copy'])
   >
     <span class="font-semibold mr-2 text-[#0366d6]">[{{ node.id }}]</span>
     <div class="flex-1">
-  <NodeRenderer :index-key="`footnote-${indexKey}`" :nodes="node.children" :typewriter="typewriter" @copy="$emit('copy', $event)" />
+      <NodeRenderer :index-key="`footnote-${indexKey}`" :nodes="node.children" :typewriter="typewriter" @copy="$emit('copy', $event)" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
- Hoist default regexes used by math and parsers\n- Replace unbounded Map caches with bounded LRUCache instances\n- Extract LRUCache to package shared util and update inline-parsers, math, container-parser, html-block-parser\n- Preserve behavior; ran typecheck and package tests