### PR TITLE
fix: preserve structured details summary rendering

### DIFF
--- a/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -156,6 +156,7 @@ onBeforeUnmount(() => {
         :custom-id="customId"
         :batch-rendering="false"
         :defer-nodes-until-visible="false"
+        :render-as-fragment="true"
       />
       <!-- Use dynamic rendering for custom components -->
       <DynamicRenderer v-else-if="renderMode.mode === 'dynamic'" :nodes="renderMode.nodes" />

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -117,6 +117,7 @@ const headingProbeWrapperRefs = reactive<Record<number, HTMLElement | null>>({
 const viewportPriorityAutoDisabled = ref(false)
 const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 const isClient = typeof window !== 'undefined'
+const renderAsFragment = computed(() => props.renderAsFragment === true)
 const debugPerformanceEnabled = computed(() => props.debugPerformance && isClient && typeof console !== 'undefined')
 const attrs = useAttrs() as RendererAttrs
 const textStreamState = new Map<string, string>()
@@ -280,6 +281,7 @@ const heightExperimentConfig = computed(() => {
 })
 const heightExperimentEnabled = computed(() => Boolean(
   isClient
+  && !renderAsFragment.value
   && props.customId
   && !isNestedListItemRenderer
   && heightExperimentConfig.value?.enabled,
@@ -289,6 +291,8 @@ const codeBlockEstimationEnabled = computed(() => heightExperimentEnabled.value 
 const experimentProbeWidth = computed(() => Math.max(320, experimentContainerWidth.value || containerRef.value?.clientWidth || 640))
 const maxLiveNodesResolved = computed(() => Math.max(1, props.maxLiveNodes ?? 320))
 const virtualizationEnabled = computed(() => {
+  if (renderAsFragment.value)
+    return false
   if ((props.maxLiveNodes ?? 0) <= 0)
     return false
   return parsedNodes.value.length > maxLiveNodesResolved.value
@@ -330,7 +334,7 @@ const resolvedInitialBatch = computed(() => {
     return resolvedBatchSize.value
   return Math.max(0, initial)
 })
-const batchingEnabled = computed(() => props.batchRendering !== false && resolvedBatchSize.value > 0 && isClient && !isTestEnv)
+const batchingEnabled = computed(() => !renderAsFragment.value && props.batchRendering !== false && resolvedBatchSize.value > 0 && isClient && !isTestEnv)
 const renderedCount = ref(0)
 const previousRenderContext = ref<{ key: typeof props.indexKey, total: number }>({
   key: props.indexKey,
@@ -360,6 +364,8 @@ let restoreReconcileTimers: number[] = []
 let detachScrollHandler: (() => void) | null = null
 let pendingFocusSync: { id: number | ReturnType<typeof setTimeout>, viaTimeout: boolean } | null = null
 const deferNodes = computed(() => {
+  if (renderAsFragment.value)
+    return false
   if (props.deferNodesUntilVisible === false)
     return false
   // In the incremental/batched mode (`maxLiveNodes <= 0`), placeholders are
@@ -2250,10 +2256,37 @@ function handleContainerMouseout(event: MouseEvent) {
     return
   emit('mouseout', event)
 }
+
+function handleFragmentMouseover(event: MouseEvent) {
+  emit('mouseover', event)
+}
+
+function handleFragmentMouseout(event: MouseEvent) {
+  emit('mouseout', event)
+}
 </script>
 
 <template>
+  <template v-if="renderAsFragment">
+    <component
+      :is="item.component"
+      v-for="item in renderedItems"
+      :key="item.index"
+      :node="item.node"
+      :loading="item.node.loading"
+      :index-key="item.indexKey"
+      v-bind="item.bindings"
+      :custom-id="props.customId"
+      :is-dark="props.isDark"
+      @click="handleContainerClick"
+      @mouseover="handleFragmentMouseover"
+      @mouseout="handleFragmentMouseout"
+      @copy="emit('copy', $event)"
+      @handle-artifact-click="emit('handleArtifactClick', $event)"
+    />
+  </template>
   <div
+    v-else
     ref="containerRef"
     class="markstream-vue markdown-renderer"
     :class="[{ dark: props.isDark }, { virtualized: virtualizationEnabled }]"

--- a/src/components/__tests__/htmlNodes.integration.test.ts
+++ b/src/components/__tests__/htmlNodes.integration.test.ts
@@ -570,4 +570,132 @@ describe('component Behavior', () => {
     expect(wrapper.html()).toContain('<pre>')
     expect(wrapper.text()).toContain('- alpha')
   })
+
+  it('renders details summary as the first direct child for issue #397 content', async () => {
+    const markdown = `# Structural Stress
+
+> 这个样例用于检查复杂结构在 streaming 中是否抖动、错位或丢节点。
+
+## 列表
+
+1. 第一层
+   - 第二层
+     - 第三层
+2. 继续
+
+## 表格
+
+| Framework | Route | Purpose |
+| --- | --- | --- |
+| Vue 3 | \`/test\` | 主调试台 |
+| Vue 2 | \`/test\` | 兼容回归 |
+| React | \`/test\` | 跨框架对照 |
+| Angular | \`/test\` | baseline 对照 |
+
+## HTML
+
+<details>
+  <summary>展开看一段 HTML</summary>
+  <p>如果这里的结构错了，通常说明 HTML block / inline 的边界处理有问题。</p>
+</details>
+
+## 长段落
+
+Markstream 现在不仅要处理单次完整渲染，还要处理 AI 场景下不断追加的 markdown 内容，所以这个页面更像一个回归驾驶舱。你可以一边编辑左侧输入，一边切换 Vue 2、React 或 Angular 的 test page，用同一段内容观察差异，判断问题是解析层、组件层，还是框架适配层。`
+
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: markdown,
+        final: true,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        typewriter: false,
+      },
+      global: {
+        stubs: {
+          transition: false,
+        },
+      },
+    })
+
+    await flushAll()
+
+    const details = wrapper.find('details.html-block-node')
+    expect(details.exists()).toBe(true)
+    expect(details.element.firstElementChild?.tagName).toBe('SUMMARY')
+    expect(details.find('summary').text()).toBe('展开看一段 HTML')
+    expect(wrapper.text()).not.toContain('<summary>')
+    expect(wrapper.text()).not.toContain('</details>')
+  })
+
+  it('keeps nested details summaries as the first direct child of each details node', async () => {
+    const wrapper = mount(HtmlBlockNode, {
+      props: {
+        node: {
+          tag: 'details',
+          content: '<details open><summary>outer</summary><p>outer body</p><details open><summary>inner</summary><p>inner body</p></details></details>',
+          attrs: [['open', '']],
+          children: [
+            {
+              type: 'html_block',
+              tag: 'summary',
+              content: '<summary>outer</summary>',
+              children: [
+                {
+                  type: 'paragraph',
+                  raw: 'outer',
+                  children: [{ type: 'text', raw: 'outer', content: 'outer' }],
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              raw: 'outer body',
+              children: [{ type: 'text', raw: 'outer body', content: 'outer body' }],
+            },
+            {
+              type: 'html_block',
+              tag: 'details',
+              content: '<details open><summary>inner</summary><p>inner body</p></details>',
+              attrs: [['open', '']],
+              children: [
+                {
+                  type: 'html_block',
+                  tag: 'summary',
+                  content: '<summary>inner</summary>',
+                  children: [
+                    {
+                      type: 'paragraph',
+                      raw: 'inner',
+                      children: [{ type: 'text', raw: 'inner', content: 'inner' }],
+                    },
+                  ],
+                },
+                {
+                  type: 'paragraph',
+                  raw: 'inner body',
+                  children: [{ type: 'text', raw: 'inner body', content: 'inner body' }],
+                },
+              ],
+            },
+          ],
+          loading: false,
+        },
+      },
+      global: {
+        stubs: {
+          transition: false,
+        },
+      },
+    })
+
+    await flushAll()
+
+    const detailsNodes = wrapper.findAll('details.html-block-node')
+    expect(detailsNodes).toHaveLength(2)
+    expect(detailsNodes[0].element.firstElementChild?.tagName).toBe('SUMMARY')
+    expect(detailsNodes[1].element.firstElementChild?.tagName).toBe('SUMMARY')
+    expect(detailsNodes[0].find('summary').text()).toBe('outer')
+    expect(detailsNodes[1].find('summary').text()).toBe('inner')
+  })
 })

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -87,4 +87,6 @@ export interface NodeRendererProps {
   maxLiveNodes?: number
   /** Number of nodes to keep before/after focus. Default: 60 */
   liveNodeBuffer?: number
+  /** Internal: render nodes as a fragment without container wrappers */
+  renderAsFragment?: boolean
 }

--- a/test/ssr-render-to-string.test.ts
+++ b/test/ssr-render-to-string.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 import { disableD2, enableD2 } from '../src/components/D2BlockNode/d2'
+import HtmlBlockNode from '../src/components/HtmlBlockNode/HtmlBlockNode.vue'
 import { setInfographicLoader } from '../src/components/InfographicBlockNode/infographic'
 import MarkdownCodeBlockNode from '../src/components/MarkdownCodeBlockNode'
 import MathBlockNode from '../src/components/MathBlockNode'
@@ -153,6 +154,43 @@ Footnotes are server-rendered.[^1]
 
     expect(html.match(/<ul/g)?.length ?? 0).toBe(1)
     expect(html.match(/alpha/g)?.length ?? 0).toBe(1)
+  })
+
+  it('renders structured details html blocks without wrapper nodes before summary', async () => {
+    const html = await renderComponent(HtmlBlockNode, {
+      node: {
+        type: 'html_block',
+        tag: 'details',
+        content: '<details open><summary>展开看一段 HTML</summary><p>body</p></details>',
+        attrs: [['open', '']],
+        children: [
+          {
+            type: 'html_block',
+            tag: 'summary',
+            content: '<summary>展开看一段 HTML</summary>',
+            children: [
+              {
+                type: 'paragraph',
+                raw: '展开看一段 HTML',
+                children: [{ type: 'text', content: '展开看一段 HTML', raw: '展开看一段 HTML' }],
+              },
+            ],
+          },
+          {
+            type: 'paragraph',
+            raw: 'body',
+            children: [{ type: 'text', content: 'body', raw: 'body' }],
+          },
+        ],
+      },
+    })
+
+    expect(html).toMatch(/<details[^>]*class="html-block-node"[^>]*>(?:<!--\[-->|<!--\]-->)*<summary[^>]*>/)
+    expect(html).not.toContain('class="markstream-vue markdown-renderer"')
+    expect(html).not.toContain('node-slot')
+    expect(html).not.toContain('data-node-index=')
+    expect(html).not.toContain('<template>')
+    expect(html).toMatch(/<p dir="auto" class="paragraph-node"[^>]*>.*?<span[^>]*><span[^>]*>body<\/span>/)
   })
 
   it('renders an explicit SSR matrix for the lighter built-in node components', async () => {


### PR DESCRIPTION
## Summary

Fix Vue 3 structured HTML rendering so elements like `<details>` keep their semantic direct-child structure when Markstream renders nested nodes.
This removes `NodeRenderer` wrapper DOM before `<summary>`, preserving correct browser behavior and adding regression coverage for both client and SSR rendering.

## Changes

- [x] Add an internal fragment rendering mode to Vue 3 `NodeRenderer` for structured HTML children
- [x] Render structured `HtmlBlockNode` children without wrapper nodes so `<summary>` stays the first direct child of `<details>`
- [x] Add integration and SSR regression tests covering issue #397 and nested `details/summary` cases

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [x] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

Repro:
https://markstream-vue.simonhe.me/test#data=z:VVNNTxpRFN3Pr3iJa0pqt4TETdMmNWls07WjTgzhMzMQ08TFOAIigtIqiIoIqICNgjYqA8PHj_HdN29W_Qu9M1NJ2cy8d-85N-fec98c-RKXE6vxhCyG7KOkKILgJ3xyQvVfrNaj4z3zqE0H--xSZRfXcJVn55ppHLJqEiptoiBDDAci64Tqd6zchUKTZUuQbb-oW9bRCR3lWaZE9QbPaqbWf1E1QZibI5A55vW2ILx9Q8zbW6qr8KAJhBCPcx3k_l1fA_quHZhHsNEyjTunBPJZbSgIm-S9LIaljagcJJtkKZqIS_j_nJBjUQVPmPd4PBj574uxbwmJvMP7sjcuKfFlPFHd4PfbvFuEg_spZH4GAqkhdPpwVoXRTweyJImr8RkI77VZPc2qz9Dtm6mWg1qIrCdCojyDWxEVKRSISGSKs3v68HXxkyD41qS4GAgpfhyBT0mEw6L83Q8PRRiqZmUPh8U6Tw7U533N2siYH5oaq1bQOWsnZ54mXZNsEwbpP8OcpZ6CrvPuIyvvO3SyEoquBomXBCKOFKTwcd8s5uAqaRbSrLJrHXesRhlN83ljfsHnnQqzxVrFCQrhhZEgLIpy0F0EYu7f41pQPU-NFG9uuaUgX2S3dejkWPGR6b_ZxSHq4ZPyFEAWPhKoDNhJl-rYYZ6V7vhkBNkaaiLYYXAtuhEhkE7h_JHKdlVqXLsratWfrPMGO3uE7QOcDUZcg6ybsXXzzDMPKJ-OanDQRQoC7BaHJT7-Ab0mHbf4-BBS11jTTUFmh-Ubrve4wa7BuMFTE21BtokkJq5LSMO3AQWbjLNw9fGWBt0L6HVgqCEAMlfYjTtJfB-8dcmqBVxnrG4aSWo849mdBmbd3bFUzUrlHYwm_AU

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)

Closes #397
