### PR TITLE
fix: restore next playground tailwind and tooltip demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ node_modules
 .history
 .DS_Store
 .tmp
-
+.next
 # vite press
 cache

--- a/packages/markstream-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/markstream-react/src/components/Tooltip/Tooltip.tsx
@@ -82,7 +82,7 @@ export function Tooltip(props: TooltipProps) {
       cancelled = true
       cleanup?.()
     }
-  }, [props.anchorEl, props.offset, props.placement, props.visible])
+  }, [props.anchorEl, props.offset, props.placement, props.visible, ready])
 
   if (typeof document === 'undefined')
     return null

--- a/playground-next14/pages/pages-ssr-lab.tsx
+++ b/playground-next14/pages/pages-ssr-lab.tsx
@@ -115,7 +115,7 @@ function renderServerMatrixHtml() {
       {items.map(item => (
         <section key={item.name} data-ssr-export={item.name} className="ssr-card">
           <h3>{item.name}</h3>
-          {item.element}
+          <div className="markstream-react ssr-matrix-renderer">{item.element}</div>
         </section>
       ))}
     </div>

--- a/playground-next14/postcss.config.cjs
+++ b/playground-next14/postcss.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/playground-next14/src/ssr-lab-client.tsx
+++ b/playground-next14/src/ssr-lab-client.tsx
@@ -84,6 +84,67 @@ export function NextCustomRenderer({ customId, nodes }: { customId: string, node
   )
 }
 
+function TooltipExportDemo() {
+  const [visible, setVisible] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold tracking-[0.04em] text-stone-900 shadow-sm transition hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-stone-300"
+        onBlur={() => setVisible(false)}
+        onFocus={(event) => {
+          setAnchorEl(event.currentTarget)
+          setVisible(true)
+        }}
+        onMouseEnter={(event) => {
+          setAnchorEl(event.currentTarget)
+          setVisible(true)
+        }}
+        onMouseLeave={() => setVisible(false)}
+      >
+        Hover for tooltip
+      </button>
+      <span className="text-xs font-medium text-stone-500">
+        hover / focus overlay export
+      </span>
+      <nextEntry.Tooltip
+        visible={visible}
+        anchorEl={anchorEl}
+        content="Tooltip body"
+      />
+    </div>
+  )
+}
+
+function HtmlPreviewFrameExportDemo() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold tracking-[0.04em] text-stone-900 shadow-sm transition hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-stone-300"
+        onClick={() => setOpen(true)}
+      >
+        Open preview
+      </button>
+      <span className="text-xs font-medium text-stone-500">
+        interactive modal export
+      </span>
+      {open
+        ? (
+            <nextEntry.HtmlPreviewFrame
+              code="<p>Preview</p>"
+              onClose={() => setOpen(false)}
+            />
+          )
+        : null}
+    </div>
+  )
+}
+
 export function NextExportMatrix() {
   const items = createMatrixCases(nextEntry, nextEntry)
 
@@ -94,7 +155,13 @@ export function NextExportMatrix() {
         {items.map(item => (
           <section key={item.name} data-ssr-export={item.name} className="ssr-card">
             <h3>{item.name}</h3>
-            {item.element}
+            <div className="markstream-react ssr-matrix-renderer">
+              {item.name === 'Tooltip'
+                ? <TooltipExportDemo />
+                : item.name === 'HtmlPreviewFrame'
+                  ? <HtmlPreviewFrameExportDemo />
+                  : item.element}
+            </div>
           </section>
         ))}
       </div>

--- a/playground-next14/src/ssr-lab-page.tsx
+++ b/playground-next14/src/ssr-lab-page.tsx
@@ -104,7 +104,7 @@ function MatrixSection({ caseName, entryName, items }: { caseName: string, entry
         {items.map(item => (
           <section key={item.name} data-ssr-export={item.name} className="ssr-card">
             <h3>{item.name}</h3>
-            {item.element}
+            <div className="markstream-react ssr-matrix-renderer">{item.element}</div>
           </section>
         ))}
       </div>
@@ -145,7 +145,7 @@ export function SsrLabPage({
   const serverMatrix = createMatrixCases(serverEntry, serverEntry)
 
   return (
-    <main data-ssr-version={version} data-ssr-router={router} className="ssr-lab-shell">
+    <main data-ssr-version={version} data-ssr-router={router} className="ssr-lab-shell markstream-react">
       <header className="ssr-hero">
         <p className="ssr-eyebrow">
           {version}

--- a/playground-next14/styles/globals.css
+++ b/playground-next14/styles/globals.css
@@ -1,4 +1,9 @@
+@import 'katex/dist/katex.min.css';
 @import 'markstream-react/index.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html {
   background: #f4f1e8;
@@ -65,6 +70,10 @@ a {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 14px;
+}
+
+.ssr-matrix-renderer {
+  position: relative;
 }
 
 .ssr-divider {

--- a/playground-next14/tailwind.config.js
+++ b/playground-next14/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: {
+    relative: true,
+    files: [
+      './app/**/*.{js,ts,jsx,tsx,mdx}',
+      './pages/**/*.{js,ts,jsx,tsx,mdx}',
+      './src/**/*.{js,ts,jsx,tsx,mdx}',
+    ],
+  },
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/playground-next15/next.config.mjs
+++ b/playground-next15/next.config.mjs
@@ -1,6 +1,26 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url))
+const reactAliases = {
+  'react': resolve(rootDir, 'node_modules/react'),
+  'react-dom': resolve(rootDir, 'node_modules/react-dom'),
+  'react/jsx-runtime': resolve(rootDir, 'node_modules/react/jsx-runtime.js'),
+  'react/jsx-dev-runtime': resolve(rootDir, 'node_modules/react/jsx-dev-runtime.js'),
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['markstream-react', 'stream-markdown-parser'],
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        ...reactAliases,
+      }
+    }
+    return config
+  },
 }
 
 export default nextConfig

--- a/playground-next15/pages/pages-ssr-lab.tsx
+++ b/playground-next15/pages/pages-ssr-lab.tsx
@@ -115,7 +115,7 @@ function renderServerMatrixHtml() {
       {items.map(item => (
         <section key={item.name} data-ssr-export={item.name} className="ssr-card">
           <h3>{item.name}</h3>
-          {item.element}
+          <div className="markstream-react ssr-matrix-renderer">{item.element}</div>
         </section>
       ))}
     </div>

--- a/playground-next15/postcss.config.cjs
+++ b/playground-next15/postcss.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/playground-next15/src/ssr-lab-client.tsx
+++ b/playground-next15/src/ssr-lab-client.tsx
@@ -84,6 +84,67 @@ export function NextCustomRenderer({ customId, nodes }: { customId: string, node
   )
 }
 
+function TooltipExportDemo() {
+  const [visible, setVisible] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold tracking-[0.04em] text-stone-900 shadow-sm transition hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-stone-300"
+        onBlur={() => setVisible(false)}
+        onFocus={(event) => {
+          setAnchorEl(event.currentTarget)
+          setVisible(true)
+        }}
+        onMouseEnter={(event) => {
+          setAnchorEl(event.currentTarget)
+          setVisible(true)
+        }}
+        onMouseLeave={() => setVisible(false)}
+      >
+        Hover for tooltip
+      </button>
+      <span className="text-xs font-medium text-stone-500">
+        hover / focus overlay export
+      </span>
+      <nextEntry.Tooltip
+        visible={visible}
+        anchorEl={anchorEl}
+        content="Tooltip body"
+      />
+    </div>
+  )
+}
+
+function HtmlPreviewFrameExportDemo() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        className="rounded-full border border-stone-300 bg-white px-4 py-2 text-xs font-semibold tracking-[0.04em] text-stone-900 shadow-sm transition hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-stone-300"
+        onClick={() => setOpen(true)}
+      >
+        Open preview
+      </button>
+      <span className="text-xs font-medium text-stone-500">
+        interactive modal export
+      </span>
+      {open
+        ? (
+            <nextEntry.HtmlPreviewFrame
+              code="<p>Preview</p>"
+              onClose={() => setOpen(false)}
+            />
+          )
+        : null}
+    </div>
+  )
+}
+
 export function NextExportMatrix() {
   const items = createMatrixCases(nextEntry, nextEntry)
 
@@ -94,7 +155,13 @@ export function NextExportMatrix() {
         {items.map(item => (
           <section key={item.name} data-ssr-export={item.name} className="ssr-card">
             <h3>{item.name}</h3>
-            {item.element}
+            <div className="markstream-react ssr-matrix-renderer">
+              {item.name === 'Tooltip'
+                ? <TooltipExportDemo />
+                : item.name === 'HtmlPreviewFrame'
+                  ? <HtmlPreviewFrameExportDemo />
+                  : item.element}
+            </div>
           </section>
         ))}
       </div>

--- a/playground-next15/src/ssr-lab-page.tsx
+++ b/playground-next15/src/ssr-lab-page.tsx
@@ -104,7 +104,7 @@ function MatrixSection({ caseName, entryName, items }: { caseName: string, entry
         {items.map(item => (
           <section key={item.name} data-ssr-export={item.name} className="ssr-card">
             <h3>{item.name}</h3>
-            {item.element}
+            <div className="markstream-react ssr-matrix-renderer">{item.element}</div>
           </section>
         ))}
       </div>
@@ -145,7 +145,7 @@ export function SsrLabPage({
   const serverMatrix = createMatrixCases(serverEntry, serverEntry)
 
   return (
-    <main data-ssr-version={version} data-ssr-router={router} className="ssr-lab-shell">
+    <main data-ssr-version={version} data-ssr-router={router} className="ssr-lab-shell markstream-react">
       <header className="ssr-hero">
         <p className="ssr-eyebrow">
           {version}

--- a/playground-next15/styles/globals.css
+++ b/playground-next15/styles/globals.css
@@ -1,4 +1,9 @@
+@import 'katex/dist/katex.min.css';
 @import 'markstream-react/index.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html {
   background: #f4f1e8;
@@ -65,6 +70,10 @@ a {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 14px;
+}
+
+.ssr-matrix-renderer {
+  position: relative;
 }
 
 .ssr-divider {

--- a/playground-next15/tailwind.config.js
+++ b/playground-next15/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: {
+    relative: true,
+    files: [
+      './app/**/*.{js,ts,jsx,tsx,mdx}',
+      './pages/**/*.{js,ts,jsx,tsx,mdx}',
+      './src/**/*.{js,ts,jsx,tsx,mdx}',
+    ],
+  },
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/playground-react19/.gitignore
+++ b/playground-react19/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.next


### PR DESCRIPTION
## Summary
- wire Tailwind utility generation into the Next 14/15 playgrounds and add preflight reset
- make HtmlPreviewFrame interactive in the export matrix instead of opening by default
- restore Tooltip hover rendering and scope standalone export demos under `.markstream-react`
- fix the Next 15 pages-router React runtime mismatch during client hydration

## Verification
- `pnpm exec vitest run`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter markstream-react typecheck`
- `pnpm --filter markstream-react build`
- `pnpm run -C playground-next14 build`
- `pnpm run -C playground-next15 build`

## Manual QA
- verified `/app-ssr-lab` and `/pages-ssr-lab` in Next 14 and Next 15
- confirmed demo Tailwind utility styles render, Tooltip shows on hover, and HtmlPreviewFrame opens and closes cleanly