### PR TITLE
fix: preserve loading table state for incomplete separators

### DIFF
--- a/packages/markdown-parser/src/plugins/fixTableTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixTableTokens.ts
@@ -97,15 +97,7 @@ function createTh(text: string) {
   }, {
     type: 'inline',
     tag: '',
-    children: [
-      {
-        tag: '',
-        type: 'text',
-        block: false,
-        content: text,
-        children: null,
-      },
-    ],
+    children: null,
     content: text,
     level: 4,
     attrs: null,
@@ -127,11 +119,11 @@ export function fixTableTokens(tokens: MarkdownToken[]): MarkdownToken[] {
   const token = tokens[i]
   if (token.type === 'inline') {
     const tcontent = String(token.content ?? '')
-    const childContent = String(token.children?.[0]?.content ?? '')
+    const headerContent = tcontent.split('\n')[0] ?? ''
 
     if (!tcontent.includes('\n') && /^\|(?:[^|\n]+\|?)+/.test(tcontent)) {
       // 解析 table
-      const body = childContent.slice(1).split('|').map(i => i.trim()).filter(Boolean).flatMap(i => createTh(i))
+      const body = headerContent.slice(1).split('|').map(i => i.trim()).filter(Boolean).flatMap(i => createTh(i))
       const insert = ([
         ...createStart(),
         ...body,
@@ -139,9 +131,9 @@ export function fixTableTokens(tokens: MarkdownToken[]): MarkdownToken[] {
       ] as unknown) as MarkdownToken[]
       fixedTokens.splice(i - 1, 3, ...insert)
     }
-    else if (/^\|(?:[^|\n]+\|)+\n\|:?-/.test(tcontent)) {
+    else if (/^\|(?:[^|\n]+\|)+\n\|(?:\s*:?-+:?\s*\|?)+$/.test(tcontent)) {
       // 解析 table
-      const body = childContent.slice(1, -1).split('|').map(i => i.trim()).flatMap(i => createTh(i))
+      const body = headerContent.slice(1, -1).split('|').map(i => i.trim()).flatMap(i => createTh(i))
       const insert = ([
         ...createStart(),
         ...body,

--- a/packages/markdown-parser/test/table-loading-midstate.test.ts
+++ b/packages/markdown-parser/test/table-loading-midstate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+describe('table loading mid-states', () => {
+  it('recognizes spaced separator rows as loading tables', () => {
+    const md = getMarkdown('table-loading-spaced-separator')
+    const markdown = `# 表格
+|列1|列2|列3|列4|列5|
+| - | - | - | - | `
+
+    const nodes = parseMarkdownToStructure(markdown, md, { final: false }) as any[]
+    const table = nodes.find(node => node.type === 'table') as any
+
+    expect(table).toBeTruthy()
+    expect(table.loading).toBe(true)
+    expect(table.header.cells.map((cell: any) => cell.raw)).toEqual(['列1', '列2', '列3', '列4', '列5'])
+  })
+
+  it('keeps header cells when the separator row is only partially typed', () => {
+    const md = getMarkdown('table-loading-partial-separator')
+    const markdown = `# 表格
+|列1|列2|列3|列4|列5|
+|:-`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { final: false }) as any[]
+    const table = nodes.find(node => node.type === 'table') as any
+
+    expect(table).toBeTruthy()
+    expect(table.loading).toBe(true)
+    expect(table.header.cells.map((cell: any) => cell.raw)).toEqual(['列1', '列2', '列3', '列4', '列5'])
+  })
+})

--- a/test/html-inline-midstates.test.ts
+++ b/test/html-inline-midstates.test.ts
@@ -441,7 +441,7 @@ $$
     expect(hasNode(inner as any, 'math_block')).toBe(true)
   })
 
-  it('streaming: unclosed <thinking> preserves partial table text (no top-level table leak)', () => {
+  it('streaming: unclosed <thinking> keeps partial table parsing scoped to inner content', () => {
     const part1 = `<thinking>
 | a | b |
 | - |`
@@ -453,8 +453,10 @@ $$
     expect(hasNode(n1 as any, 'table')).toBe(false)
 
     const inner = parseMarkdownToStructure(String((n1[0] as any).content ?? ''), md)
-    // Incomplete table should remain as text, not disappear.
-    expect(textIncludes(inner as any, '| a | b |')).toBe(true)
+    expect(hasNode(inner as any, 'table')).toBe(true)
+    expect((inner[0] as any).loading).toBe(true)
+    expect(textIncludes(inner as any, 'a')).toBe(true)
+    expect(textIncludes(inner as any, 'b')).toBe(true)
   })
 
   it('streaming: unclosed <thinking> preserves partial blockquote text (no top-level blockquote leak)', () => {


### PR DESCRIPTION
## Summary
- recognize spaced streaming separator rows like `| - | - | - | - |` as loading tables
- keep provisional header cells stable while the separator row is still incomplete
- add parser regression tests for spaced and partial separator midstates

## Testing
- `pnpm exec vitest --run packages/markdown-parser/test/table-loading-midstate.test.ts`
- `pnpm exec vitest --run test/markdown-midstates.test.ts -t "table"`

Closes #354
