### PR TITLE
fix: support pluggable code block language routing

### DIFF
--- a/docs/guide/component-overrides.md
+++ b/docs/guide/component-overrides.md
@@ -55,7 +55,7 @@ The single-argument form `setCustomComponents({ ... })` is still supported, but 
 |-----|------------------|-------|
 | `image` | `ImageNode` | Great first override for lightboxes, captions, or lazy-loading wrappers |
 | `link` | `LinkNode` | Useful for analytics, router links, or custom tooltip behavior |
-| `code_block` | Regular fenced code blocks | Does not replace `mermaid`, `d2`, or `infographic` blocks |
+| `code_block` | Regular fenced code blocks | Used as the generic fallback after exact language keys and the built-in `mermaid` / `d2` / `infographic` routes |
 | `mermaid` | Mermaid fenced blocks | Preferred over `code_block` when only Mermaid needs a custom renderer |
 | `d2` | D2 and `d2lang` fenced blocks | Same routing idea as Mermaid |
 | `infographic` | Infographic fenced blocks | Use when only infographic output changes |
@@ -109,6 +109,25 @@ setCustomComponents('docs', {
 ```
 
 This only changes regular fenced code blocks. Mermaid, D2, and infographic blocks still route to their specialized renderers unless you override `mermaid`, `d2`, or `infographic`.
+
+### Example: target one fenced language directly
+
+```ts twoslash
+import type { Component } from 'vue'
+import { setCustomComponents } from 'markstream-vue'
+
+declare const EChartsBlockNode: Component
+
+setCustomComponents('docs', {
+  echarts: EChartsBlockNode,
+})
+```
+
+This only catches fences whose language is `echarts`. The routing order for code blocks is:
+
+- exact language key such as `echarts`
+- built-in specialized routes such as `mermaid`, `d2`, and `infographic`
+- generic `code_block`
 
 ### Example: override Mermaid only
 

--- a/docs/zh/guide/component-overrides.md
+++ b/docs/zh/guide/component-overrides.md
@@ -55,7 +55,7 @@ const markdown = '![demo](https://example.com/demo.png)'
 |-----|-----------|------|
 | `image` | `ImageNode` | 最适合拿来做 lightbox、caption、懒加载封装 |
 | `link` | `LinkNode` | 适合埋点、路由跳转、自定义 tooltip |
-| `code_block` | 普通 fenced code block | 不会替换 `mermaid`、`d2`、`infographic` |
+| `code_block` | 普通 fenced code block | 作为通用兜底使用，优先级在精确语言 key 和内置 `mermaid` / `d2` / `infographic` 路由之后 |
 | `mermaid` | Mermaid fenced block | 只改 Mermaid 时优先用它，而不是改全部代码块 |
 | `d2` | D2 / `d2lang` fenced block | 与 Mermaid 同理 |
 | `infographic` | Infographic fenced block | 只影响 infographic 渲染 |
@@ -109,6 +109,25 @@ setCustomComponents('docs', {
 ```
 
 这只会影响普通代码块。Mermaid、D2 和 infographic 仍然会走各自的专用渲染器；如果你要覆盖它们，请分别使用 `mermaid`、`d2`、`infographic`。
+
+### 示例：只接管一种 fenced language
+
+```ts twoslash
+import type { Component } from 'vue'
+import { setCustomComponents } from 'markstream-vue'
+
+declare const EChartsBlockNode: Component
+
+setCustomComponents('docs', {
+  echarts: EChartsBlockNode,
+})
+```
+
+这只会命中 language 为 `echarts` 的 fence。代码块的路由优先级是：
+
+- 精确语言 key，比如 `echarts`
+- 内置专用路由，比如 `mermaid`、`d2`、`infographic`
+- 通用 `code_block`
 
 ### 示例：只覆盖 Mermaid
 

--- a/packages/markstream-angular/src/components/NodeOutlet/NodeOutlet.component.ts
+++ b/packages/markstream-angular/src/components/NodeOutlet/NodeOutlet.component.ts
@@ -40,6 +40,7 @@ import {
   coerceCustomHtmlNode,
   resolveHtmlTag,
   resolveNodeOutletCodeMode,
+  resolveNodeOutletCustomComponent,
   resolveNodeOutletCustomInputs,
 } from '../shared/node-outlet-helpers'
 import { StrikethroughNodeComponent } from '../StrikethroughNode/StrikethroughNode.component'
@@ -205,26 +206,7 @@ export class NodeOutletComponent {
   }
 
   get resolvedCustomComponent() {
-    const customComponents = this.customComponentMap
-    const direct = customComponents?.[this.resolvedType]
-    if (direct)
-      return direct
-
-    if (this.resolvedType === 'code_block') {
-      if (this.codeMode === 'mermaid' && customComponents?.mermaid)
-        return customComponents.mermaid
-      if (this.codeMode === 'd2' && customComponents?.d2)
-        return customComponents.d2
-      if (this.codeMode === 'infographic' && customComponents?.infographic)
-        return customComponents.infographic
-    }
-
-    const tag = this.htmlTag
-    // Check if there's a custom component for this tag before deciding to escape
-    if (tag && customComponents?.[tag])
-      return customComponents[tag]
-
-    return null
+    return resolveNodeOutletCustomComponent(this.node, this.context, this.customComponentMap)
   }
 
   get customNode() {

--- a/packages/markstream-angular/src/components/shared/node-outlet-helpers.ts
+++ b/packages/markstream-angular/src/components/shared/node-outlet-helpers.ts
@@ -63,3 +63,39 @@ export function resolveNodeOutletCustomInputs(
     return context?.infographicProps ?? null
   return context?.codeBlockProps ?? null
 }
+
+export function resolveNodeOutletCustomComponent(
+  node: AngularRenderableNode,
+  context?: AngularRenderContext,
+  customComponents?: Record<string, any> | null,
+) {
+  const mapping = customComponents ?? context?.customComponents ?? null
+  const resolvedType = String((node as any)?.type || '')
+
+  if (resolvedType === 'code_block') {
+    const language = resolveCodeBlockLanguage(node)
+    const customForLanguage = language ? mapping?.[language] : null
+    if (customForLanguage)
+      return customForLanguage
+
+    const codeMode = resolveNodeOutletCodeMode(node, context)
+    if (codeMode === 'mermaid' && mapping?.mermaid)
+      return mapping.mermaid
+    if (codeMode === 'd2' && mapping?.d2)
+      return mapping.d2
+    if (codeMode === 'infographic' && mapping?.infographic)
+      return mapping.infographic
+    if (mapping?.code_block)
+      return mapping.code_block
+  }
+
+  const direct = mapping?.[resolvedType]
+  if (direct)
+    return direct
+
+  const tag = resolveHtmlTag(node)
+  if (tag && mapping?.[tag])
+    return mapping[tag]
+
+  return null
+}

--- a/packages/markstream-react/README.md
+++ b/packages/markstream-react/README.md
@@ -74,6 +74,28 @@ Notes:
 - These props are forwarded to the built-in Mermaid / D2 / Infographic blocks and to custom `mermaid` / `d2` / `infographic` overrides registered with `setCustomComponents(...)`.
 - `viewportPriority` applies to those heavy nodes too, so offscreen graphs will not keep doing background work while the text stream is still updating.
 
+## Language-specific code block overrides
+
+You can register a custom component under a fenced language key without wrapping the generic `code_block` renderer:
+
+```tsx
+import type { NodeComponentProps } from 'markstream-react'
+import { setCustomComponents } from 'markstream-react'
+
+function EChartsBlockNode(props: NodeComponentProps<any>) {
+  return <div data-language={String(props.node?.language)}>{String(props.node?.code || '')}</div>
+}
+
+setCustomComponents('docs', {
+  echarts: EChartsBlockNode,
+})
+```
+
+Notes:
+- `echarts` only catches fences whose language is `echarts`.
+- Code block routing priority is exact language key -> built-in `mermaid` / `d2` / `infographic` routes -> `code_block`.
+- Custom `mermaid` / `d2` / `infographic` overrides keep their specialized top-level props; other custom language keys use the normal custom component contract (`node`, `ctx`, `renderNode`, and friends).
+
 ## Mermaid tuning
 
 Common `mermaidProps` keys for streaming scenarios:

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -45,15 +45,44 @@ import { resolveCustomHtmlTag } from '../utils/customHtmlTag'
 import { normalizeLanguageIdentifier } from '../utils/languageIcon'
 import { renderNodeChildren } from './renderChildren'
 
+function getRawCodeBlockLanguage(node: any) {
+  const trimmed = String(node?.language || '').trim()
+  if (!trimmed)
+    return ''
+  const [firstToken] = trimmed.split(/\s+/)
+  const [base] = firstToken.split(':')
+  return base.toLowerCase()
+}
+
+function renderCustomCodeBlockComponent(
+  component: any,
+  node: any,
+  key: React.Key,
+  ctx: RenderContext,
+) {
+  return React.createElement(component, {
+    key,
+    node,
+    customId: ctx.customId,
+    isDark: ctx.isDark,
+    ctx,
+    renderNode,
+    indexKey: key,
+    typewriter: ctx.typewriter,
+  })
+}
+
 function renderCodeBlock(
   node: any,
   key: React.Key,
   ctx: RenderContext,
   customComponents: Record<string, any>,
 ) {
-  const language = normalizeLanguageIdentifier(String(node.language || ''))
+  const rawLanguage = getRawCodeBlockLanguage(node)
+  const language = normalizeLanguageIdentifier(rawLanguage)
+  const customForLanguage = rawLanguage ? customComponents[rawLanguage] : null
   if (language === 'mermaid') {
-    const customMermaid = customComponents.mermaid
+    const customMermaid = customForLanguage || customComponents.mermaid
     if (customMermaid)
       return React.createElement(customMermaid as any, { key, node, isDark: ctx.isDark, ...(ctx.mermaidProps || {}) })
     if (!ctx.renderCodeBlocksAsPre) {
@@ -70,7 +99,7 @@ function renderCodeBlock(
   }
 
   if (language === 'infographic') {
-    const customInfographic = customComponents.infographic
+    const customInfographic = customForLanguage || customComponents.infographic
     if (customInfographic)
       return React.createElement(customInfographic as any, { key, node, isDark: ctx.isDark, ...(ctx.infographicProps || {}) })
 
@@ -86,7 +115,7 @@ function renderCodeBlock(
   }
 
   if (language === 'd2' || language === 'd2lang') {
-    const customD2 = customComponents.d2
+    const customD2 = customForLanguage || customComponents.d2
     if (customD2)
       return React.createElement(customD2 as any, { key, node, isDark: ctx.isDark, ...(ctx.d2Props || {}) })
 
@@ -100,6 +129,13 @@ function renderCodeBlock(
       />
     )
   }
+
+  if (customForLanguage)
+    return renderCustomCodeBlockComponent(customForLanguage, node, key, ctx)
+
+  const customCodeBlock = customComponents.code_block
+  if (customCodeBlock)
+    return renderCustomCodeBlockComponent(customCodeBlock, node, key, ctx)
 
   if (ctx.renderCodeBlocksAsPre || language === 'mermaid') {
     return <PreCodeNode key={key} node={node} />
@@ -124,7 +160,9 @@ function renderCodeBlock(
 
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
-  const custom = (customComponents as Record<string, any>)[node.type]
+  const custom = node.type === 'code_block'
+    ? null
+    : (customComponents as Record<string, any>)[node.type]
   if (custom) {
     return React.createElement(custom, {
       key,

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -145,9 +145,14 @@ function renderCodeBlock(
   ctx: RenderContext,
   customComponents: Record<string, any>,
 ) {
-  const language = normalizeLanguageIdentifier(String(node.language || ''))
+  const trimmedLanguage = String(node?.language || '').trim()
+  const rawLanguage = trimmedLanguage
+    ? String(trimmedLanguage.split(/\s+/)[0] ?? '').split(':')[0].toLowerCase()
+    : ''
+  const language = normalizeLanguageIdentifier(rawLanguage)
+  const customForLanguage = rawLanguage ? customComponents[rawLanguage] : null
   if (language === 'mermaid') {
-    const customMermaid = customComponents.mermaid
+    const customMermaid = customForLanguage || customComponents.mermaid
     if (customMermaid) {
       return React.createElement(customMermaid as any, {
         key,
@@ -168,7 +173,7 @@ function renderCodeBlock(
   }
 
   if (language === 'infographic') {
-    const customInfographic = customComponents.infographic
+    const customInfographic = customForLanguage || customComponents.infographic
     if (customInfographic) {
       return React.createElement(customInfographic as any, {
         key,
@@ -189,7 +194,7 @@ function renderCodeBlock(
   }
 
   if (language === 'd2' || language === 'd2lang') {
-    const customD2 = customComponents.d2
+    const customD2 = customForLanguage || customComponents.d2
     if (customD2) {
       return React.createElement(customD2 as any, {
         key,
@@ -207,6 +212,33 @@ function renderCodeBlock(
         {...(ctx.d2Props || {})}
       />
     )
+  }
+
+  if (customForLanguage) {
+    return React.createElement(customForLanguage as any, {
+      key,
+      node,
+      customId: ctx.customId,
+      isDark: ctx.isDark,
+      ctx,
+      renderNode,
+      indexKey: key,
+      typewriter: ctx.typewriter,
+    })
+  }
+
+  const customCodeBlock = customComponents.code_block
+  if (customCodeBlock) {
+    return React.createElement(customCodeBlock as any, {
+      key,
+      node,
+      customId: ctx.customId,
+      isDark: ctx.isDark,
+      ctx,
+      renderNode,
+      indexKey: key,
+      typewriter: ctx.typewriter,
+    })
   }
 
   if (ctx.renderCodeBlocksAsPre)
@@ -960,7 +992,9 @@ export function FallbackComponent(props: NodeComponentProps<{ type: string }>) {
 
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
-  const custom = (customComponents as Record<string, any>)[node.type]
+  const custom = node.type === 'code_block'
+    ? null
+    : (customComponents as Record<string, any>)[node.type]
   if (custom) {
     return React.createElement(custom, {
       key,

--- a/packages/markstream-vue2/README.md
+++ b/packages/markstream-vue2/README.md
@@ -178,6 +178,23 @@ Notes:
 - Use kebab-case in templates: `mermaid-props`, `d2-props`, `infographic-props`.
 - These props are forwarded to the built-in Mermaid / D2 / Infographic blocks and to custom `mermaid` / `d2` / `infographic` overrides registered with `setCustomComponents(...)`.
 
+## Language-specific code block overrides
+
+You can also register a renderer for one fenced language directly:
+
+```ts
+import { setCustomComponents } from 'markstream-vue2'
+
+setCustomComponents('docs', {
+  echarts: EChartsBlockNode,
+})
+```
+
+Notes:
+- `echarts` only catches fences whose language is `echarts`.
+- Code block routing priority is exact language key -> built-in `mermaid` / `d2` / `infographic` routes -> `code_block`.
+- `mermaid`, `d2`, and `infographic` overrides keep their specialized prop forwarding; other language keys receive the normal code-block-level bindings.
+
 ## Mermaid tuning
 
 Common `mermaid-props` keys for streaming scenarios:

--- a/packages/markstream-vue2/src/components/NodeRenderer/LegacyNodesRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/LegacyNodesRenderer.vue
@@ -211,6 +211,10 @@ function getNodeComponent(node: ParsedNode, language?: string) {
   const customForType = (customComponents as any)[String((node as any).type)]
   if (node.type === 'code_block') {
     const lang = language ?? getCodeBlockLanguage(node)
+    const customForLanguage = lang ? (customComponents as any)[lang] : undefined
+    if (customForLanguage)
+      return customForLanguage
+
     if (lang === 'mermaid') {
       const customMermaid = (customComponents as any).mermaid
       return customMermaid || PreCodeNode

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -1848,6 +1848,10 @@ function getNodeComponent(node: ParsedNode, language?: string) {
   const customForType = (customComponents as any)[String((node as any).type)]
   if (node.type === 'code_block') {
     const lang = language ?? getCodeBlockLanguage(node)
+    const customForLanguage = lang ? (customComponents as any)[lang] : undefined
+    if (customForLanguage)
+      return customForLanguage
+
     // Keep Mermaid blocks routed to MermaidBlockNode unless a specific
     // `mermaid` override is provided.
     if (lang === 'mermaid') {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -2180,6 +2180,10 @@ function getNodeComponent(node: ParsedNode, language?: string) {
   const customForType = customComponents[String(node.type)]
   if (node.type === 'code_block') {
     const lang = language ?? getCodeBlockLanguage(node)
+    const customForLanguage = lang ? customComponents[lang] : undefined
+    if (customForLanguage)
+      return customForLanguage
+
     // Keep Mermaid blocks routed to MermaidBlockNode unless a specific
     // `mermaid` override is provided.
     if (lang === 'mermaid') {

--- a/test/markstream-angular-node-outlet.test.ts
+++ b/test/markstream-angular-node-outlet.test.ts
@@ -4,8 +4,15 @@ import {
   coerceBuiltinHtmlNode,
   coerceCustomHtmlNode,
   resolveNodeOutletCodeMode,
+  resolveNodeOutletCustomComponent,
   resolveNodeOutletCustomInputs,
 } from '../packages/markstream-angular/src/components/shared/node-outlet-helpers'
+
+class ExactLanguageComponent {}
+class GenericCodeBlockComponent {}
+class MermaidComponent {}
+class D2Component {}
+class D2LangComponent {}
 
 describe('markstream-angular NodeOutlet', () => {
   it('coerces custom html tags into tag-typed nodes for custom components', () => {
@@ -79,5 +86,70 @@ describe('markstream-angular NodeOutlet', () => {
     } as any
     expect(resolveNodeOutletCodeMode(node, context as any)).toBe('code')
     expect(resolveNodeOutletCustomInputs(node, context as any)).toEqual({ showHeader: false })
+  })
+
+  it('prefers exact language custom components over code_block fallback', () => {
+    const context = {
+      customComponents: {
+        echarts: ExactLanguageComponent as any,
+        code_block: GenericCodeBlockComponent as any,
+      },
+      codeBlockProps: { showHeader: false },
+      events: {},
+    } as any
+
+    let node = {
+      type: 'code_block',
+      language: 'echarts',
+      code: 'option = {}',
+    } as any
+    expect(resolveNodeOutletCustomComponent(node, context)).toBe(ExactLanguageComponent)
+    expect(resolveNodeOutletCustomInputs(node, context)).toEqual({ showHeader: false })
+
+    node = {
+      type: 'code_block',
+      language: 'ts',
+      code: 'const value = 1',
+    } as any
+    expect(resolveNodeOutletCustomComponent(node, context)).toBe(GenericCodeBlockComponent)
+    expect(resolveNodeOutletCustomInputs(node, context)).toEqual({ showHeader: false })
+  })
+
+  it('keeps specialized mermaid routing ahead of code_block fallback', () => {
+    const context = {
+      customComponents: {
+        mermaid: MermaidComponent as any,
+        code_block: GenericCodeBlockComponent as any,
+      },
+      mermaidProps: { renderDebounceMs: 180 },
+      events: {},
+    } as any
+    const node = {
+      type: 'code_block',
+      language: 'mermaid',
+      code: 'graph TD\nA-->B\n',
+    } as any
+
+    expect(resolveNodeOutletCustomComponent(node, context)).toBe(MermaidComponent)
+    expect(resolveNodeOutletCustomInputs(node, context)).toEqual({ renderDebounceMs: 180 })
+  })
+
+  it('lets d2lang exact overrides beat d2 fallback while keeping d2 inputs', () => {
+    const context = {
+      customComponents: {
+        d2: D2Component as any,
+        d2lang: D2LangComponent as any,
+      },
+      d2Props: { themeId: 7 },
+      events: {},
+    } as any
+    const node = {
+      type: 'code_block',
+      language: 'd2lang',
+      code: 'a -> b',
+    } as any
+
+    expect(resolveNodeOutletCustomComponent(node, context)).toBe(D2LangComponent)
+    expect(resolveNodeOutletCustomInputs(node, context)).toEqual({ themeId: 7 })
   })
 })

--- a/test/node-renderer-heavy-node-props.test.ts
+++ b/test/node-renderer-heavy-node-props.test.ts
@@ -1,10 +1,152 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
 import MermaidBlockNode from '../src/components/MermaidBlockNode'
 import NodeRenderer from '../src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
 import { flushAll } from './setup/flush-all'
 
+const customId = 'vue3-heavy-props-test'
+
+const ExactLanguageProbe = defineComponent({
+  name: 'ExactLanguageProbe',
+  props: {
+    node: { type: Object, required: true },
+    showHeader: Boolean,
+    stream: Boolean,
+  },
+  setup(props) {
+    return () => h('div', {
+      'class': 'exact-language-probe',
+      'data-language': String((props.node as any)?.language ?? ''),
+      'data-show-header': String(props.showHeader),
+      'data-stream': String(props.stream),
+    })
+  },
+})
+
+const GenericCodeBlockProbe = defineComponent({
+  name: 'GenericCodeBlockProbe',
+  props: {
+    node: { type: Object, required: true },
+    showHeader: Boolean,
+  },
+  setup(props) {
+    return () => h('div', {
+      'class': 'generic-code-block-probe',
+      'data-language': String((props.node as any)?.language ?? ''),
+      'data-show-header': String(props.showHeader),
+    })
+  },
+})
+
+const CustomD2Probe = defineComponent({
+  name: 'CustomD2Probe',
+  props: {
+    node: { type: Object, required: true },
+    themeId: Number,
+  },
+  setup(props) {
+    return () => h('div', {
+      'class': 'custom-d2-probe',
+      'data-language': String((props.node as any)?.language ?? ''),
+      'data-theme-id': String(props.themeId),
+    })
+  },
+})
+
+const CustomD2LangProbe = defineComponent({
+  name: 'CustomD2LangProbe',
+  props: {
+    node: { type: Object, required: true },
+    themeId: Number,
+  },
+  setup(props) {
+    return () => h('div', {
+      'class': 'custom-d2lang-probe',
+      'data-language': String((props.node as any)?.language ?? ''),
+      'data-theme-id': String(props.themeId),
+    })
+  },
+})
+
+afterEach(() => {
+  removeCustomComponents(customId)
+})
+
 describe('nodeRenderer heavy-node prop forwarding', () => {
+  it('prefers exact language overrides over code_block fallback for custom languages', async () => {
+    setCustomComponents(customId, {
+      echarts: ExactLanguageProbe,
+      code_block: GenericCodeBlockProbe,
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        codeBlockStream: false,
+        codeBlockProps: {
+          showHeader: false,
+        },
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'echarts',
+            code: 'option = {}',
+            raw: '```echarts\noption = {}\n```',
+          },
+          {
+            type: 'code_block',
+            language: 'ts',
+            code: 'export const value = 1',
+            raw: '```ts\nexport const value = 1\n```',
+          },
+        ],
+      },
+    })
+
+    await flushAll()
+
+    const exact = wrapper.get('.exact-language-probe')
+    const generic = wrapper.get('.generic-code-block-probe')
+    expect(exact.attributes('data-language')).toBe('echarts')
+    expect(exact.attributes('data-show-header')).toBe('false')
+    expect(exact.attributes('data-stream')).toBe('false')
+    expect(generic.attributes('data-language')).toBe('ts')
+    expect(generic.attributes('data-show-header')).toBe('false')
+  })
+
+  it('lets d2lang exact overrides beat d2 fallback while keeping d2 props', async () => {
+    setCustomComponents(customId, {
+      d2: CustomD2Probe,
+      d2lang: CustomD2LangProbe,
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        d2Props: {
+          themeId: 7,
+        },
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'd2lang',
+            code: 'a -> b',
+            raw: '```d2lang\na -> b\n```',
+          },
+        ],
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.find('.custom-d2-probe').exists()).toBe(false)
+    const exact = wrapper.get('.custom-d2lang-probe')
+    expect(exact.attributes('data-language')).toBe('d2lang')
+    expect(exact.attributes('data-theme-id')).toBe('7')
+  })
+
   it('forwards mermaidProps to MermaidBlockNode', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/react-render-node-heavy-props.test.ts
+++ b/test/react-render-node-heavy-props.test.ts
@@ -16,6 +16,26 @@ const packageRequire = createRequire(new URL('../packages/markstream-react/packa
 const React = packageRequire('react') as typeof import('react')
 const { renderToStaticMarkup } = packageRequire('react-dom/server') as typeof import('react-dom/server')
 
+function ExactLanguageProbe() {
+  return null
+}
+
+function GenericCodeBlockProbe() {
+  return null
+}
+
+function CustomMermaidProbe() {
+  return null
+}
+
+function CustomD2Probe() {
+  return null
+}
+
+function CustomD2LangProbe() {
+  return null
+}
+
 describe('markstream-react heavy-node prop forwarding', () => {
   const baseCtx: RenderContext = {
     customId: 'react-heavy-props-test',
@@ -52,6 +72,170 @@ describe('markstream-react heavy-node prop forwarding', () => {
 
     expect(element?.props?.showHeader).toBe(false)
     expect(element?.props?.renderDebounceMs).toBe(180)
+  })
+
+  it('prefers exact language overrides over code_block fallback on the client renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      codeBlockProps: {
+        showHeader: false,
+      },
+      customComponents: {
+        echarts: ExactLanguageProbe,
+        code_block: GenericCodeBlockProbe,
+      },
+    }
+
+    const exactElement = clientRenderNode({
+      type: 'code_block',
+      language: 'echarts',
+      code: 'option = {}',
+      raw: '```echarts\noption = {}\n```',
+    } as any, 'echarts-client', ctx) as any
+
+    const genericElement = clientRenderNode({
+      type: 'code_block',
+      language: 'ts',
+      code: 'export const value = 1',
+      raw: '```ts\nexport const value = 1\n```',
+    } as any, 'ts-client', ctx) as any
+
+    expect(exactElement?.type).toBe(ExactLanguageProbe)
+    expect(exactElement?.props?.node?.language).toBe('echarts')
+    expect(exactElement?.props?.ctx?.codeBlockProps).toEqual({ showHeader: false })
+    expect(genericElement?.type).toBe(GenericCodeBlockProbe)
+    expect(genericElement?.props?.node?.language).toBe('ts')
+    expect(genericElement?.props?.ctx?.codeBlockProps).toEqual({ showHeader: false })
+  })
+
+  it('keeps specialized mermaid routing ahead of code_block fallback on the client renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      mermaidProps: {
+        showHeader: false,
+        renderDebounceMs: 180,
+      },
+      customComponents: {
+        mermaid: CustomMermaidProbe,
+        code_block: GenericCodeBlockProbe,
+      },
+    }
+
+    const element = clientRenderNode({
+      type: 'code_block',
+      language: 'mermaid',
+      code: 'graph LR\nA-->B\n',
+      raw: '```mermaid\ngraph LR\nA-->B\n```',
+    } as any, 'mermaid-client-priority', ctx) as any
+
+    expect(element?.type).toBe(CustomMermaidProbe)
+    expect(element?.props?.showHeader).toBe(false)
+    expect(element?.props?.renderDebounceMs).toBe(180)
+  })
+
+  it('lets d2lang exact overrides beat d2 fallback on the client renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      d2Props: {
+        themeId: 7,
+      },
+      customComponents: {
+        d2: CustomD2Probe,
+        d2lang: CustomD2LangProbe,
+      },
+    }
+
+    const element = clientRenderNode({
+      type: 'code_block',
+      language: 'd2lang',
+      code: 'a -> b',
+      raw: '```d2lang\na -> b\n```',
+    } as any, 'd2lang-client', ctx) as any
+
+    expect(element?.type).toBe(CustomD2LangProbe)
+    expect(element?.props?.themeId).toBe(7)
+  })
+
+  it('prefers exact language overrides over code_block fallback on the server renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      codeBlockProps: {
+        showHeader: false,
+      },
+      customComponents: {
+        echarts: ExactLanguageProbe,
+        code_block: GenericCodeBlockProbe,
+      },
+    }
+
+    const exactElement = serverRenderNode({
+      type: 'code_block',
+      language: 'echarts',
+      code: 'option = {}',
+      raw: '```echarts\noption = {}\n```',
+    } as any, 'echarts-server', ctx) as any
+
+    const genericElement = serverRenderNode({
+      type: 'code_block',
+      language: 'ts',
+      code: 'export const value = 1',
+      raw: '```ts\nexport const value = 1\n```',
+    } as any, 'ts-server', ctx) as any
+
+    expect(exactElement?.type).toBe(ExactLanguageProbe)
+    expect(exactElement?.props?.node?.language).toBe('echarts')
+    expect(exactElement?.props?.ctx?.codeBlockProps).toEqual({ showHeader: false })
+    expect(genericElement?.type).toBe(GenericCodeBlockProbe)
+    expect(genericElement?.props?.node?.language).toBe('ts')
+    expect(genericElement?.props?.ctx?.codeBlockProps).toEqual({ showHeader: false })
+  })
+
+  it('keeps specialized mermaid routing ahead of code_block fallback on the server renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      mermaidProps: {
+        showHeader: false,
+        renderDebounceMs: 180,
+      },
+      customComponents: {
+        mermaid: CustomMermaidProbe,
+        code_block: GenericCodeBlockProbe,
+      },
+    }
+
+    const element = serverRenderNode({
+      type: 'code_block',
+      language: 'mermaid',
+      code: 'graph LR\nA-->B\n',
+      raw: '```mermaid\ngraph LR\nA-->B\n```',
+    } as any, 'mermaid-server-priority', ctx) as any
+
+    expect(element?.type).toBe(CustomMermaidProbe)
+    expect(element?.props?.showHeader).toBe(false)
+    expect(element?.props?.renderDebounceMs).toBe(180)
+  })
+
+  it('lets d2lang exact overrides beat d2 fallback on the server renderer', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      d2Props: {
+        themeId: 7,
+      },
+      customComponents: {
+        d2: CustomD2Probe,
+        d2lang: CustomD2LangProbe,
+      },
+    }
+
+    const element = serverRenderNode({
+      type: 'code_block',
+      language: 'd2lang',
+      code: 'a -> b',
+      raw: '```d2lang\na -> b\n```',
+    } as any, 'd2lang-server', ctx) as any
+
+    expect(element?.type).toBe(CustomD2LangProbe)
+    expect(element?.props?.themeId).toBe(7)
   })
 
   it('sanitizes dangerous attrs on the client structured html wrapper path', () => {

--- a/test/vue2-node-renderer-heavy-node-props.test.ts
+++ b/test/vue2-node-renderer-heavy-node-props.test.ts
@@ -26,9 +26,139 @@ const CustomMermaidProbe = defineComponent({
   },
 })
 
+const ExactLanguageProbe = defineComponent({
+  name: 'ExactLanguageProbe',
+  props: {
+    node: { type: Object, required: true },
+    showHeader: Boolean,
+  },
+  render() {
+    return h('div', {
+      'class': 'exact-language-probe',
+      'data-language': String((this as any).node?.language ?? ''),
+      'data-show-header': String((this as any).showHeader),
+    })
+  },
+})
+
+const GenericCodeBlockProbe = defineComponent({
+  name: 'GenericCodeBlockProbe',
+  props: {
+    node: { type: Object, required: true },
+    showHeader: Boolean,
+  },
+  render() {
+    return h('div', {
+      'class': 'generic-code-block-probe',
+      'data-language': String((this as any).node?.language ?? ''),
+      'data-show-header': String((this as any).showHeader),
+    })
+  },
+})
+
+const CustomD2Probe = defineComponent({
+  name: 'CustomD2Probe',
+  props: {
+    node: { type: Object, required: true },
+    themeId: Number,
+  },
+  render() {
+    return h('div', {
+      'class': 'custom-d2-probe',
+      'data-language': String((this as any).node?.language ?? ''),
+      'data-theme-id': String((this as any).themeId),
+    })
+  },
+})
+
+const CustomD2LangProbe = defineComponent({
+  name: 'CustomD2LangProbe',
+  props: {
+    node: { type: Object, required: true },
+    themeId: Number,
+  },
+  render() {
+    return h('div', {
+      'class': 'custom-d2lang-probe',
+      'data-language': String((this as any).node?.language ?? ''),
+      'data-theme-id': String((this as any).themeId),
+    })
+  },
+})
+
 describe('markstream-vue2 heavy-node prop forwarding', () => {
   afterEach(() => {
     removeCustomComponents(customId)
+  })
+
+  it('prefers exact language overrides over code_block fallback for custom languages', async () => {
+    setCustomComponents(customId, {
+      echarts: ExactLanguageProbe as any,
+      code_block: GenericCodeBlockProbe as any,
+    })
+
+    const wrapper = mount(NodeRenderer as any, {
+      props: {
+        customId,
+        codeBlockProps: {
+          showHeader: false,
+        },
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'echarts',
+            code: 'option = {}',
+            raw: '```echarts\noption = {}\n```',
+          },
+          {
+            type: 'code_block',
+            language: 'ts',
+            code: 'export const value = 1',
+            raw: '```ts\nexport const value = 1\n```',
+          },
+        ],
+      },
+    })
+
+    await flushAll()
+
+    const exact = wrapper.get('.exact-language-probe')
+    const generic = wrapper.get('.generic-code-block-probe')
+    expect(exact.attributes('data-language')).toBe('echarts')
+    expect(exact.attributes('data-show-header')).toBe('false')
+    expect(generic.attributes('data-language')).toBe('ts')
+    expect(generic.attributes('data-show-header')).toBe('false')
+  })
+
+  it('lets d2lang exact overrides beat d2 fallback while keeping d2 props', async () => {
+    setCustomComponents(customId, {
+      d2: CustomD2Probe as any,
+      d2lang: CustomD2LangProbe as any,
+    })
+
+    const wrapper = mount(NodeRenderer as any, {
+      props: {
+        customId,
+        d2Props: {
+          themeId: 7,
+        },
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'd2lang',
+            code: 'a -> b',
+            raw: '```d2lang\na -> b\n```',
+          },
+        ],
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.find('.custom-d2-probe').exists()).toBe(false)
+    const exact = wrapper.get('.custom-d2lang-probe')
+    expect(exact.attributes('data-language')).toBe('d2lang')
+    expect(exact.attributes('data-theme-id')).toBe('7')
   })
 
   it('forwards mermaidProps to custom mermaid renderers', async () => {


### PR DESCRIPTION
Closes #399

## Summary

This change makes code block language routing pluggable across Vue 3, Vue 2, React, and Angular.
Consumers can now register `setCustomComponents(scope, { echarts: Comp })` to override one fenced language directly, without wrapping the generic `code_block` renderer.
Existing `mermaid` / `d2` / `infographic` specialized behavior and prop forwarding remain unchanged.

## Changes

- [x] Added exact language-based code block routing across Vue 3, Vue 2, React, and Angular
- [x] Preserved routing priority: exact language key -> built-in `mermaid` / `d2` / `infographic` -> `code_block` -> default renderer
- [x] Kept specialized prop forwarding for `mermaid`, `d2`, and `infographic`
- [x] Added regression tests covering exact language overrides, `code_block` fallback behavior, and `d2lang` priority
- [x] Updated docs / READMEs to document language-specific code block overrides

 
## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)
