### PR TITLE
fix: keep markdown after html comments

### DIFF
--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -145,6 +145,10 @@ function tokenToRaw(token: Token) {
   return String(shape.raw ?? shape.content ?? shape.markup ?? '')
 }
 
+function isNonElementHtmlBlock(content: string) {
+  return /^\s*<\s*[!?]/.test(content)
+}
+
 function buildCommonHtmlTagSet(extraTags?: readonly string[]) {
   const set = new Set(BASE_COMMON_HTML_TAGS)
   if (extraTags && Array.isArray(extraTags)) {
@@ -541,6 +545,9 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
 
       const rawContent = getHtmlBlockCarrierContent(t)
       if (rawContent) {
+        if (isNonElementHtmlBlock(rawContent))
+          continue
+
         // Support both opening (<tag ...>) and closing (</tag>) blocks.
         const tag = (rawContent.match(/<\s*(?:\/\s*)?([^\s>/]+)/)?.[1] ?? '').toLowerCase()
         const isClosingTag = /^\s*<\s*\//.test(rawContent)

--- a/packages/markdown-parser/test/html-block-parser.test.ts
+++ b/packages/markdown-parser/test/html-block-parser.test.ts
@@ -52,6 +52,33 @@ describe('html_block parser', () => {
     expect(c?.loading).toBe(false)
   })
 
+  it('does not let HTML comments absorb following Markdown blocks', () => {
+    const markdown = `<!-- 基础图片 -->
+![alt](https://example.com/a.png)
+
+## 标题
+
+---
+
+正文`
+
+    const md = getMarkdown('html-comment-followed-by-markdown')
+    const nodes = parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+
+    expect(nodes.map(node => node.type)).toEqual([
+      'html_block',
+      'paragraph',
+      'heading',
+      'thematic_break',
+      'paragraph',
+    ])
+    expect(String(nodes[0]?.raw ?? '').trim()).toBe('<!-- 基础图片 -->')
+    expect(nodes[1]?.children?.[0]?.type).toBe('image')
+    expect(nodes[1]?.children?.[0]?.src).toBe('https://example.com/a.png')
+    expect(nodes[2]?.text).toBe('标题')
+    expect(nodes[4]?.children?.[0]?.content).toBe('正文')
+  })
+
   it('keeps outer same-tag html blocks loading until the matching outer close arrives', () => {
     const md = getMarkdown()
     const nodes = parseMarkdownToStructure('<div>outer<div>inner</div>rest', md, { final: false })


### PR DESCRIPTION
## Summary
- prevent non-element HTML blocks such as comments from entering the custom/unknown HTML merge stack
- add a regression test for an HTML comment followed by image, heading, thematic break, and paragraph Markdown blocks

## Verification
- pnpm --filter stream-markdown-parser test:run test/html-block-parser.test.ts
- pnpm --filter stream-markdown-parser test:run
- pnpm --filter stream-markdown-parser typecheck
- pnpm run build:parser
- pnpm --filter stream-markdown-parser lint