### PR TITLE
fix: normalize KaTeX unicode units across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "test:e2e:angular-playground": "node scripts/e2e-angular-playground.mjs",
     "test:e2e:diff-theme-switch": "node scripts/e2e-diff-theme-switch.mjs",
     "test:e2e:nuxt-ssr": "node scripts/e2e-nuxt-ssr.mjs",
+    "test:e2e:katex-unicode-unit": "node scripts/e2e-katex-unicode-unit-regression.mjs",
     "lint": "eslint . --cache",
     "lint:fix": "pnpm run lint --fix",
     "test:ui": "vitest --ui",

--- a/packages/markstream-angular/src/components/MathBlockNode/MathBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/MathBlockNode/MathBlockNode.component.ts
@@ -10,6 +10,7 @@ import {
   ViewChild,
 } from '@angular/core'
 import { getKatex } from '../../optional/katex'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getString } from '../shared/node-helpers'
 
@@ -61,7 +62,7 @@ export class MathBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
     if (!target)
       return
 
-    const content = this.content
+    const content = normalizeKaTeXRenderInput(this.content)
     const version = ++this.renderVersion
     if (!content) {
       target.textContent = ''

--- a/packages/markstream-angular/src/components/MathInlineNode/MathInlineNode.component.ts
+++ b/packages/markstream-angular/src/components/MathInlineNode/MathInlineNode.component.ts
@@ -10,6 +10,7 @@ import {
   ViewChild,
 } from '@angular/core'
 import { getKatex } from '../../optional/katex'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getString } from '../shared/node-helpers'
 
@@ -69,7 +70,7 @@ export class MathInlineNodeComponent implements AfterViewInit, OnChanges, OnDest
     if (!target)
       return
 
-    const content = this.content
+    const content = normalizeKaTeXRenderInput(this.content)
     const version = ++this.renderVersion
     if (!content) {
       target.textContent = ''

--- a/packages/markstream-angular/src/enhanceRenderedHtml.ts
+++ b/packages/markstream-angular/src/enhanceRenderedHtml.ts
@@ -4,6 +4,7 @@ import { getKatex } from './optional/katex'
 import { getMermaid } from './optional/mermaid'
 import { getUseMonaco } from './optional/monaco'
 import { extractRenderedSvg, toSafeSvgMarkup } from './sanitizeSvg'
+import { normalizeKaTeXRenderInput } from './utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from './workers/katexWorkerClient'
 import { canParseOffthread, findPrefixOffthread } from './workers/mermaidWorkerClient'
 
@@ -241,8 +242,9 @@ async function renderKatex(root: HTMLElement, isActive: () => boolean) {
 }
 
 async function renderKatexMarkup(source: string, displayMode: boolean) {
+  const normalizedSource = normalizeKaTeXRenderInput(source)
   try {
-    return await renderKaTeXWithBackpressure(source, displayMode, {
+    return await renderKaTeXWithBackpressure(normalizedSource, displayMode, {
       timeout: 1500,
       waitTimeout: 0,
       maxRetries: 0,
@@ -260,11 +262,11 @@ async function renderKatexMarkup(source: string, displayMode: boolean) {
   if (!katex)
     throw new Error('KaTeX renderer is not available.')
 
-  const html = katex.renderToString(source, {
+  const html = katex.renderToString(normalizedSource, {
     displayMode,
     throwOnError: false,
   })
-  setKaTeXCache(source, displayMode, html)
+  setKaTeXCache(normalizedSource, displayMode, html)
   return html
 }
 

--- a/packages/markstream-angular/src/utils/normalizeKaTeXRenderInput.ts
+++ b/packages/markstream-angular/src/utils/normalizeKaTeXRenderInput.ts
@@ -1,0 +1,8 @@
+export function normalizeKaTeXRenderInput(content: string) {
+  if (!content)
+    return ''
+
+  return content
+    .replace(/·/g, '⋅')
+    .replace(/℃/g, '°C')
+}

--- a/packages/markstream-angular/src/workers/katexWorkerClient.ts
+++ b/packages/markstream-angular/src/workers/katexWorkerClient.ts
@@ -1,4 +1,5 @@
 import { isKatexEnabled } from '../optional/katex'
+import { normalizeKaTeXRenderInput } from '../utils/normalizeKaTeXRenderInput'
 
 export const WORKER_BUSY_CODE = 'WORKER_BUSY'
 
@@ -105,6 +106,7 @@ export function setKaTeXWorkerDebug(enabled: boolean) {
 }
 
 export async function renderKaTeXInWorker(content: string, displayMode = true, timeout = 2000, signal?: AbortSignal): Promise<string> {
+  const normalizedContent = normalizeKaTeXRenderInput(content)
   if (!isKatexEnabled()) {
     const error = new Error('KaTeX rendering disabled')
     ;(error as any).name = 'KaTeXDisabled'
@@ -115,7 +117,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
   if (workerInitError)
     return Promise.reject(workerInitError)
 
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizedContent}`
   const cached = cache.get(cacheKey)
   if (cached)
     return cached
@@ -177,14 +179,14 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
     activeWorker.postMessage({
       id,
       type: 'render',
-      content,
+      content: normalizedContent,
       displayMode,
     })
   })
 }
 
 export function setKaTeXCache(content: string, displayMode = true, html: string) {
-  rememberCache(content, displayMode, html)
+  rememberCache(normalizeKaTeXRenderInput(content), displayMode, html)
 }
 
 export function getKaTeXWorkerLoad() {

--- a/packages/markstream-react/src/components/Math/MathBlockNode.tsx
+++ b/packages/markstream-react/src/components/Math/MathBlockNode.tsx
@@ -2,6 +2,7 @@ import type { VisibilityHandle } from '../../context/viewportPriority'
 import type { MathBlockNodeProps } from '../../types/component-props'
 import { useEffect, useRef, useState } from 'react'
 import { useViewportPriority } from '../../context/viewportPriority'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getKatex } from './katex'
 
@@ -30,7 +31,7 @@ export function MathBlockNode({ node }: MathBlockNodeProps) {
   }, [registerViewport])
 
   useEffect(() => {
-    const content = node.content ?? ''
+    const content = normalizeKaTeXRenderInput(node.content ?? '')
     if (!content) {
       if (mathRef.current)
         mathRef.current.innerHTML = ''

--- a/packages/markstream-react/src/components/Math/MathInlineNode.tsx
+++ b/packages/markstream-react/src/components/Math/MathInlineNode.tsx
@@ -2,6 +2,7 @@ import type { VisibilityHandle } from '../../context/viewportPriority'
 import type { MathInlineNodeProps } from '../../types/component-props'
 import { useEffect, useRef, useState } from 'react'
 import { useViewportPriority } from '../../context/viewportPriority'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getKatex } from './katex'
 
@@ -30,7 +31,7 @@ export function MathInlineNode({ node }: MathInlineNodeProps) {
   }, [registerViewport])
 
   useEffect(() => {
-    const content = node.content ?? ''
+    const content = normalizeKaTeXRenderInput(node.content ?? '')
     if (!content) {
       if (mathRef.current)
         mathRef.current.innerHTML = ''

--- a/packages/markstream-react/src/server-renderer/katex.ts
+++ b/packages/markstream-react/src/server-renderer/katex.ts
@@ -1,3 +1,5 @@
+import { normalizeKaTeXRenderInput } from '../utils/normalizeKaTeXRenderInput'
+
 let katexModule: any | undefined
 let katexLoadAttempted = false
 
@@ -50,7 +52,8 @@ export function renderKatexToHtml(
   displayMode: boolean,
   throwOnError: boolean,
 ) {
-  if (!content)
+  const normalizedContent = normalizeKaTeXRenderInput(content)
+  if (!normalizedContent)
     return null
   if ((globalThis as any).__MARKSTREAM_REACT_DISABLE_SYNC_KATEX__)
     return null
@@ -60,7 +63,7 @@ export function renderKatexToHtml(
     return null
 
   try {
-    return katex.renderToString(content, {
+    return katex.renderToString(normalizedContent, {
       displayMode,
       throwOnError,
     })

--- a/packages/markstream-react/src/utils/normalizeKaTeXRenderInput.ts
+++ b/packages/markstream-react/src/utils/normalizeKaTeXRenderInput.ts
@@ -1,0 +1,8 @@
+export function normalizeKaTeXRenderInput(content: string) {
+  if (!content)
+    return ''
+
+  return content
+    .replace(/·/g, '⋅')
+    .replace(/℃/g, '°C')
+}

--- a/packages/markstream-react/src/workers/katexWorkerClient.ts
+++ b/packages/markstream-react/src/workers/katexWorkerClient.ts
@@ -1,3 +1,5 @@
+import { normalizeKaTeXRenderInput } from '../utils/normalizeKaTeXRenderInput'
+
 interface Pending {
   resolve: (val: string) => void
   reject: (err: any) => void
@@ -102,16 +104,17 @@ export const WORKER_BUSY_CODE = 'WORKER_BUSY'
 
 export async function renderKaTeXInWorker(content: string, displayMode = true, timeout = 2000, signal?: AbortSignal): Promise<string> {
   const startTime = performance.now()
+  const normalizedContent = normalizeKaTeXRenderInput(content)
   if (workerInitError)
     return Promise.reject(workerInitError)
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizedContent}`
   const cached = cache.get(cacheKey)
   if (cached) {
     if (perfMonitor) {
       perfMonitor.recordRender({
         type: 'cache-hit',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: true,
       })
@@ -132,7 +135,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
       perfMonitor.recordRender({
         type: 'worker',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: false,
         error: 'busy',
@@ -158,7 +161,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: false,
           error: 'timeout',
@@ -190,7 +193,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
           perfMonitor.recordRender({
             type: 'worker',
             duration: performance.now() - startTime,
-            formulaLength: content.length,
+            formulaLength: normalizedContent.length,
             timestamp: Date.now(),
             success: true,
           })
@@ -204,7 +207,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
           perfMonitor.recordRender({
             type: 'worker',
             duration: performance.now() - startTime,
-            formulaLength: content.length,
+            formulaLength: normalizedContent.length,
             timestamp: Date.now(),
             success: false,
             error: err?.code || err?.message,
@@ -216,7 +219,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
     })
 
     try {
-      wk.postMessage({ id, content, displayMode, debug: DEBUG_KATEX_WORKER })
+      wk.postMessage({ id, content: normalizedContent, displayMode, debug: DEBUG_KATEX_WORKER })
     }
     catch (err) {
       pending.delete(id)
@@ -230,7 +233,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
 }
 
 export function setKaTeXCache(content: string, displayMode: boolean, html: string) {
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizeKaTeXRenderInput(content)}`
   cache.set(cacheKey, html)
   if (cache.size > CACHE_MAX) {
     const firstKey = cache.keys().next().value

--- a/packages/markstream-vue2/src/components/MathBlockNode/MathBlockNode.vue
+++ b/packages/markstream-vue2/src/components/MathBlockNode/MathBlockNode.vue
@@ -2,6 +2,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue-demi'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { getCachedMathRender, setCachedMathRender } from '../../utils/mathRenderCache'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getKatex } from '../MathInlineNode/katex'
 
@@ -16,6 +17,7 @@ interface MathBlockNodeProps {
 }
 
 const props = defineProps<MathBlockNodeProps>()
+const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 
 const containerEl = ref<HTMLElement | null>(null)
 const registerVisibility = useViewportPriority()
@@ -41,12 +43,12 @@ async function renderWithMainThreadFallback() {
   if (!katex)
     return false
   try {
-    const html = katex.renderToString(props.node.content, {
+    const html = katex.renderToString(mathContent.value, {
       throwOnError: props.node.loading,
       displayMode: true,
     })
     applySuccessfulRender(html)
-    setKaTeXCache(props.node.content, true, html)
+    setKaTeXCache(mathContent.value, true, html)
     return true
   }
   catch {
@@ -105,7 +107,7 @@ async function renderMath() {
   currentAbortController = abortController
 
   try {
-    const html = await renderKaTeXWithBackpressure(props.node.content, true, {
+    const html = await renderKaTeXWithBackpressure(mathContent.value, true, {
       timeout: 3000,
       waitTimeout: 2000,
       maxRetries: 1,

--- a/packages/markstream-vue2/src/components/MathInlineNode/MathInlineNode.vue
+++ b/packages/markstream-vue2/src/components/MathInlineNode/MathInlineNode.vue
@@ -2,6 +2,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue-demi'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { getCachedMathRender, setCachedMathRender } from '../../utils/mathRenderCache'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 import { getKatex } from './katex'
 
@@ -26,6 +27,7 @@ let isUnmounted = false
 let currentAbortController: AbortController | null = null
 
 const displayMode = computed(() => props.node.markup === '$$')
+const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 const cacheKey = computed(() => {
   if (props.indexKey == null)
     return null
@@ -43,12 +45,12 @@ async function renderWithMainThreadFallback() {
   if (!katex)
     return false
   try {
-    const html = katex.renderToString(props.node.content, {
+    const html = katex.renderToString(mathContent.value, {
       throwOnError: props.node.loading,
       displayMode: displayMode.value,
     })
     applySuccessfulRender(html)
-    setKaTeXCache(props.node.content, displayMode.value, html)
+    setKaTeXCache(mathContent.value, displayMode.value, html)
     return true
   }
   catch {
@@ -107,7 +109,7 @@ async function renderMath() {
   }
 
   try {
-    const html = await renderKaTeXWithBackpressure(props.node.content, displayMode.value, {
+    const html = await renderKaTeXWithBackpressure(mathContent.value, displayMode.value, {
       timeout: 1500,
       waitTimeout: 0,
       maxRetries: 0,

--- a/packages/markstream-vue2/src/utils/normalizeKaTeXRenderInput.ts
+++ b/packages/markstream-vue2/src/utils/normalizeKaTeXRenderInput.ts
@@ -1,0 +1,8 @@
+export function normalizeKaTeXRenderInput(content: string) {
+  if (!content)
+    return ''
+
+  return content
+    .replace(/·/g, '⋅')
+    .replace(/℃/g, '°C')
+}

--- a/packages/markstream-vue2/src/workers/katexWorkerClient.ts
+++ b/packages/markstream-vue2/src/workers/katexWorkerClient.ts
@@ -1,4 +1,5 @@
 import { isKatexEnabled } from '../components/MathInlineNode/katex'
+import { normalizeKaTeXRenderInput } from '../utils/normalizeKaTeXRenderInput'
 
 interface Pending {
   resolve: (val: string) => void
@@ -137,6 +138,7 @@ export function setKaTeXWorkerDebug(enabled: boolean) {
 
 export async function renderKaTeXInWorker(content: string, displayMode = true, timeout = 2000, signal?: AbortSignal): Promise<string> {
   const startTime = performance.now()
+  const normalizedContent = normalizeKaTeXRenderInput(content)
 
   if (!isKatexEnabled()) {
     const err = new Error('KaTeX rendering disabled')
@@ -149,7 +151,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
     return Promise.reject(workerInitError)
   }
   // Quick cache hit
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizedContent}`
   const cached = cache.get(cacheKey)
   if (cached) {
     // Record cache hit performance
@@ -157,7 +159,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
       perfMonitor.recordRender({
         type: 'cache-hit',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: true,
       })
@@ -182,7 +184,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
       perfMonitor.recordRender({
         type: 'worker',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: false,
         error: 'busy',
@@ -211,7 +213,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: false,
           error: 'timeout',
@@ -243,7 +245,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: true,
         })
@@ -255,7 +257,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: false,
           error: err?.message || String(err),
@@ -266,14 +268,14 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
 
     pending.set(id, { resolve: wrappedResolve, reject: wrappedReject, timeoutId })
 
-    wk.postMessage({ id, content, displayMode })
+    wk.postMessage({ id, content: normalizedContent, displayMode })
   })
 }
 
 // Allow callers (e.g. main-thread fallback renderers) to populate the internal cache
 // so that synchronous renders can benefit subsequent worker-based calls.
 export function setKaTeXCache(content: string, displayMode = true, html: string) {
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizeKaTeXRenderInput(content)}`
   cache.set(cacheKey, html)
   if (cache.size > CACHE_MAX) {
     const firstKey = cache.keys().next().value

--- a/scripts/e2e-katex-unicode-unit-regression.mjs
+++ b/scripts/e2e-katex-unicode-unit-regression.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright-core'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..')
+const playgroundDir = path.join(repoRoot, 'playground')
+const host = '127.0.0.1'
+
+const issueMarkdown = `- 代入数据：$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$，$m=1.1\\ \\text{kg}$，$\\Delta t=40℃$
+- 计算得：$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$
+- 第（1）问：学生遗漏了比热容的数量级$10^3$，将$0.75\\times10^3\\ \\text{J/(kg·℃)}$错写为$0.75\\ \\text{J/(kg·℃)}$，导致计算出的$Q_1$错误。`
+
+function isPortOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port })
+    socket.on('connect', () => {
+      socket.end()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function findFreePort(start = 4291, end = 4330) {
+  for (let port = start; port <= end; port++) {
+    if (!await isPortOpen(port))
+      return port
+  }
+  throw new Error(`No free port found in ${start}-${end}`)
+}
+
+async function waitForPort(port, timeoutMs = 60000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isPortOpen(port))
+      return
+    await new Promise(resolve => setTimeout(resolve, 150))
+  }
+  throw new Error(`Timed out waiting for ${host}:${port}`)
+}
+
+function killProcessTree(child) {
+  if (!child || child.killed)
+    return
+  try {
+    child.kill('SIGTERM')
+  }
+  catch {}
+  setTimeout(() => {
+    try {
+      if (!child.killed)
+        child.kill('SIGKILL')
+    }
+    catch {}
+  }, 3000).unref?.()
+}
+
+function resolveChromeLaunchOptions() {
+  const candidates = [
+    process.env.PLAYWRIGHT_CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return {
+        executablePath: candidate,
+        headless: true,
+      }
+    }
+  }
+
+  return {
+    channel: 'chrome',
+    headless: true,
+  }
+}
+
+function startDevServer(port) {
+  const logs = []
+  const child = spawn(
+    'pnpm',
+    ['-C', playgroundDir, 'exec', 'vite', '--host', host, '--port', String(port), '--strictPort'],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        CI: '1',
+      },
+    },
+  )
+
+  child.stdout.on('data', chunk => logs.push(String(chunk)))
+  child.stderr.on('data', chunk => logs.push(String(chunk)))
+
+  return {
+    child,
+    getLogs() {
+      return logs.join('')
+    },
+  }
+}
+
+function createIssueUrl(port) {
+  return `http://${host}:${port}/test#data=raw:${encodeURIComponent(issueMarkdown)}`
+}
+
+async function waitForIssueMath(page) {
+  await page.locator('.preview-surface').waitFor({ state: 'visible', timeout: 30000 })
+  await page.waitForFunction(() => {
+    const root = document.querySelector('.preview-surface')
+    if (!root)
+      return false
+
+    const inlineNodes = Array.from(root.querySelectorAll('[data-markstream-math="inline"]'))
+    if (inlineNodes.length !== 8)
+      return false
+
+    return inlineNodes.every((node) => {
+      const mode = node.getAttribute('data-markstream-mode')
+      return mode === 'katex'
+        && Boolean(node.querySelector('.katex'))
+        && !node.querySelector('.math-inline--fallback')
+        && !node.querySelector('.math-inline__loading')
+    })
+  }, { timeout: 30000 })
+}
+
+async function readSummary(page) {
+  return page.evaluate(() => {
+    const root = document.querySelector('.preview-surface')
+    const inlineNodes = Array.from(root?.querySelectorAll('[data-markstream-math="inline"]') || [])
+    return {
+      inlineCount: inlineNodes.length,
+      inlineModes: inlineNodes.map(node => node.getAttribute('data-markstream-mode')),
+      katexCount: root?.querySelectorAll('[data-markstream-math="inline"] .katex').length || 0,
+      fallbackInlineCount: root?.querySelectorAll('.math-inline--fallback').length || 0,
+      fallbackBlockCount: root?.querySelectorAll('.math-block__fallback').length || 0,
+      loadingInlineCount: root?.querySelectorAll('.math-inline__loading').length || 0,
+      katexErrorCount: root?.querySelectorAll('.katex-error').length || 0,
+      previewText: root?.textContent || '',
+    }
+  })
+}
+
+async function main() {
+  const port = await findFreePort()
+  const server = startDevServer(port)
+  let browser
+  let page
+
+  try {
+    await waitForPort(port)
+    browser = await chromium.launch(resolveChromeLaunchOptions())
+    page = await browser.newPage({ viewport: { width: 1440, height: 1200 } })
+
+    const relevantConsoleIssues = []
+    const pageErrors = []
+
+    page.on('console', (msg) => {
+      if ((msg.type() === 'error' || msg.type() === 'warning') && /katex|cdotp|character metrics|undefined control sequence/i.test(msg.text()))
+        relevantConsoleIssues.push(`[${msg.type()}] ${msg.text()}`)
+    })
+    page.on('pageerror', error => pageErrors.push(String(error?.message || error)))
+
+    await page.goto(createIssueUrl(port), { waitUntil: 'load' })
+    await waitForIssueMath(page)
+
+    const summary = await readSummary(page)
+
+    if (summary.inlineCount !== 8)
+      throw new Error(`Expected 8 inline math nodes, got ${summary.inlineCount}`)
+    if (summary.katexCount !== 8)
+      throw new Error(`Expected 8 rendered KaTeX nodes, got ${summary.katexCount}`)
+    if (summary.inlineModes.some(mode => mode !== 'katex'))
+      throw new Error(`Expected all inline math nodes to be in katex mode, got ${summary.inlineModes.join(', ')}`)
+    if (summary.fallbackInlineCount !== 0 || summary.fallbackBlockCount !== 0)
+      throw new Error(`Unexpected fallback nodes: inline=${summary.fallbackInlineCount}, block=${summary.fallbackBlockCount}`)
+    if (summary.loadingInlineCount !== 0)
+      throw new Error(`Unexpected loading math nodes left in preview: ${summary.loadingInlineCount}`)
+    if (summary.katexErrorCount !== 0)
+      throw new Error(`Unexpected KaTeX error nodes in preview: ${summary.katexErrorCount}`)
+    if (summary.previewText.includes('$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$'))
+      throw new Error('Preview still contains raw fallback text for the first issue formula')
+    if (relevantConsoleIssues.length)
+      throw new Error(`Unexpected KaTeX console issues:\n${relevantConsoleIssues.join('\n')}`)
+    if (pageErrors.length)
+      throw new Error(`Unexpected page errors:\n${pageErrors.join('\n')}`)
+
+    console.log('KaTeX unicode-unit e2e passed.')
+    console.log(JSON.stringify(summary, null, 2))
+  }
+  catch (error) {
+    if (page) {
+      try {
+        const screenshot = '/tmp/markstream-katex-unicode-unit-regression.png'
+        await page.screenshot({ path: screenshot, fullPage: true })
+        console.error(`Saved failure screenshot to ${screenshot}`)
+      }
+      catch {}
+    }
+    console.error(server.getLogs())
+    throw error
+  }
+  finally {
+    await browser?.close().catch(() => {})
+    killProcessTree(server.child)
+  }
+}
+
+main().catch((error) => {
+  console.error('[e2e-katex-unicode-unit-regression] failed')
+  console.error(error)
+  process.exitCode = 1
+})

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import type { MathBlockNodeProps } from '../../types/component-props'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
 import { getKatex, getKatexSync } from '../MathInlineNode/katex'
 
 const props = defineProps<MathBlockNodeProps>()
 const containerEl = ref<HTMLElement | null>(null)
+const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 
 function resolveInitialState() {
   if (!props.node.content) {
@@ -31,7 +33,7 @@ function resolveInitialState() {
 
   try {
     return {
-      html: katex.renderToString(props.node.content, {
+      html: katex.renderToString(mathContent.value, {
         throwOnError: props.node.loading,
         displayMode: true,
       }),
@@ -98,7 +100,7 @@ async function renderMath() {
   const abortController = new AbortController()
   currentAbortController = abortController
 
-  renderKaTeXWithBackpressure(props.node.content, true, {
+  renderKaTeXWithBackpressure(mathContent.value, true, {
     timeout: 3000,
     waitTimeout: 2000,
     maxRetries: 1,
@@ -135,7 +137,7 @@ async function renderMath() {
         const katex = await getKatex()
         if (katex) {
           try {
-            const html = katex.renderToString(props.node.content, {
+            const html = katex.renderToString(mathContent.value, {
               throwOnError: props.node.loading,
               displayMode: true,
             })
@@ -144,7 +146,7 @@ async function renderMath() {
             hasRenderedOnce = true
             renderingLoading.value = false
             // populate worker client cache so future calls hit cache
-            setKaTeXCache(props.node.content, true, html)
+            setKaTeXCache(mathContent.value, true, html)
           }
           catch {
           }

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -2,6 +2,7 @@
 import type { MathInlineNodeProps } from '../../types/component-props'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
+import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
 import { getKatex, getKatexSync } from './katex'
@@ -11,6 +12,7 @@ const props = defineProps<MathInlineNodeProps>()
 const containerEl = ref<HTMLElement | null>(null)
 const isServer = typeof window === 'undefined'
 const displayMode = computed(() => props.node.markup === '$$')
+const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 
 function resolveInitialState() {
   if (!props.node.content) {
@@ -43,7 +45,7 @@ function resolveInitialState() {
 
   try {
     return {
-      html: katex.renderToString(props.node.content, {
+      html: katex.renderToString(mathContent.value, {
         throwOnError: props.node.loading,
         displayMode: displayMode.value,
       }),
@@ -106,7 +108,7 @@ async function renderMath() {
     catch {}
   }
 
-  renderKaTeXWithBackpressure(props.node.content, displayMode.value, {
+  renderKaTeXWithBackpressure(mathContent.value, displayMode.value, {
     // Inline math should not wait on worker slots; fallback to sync render immediately
     timeout: 1500,
     waitTimeout: 0,
@@ -137,7 +139,7 @@ async function renderMath() {
         const katex = await getKatex()
         if (katex) {
           try {
-            const html = katex.renderToString(props.node.content, {
+            const html = katex.renderToString(mathContent.value, {
               throwOnError: props.node.loading,
               displayMode: displayMode.value,
             })
@@ -146,7 +148,7 @@ async function renderMath() {
             renderingLoading.value = false
             hasRenderedOnce = true
             // populate worker client cache for inline as well
-            setKaTeXCache(props.node.content, displayMode.value, html)
+            setKaTeXCache(mathContent.value, displayMode.value, html)
           }
           catch {
           }

--- a/src/utils/normalizeKaTeXRenderInput.ts
+++ b/src/utils/normalizeKaTeXRenderInput.ts
@@ -1,0 +1,10 @@
+export function normalizeKaTeXRenderInput(content: string) {
+  if (!content)
+    return ''
+
+  return content
+    // KaTeX maps U+00B7 to \cdotp, which breaks inside \text{...}.
+    .replace(/·/g, '⋅')
+    // U+2103 has no built-in metrics; split it into supported symbols.
+    .replace(/℃/g, '°C')
+}

--- a/src/workers/katexWorkerClient.ts
+++ b/src/workers/katexWorkerClient.ts
@@ -1,4 +1,5 @@
 import { isKatexEnabled } from '../components/MathInlineNode/katex'
+import { normalizeKaTeXRenderInput } from '../utils/normalizeKaTeXRenderInput'
 
 interface Pending {
   resolve: (val: string) => void
@@ -136,6 +137,7 @@ export function setKaTeXWorkerDebug(enabled: boolean) {
 
 export async function renderKaTeXInWorker(content: string, displayMode = true, timeout = 2000, signal?: AbortSignal): Promise<string> {
   const startTime = performance.now()
+  const normalizedContent = normalizeKaTeXRenderInput(content)
 
   if (!isKatexEnabled()) {
     const err = new Error('KaTeX rendering disabled')
@@ -148,7 +150,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
     return Promise.reject(workerInitError)
   }
   // Quick cache hit
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizedContent}`
   const cached = cache.get(cacheKey)
   if (cached) {
     // Record cache hit performance
@@ -156,7 +158,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
       perfMonitor.recordRender({
         type: 'cache-hit',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: true,
       })
@@ -181,7 +183,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
       perfMonitor.recordRender({
         type: 'worker',
         duration: performance.now() - startTime,
-        formulaLength: content.length,
+        formulaLength: normalizedContent.length,
         timestamp: Date.now(),
         success: false,
         error: 'busy',
@@ -210,7 +212,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: false,
           error: 'timeout',
@@ -242,7 +244,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: true,
         })
@@ -254,7 +256,7 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
         perfMonitor.recordRender({
           type: 'worker',
           duration: performance.now() - startTime,
-          formulaLength: content.length,
+          formulaLength: normalizedContent.length,
           timestamp: Date.now(),
           success: false,
           error: err?.message || String(err),
@@ -265,17 +267,17 @@ export async function renderKaTeXInWorker(content: string, displayMode = true, t
 
     pending.set(id, { resolve: wrappedResolve, reject: wrappedReject, timeoutId })
 
-    wk.postMessage({ id, content, displayMode })
+    wk.postMessage({ id, content: normalizedContent, displayMode })
   })
 }
 
 // Allow callers (e.g. main-thread fallback renderers) to populate the internal cache
 // so that synchronous renders can benefit subsequent worker-based calls.
 export function setKaTeXCache(content: string, displayMode = true, html: string) {
-  const cacheKey = `${displayMode ? 'd' : 'i'}:${content}`
+  const cacheKey = `${displayMode ? 'd' : 'i'}:${normalizeKaTeXRenderInput(content)}`
   cache.set(cacheKey, html)
   if (cache.size > CACHE_MAX) {
-    const firstKey = cache.keys().next().value
+    const firstKey = cache.keys().next().value!
     cache.delete(firstKey)
   }
 }

--- a/test/issue378-math-parse-regression.test.ts
+++ b/test/issue378-math-parse-regression.test.ts
@@ -1,0 +1,40 @@
+import { getMarkdown, parseMarkdownToStructure } from 'stream-markdown-parser'
+import { describe, expect, it } from 'vitest'
+
+const markdown = `- 代入数据：$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$，$m=1.1\\ \\text{kg}$，$\\Delta t=40℃$
+- 计算得：$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$
+- 第（1）问：学生遗漏了比热容的数量级$10^3$，将$0.75\\times10^3\\ \\text{J/(kg·℃)}$错写为$0.75\\ \\text{J/(kg·℃)}$，导致计算出的$Q_1$错误。`
+
+function collectMathNodes(node: any, mathNodes: any[] = []) {
+  if (!node)
+    return mathNodes
+
+  if (node.type === 'math_inline' || node.type === 'math_block')
+    mathNodes.push(node)
+
+  if (Array.isArray(node.children))
+    node.children.forEach(child => collectMathNodes(child, mathNodes))
+  if (Array.isArray(node.items))
+    node.items.forEach(child => collectMathNodes(child, mathNodes))
+
+  return mathNodes
+}
+
+describe('issue #378 parse regression', () => {
+  it('keeps the affected unit formulas as math nodes', () => {
+    const md = getMarkdown('issue-378-parse')
+    const nodes = parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+    const mathNodes = nodes.flatMap(node => collectMathNodes(node))
+
+    expect(mathNodes.map(node => node.raw)).toEqual([
+      '$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$',
+      '$m=1.1\\ \\text{kg}$',
+      '$\\Delta t=40℃$',
+      '$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$',
+      '$10^3$',
+      '$0.75\\times10^3\\ \\text{J/(kg·℃)}$',
+      '$0.75\\ \\text{J/(kg·℃)}$',
+      '$Q_1$',
+    ])
+  })
+})

--- a/test/markstream-angular-katex-unicode-unit-regression.test.ts
+++ b/test/markstream-angular-katex-unicode-unit-regression.test.ts
@@ -1,0 +1,76 @@
+import katex from 'katex'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+class FakeKaTeXWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+
+  postMessage(data: { id: string, content: string, displayMode: boolean }) {
+    queueMicrotask(() => {
+      try {
+        const html = katex.renderToString(data.content, {
+          throwOnError: true,
+          displayMode: data.displayMode,
+          output: 'html',
+          strict: 'ignore',
+        })
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            html,
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+      catch (error: any) {
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            error: error?.message || String(error),
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {}
+}
+
+let katexWorkerClient: typeof import('../packages/markstream-angular/src/workers/katexWorkerClient') | null = null
+
+afterEach(() => {
+  katexWorkerClient?.clearKaTeXWorker()
+  katexWorkerClient = null
+  vi.resetModules()
+})
+
+describe('markstream-angular katex unicode unit render regression', () => {
+  it('enhances inline and block math with unicode unit glyphs through the worker path', async () => {
+    katexWorkerClient = await import('../packages/markstream-angular/src/workers/katexWorkerClient')
+    katexWorkerClient.setKaTeXWorker(new FakeKaTeXWorker() as unknown as Worker)
+    const { enhanceRenderedHtml } = await import('../packages/markstream-angular/src/enhanceRenderedHtml')
+
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="markstream-angular markdown-renderer">
+        <span class="markstream-nested-math" data-display="inline">
+          <span class="markstream-nested-math__source">c=0.75\\times10^3\\ \\text{J/(kg·℃)}</span>
+          <span class="markstream-nested-math__render"></span>
+        </span>
+        <div class="markstream-nested-math-block">
+          <pre class="markstream-nested-math-block__source"><code>Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}</code></pre>
+          <div class="markstream-nested-math-block__render"></div>
+        </div>
+      </div>
+    `
+
+    const shell = root.querySelector('.markstream-angular') as HTMLElement
+    await enhanceRenderedHtml(shell, { final: false })
+
+    expect(shell.querySelector('.markstream-nested-math__render .katex')).toBeTruthy()
+    expect(shell.querySelector('.markstream-nested-math-block__render .katex-display')).toBeTruthy()
+  })
+})

--- a/test/math-block-unicode-unit-render-regression.test.ts
+++ b/test/math-block-unicode-unit-render-regression.test.ts
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import katex from 'katex'
+import { describe, expect, it, vi } from 'vitest'
+import MathBlockNode from '../src/components/MathBlockNode/MathBlockNode.vue'
+import { flushAll } from './setup/flush-all'
+
+vi.mock('../src/components/MathInlineNode/katex', () => ({
+  getKatexSync: () => null,
+  getKatex: async () => ({
+    renderToString: (content: string, opts: any) => katex.renderToString(content, {
+      ...opts,
+      output: 'html',
+      strict: 'ignore',
+    }),
+  }),
+}))
+
+vi.mock('../src/workers/katexWorkerClient', async () => {
+  const actual: any = await vi.importActual('../src/workers/katexWorkerClient')
+  return {
+    ...actual,
+    renderKaTeXWithBackpressure: async (content: string, displayMode = true) => katex.renderToString(content, {
+      throwOnError: true,
+      displayMode,
+      output: 'html',
+      strict: 'ignore',
+    }),
+    setKaTeXCache: vi.fn(),
+  }
+})
+
+describe('mathBlockNode unicode unit render regression', () => {
+  it('normalizes unsupported unit glyphs before worker rendering', async () => {
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: 'Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}',
+          raw: '$$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$$',
+          markup: '$$',
+          loading: false,
+        },
+      },
+    })
+
+    await flushAll()
+
+    const html = wrapper.html()
+    expect(html).toContain('data-markstream-mode="katex"')
+    expect(html).toContain('class="katex"')
+    expect(html).not.toContain('math-block__fallback')
+    expect(html).not.toContain('$$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$$')
+  })
+})

--- a/test/math-inline-unicode-unit-render-regression.test.ts
+++ b/test/math-inline-unicode-unit-render-regression.test.ts
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import katex from 'katex'
+import { describe, expect, it, vi } from 'vitest'
+import MathInlineNode from '../src/components/MathInlineNode/MathInlineNode.vue'
+import { flushAll } from './setup/flush-all'
+
+vi.mock('../src/components/MathInlineNode/katex', () => ({
+  getKatexSync: () => null,
+  getKatex: async () => ({
+    renderToString: (content: string, opts: any) => katex.renderToString(content, {
+      ...opts,
+      output: 'html',
+      strict: 'ignore',
+    }),
+  }),
+}))
+
+vi.mock('../src/workers/katexWorkerClient', async () => {
+  const actual: any = await vi.importActual('../src/workers/katexWorkerClient')
+  return {
+    ...actual,
+    renderKaTeXWithBackpressure: async (content: string, displayMode = false) => katex.renderToString(content, {
+      throwOnError: true,
+      displayMode,
+      output: 'html',
+      strict: 'ignore',
+    }),
+    setKaTeXCache: vi.fn(),
+  }
+})
+
+describe('mathInlineNode unicode unit render regression', () => {
+  it('normalizes unsupported unit glyphs before worker rendering', async () => {
+    const wrapper = mount(MathInlineNode as any, {
+      props: {
+        node: {
+          type: 'math_inline',
+          content: 'c=0.75\\times10^3\\ \\text{J/(kg·℃)}',
+          raw: '$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$',
+          markup: '$',
+          loading: false,
+        },
+      },
+    })
+
+    await flushAll()
+
+    const html = wrapper.html()
+    expect(html).toContain('data-markstream-mode="katex"')
+    expect(html).toContain('class="katex"')
+    expect(html).not.toContain('math-inline--fallback')
+    expect(html).not.toContain('$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$')
+  })
+})

--- a/test/normalize-katex-render-input.test.ts
+++ b/test/normalize-katex-render-input.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeKaTeXRenderInput } from '../src/utils/normalizeKaTeXRenderInput'
+
+describe('normalizeKaTeXRenderInput', () => {
+  it('normalizes unsupported KaTeX unit glyphs', () => {
+    expect(normalizeKaTeXRenderInput('\\text{J/(kg·℃)}')).toBe('\\text{J/(kg⋅°C)}')
+    expect(normalizeKaTeXRenderInput('\\Delta t=40℃')).toBe('\\Delta t=40°C')
+  })
+
+  it('leaves already safe math content unchanged', () => {
+    expect(normalizeKaTeXRenderInput('E=mc^2')).toBe('E=mc^2')
+    expect(normalizeKaTeXRenderInput('\\text{kg}')).toBe('\\text{kg}')
+  })
+})

--- a/test/react-math-unicode-unit-render-regression.test.tsx
+++ b/test/react-math-unicode-unit-render-regression.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable antfu/no-import-node-modules-by-path */
+import katex from 'katex'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React, { act } from '../packages/markstream-react/node_modules/react'
+import { createRoot } from '../packages/markstream-react/node_modules/react-dom/client'
+
+class FakeKaTeXWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+
+  postMessage(data: { id: string, content: string, displayMode: boolean }) {
+    queueMicrotask(() => {
+      try {
+        const html = katex.renderToString(data.content, {
+          throwOnError: true,
+          displayMode: data.displayMode,
+          output: 'html',
+          strict: 'ignore',
+        })
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            html,
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+      catch (error: any) {
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            error: error?.message || String(error),
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {}
+}
+
+let katexWorkerClient: typeof import('../packages/markstream-react/src/workers/katexWorkerClient') | null = null
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  katexWorkerClient?.clearKaTeXWorker()
+  katexWorkerClient?.clearKaTeXCache()
+  katexWorkerClient = null
+  vi.resetModules()
+  document.body.innerHTML = ''
+})
+
+describe('markstream-react math unicode unit render regression', () => {
+  it('renders inline formulas with unicode unit glyphs through the worker path', async () => {
+    katexWorkerClient = await import('../packages/markstream-react/src/workers/katexWorkerClient')
+    katexWorkerClient.setKaTeXWorker(new FakeKaTeXWorker() as unknown as Worker)
+    const { MathInlineNode } = await import('../packages/markstream-react/src/components/Math/MathInlineNode')
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+
+    await act(async () => {
+      root.render(React.createElement(MathInlineNode as any, {
+        node: {
+          type: 'math_inline',
+          content: 'c=0.75\\times10^3\\ \\text{J/(kg·℃)}',
+          raw: '$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$',
+          markup: '$',
+          loading: false,
+        },
+      }))
+    })
+    await flushReact()
+
+    expect(host.innerHTML).toContain('class="katex"')
+    expect(host.textContent).not.toContain('$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$')
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
+  it('renders block formulas with unicode unit glyphs through the worker path', async () => {
+    katexWorkerClient = await import('../packages/markstream-react/src/workers/katexWorkerClient')
+    katexWorkerClient.setKaTeXWorker(new FakeKaTeXWorker() as unknown as Worker)
+    const { MathBlockNode } = await import('../packages/markstream-react/src/components/Math/MathBlockNode')
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+
+    await act(async () => {
+      root.render(React.createElement(MathBlockNode as any, {
+        node: {
+          type: 'math_block',
+          content: 'Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}',
+          raw: '$$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$$',
+          loading: false,
+        },
+      }))
+    })
+    await flushReact()
+
+    expect(host.innerHTML).toContain('class="katex-display"')
+    expect(host.textContent).not.toContain('$$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$$')
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+})

--- a/test/react-ssr-math-unicode-unit-render-regression.test.tsx
+++ b/test/react-ssr-math-unicode-unit-render-regression.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const packageRequire = createRequire(new URL('../packages/markstream-react/package.json', import.meta.url))
+const React = packageRequire('react') as typeof import('react')
+const { renderToStaticMarkup } = packageRequire('react-dom/server') as typeof import('react-dom/server')
+
+describe('markstream-react SSR math unicode unit render regression', () => {
+  it('renders inline and block formulas with unicode unit glyphs on the server', async () => {
+    const serverEntry = await import('../packages/markstream-react/src/server')
+
+    const inlineHtml = renderToStaticMarkup(
+      React.createElement(serverEntry.MathInlineNode, {
+        node: {
+          type: 'math_inline',
+          content: 'c=0.75\\times10^3\\ \\text{J/(kg·℃)}',
+          raw: '$c=0.75\\times10^3\\ \\text{J/(kg·℃)}$',
+          markup: '$',
+          loading: false,
+        },
+      }),
+    )
+
+    const blockHtml = renderToStaticMarkup(
+      React.createElement(serverEntry.MathBlockNode, {
+        node: {
+          type: 'math_block',
+          content: 'Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}',
+          raw: '$$Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}$$',
+          loading: false,
+        },
+      }),
+    )
+
+    expect(inlineHtml).toContain('class="katex"')
+    expect(inlineHtml).not.toContain('math-inline--fallback')
+    expect(blockHtml).toContain('class="katex-display"')
+    expect(blockHtml).not.toContain('math-block__fallback')
+  })
+})

--- a/test/vue2-math-unicode-unit-render-regression.test.ts
+++ b/test/vue2-math-unicode-unit-render-regression.test.ts
@@ -1,0 +1,67 @@
+import katex from 'katex'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+class FakeKaTeXWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+  renderCount = 0
+
+  postMessage(data: { id: string, content: string, displayMode: boolean }) {
+    this.renderCount += 1
+    queueMicrotask(() => {
+      try {
+        const html = katex.renderToString(data.content, {
+          throwOnError: true,
+          displayMode: data.displayMode,
+          output: 'html',
+          strict: 'ignore',
+        })
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            html,
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+      catch (error: any) {
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            error: error?.message || String(error),
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {}
+}
+
+let katexWorkerClient: typeof import('../packages/markstream-vue2/src/workers/katexWorkerClient') | null = null
+
+afterEach(() => {
+  katexWorkerClient?.clearKaTeXWorker()
+  katexWorkerClient = null
+  vi.resetModules()
+})
+
+describe('markstream-vue2 math unicode unit render regression', () => {
+  it('normalizes unicode unit glyphs before worker rendering and caching', async () => {
+    const worker = new FakeKaTeXWorker()
+    katexWorkerClient = await import('../packages/markstream-vue2/src/workers/katexWorkerClient')
+    katexWorkerClient.setKaTeXWorker(worker as unknown as Worker)
+
+    const inlineHtml = await katexWorkerClient.renderKaTeXInWorker('c=0.75\\times10^3\\ \\text{J/(kg·℃)}', false)
+    const blockHtml = await katexWorkerClient.renderKaTeXInWorker('Q_1=0.75\\times10^3\\ \\text{J/(kg·℃)}\\times1.1\\ \\text{kg}\\times40℃=3.3\\times 10^{4}\\ \\text{J}', true)
+    const cachedInlineHtml = await katexWorkerClient.renderKaTeXInWorker('c=0.75\\times10^3\\ \\text{J/(kg·℃)}', false)
+
+    expect(inlineHtml).toContain('class="katex"')
+    expect(blockHtml).toContain('class="katex-display"')
+    expect(cachedInlineHtml).toBe(inlineHtml)
+    expect(worker.renderCount).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- normalize KaTeX render input for `·` and `℃` before worker/main-thread rendering
- sync the same fix to `markstream-vue2`, `markstream-react`, and `markstream-angular`
- add regression coverage for parse, component/worker, React SSR, Angular enhancement, and browser e2e paths

## Verification
- `pnpm test --run`
- `pnpm typecheck`
- `pnpm run test:e2e:katex-unicode-unit`