### PR TITLE
feat: add SSR coverage and Nuxt verification

### DIFF
--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -18,11 +18,11 @@ If you are still deciding where to customize the pipeline, start with:
 | Component | Best for | Key props/events | Extra CSS / peers | Troubleshooting hooks |
 | --------- | -------- | ---------------- | ----------------- | --------------------- |
 | `MarkdownRender` | Rendering full AST trees (default export) | Props: `content` / `nodes`, `custom-id`, `final`, `parse-options`, `custom-html-tags`, `is-dark`, `code-block-props`, `mermaid-props`, `d2-props`, `infographic-props`; events: `copy`, `handleArtifactClick`, `click`, `mouseover`, `mouseout` | Import `markstream-vue/index.css` inside a reset-aware layer (CSS is scoped under an internal `.markstream-vue` container) | Use `setCustomComponents(customId, mapping)` + `custom-id` to scope overrides; see [CSS checklist](/guide/troubleshooting#css-looks-wrong-start-here) |
-| `CodeBlockNode` | Monaco-powered code blocks, streaming diffs | `node`, `monacoOptions`, `stream`, `loading`; events: `copy`, `previewCode`; slots `header-left` / `header-right`; diff hover actions live under `monacoOptions` (`diffHunkActionsOnHover`, `diffHunkHoverHideDelayMs`, `onDiffHunkAction`) | Install `stream-monaco` (peer) + bundle Monaco workers | Blank editor => check worker bundling + SSR guards |
+| `CodeBlockNode` | Monaco-powered code blocks, streaming diffs | `node`, `monacoOptions`, `stream`, `loading`; events: `copy`, `previewCode`; slots `header-left` / `header-right`; diff hover actions live under `monacoOptions` (`diffHunkActionsOnHover`, `diffHunkHoverHideDelayMs`, `onDiffHunkAction`) | Install `stream-monaco` (peer) + bundle Monaco workers | SSR sends a `<pre><code>` fallback first; blank editor => check worker bundling + client enhancement setup |
 | `MarkdownCodeBlockNode` | Lightweight highlighting via `shiki` | `node`, `stream`, `loading`; slots `header-left` / `header-right` | Requires `shiki` + `stream-markdown` | Use for SSR-friendly or low-bundle scenarios |
-| `MermaidBlockNode` | Progressive Mermaid diagrams | `node`, `isDark`, `isStrict`, `maxHeight`; emits `copy`, `export`, `openModal`, `toggleMode` | Peer `mermaid` >= 11; no extra CSS required | For async errors see `/guide/mermaid` |
-| `D2BlockNode` | Progressive D2 diagrams | `node`, `isDark`, `maxHeight`, `progressiveRender`, `progressiveIntervalMs`; toolbar toggles | Peer `@terrastruct/d2`; no extra CSS | Missing peer falls back to source; see `/guide/d2` |
-| `MathBlockNode` / `MathInlineNode` | KaTeX rendering | `node` | Install `katex` and import `katex/dist/katex.min.css` | SSR requires `client-only` in Nuxt |
+| `MermaidBlockNode` | Progressive Mermaid diagrams | `node`, `isDark`, `isStrict`, `maxHeight`; emits `copy`, `export`, `openModal`, `toggleMode` | Peer `mermaid` >= 11; no extra CSS required | SSR sends readable fallback markup first; for async errors see `/guide/mermaid` |
+| `D2BlockNode` | Progressive D2 diagrams | `node`, `isDark`, `maxHeight`, `progressiveRender`, `progressiveIntervalMs`; toolbar toggles | Peer `@terrastruct/d2`; no extra CSS | SSR sends fallback/source first; missing peer stays on fallback; see `/guide/d2` |
+| `MathBlockNode` / `MathInlineNode` | KaTeX rendering | `node` | Install `katex` and import `katex/dist/katex.min.css` | SSR can emit KaTeX HTML when you register a sync loader; otherwise it falls back to raw text |
 | `ImageNode` | Custom previews/lightboxes | Props: `fallback-src`, `show-caption`, `lazy`, `svg-min-height`, `use-placeholder`; emits `click`, `load`, `error` | None, but respects global CSS | Wrap in a custom component + `setCustomComponents` to intercept events |
 | `LinkNode` | Animated underline, tooltips | `color`, `underlineHeight`, `showTooltip` | No extra CSS | Browser defaults can override `a` styles; import reset |
 | `VmrContainerNode` | Custom `:::` containers | `node` (`name`, `attrs`, `loading`, `children`) | Minimal base CSS; override via `setCustomComponents` | JSON attrs are normalized onto `node.attrs` (keys without `data-`); invalid/partial JSON becomes `attrs.attrs`; args after name stored in `attrs.args` |
@@ -179,7 +179,7 @@ setCustomComponents('docs', {
 
 - **Broken styles**: start with the [CSS checklist](/guide/troubleshooting#css-looks-wrong-start-here).
 - **Utility class leakage**: pass `custom-id` and scope overrides with `[data-custom-id="docs"]`.
-- **SSR errors**: wrap browser-only peers such as Mermaid, D2, and Monaco with client-only guards.
+- **SSR errors**: the renderer itself is SSR-safe; only gate your own browser-only page logic or manual peer initialization with client-only / mounted guards.
 
 ### Use this when
 
@@ -229,7 +229,7 @@ Choose this when you do not need Monaco's editing surface or diff interactions.
 - **Key props**: `node`, `isDark`, `isStrict`, `maxHeight`
 - **Events**: `copy`, `export`, `openModal`, `toggleMode`
 - **Peer**: `mermaid` >= 11
-- **Common gotcha**: SSR setups must gate Mermaid initialization to the client
+- **Common gotcha**: treat Mermaid as client enhancement; SSR already returns fallback markup, but preview rendering still initializes on the client
 
 Deep dive: [Mermaid](/guide/mermaid), [MermaidBlockNode](/guide/mermaid-block-node)
 

--- a/docs/nuxt-ssr.md
+++ b/docs/nuxt-ssr.md
@@ -51,8 +51,8 @@ This gives you server HTML immediately. Heavy nodes still upgrade after hydratio
 SSR also works when you render from `nodes` instead of `content`, or when you register scoped custom components.
 
 ```ts
-import { defineComponent, h } from 'vue'
 import { setCustomComponents } from 'markstream-vue'
+import { defineComponent, h } from 'vue'
 
 setCustomComponents('docs-ssr', {
   thinking: defineComponent({
@@ -70,7 +70,7 @@ setCustomComponents('docs-ssr', {
 <template>
   <MarkdownRender
     custom-id="docs-ssr"
-    :content="'<thinking>Server custom tag</thinking>'"
+    content="<thinking>Server custom tag</thinking>"
     :custom-html-tags="['thinking']"
     :final="true"
   />

--- a/docs/nuxt-ssr.md
+++ b/docs/nuxt-ssr.md
@@ -1,71 +1,151 @@
 ---
-description: Integrate markstream-vue safely into Nuxt 3 SSR with client-only peers, browser guards, and worker-aware setup.
+description: Use markstream-vue in Nuxt SSR with server-rendered HTML, stable fallbacks, and client enhancement for rich nodes.
 ---
 
 # Nuxt 3 SSR usage (example)
 
 > 中文版请查看 [Nuxt 3 SSR（中文）](/zh/nuxt-ssr)。
 
-This short recipe shows a minimal, safe way to use `markstream-vue` in Nuxt 3 so that client-only features (Monaco, Mermaid, Web Workers) are only initialized in the browser.
+`markstream-vue` can now render directly during Nuxt SSR. You do not need to wrap `<MarkdownRender>` in `<client-only>` just to stay safe.
 
-## Install peers (client-side)
+The SSR model is:
 
-Install the peers you need in your Nuxt app. For example, to enable Mermaid and Monaco editor previews (optional):
+- Standard markdown, HTML, links, tables, footnotes, and images render on the server.
+- Code blocks render a stable server `<pre><code>` fallback first, then enhance to Monaco on the client.
+- Math can render real KaTeX HTML on the server when you provide a synchronous KaTeX loader.
+- Mermaid, D2, and Infographic render readable SSR fallbacks first, then enhance on the client.
+- Scoped custom component overrides, custom node types, and trusted `customHtmlTags` also render on the server.
 
-```bash
-# pnpm (recommended)
-pnpm add mermaid stream-monaco
-
-# npm
-npm install mermaid stream-monaco
-```
-
-Do NOT import these peers from server-only code paths during SSR.
-
-## Example page (client-only wrapper)
-
-Create a page or component that defers mounting the renderer to the client. Nuxt provides a `<client-only>` built-in wrapper which is perfect:
+## Minimal SSR page
 
 ```vue
 <script setup lang="ts">
 import MarkdownRender from 'markstream-vue'
 import { ref } from 'vue'
 
-const markdown = ref(`# Hello from Nuxt 3\n\nThis content is rendered only on the client.`)
+const markdown = ref(`
+# Hello from Nuxt SSR
+
+Inline math: $E = mc^2$
+
+\`\`\`ts
+export const greet = (name: string) => \`hello \${name}\`
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  SSR --> Hydration
+\`\`\`
+`.trim())
 </script>
 
 <template>
-  <client-only>
-    <MarkdownRender :content="markdown" />
-  </client-only>
+  <MarkdownRender :content="markdown" :final="true" />
 </template>
 ```
 
-This ensures the `MarkdownRender` component (and any optional peers it lazy-loads) are only imported/initialized in the browser.
+This gives you server HTML immediately. Heavy nodes still upgrade after hydration, but the first response is not an empty shell.
 
-## Server-rendered diagrams or math
+## Pre-parsed nodes and custom components
 
-If you need server-rendered HTML for diagrams or math (so crawlers or first paint include them), pre-render those outputs during your build step or via a small server-side task. Example approaches:
+SSR also works when you render from `nodes` instead of `content`, or when you register scoped custom components.
 
-- Use a build script that runs `mermaid-cli` / `katex` to convert certain diagrams/formulas to HTML/SVG during content generation and embed the resulting HTML into the page.
-- Use a server endpoint that returns pre-rendered diagram SVG/HTML and fetch it on the client as needed.
+```ts
+import { defineComponent, h } from 'vue'
+import { setCustomComponents } from 'markstream-vue'
 
-Then pass pre-rendered fragments into the renderer as trusted HTML or a server-side AST so the client avoids heavy initialization for those artifacts.
+setCustomComponents('docs-ssr', {
+  thinking: defineComponent({
+    props: {
+      node: { type: Object, required: true },
+    },
+    setup(props) {
+      return () => h('aside', { 'data-ssr-thinking': '1' }, String((props.node as any).content ?? ''))
+    },
+  }),
+})
+```
 
-## Notes
+```vue
+<template>
+  <MarkdownRender
+    custom-id="docs-ssr"
+    :content="'<thinking>Server custom tag</thinking>'"
+    :custom-html-tags="['thinking']"
+    :final="true"
+  />
+</template>
+```
 
-- Prefer `client-only` when using Monaco Editor, Web Workers, or progressive Mermaid.
-- The library is designed to be import-safe during SSR: heavy peers are lazy-loaded in the browser and many DOM/Worker usages are guarded. If you see an import-time ReferenceError, please provide the stack trace.
+Use `nodes + final` when you already have pre-parsed AST content on the server and want deterministic SSR without re-parsing in the browser.
 
----
+## Server-rendered math with KaTeX
+
+If you want KaTeX HTML in the SSR response, register a sync loader in your Nuxt app:
+
+```ts
+import katex from 'katex'
+import { enableKatex } from 'markstream-vue'
+
+enableKatex(() => katex)
+```
+
+Without that loader, math still stays SSR-safe and falls back to readable raw text.
+
+## When to still use `<client-only>`
+
+You usually do not need it anymore for the renderer itself.
+
+Use `<client-only>` only when your own page logic is browser-only, or when you intentionally want to skip SSR for a whole region.
 
 ## Nuxt playground
 
-This repository now ships with a Nuxt playground that mirrors the streaming demo from the Vite playground. It lives in `playground-nuxt/` at the repo root.
+This repository ships with a Nuxt playground in `playground-nuxt/`.
 
 ```bash
 pnpm install
 pnpm play:nuxt
 ```
 
-The command boots Nuxt 4 (dev server at `http://localhost:3000`) and renders the same Markdown stream as the main playground, so you can verify SSR, workers, and Tailwind interactions in an actual Nuxt environment. Feel free to copy pieces from that folder when wiring up your own project.
+The dedicated SSR verification route is:
+
+- `/ssr-lab`
+
+It contains a fixed matrix for:
+
+- basic markdown + HTML SSR
+- rich-node SSR fallback
+- hydration-time enhancement
+- disabled-enhancement fallback
+- custom-tag and scoped override validation
+
+## SSR regression command
+
+Run the dedicated Nuxt SSR regression suite with:
+
+```bash
+pnpm test:e2e:nuxt-ssr
+```
+
+That command verifies both:
+
+- `nuxt dev`
+- `nuxt build && nuxt preview`
+
+Each mode checks the raw HTTP HTML for `/ssr-lab`, then opens the page in a browser to verify hydration and enhancement stability.
+
+## Library-level SSR regression coverage
+
+The repository also keeps a direct `renderToString` regression suite for the renderer itself:
+
+```bash
+pnpm test --run test/ssr-render-to-string.test.ts test/ssr-import.test.ts
+```
+
+That suite explicitly covers:
+
+- a built-in node matrix for lighter SSR nodes such as headings, paragraphs, inline formatting, links, lists, tables, footnotes, admonitions, and `vmr_container`
+- the standalone `MarkdownCodeBlockNode` shell during SSR
+- scoped built-in overrides via `setCustomComponents`
+- direct custom node types rendered through `nodes`
+- trusted custom tags wired through `customHtmlTags`

--- a/docs/zh/guide/components.md
+++ b/docs/zh/guide/components.md
@@ -18,11 +18,11 @@ description: 快速查阅 MarkdownRender、CodeBlockNode、MermaidBlockNode、Im
 | 组件 | 推荐场景 | 关键 props / 事件 | 额外 CSS / 同伴依赖 | 排障提示 |
 | ---- | -------- | ---------------- | ------------------- | -------- |
 | `MarkdownRender` | 渲染完整 AST（默认导出） | Props：`content` / `nodes`、`custom-id`、`final`、`parse-options`、`custom-html-tags`、`is-dark`、`code-block-props`、`mermaid-props`、`d2-props`、`infographic-props`；事件：`copy`、`handleArtifactClick`、`click`、`mouseover`、`mouseout` | 在 reset 之后引入 `markstream-vue/index.css`（CSS 已被限定在内部 `.markstream-vue` 容器中），并放入受控 layer | 用 `setCustomComponents(customId, mapping)` + `custom-id` 限定覆盖范围；配合 [CSS 排查清单](/zh/guide/troubleshooting#css-looks-wrong-start-here) |
-| `CodeBlockNode` | 基于 Monaco 的交互式代码块、流式 diff | `node`、`monacoOptions`、`stream`、`loading`；事件：`copy`、`previewCode`；插槽 `header-left` / `header-right`；diff 悬浮操作配置放在 `monacoOptions`（`diffHunkActionsOnHover`、`diffHunkHoverHideDelayMs`、`onDiffHunkAction`） | 安装 `stream-monaco`（peer）并打包 Monaco workers | 空白编辑器 → 优先检查 worker 打包与 SSR |
+| `CodeBlockNode` | 基于 Monaco 的交互式代码块、流式 diff | `node`、`monacoOptions`、`stream`、`loading`；事件：`copy`、`previewCode`；插槽 `header-left` / `header-right`；diff 悬浮操作配置放在 `monacoOptions`（`diffHunkActionsOnHover`、`diffHunkHoverHideDelayMs`、`onDiffHunkAction`） | 安装 `stream-monaco`（peer）并打包 Monaco workers | SSR 首包会先给 `<pre><code>` fallback；编辑器空白时优先检查 worker 打包和客户端增强链路 |
 | `MarkdownCodeBlockNode` | 轻量级高亮（Shiki） | `node`、`stream`、`loading`；插槽 `header-left` / `header-right` | 同伴依赖 `shiki` + `stream-markdown` | SSR/低体积场景优先使用 |
-| `MermaidBlockNode` | 渐进式 Mermaid 图 | `node`、`isDark`、`isStrict`、`maxHeight`；事件 `copy`、`export`、`openModal`、`toggleMode` | `mermaid` >= 11；无需额外 CSS | 详见 `/zh/guide/mermaid` |
-| `D2BlockNode` | 渐进式 D2 图 | `node`、`isDark`、`maxHeight`、`progressiveRender`、`progressiveIntervalMs`；工具栏开关 | `@terrastruct/d2`；无需额外 CSS | 缺少依赖会回退到源码；详见 `/zh/guide/d2` |
-| `MathBlockNode` / `MathInlineNode` | KaTeX 公式 | `node` | 安装 `katex` 并引入 `katex/dist/katex.min.css` | Nuxt SSR 中需 `<ClientOnly>` |
+| `MermaidBlockNode` | 渐进式 Mermaid 图 | `node`、`isDark`、`isStrict`、`maxHeight`；事件 `copy`、`export`、`openModal`、`toggleMode` | `mermaid` >= 11；无需额外 CSS | SSR 首包先给可读 fallback；异步渲染问题详见 `/zh/guide/mermaid` |
+| `D2BlockNode` | 渐进式 D2 图 | `node`、`isDark`、`maxHeight`、`progressiveRender`、`progressiveIntervalMs`；工具栏开关 | `@terrastruct/d2`；无需额外 CSS | SSR 首包先给 fallback / 源码；缺少依赖时保持 fallback；详见 `/zh/guide/d2` |
+| `MathBlockNode` / `MathInlineNode` | KaTeX 公式 | `node` | 安装 `katex` 并引入 `katex/dist/katex.min.css` | 注册同步 KaTeX loader 后可直接 SSR 出 HTML；否则稳定回退为原文 |
 | `ImageNode` | 自定义图片预览 / 懒加载 | Props：`fallback-src`、`show-caption`、`lazy`、`svg-min-height`、`use-placeholder`；事件：`click` / `load` / `error` | 无额外 CSS | 通过 `setCustomComponents` 包装，实现 lightbox |
 | `LinkNode` | 下划线动画、颜色自定义 | `color`、`underlineHeight`、`showTooltip` | 无 | 浏览器默认 `a` 样式可通过 reset 解决 |
 | `VmrContainerNode` | 自定义 `:::` 容器 | `node`（`name`、`attrs`、`loading`、`children`） | 极简基础 CSS；通过 `setCustomComponents` 覆盖 | JSON attrs 会规范到 `node.attrs`（去掉 `data-` 前缀）；无效/不完整 JSON 存到 `attrs.attrs`；name 后面的 args 存到 `attrs.args` |
@@ -179,7 +179,7 @@ setCustomComponents('docs', {
 
 - **样式错乱**：先检查 [CSS 排查清单](/zh/guide/troubleshooting#css-looks-wrong-start-here)。
 - **工具类覆盖**：传入 `custom-id` 并使用 `[data-custom-id="docs"]` 限定样式。
-- **SSR 报错**：对只在浏览器可用的同伴依赖（Mermaid、D2、Monaco）使用 `<ClientOnly>` 或 `onMounted`。
+- **SSR 报错**：渲染器本身已经 SSR-safe；只把你自己的浏览器专属页面逻辑，或手动初始化的 peer，放到 `<ClientOnly>` / `onMounted` 后面。
 
 ### 什么时候优先用它
 
@@ -229,7 +229,7 @@ setCustomComponents('docs', {
 - **关键 props**：`node`、`isDark`、`isStrict`、`maxHeight`
 - **事件**：`copy`、`export`、`openModal`、`toggleMode`
 - **同伴依赖**：`mermaid` >= 11
-- **常见问题**：SSR 场景要把 Mermaid 初始化放到客户端边界之后
+- **常见问题**：把 Mermaid 当成客户端增强能力看待；SSR 首包已经有 fallback，真正的 preview 仍然在客户端初始化
 
 深入页面： [Mermaid](/zh/guide/mermaid)、[MermaidBlockNode](/zh/guide/mermaid-block-node)
 

--- a/docs/zh/nuxt-ssr.md
+++ b/docs/zh/nuxt-ssr.md
@@ -1,71 +1,150 @@
----
-description: 在 Nuxt 3 SSR 中安全接入 markstream-vue，处理客户端依赖、浏览器边界与 Worker 初始化问题。
+description: 在 Nuxt 3 SSR 中使用 markstream-vue，获得服务端 HTML、稳定 fallback，以及重节点的客户端增强。
 ---
 
 # Nuxt 3 SSR 用法示例
 
 > For the English version, see [nuxt-ssr.md](../nuxt-ssr.md).
 
-本示例演示如何在 Nuxt 3 中安全地集成 `markstream-vue`，确保仅在浏览器端初始化 Monaco、Mermaid、Web Worker 等客户端功能。
+`markstream-vue` 现在可以直接在 Nuxt SSR 中产出服务端 HTML。为了“能跑”而把整个 `<MarkdownRender>` 包进 `<ClientOnly>`，已经不是默认推荐做法。
 
-## 安装浏览器端依赖
+当前的 SSR 模型是：
 
-根据需要安装可选依赖。例如要启用 Mermaid 和 Monaco 代码编辑器：
+- 普通 markdown、HTML、链接、表格、脚注、图片会直接在服务端渲染。
+- 代码块会先输出稳定的服务端 `<pre><code>` fallback，再在客户端增强成 Monaco。
+- 数学公式在提供同步 KaTeX loader 时，可以直接在服务端输出真正的 KaTeX HTML。
+- Mermaid、D2、Infographic 会先输出可读的 SSR fallback，再在客户端增强。
+- scoped 自定义组件覆盖、自定义 node type、以及 `customHtmlTags` 也都能参与服务端渲染。
 
-```bash
-# pnpm（推荐）
-pnpm add mermaid stream-monaco
-
-# npm
-npm install mermaid stream-monaco
-```
-
-**请勿**在 SSR 的服务端上下文中直接导入这些依赖。
-
-## 示例页面（仅客户端渲染）
-
-创建一个页面或组件，通过 Nuxt 内置的 `<client-only>` 包裹，从而确保渲染器只在客户端挂载：
+## 最小 SSR 页面
 
 ```vue
 <script setup lang="ts">
 import MarkdownRender from 'markstream-vue'
 import { ref } from 'vue'
 
-const markdown = ref(`# 来自 Nuxt 3 的问候\n\n这段内容仅在客户端渲染。`)
+const markdown = ref(`
+# 来自 Nuxt SSR 的问候
+
+行内公式：$E = mc^2$
+
+\`\`\`ts
+export const greet = (name: string) => \`hello \${name}\`
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  SSR --> Hydration
+\`\`\`
+`.trim())
 </script>
 
 <template>
-  <client-only>
-    <MarkdownRender :content="markdown" />
-  </client-only>
+  <MarkdownRender :content="markdown" :final="true" />
 </template>
 ```
 
-这样可以保证 `MarkdownRender` 组件及其懒加载的可选依赖只会在浏览器端被导入与初始化。
+这样首包就已经有服务端 HTML；重节点仍然会在 hydration 后增强，但不会先给你一个空壳。
 
-## 服务端渲染图表或公式
+## 服务端渲染数学公式
 
-如果希望图表或数学公式在服务端即生成 HTML（提高首屏或 SEO），可以在构建阶段或服务端任务中预渲染：
+如果你希望 SSR 响应里直接带 KaTeX HTML，可以在 Nuxt 应用里注册同步 loader：
 
-- 使用 `mermaid-cli` / `katex` 等工具在构建时将特定内容转换为 HTML/SVG 并嵌入页面。
-- 提供一个服务端接口返回预渲染的图表 HTML/SVG，客户端按需拉取。
+```ts
+import katex from 'katex'
+import { enableKatex } from 'markstream-vue'
 
-随后将这些预渲染内容作为可信 HTML 或服务端生成的 AST 传入渲染器，即可避免在客户端重复初始化重型依赖。
+enableKatex(() => katex)
+```
 
-## 注意事项
+如果没有这个 loader，数学公式也仍然是 SSR-safe，只是会稳定回退成可读原文。
 
-- 使用 Monaco 编辑器、Web Worker 或渐进式 Mermaid 时，推荐始终配合 `<client-only>`。
-- 库经过 SSR 导入安全性设计：重型依赖采用浏览器端懒加载，并对 DOM/Worker 调用做了守卫。如果仍遇到导入阶段的 `ReferenceError`，请附上堆栈信息提交 issue。
+## 预解析 nodes 与自定义组件
 
----
+除了直接传 `content`，你也可以在 SSR 中传 `nodes`，或者配合 scoped custom components / trusted custom tags 一起使用。
+
+```ts
+import { defineComponent, h } from 'vue'
+import { setCustomComponents } from 'markstream-vue'
+
+setCustomComponents('docs-ssr', {
+  thinking: defineComponent({
+    props: {
+      node: { type: Object, required: true },
+    },
+    setup(props) {
+      return () => h('aside', { 'data-ssr-thinking': '1' }, String((props.node as any).content ?? ''))
+    },
+  }),
+})
+```
+
+```vue
+<template>
+  <MarkdownRender
+    custom-id="docs-ssr"
+    :content="'<thinking>服务端自定义标签</thinking>'"
+    :custom-html-tags="['thinking']"
+    :final="true"
+  />
+</template>
+```
+
+如果你的服务端已经拿到了 AST，优先用 `nodes + final`，这样可以避免浏览器端重复解析，SSR 输出也更可控。
+
+## 什么时候还需要 `<ClientOnly>`
+
+通常不是给渲染器本身用的。
+
+只有当你自己的页面逻辑本身依赖浏览器 API，或者你明确想让一整块区域跳过 SSR 时，才需要 `<ClientOnly>`。
 
 ## Nuxt playground
 
-仓库已经提供了一个完整的 Nuxt playground，路径为 `playground-nuxt/`，它复刻了 Vite playground 的流式示例，方便验证 SSR / Worker / Tailwind 等场景。
+仓库里已经提供了完整的 Nuxt playground，路径是 `playground-nuxt/`：
 
 ```bash
 pnpm install
 pnpm play:nuxt
 ```
 
-上述命令会启动 Nuxt 4 开发服务器（默认 `http://localhost:3000`），你可以直接在其中测试 `markstream-vue` 的 Nuxt 集成，并按需拷贝其中的配置到你的项目。
+专门的 SSR 验证路由是：
+
+- `/ssr-lab`
+
+这个页面里有固定矩阵，用来覆盖：
+
+- 基础 markdown + HTML 的 SSR
+- 重节点的 SSR fallback
+- hydration 后的增强路径
+- 显式禁用增强时的稳定 fallback
+- 自定义标签与 scoped override 的验证
+
+## SSR 验收命令
+
+Nuxt SSR 的验收 e2e 命令是：
+
+```bash
+pnpm test:e2e:nuxt-ssr
+```
+
+它会同时验证：
+
+- `nuxt dev`
+- `nuxt build && nuxt preview`
+
+每种模式都会先检查 `/ssr-lab` 的原始 HTTP HTML，再打开浏览器验证 hydration、增强、reload 和路由往返后的稳定性。
+
+## 库级 SSR 回归覆盖
+
+仓库里还有一层直接针对渲染器的 `renderToString` 回归测试：
+
+```bash
+pnpm test --run test/ssr-render-to-string.test.ts test/ssr-import.test.ts
+```
+
+这层测试显式覆盖了：
+
+- 轻节点 SSR 组件矩阵，例如 heading、paragraph、行内格式、link、list、table、footnote、admonition、`vmr_container`
+- 独立的 `MarkdownCodeBlockNode` SSR shell
+- 通过 `setCustomComponents` 做 scoped 内置覆盖
+- 直接自定义 node type 的 SSR
+- 通过 `customHtmlTags` 接入的可信自定义标签 SSR

--- a/docs/zh/nuxt-ssr.md
+++ b/docs/zh/nuxt-ssr.md
@@ -63,8 +63,8 @@ enableKatex(() => katex)
 除了直接传 `content`，你也可以在 SSR 中传 `nodes`，或者配合 scoped custom components / trusted custom tags 一起使用。
 
 ```ts
-import { defineComponent, h } from 'vue'
 import { setCustomComponents } from 'markstream-vue'
+import { defineComponent, h } from 'vue'
 
 setCustomComponents('docs-ssr', {
   thinking: defineComponent({
@@ -82,7 +82,7 @@ setCustomComponents('docs-ssr', {
 <template>
   <MarkdownRender
     custom-id="docs-ssr"
-    :content="'<thinking>服务端自定义标签</thinking>'"
+    content="<thinking>服务端自定义标签</thinking>"
     :custom-html-tags="['thinking']"
     :final="true"
   />

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "test:e2e:codeblock-highlight-stability": "node scripts/e2e-codeblock-highlight-stability.mjs",
     "test:e2e:angular-playground": "node scripts/e2e-angular-playground.mjs",
     "test:e2e:diff-theme-switch": "node scripts/e2e-diff-theme-switch.mjs",
+    "test:e2e:nuxt-ssr": "node scripts/e2e-nuxt-ssr.mjs",
     "lint": "eslint . --cache",
     "lint:fix": "pnpm run lint --fix",
     "test:ui": "vitest --ui",

--- a/playground-nuxt/nuxt.config.ts
+++ b/playground-nuxt/nuxt.config.ts
@@ -19,6 +19,16 @@ export default defineNuxtConfig({
   },
   vite: {
     optimizeDeps: {
+      include: [
+        '@antv/infographic',
+        '@floating-ui/dom',
+        '@terrastruct/d2',
+        'katex',
+        'katex/dist/contrib/mhchem',
+        'mermaid',
+        'stream-markdown',
+        'vue-i18n',
+      ],
       exclude: ['monaco-editor', 'stream-monaco', 'markstream-vue'],
     },
     worker: {

--- a/playground-nuxt/pages/ssr-lab.vue
+++ b/playground-nuxt/pages/ssr-lab.vue
@@ -1,0 +1,378 @@
+<script setup lang="ts">
+import type { PropType } from 'vue'
+import katex from 'katex'
+import MarkdownRender, { enableKatex, getUseMonaco, setCustomComponents, setKaTeXWorker, setMermaidWorker } from 'markstream-vue'
+import KatexWorker from 'markstream-vue/workers/katexRenderer.worker?worker&inline'
+import MermaidWorker from 'markstream-vue/workers/mermaidParser.worker?worker&inline'
+import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker&inline'
+import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker&inline'
+import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker&inline'
+import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker&inline'
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker&inline'
+import { computed, defineComponent, h, onBeforeUnmount, onMounted, ref } from 'vue'
+
+interface NodeLike {
+  content?: string
+  raw?: string
+  code?: string
+}
+
+function createDiagramFallback(kind: string, label: string) {
+  return defineComponent({
+    name: `${label}SsrFallback`,
+    props: {
+      node: {
+        type: Object as PropType<NodeLike>,
+        required: true,
+      },
+    },
+    setup(props) {
+      return () => h('div', {
+        'class': 'my-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 text-slate-900',
+        'data-ssr-fallback': kind,
+        'data-markstream-mode': 'fallback',
+      }, [
+        h('div', {
+          class: 'border-b border-slate-200 px-4 py-2 text-sm font-mono text-slate-600',
+        }, `${label} fallback`),
+        h('pre', {
+          class: 'm-0 overflow-x-auto px-4 py-4 text-sm whitespace-pre-wrap',
+        }, [
+          h('code', String(props.node.code ?? props.node.raw ?? '')),
+        ]),
+      ])
+    },
+  })
+}
+
+const SsrBadgeNode = defineComponent({
+  name: 'SsrBadgeNode',
+  props: {
+    node: {
+      type: Object as PropType<NodeLike>,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () => h('span', {
+      'class': 'inline-flex items-center rounded-full border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700',
+      'data-ssr-custom': 'badge',
+    }, String(props.node.content ?? ''))
+  },
+})
+
+const SsrMathInlineFallback = defineComponent({
+  name: 'SsrMathInlineFallback',
+  props: {
+    node: {
+      type: Object as PropType<NodeLike>,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () => h('span', {
+      'class': 'font-mono text-sm text-slate-700',
+      'data-ssr-fallback': 'math-inline',
+      'data-markstream-mode': 'fallback',
+    }, String(props.node.raw ?? props.node.content ?? ''))
+  },
+})
+
+const SsrMathBlockFallback = defineComponent({
+  name: 'SsrMathBlockFallback',
+  props: {
+    node: {
+      type: Object as PropType<NodeLike>,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () => h('pre', {
+      'class': 'm-0 overflow-x-auto rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-4 text-left text-sm whitespace-pre-wrap text-slate-900',
+      'data-ssr-fallback': 'math-block',
+      'data-markstream-mode': 'fallback',
+    }, String(props.node.raw ?? props.node.content ?? ''))
+  },
+})
+
+const SsrMermaidFallback = createDiagramFallback('mermaid', 'Mermaid')
+const SsrD2Fallback = createDiagramFallback('d2', 'D2')
+const SsrInfographicFallback = createDiagramFallback('infographic', 'Infographic')
+
+const BASIC_SCOPE = 'ssr-lab-basic'
+const FALLBACK_SCOPE = 'ssr-lab-disabled'
+
+setCustomComponents(BASIC_SCOPE, {
+  'ssr-badge': SsrBadgeNode,
+})
+
+setCustomComponents(FALLBACK_SCOPE, {
+  math_inline: SsrMathInlineFallback,
+  math_block: SsrMathBlockFallback,
+  mermaid: SsrMermaidFallback,
+  d2: SsrD2Fallback,
+  infographic: SsrInfographicFallback,
+})
+
+enableKatex(() => katex)
+
+if (process.client) {
+  const existingMonacoEnvironment = (globalThis as any).MonacoEnvironment
+  if (!existingMonacoEnvironment?.getWorker && !existingMonacoEnvironment?.getWorkerUrl) {
+    ;(globalThis as any).MonacoEnvironment = {
+      getWorker(_: unknown, label: string) {
+        if (label === 'json')
+          return new JsonWorker()
+        if (label === 'css' || label === 'scss' || label === 'less')
+          return new CssWorker()
+        if (label === 'html' || label === 'handlebars' || label === 'razor')
+          return new HtmlWorker()
+        if (label === 'typescript' || label === 'javascript')
+          return new TsWorker()
+        return new EditorWorker()
+      },
+    }
+  }
+  getUseMonaco()
+  setKaTeXWorker(new KatexWorker())
+  setMermaidWorker(new MermaidWorker())
+}
+
+const basicMarkdown = `
+# SSR Basic Coverage
+
+Inline HTML stays visible: <mark data-ssr-inline-html="1">inline html</mark>.
+
+Trusted custom tag: <ssr-badge>Custom HTML tag rendered on the server</ssr-badge>
+
+> Blockquote content should be present in the first HTML response.
+
+- [x] Checklist survives SSR
+- [ ] Pending item stays visible
+
+| Name | Role |
+| --- | --- |
+| Simon | Maintainer |
+| Markstream | Renderer |
+
+Footnotes also render on the server.[^1]
+
+![Markstream icon](/vue-markdown-icon.svg "Markstream icon")
+
+<div class="rounded border border-slate-200 bg-slate-50 px-3 py-2" data-ssr-html-block="1">
+  <strong>HTML block</strong> content is already present in SSR output.
+</div>
+
+[^1]: Footnote content is part of the server HTML.
+`.trim()
+
+const enhancedMarkdown = `
+# SSR Enhanced Coverage
+
+Inline math renders to KaTeX: $E = mc^2$.
+
+Block math should already be HTML:
+
+$$
+\\int_0^1 x^2 \\, dx = \\frac{1}{3}
+$$
+
+\`\`\`diff
+--- a/file.txt
++++ b/file.txt
+@@
+- old line
++ new line
+\`\`\`
+
+\`\`\`ts
+export const greet = (name: string) => \`hello \${name}\`
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  Start --> Render
+  Render --> Hydrate
+\`\`\`
+
+\`\`\`d2
+client: Browser
+server: SSR
+client -> server: request
+server -> client: html
+\`\`\`
+
+\`\`\`infographic
+infographic list-row-simple-horizontal-arrow
+data
+  items
+    - label SSR
+      desc First paint
+    - label Hydration
+      desc Attach interactivity
+    - label Enhanced
+      desc Rich preview
+\`\`\`
+`.trim()
+
+const fallbackMarkdown = `
+# Disabled Enhancements
+
+Inline math fallback: $a^2 + b^2 = c^2$.
+
+$$
+\\sum_{n=1}^{3} n = 6
+$$
+
+\`\`\`mermaid
+graph LR
+  Raw --> Stable
+\`\`\`
+
+\`\`\`d2
+stable -> fallback
+\`\`\`
+
+\`\`\`infographic
+infographic list-row-simple-horizontal-arrow
+data
+  items
+    - label Disabled
+      desc Static fallback
+    - label Stable
+      desc SSR-friendly
+\`\`\`
+`.trim()
+
+const hydrated = ref(false)
+const status = ref({
+  code: false,
+  math: false,
+  mermaid: false,
+  d2: false,
+  infographic: false,
+})
+
+let statusTimer: ReturnType<typeof setInterval> | null = null
+
+function updateStatus() {
+  if (typeof document === 'undefined')
+    return
+  status.value = {
+    code: !!document.querySelector('[data-ssr-case="enhanced"] [data-markstream-code-block="1"][data-markstream-enhanced="true"]'),
+    math: !!document.querySelector('[data-ssr-case="enhanced"] [data-markstream-math][data-markstream-mode="katex"] .katex'),
+    mermaid: !!document.querySelector('[data-ssr-case="enhanced"] [data-markstream-mermaid="1"][data-markstream-mode="preview"] ._mermaid svg'),
+    d2: !!document.querySelector('[data-ssr-case="enhanced"] [data-markstream-d2="1"][data-markstream-mode="preview"] svg.markstream-d2-root-svg'),
+    infographic: !!document.querySelector('[data-ssr-case="enhanced"] [data-markstream-infographic="1"][data-markstream-mode="preview"] svg'),
+  }
+}
+
+const readyCount = computed(() => Object.values(status.value).filter(Boolean).length)
+
+onMounted(() => {
+  hydrated.value = true
+  updateStatus()
+  statusTimer = setInterval(updateStatus, 250)
+})
+
+onBeforeUnmount(() => {
+  if (statusTimer)
+    clearInterval(statusTimer)
+})
+</script>
+
+<template>
+  <main class="min-h-screen bg-[radial-gradient(circle_at_top,#f8fafc,white_55%)] px-4 py-10 text-slate-900 sm:px-6">
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-8">
+      <header class="rounded-3xl border border-slate-200 bg-white/90 px-6 py-6 shadow-sm backdrop-blur">
+        <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          markstream-vue / Nuxt SSR
+        </p>
+        <div class="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div class="max-w-3xl">
+            <h1 class="text-3xl font-semibold tracking-tight text-slate-950">
+              SSR Lab
+            </h1>
+            <p class="mt-2 text-sm leading-6 text-slate-600">
+              This route exists to verify first-response HTML, hydration stability, and rich-node enhancement in one fixed Nuxt page.
+            </p>
+          </div>
+          <div
+            class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm"
+            data-ssr-case="hydration"
+            :data-ssr-hydrated="hydrated ? 'true' : 'false'"
+          >
+            <div class="font-medium text-slate-700">
+              Hydration status
+            </div>
+            <div class="mt-1 text-slate-600">
+              Hydrated: <span data-ssr-status="hydrated">{{ hydrated ? 'yes' : 'no' }}</span>
+            </div>
+            <div class="text-slate-600">
+              Enhanced widgets ready: <span data-ssr-status="ready-count">{{ readyCount }}</span>/5
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section data-ssr-case="basic" class="rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-sm">
+        <div class="mb-4">
+          <h2 class="text-xl font-semibold text-slate-950">
+            Basic markdown and HTML
+          </h2>
+          <p class="mt-1 text-sm text-slate-600">
+            Titles, lists, tables, footnotes, HTML inline/block, custom tags, and images must all be present in the raw SSR response.
+          </p>
+        </div>
+        <MarkdownRender
+          :content="basicMarkdown"
+          :final="true"
+          :custom-html-tags="['ssr-badge']"
+          :custom-id="BASIC_SCOPE"
+        />
+      </section>
+
+      <section data-ssr-case="enhanced" class="rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-sm">
+        <div class="mb-4">
+          <h2 class="text-xl font-semibold text-slate-950">
+            Rich nodes with client enhancement
+          </h2>
+          <p class="mt-1 text-sm text-slate-600">
+            SSR should send readable HTML immediately, then upgrade math, code, Mermaid, D2, and Infographic after hydration.
+          </p>
+        </div>
+        <MarkdownRender
+          :content="enhancedMarkdown"
+          :final="true"
+        />
+      </section>
+
+      <section data-ssr-case="fallback" class="rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-sm">
+        <div class="mb-4">
+          <h2 class="text-xl font-semibold text-slate-950">
+            Disabled enhancement fallback
+          </h2>
+          <p class="mt-1 text-sm text-slate-600">
+            This section simulates unavailable heavy peers through scoped custom overrides so SSR fallback stays stable on the same page.
+          </p>
+        </div>
+        <MarkdownRender
+          :content="fallbackMarkdown"
+          :final="true"
+          :custom-id="FALLBACK_SCOPE"
+        />
+      </section>
+
+      <section class="rounded-3xl border border-slate-200 bg-slate-950 px-6 py-6 text-slate-100 shadow-sm">
+        <h2 class="text-xl font-semibold">
+          What the e2e checks
+        </h2>
+        <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-300">
+          <li>The raw HTML for <code>/ssr-lab</code> already contains the basic content and SSR fallbacks.</li>
+          <li>Hydration flips the status card to <code>yes</code> without Vue mismatch warnings.</li>
+          <li>Enhanced widgets become ready in the rich-node section while the disabled section stays in fallback mode.</li>
+        </ul>
+      </section>
+    </div>
+  </main>
+</template>

--- a/playground-nuxt/pages/ssr-lab.vue
+++ b/playground-nuxt/pages/ssr-lab.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
+/* eslint-disable vue/one-component-per-file */
 import type { PropType } from 'vue'
 import katex from 'katex'
 import MarkdownRender, { enableKatex, getUseMonaco, setCustomComponents, setKaTeXWorker, setMermaidWorker } from 'markstream-vue'
 import KatexWorker from 'markstream-vue/workers/katexRenderer.worker?worker&inline'
 import MermaidWorker from 'markstream-vue/workers/mermaidParser.worker?worker&inline'
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker&inline'
 import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker&inline'
 import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker&inline'
 import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker&inline'
 import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker&inline'
-import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker&inline'
 import { computed, defineComponent, h, onBeforeUnmount, onMounted, ref } from 'vue'
 
 interface NodeLike {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@4.1.0(vitest@4.1.0))(jiti@2.6.1)(jsdom@24.1.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@4.1.0)(jiti@2.6.1)(jsdom@24.1.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/markstream-angular:
     dependencies:
@@ -26420,7 +26420,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@4.1.0(vitest@4.1.0))(jiti@2.6.1)(jsdom@24.1.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@4.1.0)(jiti@2.6.1)(jsdom@24.1.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4

--- a/scripts/e2e-nuxt-ssr.mjs
+++ b/scripts/e2e-nuxt-ssr.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright-core'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..')
+const playgroundDir = path.join(repoRoot, 'playground-nuxt')
+const host = '127.0.0.1'
+
+function assert(condition, message) {
+  if (!condition)
+    throw new Error(message)
+}
+
+function isPortOpen(port, listenHost = host) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: listenHost, port })
+    socket.on('connect', () => {
+      socket.end()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function findFreePort(start = 4300, end = 4360) {
+  for (let port = start; port <= end; port++) {
+    if (!await isPortOpen(port))
+      return port
+  }
+  throw new Error(`No free port found in ${start}-${end}`)
+}
+
+async function waitForPort(port, timeoutMs = 90000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isPortOpen(port))
+      return
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`Timed out waiting for ${host}:${port}`)
+}
+
+async function waitForHttpReady(url, timeoutMs = 90000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url)
+      if (response.ok)
+        return
+    }
+    catch {}
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for HTTP readiness: ${url}`)
+}
+
+function killProcessTree(child) {
+  if (!child || child.killed)
+    return
+  try {
+    child.kill('SIGTERM')
+  }
+  catch {}
+  setTimeout(() => {
+    try {
+      if (!child.killed)
+        child.kill('SIGKILL')
+    }
+    catch {}
+  }, 3000).unref?.()
+}
+
+function resolveChromeLaunchOptions() {
+  const candidates = [
+    process.env.PLAYWRIGHT_CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return {
+        executablePath: candidate,
+        headless: true,
+      }
+    }
+  }
+
+  return {
+    channel: 'chrome',
+    headless: true,
+  }
+}
+
+function createProcessRunner(command, args, cwd, extraEnv = {}) {
+  const logBuffer = []
+  const child = spawn(command, args, {
+    cwd,
+    env: {
+      ...process.env,
+      CI: '1',
+      NUXT_TELEMETRY_DISABLED: '1',
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  const appendLogs = (chunk) => {
+    const text = String(chunk)
+    logBuffer.push(text)
+    if (logBuffer.length > 240)
+      logBuffer.splice(0, logBuffer.length - 240)
+  }
+
+  child.stdout.on('data', appendLogs)
+  child.stderr.on('data', appendLogs)
+
+  return {
+    child,
+    getLogs() {
+      return logBuffer.join('')
+    },
+  }
+}
+
+async function runCommand(command, args, cwd, label) {
+  const runner = createProcessRunner(command, args, cwd)
+  const exitCode = await new Promise((resolve, reject) => {
+    runner.child.on('error', reject)
+    runner.child.on('exit', resolve)
+  })
+  if (exitCode !== 0) {
+    throw new Error(`${label} failed with exit code ${exitCode}\n${runner.getLogs()}`)
+  }
+}
+
+function startNuxtDev(port) {
+  return createProcessRunner('pnpm', ['exec', 'nuxt', 'dev', '--host', host, '--port', String(port)], playgroundDir)
+}
+
+function startNuxtPreview(port) {
+  return createProcessRunner(
+    'pnpm',
+    ['exec', 'nuxt', 'preview'],
+    playgroundDir,
+    {
+      HOST: host,
+      PORT: String(port),
+      NITRO_HOST: host,
+      NITRO_PORT: String(port),
+    },
+  )
+}
+
+async function assertRawHtml(baseUrl, mode) {
+  const response = await fetch(`${baseUrl}/ssr-lab`)
+  assert(response.ok, `[${mode}] raw SSR fetch failed with status ${response.status}`)
+  const html = await response.text()
+
+  const expectedSnippets = [
+    'data-ssr-case="basic"',
+    'data-ssr-case="enhanced"',
+    'data-ssr-case="fallback"',
+    'SSR Basic Coverage',
+    'data-ssr-inline-html="1"',
+    'data-ssr-html-block="1"',
+    'data-markstream-code-block="1"',
+    'data-markstream-pre="1"',
+    'data-markstream-math="inline"',
+    'data-markstream-mode="katex"',
+    'data-markstream-mermaid="1"',
+    'data-markstream-d2="1"',
+    'data-markstream-infographic="1"',
+    'data-ssr-fallback="math-inline"',
+    'data-ssr-fallback="mermaid"',
+  ]
+
+  for (const snippet of expectedSnippets)
+    assert(html.includes(snippet), `[${mode}] raw SSR HTML is missing expected snippet: ${snippet}`)
+}
+
+function collectUnexpectedIssues(entries) {
+  const patterns = [
+    /hydration/i,
+    /window is not defined/i,
+    /referenceerror/i,
+    /cannot read properties/i,
+    /failed to initialize mermaid renderer/i,
+    /failed to render/i,
+  ]
+
+  return entries.filter(({ type, text }) => {
+    if (type === 'pageerror')
+      return String(text || '').trim() !== 'Event'
+    if (/Could not create web worker\(s\)\./.test(text))
+      return false
+    return patterns.some(pattern => pattern.test(text))
+  })
+}
+
+async function waitForEnhancedWidgets(page, mode) {
+  await page.locator('[data-ssr-case="enhanced"]').scrollIntoViewIfNeeded()
+  await page.waitForSelector('[data-ssr-case="hydration"][data-ssr-hydrated="true"]', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-code-block="1"][data-markstream-enhanced="true"]', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-math="inline"][data-markstream-mode="katex"] .katex', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-math="block"][data-markstream-mode="katex"] .katex-display', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-mermaid="1"][data-markstream-mode="preview"] ._mermaid svg', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-d2="1"][data-markstream-mode="preview"] svg.markstream-d2-root-svg', { timeout: 90000 })
+  await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-infographic="1"][data-markstream-mode="preview"] svg', { timeout: 90000 })
+  await page.waitForFunction(() => {
+    const readyCount = document.querySelector('[data-ssr-status="ready-count"]')?.textContent?.trim()
+    return readyCount === '5'
+  }, { timeout: 90000 })
+}
+
+async function assertFallbackSection(page, mode) {
+  const fallbackState = await page.evaluate(() => {
+    const section = document.querySelector('[data-ssr-case="fallback"]')
+    return {
+      mathInline: !!section?.querySelector('[data-ssr-fallback="math-inline"]'),
+      mathBlock: !!section?.querySelector('[data-ssr-fallback="math-block"]'),
+      mermaid: !!section?.querySelector('[data-ssr-fallback="mermaid"]'),
+      d2: !!section?.querySelector('[data-ssr-fallback="d2"]'),
+      infographic: !!section?.querySelector('[data-ssr-fallback="infographic"]'),
+      previewLeak: !!section?.querySelector('[data-markstream-mode="preview"]'),
+    }
+  })
+
+  assert(fallbackState.mathInline, `[${mode}] fallback section lost inline math fallback`)
+  assert(fallbackState.mathBlock, `[${mode}] fallback section lost block math fallback`)
+  assert(fallbackState.mermaid, `[${mode}] fallback section lost mermaid fallback`)
+  assert(fallbackState.d2, `[${mode}] fallback section lost d2 fallback`)
+  assert(fallbackState.infographic, `[${mode}] fallback section lost infographic fallback`)
+  assert(!fallbackState.previewLeak, `[${mode}] fallback section unexpectedly switched to preview mode`)
+}
+
+async function assertBrowserBehavior(baseUrl, mode) {
+  const browser = await chromium.launch(resolveChromeLaunchOptions())
+  const page = await browser.newPage()
+  const issues = []
+
+  page.on('console', (msg) => {
+    const type = msg.type()
+    if (type === 'error' || type === 'warning')
+      issues.push({ type, text: msg.text() })
+  })
+  page.on('pageerror', (error) => {
+    issues.push({ type: 'pageerror', text: String(error?.message ?? error) })
+  })
+
+  try {
+    await page.goto(`${baseUrl}/ssr-lab`, { waitUntil: 'domcontentloaded', timeout: 90000 })
+    await waitForEnhancedWidgets(page, mode)
+    await assertFallbackSection(page, mode)
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 90000 })
+    await waitForEnhancedWidgets(page, `${mode} reload`)
+    await assertFallbackSection(page, `${mode} reload`)
+
+    await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: 90000 })
+    await page.goto(`${baseUrl}/ssr-lab`, { waitUntil: 'domcontentloaded', timeout: 90000 })
+    await waitForEnhancedWidgets(page, `${mode} route`)
+    await assertFallbackSection(page, `${mode} route`)
+  }
+  finally {
+    await browser.close()
+  }
+
+  const unexpectedIssues = collectUnexpectedIssues(issues)
+  assert(unexpectedIssues.length === 0, `[${mode}] browser reported unexpected issues:\n${unexpectedIssues.map(issue => `${issue.type}: ${issue.text}`).join('\n')}`)
+}
+
+async function runDevMode() {
+  const port = await findFreePort(4300, 4330)
+  const runner = startNuxtDev(port)
+  const baseUrl = `http://${host}:${port}`
+
+  try {
+    await waitForPort(port)
+    await waitForHttpReady(`${baseUrl}/ssr-lab`)
+    await assertRawHtml(baseUrl, 'nuxt dev')
+    await assertBrowserBehavior(baseUrl, 'nuxt dev')
+  }
+  catch (error) {
+    throw new Error(`${error.message}\n\nNuxt dev logs:\n${runner.getLogs()}`)
+  }
+  finally {
+    killProcessTree(runner.child)
+  }
+}
+
+async function runPreviewMode() {
+  await runCommand('pnpm', ['exec', 'nuxt', 'build'], playgroundDir, 'Nuxt build')
+
+  const port = await findFreePort(4331, 4360)
+  const runner = startNuxtPreview(port)
+  const baseUrl = `http://${host}:${port}`
+
+  try {
+    await waitForPort(port)
+    await waitForHttpReady(`${baseUrl}/ssr-lab`)
+    await assertRawHtml(baseUrl, 'nuxt preview')
+    await assertBrowserBehavior(baseUrl, 'nuxt preview')
+  }
+  catch (error) {
+    throw new Error(`${error.message}\n\nNuxt preview logs:\n${runner.getLogs()}`)
+  }
+  finally {
+    killProcessTree(runner.child)
+  }
+}
+
+async function main() {
+  await runCommand('pnpm', ['build'], repoRoot, 'Library build')
+  await runDevMode()
+  await runPreviewMode()
+  console.log('Nuxt SSR e2e passed in dev and preview modes.')
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })

--- a/scripts/e2e-nuxt-ssr.mjs
+++ b/scripts/e2e-nuxt-ssr.mjs
@@ -213,7 +213,7 @@ function collectUnexpectedIssues(entries) {
   })
 }
 
-async function waitForEnhancedWidgets(page, mode) {
+async function waitForEnhancedWidgets(page) {
   await page.locator('[data-ssr-case="enhanced"]').scrollIntoViewIfNeeded()
   await page.waitForSelector('[data-ssr-case="hydration"][data-ssr-hydrated="true"]', { timeout: 90000 })
   await page.waitForSelector('[data-ssr-case="enhanced"] [data-markstream-code-block="1"][data-markstream-enhanced="true"]', { timeout: 90000 })

--- a/src/components/AdmonitionNode/AdmonitionNode.vue
+++ b/src/components/AdmonitionNode/AdmonitionNode.vue
@@ -81,7 +81,6 @@ const headerId = `admonition-${Math.random().toString(36).slice(2, 9)}`
       :aria-labelledby="headerId"
     >
       <NodeRenderer
-        v-memo="[props.node.children]"
         :index-key="`admonition-${indexKey}`"
         :nodes="props.node.children"
         :custom-id="props.customId"

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -32,7 +32,6 @@ defineEmits<{
 <template>
   <blockquote class="blockquote" dir="auto" :cite="node.cite">
     <NodeRenderer
-      v-memo="[props.node.children]"
       :index-key="`blockquote-${props.indexKey}`"
       :nodes="props.node.children || []"
       :custom-id="props.customId"

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -254,9 +254,6 @@ const preFallbackWrap = computed(() => {
   return String(wordWrap) !== 'off'
 })
 const showPreWhileMonacoLoads = computed(() => {
-  // Avoid SSR hydration mismatches by only enabling this placeholder on client.
-  if (typeof window === 'undefined')
-    return false
   // If Monaco isn't available at all, the component renders a standalone PreCodeNode.
   if (usePreCodeRender.value)
     return false
@@ -1796,6 +1793,8 @@ onUnmounted(() => {
     ref="container"
     :style="containerStyle"
     class="code-block-container my-4 rounded-lg border overflow-hidden shadow-sm"
+    data-markstream-code-block="1"
+    :data-markstream-enhanced="editorMounted && !usePreCodeRender ? 'true' : 'false'"
     :class="[
       { 'is-rendering': props.loading, 'is-dark': resolvedSurfaceIsDark, 'is-diff': isDiff, 'is-plain-text': isPlainTextLanguage },
     ]"

--- a/src/components/D2BlockNode/D2BlockNode.vue
+++ b/src/components/D2BlockNode/D2BlockNode.vue
@@ -457,6 +457,8 @@ onBeforeUnmount(() => {
 <template>
   <div
     class="d2-block-container my-4 rounded-lg border overflow-hidden shadow-sm"
+    data-markstream-d2="1"
+    :data-markstream-mode="showSourceFallback ? 'fallback' : 'preview'"
     :class="props.isDark ? 'border-gray-700/30 bg-gray-900 text-gray-100' : 'border-gray-200 bg-white text-gray-900'"
   >
     <div

--- a/src/components/FootnoteNode/FootnoteNode.vue
+++ b/src/components/FootnoteNode/FootnoteNode.vue
@@ -29,7 +29,6 @@ defineEmits(['copy'])
     <!-- <span class="font-semibold mr-2 text-[#0366d6]">[{{ node.id }}]</span> -->
     <div class="flex-1">
       <NodeRenderer
-        v-memo="[props.node.children]"
         :index-key="`footnote-${props.indexKey}`"
         :nodes="props.node.children"
         :custom-id="props.customId"

--- a/src/components/HeadingNode/HeadingNode.vue
+++ b/src/components/HeadingNode/HeadingNode.vue
@@ -66,7 +66,6 @@ const nodeComponents = {
 <template>
   <component
     :is="`h${node.level}`"
-    v-memo="[node.level, node.children, node.attrs]"
     class="heading-node"
     :class="[`heading-${node.level}`]"
     dir="auto"
@@ -76,7 +75,6 @@ const nodeComponents = {
       :is="nodeComponents[child.type]"
       v-for="(child, index) in node.children"
       :key="`${indexKey || 'heading'}-${index}`"
-      v-memo="[child]"
       :custom-id="props.customId"
       :node="child"
       :index-key="`${indexKey || 'heading'}-${index}`"

--- a/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -148,7 +148,7 @@ onBeforeUnmount(() => {
       <DynamicRenderer v-if="renderMode.mode === 'dynamic'" :nodes="renderMode.nodes" />
       <pre v-else-if="renderMode.mode === 'text'" class="html-block-node__raw">{{ renderMode.content }}</pre>
       <!-- Fallback to v-html for standard HTML -->
-      <div v-else v-memo="[renderContent]" v-html="renderContent" />
+      <div v-else v-html="renderContent" />
     </template>
     <div v-else class="html-block-node__placeholder">
       <slot name="placeholder" :node="node">

--- a/src/components/HtmlInlineNode/HtmlInlineNode.vue
+++ b/src/components/HtmlInlineNode/HtmlInlineNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineComponent, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
 import { customComponentsRevision, getCustomNodeComponents } from '../../utils/nodeComponents'
 
@@ -41,6 +41,9 @@ const renderMode = computed(() => {
   if (!content)
     return { mode: 'html', content: '' }
 
+  if (props.node.loading && !props.node.autoClosed)
+    return { mode: 'text', content }
+
   // When the inline HTML node is in a streaming mid-state and the parser has
   // auto-closed it for rendering (`autoClosed: true`), prefer VNode rendering.
   // Using `innerHTML` repeatedly replaces the subtree and can cause flicker.
@@ -61,90 +64,6 @@ const renderMode = computed(() => {
 
   return { mode: 'dynamic', nodes }
 })
-
-const containerRef = ref<HTMLElement | null>(null)
-const isClient = typeof window !== 'undefined'
-type DomRenderMode = 'html' | 'text'
-const lastDomRender = ref<{ mode: DomRenderMode | '', content: string, el: HTMLElement | null }>({
-  mode: '',
-  content: '',
-  el: null,
-})
-let templateEl: HTMLTemplateElement | null = null
-
-function getTemplateEl() {
-  if (!templateEl && isClient)
-    templateEl = document.createElement('template')
-  return templateEl
-}
-
-function commitDomRender(mode: DomRenderMode, content: string) {
-  if (!isClient || !containerRef.value)
-    return
-  const host = containerRef.value
-  const last = lastDomRender.value
-  if (last.el === host && last.mode === mode && last.content === content)
-    return
-  if (mode === 'text') {
-    host.textContent = content
-  }
-  else {
-    const template = getTemplateEl()
-    if (template) {
-      template.innerHTML = content
-      const fragment = template.content.cloneNode(true)
-      if (typeof host.replaceChildren === 'function') {
-        host.replaceChildren(fragment)
-      }
-      else {
-        host.innerHTML = ''
-        host.appendChild(fragment)
-      }
-    }
-    else {
-      host.innerHTML = content
-    }
-  }
-  lastDomRender.value = { mode, content, el: host }
-}
-
-function renderHtmlContent() {
-  commitDomRender('html', props.node.content)
-}
-
-function renderLoadingContent() {
-  commitDomRender('text', props.node.content)
-}
-
-watch(
-  () => [props.node.content, props.node.loading, props.node.autoClosed, renderMode.value.mode],
-  () => {
-    // Only use DOM rendering for non-custom-component content
-    if (renderMode.value.mode === 'html') {
-      if (props.node.loading && !props.node.autoClosed)
-        renderLoadingContent()
-      else
-        renderHtmlContent()
-    }
-  },
-)
-
-onMounted(() => {
-  // Initial render for non-custom-component content (DOM rendering path).
-  if (renderMode.value.mode !== 'html')
-    return
-  if (props.node.loading && !props.node.autoClosed)
-    renderLoadingContent()
-  else
-    renderHtmlContent()
-})
-
-onBeforeUnmount(() => {
-  if (!containerRef.value)
-    return
-  containerRef.value.innerHTML = ''
-  lastDomRender.value = { mode: '', content: '', el: null }
-})
 </script>
 
 <template>
@@ -156,10 +75,15 @@ onBeforeUnmount(() => {
     <DynamicRenderer :nodes="renderMode.nodes" />
   </span>
   <span
-    v-else
-    ref="containerRef"
+    v-else-if="renderMode.mode === 'text'"
     class="html-inline-node"
     :class="{ 'html-inline-node--loading': props.node.loading }"
+  >{{ renderMode.content }}</span>
+  <span
+    v-else
+    class="html-inline-node"
+    :class="{ 'html-inline-node--loading': props.node.loading }"
+    v-html="renderMode.content"
   />
 </template>
 

--- a/src/components/ImageNode/ImageNode.vue
+++ b/src/components/ImageNode/ImageNode.vue
@@ -26,6 +26,7 @@ const figureRef = ref<HTMLElement | null>(null)
 const registerVisibility = useViewportPriority()
 const visibilityHandle = ref<ReturnType<typeof registerVisibility> | null>(null)
 const isVisible = ref(typeof window === 'undefined')
+const visibilityReady = ref(typeof window === 'undefined')
 
 if (typeof window !== 'undefined') {
   watch(
@@ -35,11 +36,13 @@ if (typeof window !== 'undefined') {
       visibilityHandle.value = null
       if (!el) {
         isVisible.value = false
+        visibilityReady.value = false
         return
       }
       const handle = registerVisibility(el, { rootMargin: '400px' })
       visibilityHandle.value = handle
       isVisible.value = handle.isVisible.value
+      visibilityReady.value = true
       handle.whenVisible.then(() => {
         isVisible.value = true
       })
@@ -55,7 +58,7 @@ onBeforeUnmount(() => {
 
 // 计算当前用于渲染的 src（当有 error 且提供 fallback 时使用 fallback）
 const displaySrc = computed(() => hasError.value && props.fallbackSrc ? props.fallbackSrc : props.node.src)
-const canRenderImage = computed(() => !props.lazy || isVisible.value)
+const canRenderImage = computed(() => !props.lazy || isVisible.value || !visibilityReady.value)
 
 // 是否为 svg 文件（可能没有内置尺寸）
 const isSvg = computed(() => /\.svg(?:\?|$)/i.test(displaySrc.value))

--- a/src/components/InfographicBlockNode/InfographicBlockNode.vue
+++ b/src/components/InfographicBlockNode/InfographicBlockNode.vue
@@ -28,11 +28,13 @@ const { t } = useSafeI18n()
 const copyText = ref(false)
 const isCollapsed = ref(false)
 const infographicContainer = ref<HTMLElement>()
-const showSource = ref(false)
+const showSource = ref(true)
+const userToggledShowSource = ref(false)
 const containerHeight = ref<string>('360px')
 const isModalOpen = ref(false)
 const modalContent = ref<HTMLElement>()
 const modalCloneWrapper = ref<HTMLElement | null>(null)
+const hasPreview = ref(false)
 
 function resolveContainerHeight(actualHeight: number) {
   if (!props.maxHeight || props.maxHeight === 'none')
@@ -107,6 +109,7 @@ async function copy() {
 }
 
 function handleSwitchMode(mode: 'preview' | 'source') {
+  userToggledShowSource.value = true
   showSource.value = mode === 'source'
 }
 
@@ -314,6 +317,7 @@ async function renderInfographic() {
 
     // Render the syntax
     infographicInstance.render(baseCode.value)
+    hasPreview.value = true
 
     // Update container height after render
     nextTick(() => {
@@ -322,6 +326,7 @@ async function renderInfographic() {
   }
   catch (error) {
     console.error('Failed to render infographic:', error)
+    hasPreview.value = false
     if (infographicContainer.value) {
       infographicContainer.value.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
     }
@@ -376,6 +381,8 @@ watch(
 )
 
 onMounted(() => {
+  if (!userToggledShowSource.value)
+    showSource.value = false
   if (!showSource.value && !isCollapsed.value) {
     nextTick(() => {
       renderInfographic()
@@ -403,6 +410,11 @@ const computedButtonStyle = computed(() => {
 })
 
 const isFullscreenDisabled = computed(() => showSource.value || isCollapsed.value)
+const renderMode = computed(() => {
+  if (showSource.value)
+    return 'fallback'
+  return hasPreview.value ? 'preview' : 'pending'
+})
 
 const transformStyle = computed(() => ({
   transform: `translate(${translateX.value}px, ${translateY.value}px) scale(${zoom.value})`,
@@ -422,6 +434,8 @@ watch(
 <template>
   <div
     class="my-4 rounded-lg border overflow-hidden shadow-sm"
+    data-markstream-infographic="1"
+    :data-markstream-mode="renderMode"
     :class="[
       props.isDark ? 'border-gray-700/30' : 'border-gray-200',
       { 'is-rendering': props.loading },

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -45,7 +45,6 @@ const liValueAttr = computed(() =>
 <template>
   <li class="list-item pl-1.5 my-2" dir="auto" v-bind="liValueAttr">
     <NodeRenderer
-      v-memo="[itemNode?.children]"
       v-bind="{ showTooltips: props.showTooltips }"
       :index-key="`list-item-${props.indexKey}`"
       :nodes="itemNode?.children ?? []"

--- a/src/components/ListNode/ListNode.vue
+++ b/src/components/ListNode/ListNode.vue
@@ -50,7 +50,6 @@ const listItemComponent = computed(() => {
       :is="listItemComponent"
       v-for="(item, index) in node.items"
       :key="`${indexKey || 'list'}-${index}`"
-      v-memo="[item]"
       v-bind="{ showTooltips }"
       :node="item"
       :custom-id="customId"

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -19,6 +19,17 @@ function resolveInitialState() {
     }
   }
 
+  // Only perform a sync render during SSR so the server and client initial
+  // markup always match.  On the client the post-mount renderMath() call will
+  // enhance the component, avoiding SSR/client hydration divergence.
+  if (!isServer) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
   const katex = getKatexSync()
   if (!katex) {
     return {

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -19,6 +19,17 @@ function resolveInitialState() {
     }
   }
 
+  // On the client, always start from the raw fallback and enhance after mount to
+  // avoid hydration mismatches when the server rendered a different initial state
+  // (e.g. when a sync loader is only registered in a client-only plugin / CDN setup).
+  if (!isServer) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
   const katex = getKatexSync()
   if (!katex) {
     return {

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -4,26 +4,71 @@ import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
-import { getKatex } from '../MathInlineNode/katex'
+import { getKatex, getKatexSync } from '../MathInlineNode/katex'
 
 const props = defineProps<MathBlockNodeProps>()
 const containerEl = ref<HTMLElement | null>(null)
-const mathBlockElement = ref<HTMLElement | null>(null)
+const isServer = typeof window === 'undefined'
+
+function resolveInitialState() {
+  if (!props.node.content) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
+  const katex = getKatexSync()
+  if (!katex) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
+  try {
+    return {
+      html: katex.renderToString(props.node.content, {
+        throwOnError: props.node.loading,
+        displayMode: true,
+      }),
+      text: '',
+      loading: false,
+    }
+  }
+  catch {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+}
+
+const initialState = resolveInitialState()
+const renderedHtml = ref(initialState.html)
+const renderedText = ref(initialState.text)
 let hasRenderedOnce = false
 let currentRenderId = 0
 let isUnmounted = false
 let currentAbortController: AbortController | null = null
 const registerVisibility = useViewportPriority()
 let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
-const renderingLoading = ref(true)
+const renderingLoading = ref(initialState.loading)
+
+if (initialState.html || initialState.text)
+  hasRenderedOnce = true
 
 // Function to render math using KaTeX
 async function renderMath() {
-  if (!mathBlockElement.value || isUnmounted)
+  if (isUnmounted)
     return
   if (!props.node.content) {
     renderingLoading.value = false
-    mathBlockElement.value.textContent = props.node.raw
+    renderedHtml.value = ''
+    renderedText.value = props.node.raw
     hasRenderedOnce = true
     return
   }
@@ -62,17 +107,14 @@ async function renderMath() {
       // ignore if a newer render was requested or component unmounted
       if (isUnmounted || renderId !== currentRenderId)
         return
-      if (!mathBlockElement.value)
-        return
-      mathBlockElement.value.innerHTML = html
+      renderedHtml.value = html
+      renderedText.value = ''
       hasRenderedOnce = true
       renderingLoading.value = false
     })
     .catch(async (err: any) => {
       // ignore if a newer render was requested or component unmounted
       if (isUnmounted || renderId !== currentRenderId)
-        return
-      if (!mathBlockElement.value)
         return
 
       // If the worker failed to initialize (e.g. bad new Worker path), the
@@ -96,7 +138,8 @@ async function renderMath() {
               throwOnError: props.node.loading,
               displayMode: true,
             })
-            mathBlockElement.value.innerHTML = html
+            renderedHtml.value = html
+            renderedText.value = ''
             hasRenderedOnce = true
             renderingLoading.value = false
             // populate worker client cache so future calls hit cache
@@ -112,7 +155,8 @@ async function renderMath() {
 
       if (isDisabled) {
         renderingLoading.value = false
-        mathBlockElement.value.textContent = props.node.raw
+        renderedHtml.value = ''
+        renderedText.value = props.node.raw
         return
       }
 
@@ -121,7 +165,8 @@ async function renderMath() {
       }
       if (!props.node.loading) {
         renderingLoading.value = false
-        mathBlockElement.value.textContent = props.node.raw
+        renderedHtml.value = ''
+        renderedText.value = props.node.raw
       }
     })
 }
@@ -133,6 +178,8 @@ watch(
   },
 )
 onMounted(() => {
+  if (isServer || renderedHtml.value)
+    return
   renderMath()
 })
 
@@ -149,13 +196,25 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="containerEl" class="math-block text-center overflow-x-auto relative min-h-[40px]">
+  <div
+    ref="containerEl"
+    class="math-block text-center overflow-x-auto relative min-h-[40px]"
+    data-markstream-math="block"
+    :data-markstream-mode="renderedHtml ? 'katex' : renderedText ? 'fallback' : 'loading'"
+  >
     <Transition name="math-fade">
-      <div v-if="renderingLoading" class="math-loading-overlay">
+      <div v-if="renderingLoading && !renderedHtml && !renderedText" class="math-loading-overlay">
         <div class="math-loading-spinner" />
       </div>
     </Transition>
-    <div ref="mathBlockElement" :class="{ 'math-rendering': renderingLoading }" />
+    <div
+      v-if="renderedHtml"
+      class="math-block__content"
+      :class="{ 'math-rendering': renderingLoading }"
+      v-html="renderedHtml"
+    />
+    <pre v-else-if="renderedText" class="math-block__fallback text-left">{{ renderedText }}</pre>
+    <div v-else class="math-block__content" :class="{ 'math-rendering': renderingLoading }" />
   </div>
 </template>
 
@@ -191,6 +250,12 @@ onBeforeUnmount(() => {
 .math-rendering {
   opacity: 0.3;
   transition: opacity 0.2s ease;
+}
+
+.math-block__fallback {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0;
 }
 
 .math-fade-enter-active,

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -21,6 +21,17 @@ function resolveInitialState() {
     }
   }
 
+  // On the client, always start from the raw fallback and enhance after mount to
+  // avoid hydration mismatches when the server rendered a different initial state
+  // (e.g. when a sync loader is only registered in a client-only plugin / CDN setup).
+  if (!isServer) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
   const katex = getKatexSync()
   if (!katex) {
     return {

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -1,29 +1,75 @@
 <script setup lang="ts">
 import type { MathInlineNodeProps } from '../../types/component-props'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
-import { getKatex } from './katex'
+import { getKatex, getKatexSync } from './katex'
 
 const props = defineProps<MathInlineNodeProps>()
 
 const containerEl = ref<HTMLElement | null>(null)
-const mathElement = ref<HTMLElement | null>(null)
+const isServer = typeof window === 'undefined'
+const displayMode = computed(() => props.node.markup === '$$')
+
+function resolveInitialState() {
+  if (!props.node.content) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
+  const katex = getKatexSync()
+  if (!katex) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
+  try {
+    return {
+      html: katex.renderToString(props.node.content, {
+        throwOnError: props.node.loading,
+        displayMode: displayMode.value,
+      }),
+      text: '',
+      loading: false,
+    }
+  }
+  catch {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+}
+
+const initialState = resolveInitialState()
+const renderedHtml = ref(initialState.html)
+const renderedText = ref(initialState.text)
 let hasRenderedOnce = false
 let currentRenderId = 0
 let isUnmounted = false
 let currentAbortController: AbortController | null = null
-const renderingLoading = ref(true)
+const renderingLoading = ref(initialState.loading)
 const registerVisibility = useViewportPriority()
 let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
 
+if (initialState.html || initialState.text)
+  hasRenderedOnce = true
+
 async function renderMath() {
-  if (!mathElement.value || isUnmounted)
+  if (isUnmounted)
     return
   if (!props.node.content) {
     renderingLoading.value = false
-    mathElement.value.textContent = props.node.raw
+    renderedHtml.value = ''
+    renderedText.value = props.node.raw
     hasRenderedOnce = true
     return
   }
@@ -49,8 +95,7 @@ async function renderMath() {
     catch {}
   }
 
-  const displayMode = props.node.markup === '$$'
-  renderKaTeXWithBackpressure(props.node.content, displayMode, {
+  renderKaTeXWithBackpressure(props.node.content, displayMode.value, {
     // Inline math should not wait on worker slots; fallback to sync render immediately
     timeout: 1500,
     waitTimeout: 0,
@@ -60,16 +105,13 @@ async function renderMath() {
     .then((html) => {
       if (isUnmounted || renderId !== currentRenderId)
         return
-      if (!mathElement.value)
-        return
-      mathElement.value.innerHTML = html
+      renderedHtml.value = html
+      renderedText.value = ''
       renderingLoading.value = false
       hasRenderedOnce = true
     })
     .catch(async (err: any) => {
       if (isUnmounted || renderId !== currentRenderId)
-        return
-      if (!mathElement.value)
         return
       // Fallback cases:
       // 1) Worker failed to initialize -> try sync render
@@ -84,13 +126,16 @@ async function renderMath() {
         const katex = await getKatex()
         if (katex) {
           try {
-            const displayMode = props.node.markup === '$$'
-            const html = katex.renderToString(props.node.content, { throwOnError: props.node.loading, displayMode })
+            const html = katex.renderToString(props.node.content, {
+              throwOnError: props.node.loading,
+              displayMode: displayMode.value,
+            })
+            renderedHtml.value = html
+            renderedText.value = ''
             renderingLoading.value = false
-            mathElement.value.innerHTML = html
             hasRenderedOnce = true
             // populate worker client cache for inline as well
-            setKaTeXCache(props.node.content, displayMode, html)
+            setKaTeXCache(props.node.content, displayMode.value, html)
           }
           catch {
           }
@@ -100,7 +145,8 @@ async function renderMath() {
       }
       if (isDisabled) {
         renderingLoading.value = false
-        mathElement.value.textContent = props.node.raw
+        renderedHtml.value = ''
+        renderedText.value = props.node.raw
         return
       }
       // If we reach here, the worker render failed and sync fallback was not possible.
@@ -111,10 +157,12 @@ async function renderMath() {
       }
       if (!props.node.loading) {
         renderingLoading.value = false
-        mathElement.value.textContent = props.node.raw
+        renderedHtml.value = ''
+        renderedText.value = props.node.raw
       }
       else if (isDisabled) {
-        mathElement.value.textContent = props.node.raw
+        renderedHtml.value = ''
+        renderedText.value = props.node.raw
       }
     })
 }
@@ -127,6 +175,8 @@ watch(
 )
 
 onMounted(() => {
+  if (isServer || renderedHtml.value)
+    return
   renderMath()
 })
 
@@ -142,9 +192,15 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <span ref="containerEl" class="math-inline-wrapper">
-    <span v-show="!renderingLoading" ref="mathElement" class="math-inline" />
-    <transition v-if="renderingLoading" name="table-node-fade">
+  <span
+    ref="containerEl"
+    class="math-inline-wrapper"
+    data-markstream-math="inline"
+    :data-markstream-mode="renderedHtml ? 'katex' : renderedText ? 'fallback' : 'loading'"
+  >
+    <span v-if="renderedHtml" class="math-inline" v-html="renderedHtml" />
+    <span v-else-if="renderedText" class="math-inline math-inline--fallback">{{ renderedText }}</span>
+    <transition v-else-if="renderingLoading" name="table-node-fade">
       <span
         class="math-inline__loading"
         role="status"
@@ -168,6 +224,10 @@ onBeforeUnmount(() => {
 .math-inline {
   display: inline-block;
   vertical-align: middle;
+}
+
+.math-inline--fallback {
+  white-space: pre-wrap;
 }
 
 .math-inline__loading {

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -21,6 +21,17 @@ function resolveInitialState() {
     }
   }
 
+  // Only perform a sync render during SSR so the server and client initial
+  // markup always match.  On the client the post-mount renderMath() call will
+  // enhance the component, avoiding SSR/client hydration divergence.
+  if (!isServer) {
+    return {
+      html: '',
+      text: props.node.raw,
+      loading: false,
+    }
+  }
+
   const katex = getKatexSync()
   if (!katex) {
     return {

--- a/src/components/MathInlineNode/katex.ts
+++ b/src/components/MathInlineNode/katex.ts
@@ -62,6 +62,32 @@ export function isKatexEnabled() {
   return typeof katexLoader === 'function'
 }
 
+export function getKatexSync() {
+  const globalKatex = getGlobalKatex()
+  if (globalKatex) {
+    katex = globalKatex
+    return katex
+  }
+
+  if (katex)
+    return katex
+
+  const loader = katexLoader
+  if (!loader || loader === defaultKatexLoader)
+    return null
+
+  try {
+    const result = loader()
+    if (!result || typeof (result as PromiseLike<any>)?.then === 'function')
+      return null
+    katex = normalizeKatexModule(result) ?? result
+    return katex
+  }
+  catch {
+    return null
+  }
+}
+
 export async function getKatex() {
   const globalKatex = getGlobalKatex()
   if (globalKatex) {

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -252,7 +252,7 @@ const translateX = ref(0)
 const translateY = ref(0)
 const isDragging = ref(false)
 const dragStart = ref({ x: 0, y: 0 })
-const showSource = ref(false)
+const showSource = ref(true)
 const userToggledShowSource = ref(false)
 const isRendering = ref(false)
 const renderQueue = ref<Promise<void> | null>(null)
@@ -1710,6 +1710,8 @@ const computedButtonStyle = computed(() => {
 <template>
   <div
     class="my-4 rounded-lg border overflow-hidden shadow-sm"
+    data-markstream-mermaid="1"
+    :data-markstream-mode="showSource ? 'fallback' : hasRenderedOnce ? 'preview' : 'pending'"
     :class="[
       props.isDark ? 'border-gray-700/30' : 'border-gray-200',
       { 'is-rendering': props.loading },

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -10,7 +10,7 @@ export const MathInlineNodeAsync = defineAsyncComponent(async () => {
     && typeof (globalThis as any).process !== 'undefined'
     // eslint-disable-next-line node/prefer-global/process
     && (globalThis as any).process?.env?.NODE_ENV === 'test'
-  if (isTestEnv) {
+  if (isTestEnv && typeof window !== 'undefined') {
     return (props) => {
       // test fallback should be deterministic and minimal
       return h(TextNode, {

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { getCustomNodeComponents } from '../../utils/nodeComponents'
 import CheckboxNode from '../CheckboxNode'
 import EmojiNode from '../EmojiNode'
@@ -38,6 +39,20 @@ const props = defineProps<{
   indexKey?: number | string
 }>()
 const overrides = getCustomNodeComponents(props.customId)
+const paragraphTag = computed(() => {
+  if (props.node.children.length === 0)
+    return 'p'
+
+  const isMediaOnlyParagraph = props.node.children.every((child) => {
+    if (child.type === 'image')
+      return true
+    if (child.type !== 'text')
+      return false
+    return String((child as any).content ?? '').trim() === ''
+  })
+
+  return isMediaOnlyParagraph ? 'div' : 'p'
+})
 
 const nodeComponents = {
   inline_code: InlineCodeNode,
@@ -66,7 +81,7 @@ const nodeComponents = {
 </script>
 
 <template>
-  <p dir="auto" class="paragraph-node">
+  <component :is="paragraphTag" dir="auto" class="paragraph-node">
     <component
       :is="nodeComponents[child.type]"
       v-for="(child, index) in node.children"
@@ -75,7 +90,7 @@ const nodeComponents = {
       :index-key="`${indexKey}-${index}`"
       :custom-id="props.customId"
     />
-  </p>
+  </component>
 </template>
 
 <style scoped>

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -27,6 +27,7 @@ const ariaLabel = computed(() => {
     :aria-busy="node.loading === true"
     :aria-label="ariaLabel"
     :data-language="normalizedLanguage"
+    data-markstream-pre="1"
     tabindex="0"
   ><code translate="no" v-text="node.code" /></pre>
 </template>

--- a/src/components/VmrContainerNode/VmrContainerNode.vue
+++ b/src/components/VmrContainerNode/VmrContainerNode.vue
@@ -73,7 +73,6 @@ function getNodeComponent(type: string) {
       :is="getNodeComponent(child.type)"
       v-for="(child, index) in node.children"
       :key="`${indexKey || 'vmr-container'}-${index}`"
-      v-memo="[child]"
       :custom-id="props.customId"
       :node="child"
       :index-key="`${indexKey || 'vmr-container'}-${index}`"

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -122,7 +122,7 @@ exports[`markdownRender node e2e coverage > renders code block node 1`] = `
   <!--v-if-->
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="code_block">
     <div data-v-8dfe8a80="" class="node-content">
-      <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals --><pre data-v-8dfe8a80="" class="language-ts" aria-busy="false" aria-label="Code block: ts" data-language="ts" tabindex="0" loading="false" index-key="markdown-renderer-0" stream="true" showtooltips="true" is-dark="false"><code translate="no">export const sum = (a: number, b: number) =&gt; a + b
+      <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals --><pre data-v-8dfe8a80="" class="language-ts" aria-busy="false" aria-label="Code block: ts" data-language="ts" data-markstream-pre="1" tabindex="0" loading="false" index-key="markdown-renderer-0" stream="true" showtooltips="true" is-dark="false"><code translate="no">export const sum = (a: number, b: number) =&gt; a + b
 </code></pre>
     </div>
   </div>
@@ -367,15 +367,15 @@ exports[`markdownRender node e2e coverage > renders image node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="typewriter" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="true" is-dark="false">
-        <figure data-v-4ff2ac62="" data-v-93ee5c2d="" class="text-center my-8" index-key="markdown-renderer-0-0">
-          <div data-v-4ff2ac62="" class="relative inline-block">
-            <!-- 包裹条件渲染元素，启用 out-in 模式以在替换时做平滑过渡 -->
-            <transition-stub data-v-4ff2ac62="" name="img-switch" mode="out-in" appear="false" persisted="false" css="true"><img data-v-4ff2ac62="" src="https://example.com/vue.png" alt="Vue Logo" title="Vue Logo" class="max-w-96 h-auto rounded-lg transition-opacity duration-200 ease-in-out opacity-0" loading="lazy" decoding="async" tabindex="-1" aria-label="Vue Logo"></transition-stub>
-          </div>
-          <!--v-if-->
-        </figure>
-        </p>
+        <div data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="true" is-dark="false">
+          <figure data-v-4ff2ac62="" data-v-93ee5c2d="" class="text-center my-8" index-key="markdown-renderer-0-0">
+            <div data-v-4ff2ac62="" class="relative inline-block">
+              <!-- 包裹条件渲染元素，启用 out-in 模式以在替换时做平滑过渡 -->
+              <transition-stub data-v-4ff2ac62="" name="img-switch" mode="out-in" appear="false" persisted="false" css="true"><img data-v-4ff2ac62="" src="https://example.com/vue.png" alt="Vue Logo" title="Vue Logo" class="max-w-96 h-auto rounded-lg transition-opacity duration-200 ease-in-out opacity-0" loading="lazy" decoding="async" tabindex="-1" aria-label="Vue Logo"></transition-stub>
+            </div>
+            <!--v-if-->
+          </figure>
+        </div>
       </transition-stub>
     </div>
   </div>

--- a/test/e2e/mermaid-export-playground.test.ts
+++ b/test/e2e/mermaid-export-playground.test.ts
@@ -19,6 +19,8 @@ describe('playground mermaid-export demo', () => {
 
     // Ensure the export button will be shown by setting mermaidAvailable
     ;(m.vm as any).mermaidAvailable = true
+    ;(m.vm as any).showSource = false
+    await nextTick()
 
     // Inject a fake SVG into the mermaid content area so export handler has something
     const content = m.find('div._mermaid')

--- a/test/math-block-busy-fallback.test.ts
+++ b/test/math-block-busy-fallback.test.ts
@@ -7,6 +7,7 @@ import { flushAll } from './setup/flush-all'
 
 // Mock getKatex to return a lightweight renderer
 vi.mock('../src/components/MathInlineNode/katex', () => ({
+  getKatexSync: () => null,
   getKatex: async () => ({
     renderToString: (content: string, opts: any) => `<span class="katex ${opts?.displayMode ? 'block' : 'inline'}">${content}</span>`,
   }),

--- a/test/math-inline-busy-fallback.test.ts
+++ b/test/math-inline-busy-fallback.test.ts
@@ -5,6 +5,7 @@ import MathInlineNode from '../src/components/MathInlineNode/MathInlineNode.vue'
 import { flushAll } from './setup/flush-all'
 
 vi.mock('../src/components/MathInlineNode/katex', () => ({
+  getKatexSync: () => null,
   getKatex: async () => ({
     renderToString: (content: string) => `<span class="katex inline">${content}</span>`,
   }),

--- a/test/mermaid-export-svg-string.test.ts
+++ b/test/mermaid-export-svg-string.test.ts
@@ -16,12 +16,15 @@ describe('mermaid block export event', () => {
       props: {
         node,
         loading: false,
+        onExport: (ev: any) => ev.preventDefault(),
       },
       attachTo: document.body,
     })
 
     // Make the component think mermaid is available so the export button renders
     ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).showSource = false
+    await nextTick()
 
     // Populate the mermaid content area with an SVG so the export handler can find it
     const content = wrapper.find('div._mermaid')

--- a/test/mermaid-max-height.test.ts
+++ b/test/mermaid-max-height.test.ts
@@ -18,6 +18,10 @@ async function renderWithMaxHeight(maxHeight: string) {
     attachTo: document.body,
   })
 
+  ;(wrapper.vm as any).mermaidAvailable = true
+  ;(wrapper.vm as any).showSource = false
+  await nextTick()
+
   const content = wrapper.get('div._mermaid').element as HTMLElement
   content.innerHTML = '<svg viewBox="0 0 100 200"></svg>'
 

--- a/test/ssr-render-to-string.test.ts
+++ b/test/ssr-render-to-string.test.ts
@@ -1,0 +1,568 @@
+/**
+ * @vitest-environment node
+ */
+
+import katex from 'katex'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { disableD2, enableD2 } from '../src/components/D2BlockNode/d2'
+import { setInfographicLoader } from '../src/components/InfographicBlockNode/infographic'
+import MarkdownCodeBlockNode from '../src/components/MarkdownCodeBlockNode'
+import MathBlockNode from '../src/components/MathBlockNode'
+import MathInlineNode from '../src/components/MathInlineNode'
+import { disableKatex, enableKatex, setKatexLoader } from '../src/components/MathInlineNode/katex'
+import { disableMermaid, enableMermaid } from '../src/components/MermaidBlockNode/mermaid'
+import MarkdownRender from '../src/components/NodeRenderer'
+import { clearGlobalCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
+
+const BASIC_SCOPE = 'ssr-render-basic'
+const defaultInfographicLoader = () => import('@antv/infographic')
+
+async function renderComponent(component: any, props: Record<string, any>) {
+  const app = createSSRApp({
+    render: () => h(component, props),
+  })
+  return renderToString(app)
+}
+
+async function renderMarkdown(content: string, props: Record<string, any> = {}) {
+  return renderComponent(MarkdownRender, {
+    content,
+    final: true,
+    ...props,
+  })
+}
+
+function textNode(content: string) {
+  return {
+    type: 'text',
+    content,
+    raw: content,
+  }
+}
+
+function paragraphNode(children: any[], raw?: string) {
+  return {
+    type: 'paragraph',
+    children,
+    raw: raw ?? children.map(child => String(child?.raw ?? child?.content ?? '')).join(''),
+  }
+}
+
+function inlineWrapper(type: string, content: string, raw: string) {
+  return {
+    type,
+    children: [textNode(content)],
+    raw,
+  }
+}
+
+function linkNode(content: string, href: string) {
+  return {
+    type: 'link',
+    href,
+    title: href,
+    text: content,
+    raw: `[${content}](${href})`,
+    children: [textNode(content)],
+  }
+}
+
+describe('ssr renderToString coverage', () => {
+  afterEach(() => {
+    clearGlobalCustomComponents()
+    enableKatex()
+    enableMermaid()
+    enableD2()
+    setInfographicLoader(defaultInfographicLoader)
+  })
+
+  it('renders basic markdown, HTML, and custom HTML tags on the server', async () => {
+    setCustomComponents(BASIC_SCOPE, {
+      'ssr-badge': defineComponent({
+        name: 'SsrBadgeNode',
+        setup(_, { slots }) {
+          return () => h('span', { 'data-ssr-custom': 'badge' }, slots.default?.() ?? [])
+        },
+      }),
+    })
+
+    const html = await renderMarkdown(`
+# SSR Basics
+
+Inline HTML: <mark data-ssr-inline-html="1">inline html</mark>
+
+Trusted custom tag: <ssr-badge>server custom tag</ssr-badge>
+
+- [x] done
+- [ ] pending
+
+| Name | Role |
+| --- | --- |
+| Markstream | Renderer |
+
+Visit [Vue](https://vuejs.org).
+
+![Markstream icon](/vue-markdown-icon.svg "Markstream icon")
+
+<div data-ssr-html-block="1"><strong>HTML block</strong> is present.</div>
+
+Footnotes are server-rendered.[^1]
+
+[^1]: Footnote body
+    `.trim(), {
+      customHtmlTags: ['ssr-badge'],
+      customId: BASIC_SCOPE,
+    })
+
+    expect(html).toContain('<h1')
+    expect(html).toContain('data-ssr-inline-html="1"')
+    expect(html).toContain('data-ssr-html-block="1"')
+    expect(html).toContain('data-ssr-custom="badge"')
+    expect(html).toContain('<table')
+    expect(html).toContain('href="https://vuejs.org"')
+    expect(html).toContain('src="/vue-markdown-icon.svg"')
+    expect(html).toContain('<figure')
+    expect(html).not.toMatch(/<p[^>]*>\s*<figure/)
+    expect(html).toContain('Footnote body')
+  })
+
+  it('renders an explicit SSR matrix for the lighter built-in node components', async () => {
+    const matrixNodes = [
+      {
+        type: 'heading',
+        level: 2,
+        text: 'SSR Matrix Heading',
+        raw: '## SSR Matrix Heading',
+        attrs: { id: 'ssr-matrix-heading' },
+        children: [
+          textNode('SSR Matrix '),
+          { type: 'emoji', name: '😄', markup: ':smile:', raw: ':smile:' },
+          textNode(' Heading'),
+        ],
+      },
+      paragraphNode([
+        textNode('Inline matrix: '),
+        inlineWrapper('strong', 'bold', '**bold**'),
+        textNode(' '),
+        inlineWrapper('emphasis', 'italic', '*italic*'),
+        textNode(' '),
+        inlineWrapper('strikethrough', 'strike', '~~strike~~'),
+        textNode(' '),
+        inlineWrapper('highlight', 'mark', '==mark=='),
+        textNode(' '),
+        inlineWrapper('insert', 'inserted', '++inserted++'),
+        textNode(' H'),
+        inlineWrapper('subscript', '2', '~2~'),
+        textNode('O x'),
+        inlineWrapper('superscript', '2', '^2^'),
+        textNode(' '),
+        { type: 'inline_code', code: 'const x = 1', raw: '`const x = 1`' },
+        textNode(' '),
+        linkNode('Example link', 'https://example.com'),
+        textNode(' '),
+        {
+          type: 'html_inline',
+          content: '<mark data-ssr-inline-node="1">inline html</mark>',
+          raw: '<mark data-ssr-inline-node="1">inline html</mark>',
+          loading: false,
+        },
+        textNode(' '),
+        { type: 'reference', id: '7', raw: '[7]' },
+        textNode(' '),
+        { type: 'footnote_reference', id: 'matrix-1', raw: '[^matrix-1]' },
+        { type: 'hardbreak', raw: '  \n' },
+        textNode('After hard break'),
+      ]),
+      {
+        type: 'blockquote',
+        cite: 'https://example.com/source',
+        raw: '> Quoted block content',
+        children: [
+          paragraphNode([textNode('Quoted block content')]),
+        ],
+      },
+      {
+        type: 'list',
+        ordered: true,
+        start: 3,
+        raw: '3. Checked task item\n4. Ordered second item',
+        items: [
+          {
+            type: 'list_item',
+            raw: '[x] Checked task item',
+            children: [
+              paragraphNode([
+                { type: 'checkbox', checked: true, raw: '[x]' },
+                textNode(' Checked task item'),
+              ]),
+            ],
+          },
+          {
+            type: 'list_item',
+            raw: 'Ordered second item',
+            children: [
+              paragraphNode([textNode('Ordered second item')]),
+            ],
+          },
+        ],
+      },
+      {
+        type: 'definition_list',
+        raw: 'SSR term: SSR definition',
+        items: [
+          {
+            type: 'definition_item',
+            raw: 'SSR term: SSR definition',
+            term: [textNode('SSR term')],
+            definition: [paragraphNode([textNode('SSR definition')])],
+          },
+        ],
+      },
+      {
+        type: 'table',
+        raw: '| Column | Value |\n| --- | --- |\n| SSR | Stable |',
+        loading: false,
+        header: {
+          type: 'table_row',
+          raw: '| Column | Value |',
+          cells: [
+            { type: 'table_cell', header: true, raw: 'Column', children: [textNode('Column')] },
+            { type: 'table_cell', header: true, raw: 'Value', children: [textNode('Value')] },
+          ],
+        },
+        rows: [
+          {
+            type: 'table_row',
+            raw: '| SSR | Stable |',
+            cells: [
+              { type: 'table_cell', header: false, raw: 'SSR', children: [textNode('SSR')] },
+              { type: 'table_cell', header: false, raw: 'Stable', children: [textNode('Stable')] },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'footnote',
+        id: 'matrix-1',
+        raw: '[^matrix-1]: Footnote body',
+        children: [
+          paragraphNode([
+            textNode('Footnote body'),
+            { type: 'footnote_anchor', id: 'matrix-1', raw: '↩︎' },
+          ]),
+        ],
+      },
+      {
+        type: 'admonition',
+        kind: 'tip',
+        title: 'SSR Tip',
+        raw: '::: tip SSR Tip\nAdmonition body\n:::',
+        children: [
+          paragraphNode([textNode('Admonition body')]),
+        ],
+      },
+      {
+        type: 'vmr_container',
+        name: 'callout',
+        raw: '::: callout\nContainer body\n:::',
+        attrs: { 'data-ssr-container': '1' },
+        children: [
+          paragraphNode([textNode('Container body')]),
+        ],
+      },
+      {
+        type: 'thematic_break',
+        raw: '---',
+      },
+    ]
+
+    const html = await renderMarkdown('', {
+      nodes: matrixNodes,
+    })
+
+    expect(html).toContain('id="ssr-matrix-heading"')
+    expect(html).toContain('class="paragraph-node"')
+    expect(html).toContain('class="strong-node"')
+    expect(html).toContain('class="emphasis-node"')
+    expect(html).toContain('class="strikethrough-node"')
+    expect(html).toContain('class="highlight-node"')
+    expect(html).toContain('class="insert-node"')
+    expect(html).toContain('class="subscript-node"')
+    expect(html).toContain('class="superscript-node"')
+    expect(html).toContain('class="emoji-node"')
+    expect(html).toContain('data-ssr-inline-node="1"')
+    expect(html).toContain('href="https://example.com"')
+    expect(html).toContain('class="reference-node')
+    expect(html).toContain('class="footnote-reference"')
+    expect(html).toContain('class="hard-break"')
+    expect(html).toContain('<blockquote')
+    expect(html).toContain('type="checkbox"')
+    expect(html).toContain('<ol')
+    expect(html).toContain('<dl')
+    expect(html).toContain('<table')
+    expect(html).toContain('class="footnote-anchor')
+    expect(html).toContain('class="admonition admonition-tip')
+    expect(html).toContain('data-ssr-container="1"')
+    expect(html).toContain('class="vmr-container vmr-container-callout"')
+    expect(html).toContain('<hr class="hr-node"')
+    expect(html).toContain('After hard break')
+  })
+
+  it('renders code blocks with an SSR pre fallback inside the code shell', async () => {
+    const html = await renderMarkdown(`
+\`\`\`diff
+--- a/file.txt
++++ b/file.txt
+@@
+- old line
++ new line
+\`\`\`
+
+\`\`\`ts
+export const greet = (name: string) => \`hello \${name}\`
+\`\`\`
+    `.trim())
+
+    expect(html).toContain('data-markstream-code-block="1"')
+    expect(html).toContain('data-markstream-enhanced="false"')
+    expect(html).toContain('data-markstream-pre="1"')
+    expect(html).toContain('@@')
+    expect(html).toContain('new line')
+    expect(html).toContain('hello ' + '$' + '{name}')
+  })
+
+  it('renders the standalone MarkdownCodeBlockNode shell during SSR', async () => {
+    const html = await renderComponent(MarkdownCodeBlockNode, {
+      node: {
+        type: 'code_block',
+        language: 'ts',
+        code: 'export const value = 1',
+        raw: '```ts\nexport const value = 1\n```',
+      },
+      loading: false,
+      stream: false,
+    })
+
+    expect(html).toContain('code-block-container')
+    expect(html).toContain('code-block-header')
+    expect(html).toContain('code-block-content')
+    expect(html).toContain('Typescript')
+  })
+
+  it('renders KaTeX HTML during SSR when a sync loader is configured', async () => {
+    enableKatex(() => katex)
+
+    const html = await renderMarkdown(`
+Inline math: $E = mc^2$.
+
+$$
+\\int_0^1 x^2 \\, dx = \\frac{1}{3}
+$$
+    `.trim())
+
+    expect(html).toContain('data-markstream-math="inline"')
+    expect(html).toContain('data-markstream-math="block"')
+    expect(html).toContain('data-markstream-mode="katex"')
+    expect(html).toContain('class="katex')
+  })
+
+  it('renders HTML and diagram fallbacks in the raw SSR response', async () => {
+    const html = await renderMarkdown(`
+Inline HTML stays visible: <mark data-ssr-inline-html="1">inline html</mark>.
+
+<div data-ssr-html-block="1"><strong>HTML block</strong> is present.</div>
+
+\`\`\`mermaid
+graph TD
+  A --> B
+\`\`\`
+
+\`\`\`d2
+client -> server: request
+\`\`\`
+
+\`\`\`infographic
+infographic list-row-simple-horizontal-arrow
+data
+  items
+    - label SSR
+      desc First paint
+\`\`\`
+    `.trim())
+
+    expect(html).toContain('data-ssr-inline-html="1"')
+    expect(html).toContain('data-ssr-html-block="1"')
+    expect(html).toContain('data-markstream-mermaid="1"')
+    expect(html).toContain('data-markstream-d2="1"')
+    expect(html).toContain('data-markstream-infographic="1"')
+    expect(html).toContain('data-markstream-mode="fallback"')
+    expect(html).toContain('graph TD')
+    expect(html).toContain('client -&gt; server: request')
+    expect(html).toContain('label SSR')
+  })
+
+  it('keeps diagram SSR fallbacks stable when optional loaders are unavailable', async () => {
+    disableMermaid()
+    disableD2()
+    setInfographicLoader(null)
+
+    const html = await renderMarkdown(`
+\`\`\`mermaid
+graph LR
+  Raw --> Stable
+\`\`\`
+
+\`\`\`d2
+stable -> fallback
+\`\`\`
+
+\`\`\`infographic
+infographic list-row-simple-horizontal-arrow
+data
+  items
+    - label Disabled
+      desc Static fallback
+\`\`\`
+    `.trim())
+
+    expect(html).toContain('data-markstream-mermaid="1"')
+    expect(html).toContain('data-markstream-d2="1"')
+    expect(html).toContain('data-markstream-infographic="1"')
+    expect(html).toContain('data-markstream-mode="fallback"')
+    expect(html).toContain('Raw --&gt; Stable')
+    expect(html).toContain('stable -&gt; fallback')
+    expect(html).toContain('label Disabled')
+  })
+
+  it('renders scoped custom overrides, custom node types, and trusted custom tags during SSR', async () => {
+    const scopeId = 'ssr-render-custom-components'
+
+    const CustomListItem = defineComponent({
+      name: 'SsrCustomListItem',
+      props: {
+        node: { type: Object, required: true },
+        indexKey: [String, Number],
+        customId: String,
+      },
+      setup(props) {
+        return () => h('li', { 'data-ssr-custom-list-item': '1' }, [
+          h(MarkdownRender, {
+            nodes: (props.node as any).children || [],
+            customId: props.customId,
+            indexKey: `ssr-custom-list-item-${String(props.indexKey ?? '')}`,
+            final: true,
+            typewriter: false,
+            batchRendering: false,
+          }),
+        ])
+      },
+    })
+
+    const CustomNodeCard = defineComponent({
+      name: 'SsrCustomNodeCard',
+      props: {
+        node: { type: Object, required: true },
+      },
+      setup(props) {
+        return () => h('section', { 'data-ssr-custom-node': '1' }, String((props.node as any).content ?? ''))
+      },
+    })
+
+    const ThinkingNode = defineComponent({
+      name: 'SsrThinkingNode',
+      props: {
+        node: { type: Object, required: true },
+      },
+      setup(props) {
+        return () => h('aside', { 'data-ssr-custom-tag': '1' }, String((props.node as any).content ?? ''))
+      },
+    })
+
+    setCustomComponents(scopeId, {
+      list_item: CustomListItem,
+      ssr_card: CustomNodeCard,
+      thinking: ThinkingNode,
+    })
+
+    const html = await renderMarkdown('', {
+      customId: scopeId,
+      customHtmlTags: ['thinking'],
+      nodes: [
+        {
+          type: 'list',
+          ordered: false,
+          raw: '- Override one\n- Override two',
+          items: [
+            {
+              type: 'list_item',
+              raw: 'Override one',
+              children: [paragraphNode([textNode('Override one')])],
+            },
+            {
+              type: 'list_item',
+              raw: 'Override two',
+              children: [paragraphNode([textNode('Override two')])],
+            },
+          ],
+        },
+        {
+          type: 'ssr_card',
+          raw: 'Scoped custom node content',
+          content: 'Scoped custom node content',
+        },
+        {
+          type: 'html_block',
+          tag: 'thinking',
+          content: '<thinking>Trusted custom tag content</thinking>',
+          raw: '<thinking>Trusted custom tag content</thinking>',
+          loading: false,
+        },
+      ],
+    })
+
+    expect(html).toContain('data-ssr-custom-list-item="1"')
+    expect(html).toContain('Override one')
+    expect(html).toContain('Override two')
+    expect(html).toContain('data-ssr-custom-node="1"')
+    expect(html).toContain('Scoped custom node content')
+    expect(html).toContain('data-ssr-custom-tag="1"')
+    expect(html).toContain('Trusted custom tag content')
+  })
+
+  it('renders stable raw math fallback when KaTeX is disabled or unavailable', async () => {
+    disableKatex()
+
+    const inlineHtml = await renderComponent(MathInlineNode, {
+      node: {
+        type: 'math_inline',
+        content: 'a^2 + b^2 = c^2',
+        raw: '$a^2 + b^2 = c^2$',
+        markup: '$',
+        loading: false,
+      },
+    })
+
+    setKatexLoader(() => {
+      throw new Error('KaTeX unavailable')
+    })
+
+    const blockHtml = await renderComponent(MathBlockNode, {
+      node: {
+        type: 'math_block',
+        content: '\\sum_{n=1}^{3} n = 6',
+        raw: '$$\\sum_{n=1}^{3} n = 6$$',
+        markup: '$$',
+        loading: false,
+      },
+    })
+
+    expect(inlineHtml).toContain('data-markstream-mode="fallback"')
+    expect(inlineHtml).toContain('$a^2 + b^2 = c^2$')
+    expect(inlineHtml).not.toContain('class="katex')
+    expect(blockHtml).toContain('data-markstream-mode="fallback"')
+    expect(blockHtml).toContain('\\sum_{n=1}^{3} n = 6')
+    expect(blockHtml).not.toContain('class="katex')
+  })
+})


### PR DESCRIPTION
## Summary
- add SSR-safe rendering paths for rich nodes and lightweight node matrix coverage
- add a dedicated Nuxt `/ssr-lab` SSR demo plus `pnpm test:e2e:nuxt-ssr`
- document the current SSR model, custom component support, and regression commands

## Validation
- `pnpm test --run test/ssr-render-to-string.test.ts test/ssr-import.test.ts`
- `pnpm test:e2e:nuxt-ssr`
- `pnpm docs:build`
