### PR TITLE
Revert "feat(markdown)!: strict math delimiters, robust inline code parsing; drop plain parentheses as math"

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,17 +112,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.4",
-    "markdown-it": "^14.1.0",
-    "markdown-it-container": "^4.0.0",
-    "markdown-it-emoji": "^3.0.0",
-    "markdown-it-footnote": "^4.0.0",
-    "markdown-it-ins": "^4.0.0",
-    "markdown-it-mark": "^4.0.0",
-    "markdown-it-sub": "^2.0.0",
-    "markdown-it-sup": "^2.0.0",
-    "markdown-it-task-checkbox": "^1.0.6",
-    "markdown-it-ts": "0.0.2-beta.4",
-    "stream-markdown-parser": "workspace:^"
+    "stream-markdown-parser": "^0.0.30"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",

--- a/packages/markdown-parser/src/config.ts
+++ b/packages/markdown-parser/src/config.ts
@@ -12,13 +12,6 @@ export interface MathOptions {
   commands?: readonly string[]
   /** Whether to escape standalone '!' (default: true). */
   escapeExclamation?: boolean
-  /**
-   * Strict delimiter mode.
-   * - When true, only explicit TeX delimiters are recognized as math:
-   *   inline: `$...$` and `\(...\)`; block: `$$...$$` and `\[...\]`.
-   * - Heuristics and mid-state (unclosed) math detection are disabled.
-   */
-  strictDelimiters?: boolean
 }
 
 let defaultMathOptions: MathOptions | undefined

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -63,7 +63,11 @@ export function parseList(
           tokens[k].type === 'bullet_list_open'
           || tokens[k].type === 'ordered_list_open'
         ) {
-          // Parse nested list (do not skip '*' — treat all bullet types consistently)
+          if (tokens[k].markup === '*') {
+            k++
+            continue
+          }
+          // Parse nested list
           const [nestedListNode, newIndex] = parseNestedList(tokens, k)
           itemChildren.push(nestedListNode)
           k = newIndex
@@ -202,6 +206,11 @@ function parseNestedList(
           tokens[k].type === 'bullet_list_open'
           || tokens[k].type === 'ordered_list_open'
         ) {
+          if (tokens[k].markup === '*') {
+            k++
+            continue
+          }
+
           // Handle deeper nested lists
           const [deeperNestedListNode, newIndex] = parseNestedList(tokens, k)
           itemChildren.push(deeperNestedListNode)

--- a/packages/markdown-parser/src/plugins/isMathLike.ts
+++ b/packages/markdown-parser/src/plugins/isMathLike.ts
@@ -90,11 +90,9 @@ export function isMathLike(s: string) {
   const funcCall = FUNC_CALL_RE.test(norm)
   // common math words
   const words = WORDS_RE.test(norm)
-  // 纯单个英文字母也渲染成数学公式（常见变量/元素符号）
-  // e.g. (w) (x) (y) (z) 或 $H$, $x$ 等
-  const pureWord = /^\([a-z]\)$/i.test(stripped) || /^[a-z]$/i.test(stripped)
-  // 简单的化学式/下标：如 H_2O, CO_2, CH_3CH_2OH, CH_3COOH
-  const chemicalLike = /^(?:[A-Z][a-z]?(_\{?[A-Za-z0-9]+\}?|\^[A-Za-z0-9]+)?)+$/i.test(stripped)
+  // 纯单个英文字母也渲染成数学公式
+  // e.g. (w) (x) (y) (z)
+  const pureWord = /^\([a-z]\)$/i.test(stripped)
 
-  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || words || pureWord || chemicalLike
+  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || words || pureWord
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,36 +14,6 @@ importers:
       katex:
         specifier: '>=0.16.22'
         version: 0.16.25
-      markdown-it:
-        specifier: ^14.1.0
-        version: 14.1.0
-      markdown-it-container:
-        specifier: ^4.0.0
-        version: 4.0.0
-      markdown-it-emoji:
-        specifier: ^3.0.0
-        version: 3.0.0
-      markdown-it-footnote:
-        specifier: ^4.0.0
-        version: 4.0.0
-      markdown-it-ins:
-        specifier: ^4.0.0
-        version: 4.0.0
-      markdown-it-mark:
-        specifier: ^4.0.0
-        version: 4.0.0
-      markdown-it-sub:
-        specifier: ^2.0.0
-        version: 2.0.0
-      markdown-it-sup:
-        specifier: ^2.0.0
-        version: 2.0.0
-      markdown-it-task-checkbox:
-        specifier: ^1.0.6
-        version: 1.0.6
-      markdown-it-ts:
-        specifier: 0.0.2-beta.4
-        version: 0.0.2-beta.4
       mermaid:
         specifier: '>=11'
         version: 11.12.1
@@ -54,8 +24,8 @@ importers:
         specifier: '>=0.0.10'
         version: 0.0.10(shiki@3.15.0)
       stream-markdown-parser:
-        specifier: workspace:^
-        version: link:packages/markdown-parser
+        specifier: ^0.0.30
+        version: 0.0.30
       stream-monaco:
         specifier: '>=0.0.6'
         version: 0.0.6(monaco-editor@0.52.2)
@@ -3205,10 +3175,6 @@ packages:
     resolution: {integrity: sha512-IODjyQuedEjZkUoILLHOvPvG1CEyDECr8bja5VLTwQ2UD0wGSA9guNrD+ko8t5LLR1dglcBTEsMw9iYt7Ngrsg==}
     engines: {node: '>=18'}
 
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
-    hasBin: true
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -3985,6 +3951,9 @@ packages:
 
   stream-markdown-parser@0.0.29:
     resolution: {integrity: sha512-ZKn+plQ7rtanWhh3dwcOTeOu4ph4J12elOvq7+hJJbbIWTKIly8JFQMaJ4iAf527cmyQIIuzmh75bq/PR3PJNQ==}
+
+  stream-markdown-parser@0.0.30:
+    resolution: {integrity: sha512-naWIooFNnhi+lO2obMfHQiv6xyHjgcDiaIaE/jNTrEfh/zDkQSBHEuL/nO1ToNaXZPj/JHFBp6qKMUNeaSbsXA==}
 
   stream-markdown@0.0.10:
     resolution: {integrity: sha512-k3B1h1gUga0nArchDSD6O8+rxXiL6WvuZ11hZgxpYy9Z1Pihjt8rYROoTdJeC2k2ymctLYTDIGRI6AASjipLeg==}
@@ -7867,15 +7836,6 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  markdown-it@14.1.0:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.0
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
@@ -8832,6 +8792,18 @@ snapshots:
   std-env@3.10.0: {}
 
   stream-markdown-parser@0.0.29:
+    dependencies:
+      markdown-it-container: 4.0.0
+      markdown-it-emoji: 3.0.0
+      markdown-it-footnote: 4.0.0
+      markdown-it-ins: 4.0.0
+      markdown-it-mark: 4.0.0
+      markdown-it-sub: 2.0.0
+      markdown-it-sup: 2.0.0
+      markdown-it-task-checkbox: 1.0.6
+      markdown-it-ts: 0.0.2-beta.4
+
+  stream-markdown-parser@0.0.30:
     dependencies:
       markdown-it-container: 4.0.0
       markdown-it-emoji: 3.0.0

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,6 +84,15 @@ export default defineConfig(({ mode }) => {
             return true
           return [
             'vue',
+            'markdown-it-ts',
+            'markdown-it-container',
+            'markdown-it-emoji',
+            'markdown-it-footnote',
+            'markdown-it-ins',
+            'markdown-it-mark',
+            'markdown-it-sub',
+            'markdown-it-sup',
+            'markdown-it-task-checkbox',
             'vue-i18n',
             'katex',
             'stream-monaco',


### PR DESCRIPTION
Reverts Simon-He95/vue-markdown-renderer#148