### PR TITLE
fix: allow vertical scroll chain in table

### DIFF
--- a/packages/markstream-react/src/index.css
+++ b/packages/markstream-react/src/index.css
@@ -313,7 +313,8 @@ li .paragraph-node {
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
   scrollbar-gutter: stable;
 }
 

--- a/packages/markstream-vue2/src/components/TableNode/TableNode.vue
+++ b/packages/markstream-vue2/src/components/TableNode/TableNode.vue
@@ -126,7 +126,8 @@ const bodyRows = computed(() => props.node.rows ?? [])
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
   scrollbar-gutter: stable;
 }
 

--- a/playground-vue2-cli/package.json
+++ b/playground-vue2-cli/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "katex": "^0.16.25",
     "markstream-vue2": "workspace:*",
-    "stream-monaco": "file:../../stream-monaco",
     "stream-markdown": ">=0.0.13",
     "vue": "2.7.16"
   },
@@ -16,7 +15,6 @@
     "@vue/cli-plugin-babel": "^4.5.19",
     "@vue/cli-service": "^4.5.19",
     "core-js": "^3.41.0",
-    "monaco-editor": "^0.52.2",
     "vue-template-compiler": "2.7.16"
   }
 }

--- a/playground-vue2-cli/src/App.vue
+++ b/playground-vue2-cli/src/App.vue
@@ -24,11 +24,11 @@ export default {
       <MarkdownRender
         :content="content"
         :final="true"
-        :deferNodesUntilVisible="false"
-        :batchRendering="false"
-        :viewportPriority="false"
+        :defer-nodes-until-visible="false"
+        :batch-rendering="false"
+        :viewport-priority="false"
         :themes="['vitesse-dark', 'vitesse-light']"
-        :isDark="false"
+        :is-dark="false"
       />
     </div>
   </div>

--- a/playground-vue2-cli/src/main.js
+++ b/playground-vue2-cli/src/main.js
@@ -1,10 +1,10 @@
 import {
   createKaTeXWorkerFromCDN,
   createMermaidWorkerFromCDN,
-  setKaTeXWorker,
-  setMermaidWorker,
   MarkdownCodeBlockNode,
   setCustomComponents,
+  setKaTeXWorker,
+  setMermaidWorker,
   VueRendererMarkdown,
 } from 'markstream-vue2'
 import Vue from 'vue'

--- a/playground-vue2-cli/vue.config.js
+++ b/playground-vue2-cli/vue.config.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const webpack = require('webpack')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const webpack = require('webpack')
 
 function tryResolve(specifier) {
   try {

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -126,7 +126,8 @@ const bodyRows = computed(() => props.node.rows ?? [])
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
   scrollbar-gutter: stable;
 }
 


### PR DESCRIPTION
Fixes #271

Change `overscroll-behavior` to only contain the x-axis so horizontal table scrolling doesn't trap page scrolling.