### PR TITLE
fix: prevent filename-like text from being auto-linkified

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -262,12 +262,6 @@ function isWordOnly(text: string) {
   return WORD_ONLY_RE.test(text)
 }
 
-function getTrailingTextChar(token: MarkdownToken | undefined) {
-  if (token?.type !== 'text' || typeof token.content !== 'string' || !token.content)
-    return ''
-  return token.content[token.content.length - 1] ?? ''
-}
-
 function getAsteriskRunInfo(content: string, start: number) {
   let end = start
   while (end < content.length && content[end] === '*')
@@ -1312,15 +1306,13 @@ export function parseInlineTokens(
 
     // mirror logic previously in the switch-case for 'link_open'
     resetCurrentTextNode()
-    const previousVisibleChar = getTrailingTextChar(tokens[i - 1])
-
     // 直接使用 parseLinkToken 来解析链接及其子节点，这能正确处理包含 code_inline 等复杂内容的链接
     const { node, nextIndex } = parseLinkToken(tokens, i, options as any)
     i = nextIndex
 
     if (
       token.markup === 'linkify'
-      && shouldDemoteFilenameLikeLinkify(node.text || node.href || '', previousVisibleChar)
+      && shouldDemoteFilenameLikeLinkify(node.text || node.href || '')
     ) {
       pushText(node.text || node.href || '', node.text || node.href || '')
       return

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,5 +1,6 @@
 import type { MarkdownIt } from 'markdown-it-ts'
 import type { MarkdownToken, ParsedNode, ParseOptions, TextNode } from '../../types'
+import { shouldDemoteFilenameLikeLinkify } from '../linkifyHeuristics'
 import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
@@ -259,6 +260,12 @@ function isWordOnly(text: string) {
   if (!text)
     return false
   return WORD_ONLY_RE.test(text)
+}
+
+function getTrailingTextChar(token: MarkdownToken | undefined) {
+  if (token?.type !== 'text' || typeof token.content !== 'string' || !token.content)
+    return ''
+  return token.content[token.content.length - 1] ?? ''
 }
 
 function getAsteriskRunInfo(content: string, start: number) {
@@ -1305,10 +1312,19 @@ export function parseInlineTokens(
 
     // mirror logic previously in the switch-case for 'link_open'
     resetCurrentTextNode()
+    const previousVisibleChar = getTrailingTextChar(tokens[i - 1])
 
     // 直接使用 parseLinkToken 来解析链接及其子节点，这能正确处理包含 code_inline 等复杂内容的链接
     const { node, nextIndex } = parseLinkToken(tokens, i, options as any)
     i = nextIndex
+
+    if (
+      token.markup === 'linkify'
+      && shouldDemoteFilenameLikeLinkify(node.text || node.href || '', previousVisibleChar)
+    ) {
+      pushText(node.text || node.href || '', node.text || node.href || '')
+      return
+    }
 
     const hasSingleTextChild = node.children.length === 1 && node.children[0]?.type === 'text'
     if (node.loading && raw && node.text === node.href && hasSingleTextChild) {

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -3,9 +3,17 @@ const FILENAMEISH_SEGMENT_RE = /[_()[\]{}<>]/u
 const URL_PREFIX_HINT_RE = /^(?:https?:\/\/|ftp:\/\/|mailto:|www\.)/i
 const URL_QUERY_OR_AUTH_HINT_RE = /[?#@]/u
 const PATH_SEPARATOR_RE = /[\\/]/u
-const ASCII_DOMAIN_CHARS_RE = /^[A-Za-z0-9./\\-]+$/
+const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
+const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
+  'ai',
+  'md',
+  'py',
+  'rs',
+  'sh',
+  'zip',
+])
 const FILENAMEISH_LINK_EXTENSIONS = new Set([
   '7z',
   'ai',
@@ -74,14 +82,6 @@ const FILENAMEISH_LINK_EXTENSIONS = new Set([
   'zsh',
 ])
 
-function hasNonAsciiChar(text: string) {
-  for (const char of text) {
-    if ((char.codePointAt(0) ?? 0) > 0x7F)
-      return true
-  }
-  return false
-}
-
 function isPlausibleBareDomain(text: string) {
   const labels = text.split('.')
   if (labels.length < 2)
@@ -105,10 +105,10 @@ function isUppercaseFilenameSegment(segment: string) {
 }
 
 function hasStrongFilenameSignals(linkText: string) {
-  if (hasNonAsciiChar(linkText) || FILENAMEISH_SEGMENT_RE.test(linkText))
+  if (FILENAMEISH_SEGMENT_RE.test(linkText))
     return true
 
-  if (!ASCII_DOMAIN_CHARS_RE.test(linkText))
+  if (!DOMAINISH_TEXT_RE.test(linkText))
     return true
 
   if (PATH_SEPARATOR_RE.test(linkText))
@@ -130,6 +130,13 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string) {
   const extension = String(extensionMatch[1] ?? '').toLowerCase()
   if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
     return false
+
+  // Extensions like `.ai` and `.md` can be both real bare-domain TLDs and
+  // common filenames. Keep those linkified unless we also see stronger
+  // filename-only signals such as path separators, underscores, brackets, or
+  // all-uppercase filename segments like `README`.
+  if (!AMBIGUOUS_BARE_DOMAIN_EXTENSIONS.has(extension))
+    return true
 
   return hasStrongFilenameSignals(linkText)
 }

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -1,0 +1,103 @@
+const WORD_LIKE_CHAR_RE = /[\p{L}\p{N}]/u
+const FILENAMEISH_EXTENSION_RE = /\.([a-z0-9]{1,10})$/i
+const FILENAMEISH_SIGNAL_RE = /[A-Z_()[\]{}<>]/u
+const URL_PREFIX_HINT_RE = /^(?:https?:\/\/|ftp:\/\/|mailto:|www\.)/i
+const URL_PATH_HINT_RE = /[/?#@]/u
+const FILENAMEISH_LINK_EXTENSIONS = new Set([
+  '7z',
+  'ai',
+  'astro',
+  'avi',
+  'bash',
+  'bz2',
+  'c',
+  'cjs',
+  'cpp',
+  'cs',
+  'csv',
+  'doc',
+  'docx',
+  'fish',
+  'flac',
+  'gif',
+  'go',
+  'gz',
+  'h',
+  'hpp',
+  'html',
+  'java',
+  'jpeg',
+  'jpg',
+  'js',
+  'json',
+  'jsx',
+  'kt',
+  'md',
+  'mdx',
+  'mjs',
+  'mov',
+  'mp3',
+  'mp4',
+  'pdf',
+  'php',
+  'png',
+  'ppt',
+  'pptx',
+  'ps1',
+  'py',
+  'rar',
+  'rb',
+  'rs',
+  'sh',
+  'sql',
+  'svg',
+  'swift',
+  'svelte',
+  'tar',
+  'tgz',
+  'toml',
+  'ts',
+  'tsx',
+  'txt',
+  'vue',
+  'wav',
+  'webp',
+  'xls',
+  'xlsx',
+  'xml',
+  'yaml',
+  'yml',
+  'zip',
+  'zsh',
+])
+
+function isWordLikeChar(ch?: string) {
+  return !!ch && WORD_LIKE_CHAR_RE.test(ch)
+}
+
+function hasNonAsciiChar(text: string) {
+  for (const char of text) {
+    if ((char.codePointAt(0) ?? 0) > 0x7F)
+      return true
+  }
+  return false
+}
+
+export function shouldDemoteFilenameLikeLinkify(linkText: string, previousVisibleChar = '') {
+  if (!linkText || URL_PREFIX_HINT_RE.test(linkText) || URL_PATH_HINT_RE.test(linkText))
+    return false
+
+  const extensionMatch = linkText.match(FILENAMEISH_EXTENSION_RE)
+  if (!extensionMatch)
+    return false
+
+  const extension = String(extensionMatch[1] ?? '').toLowerCase()
+  if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
+    return false
+
+  return (
+    isWordLikeChar(previousVisibleChar)
+    || hasNonAsciiChar(linkText)
+    || FILENAMEISH_SIGNAL_RE.test(linkText)
+  )
+}

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -1,8 +1,11 @@
-const WORD_LIKE_CHAR_RE = /[\p{L}\p{N}]/u
 const FILENAMEISH_EXTENSION_RE = /\.([a-z0-9]{1,10})$/i
-const FILENAMEISH_SIGNAL_RE = /[A-Z_()[\]{}<>]/u
+const FILENAMEISH_SEGMENT_RE = /[_()[\]{}<>]/u
 const URL_PREFIX_HINT_RE = /^(?:https?:\/\/|ftp:\/\/|mailto:|www\.)/i
-const URL_PATH_HINT_RE = /[/?#@]/u
+const URL_QUERY_OR_AUTH_HINT_RE = /[?#@]/u
+const PATH_SEPARATOR_RE = /[\\/]/u
+const ASCII_DOMAIN_CHARS_RE = /^[A-Za-z0-9./\\-]+$/
+const DOMAIN_LABEL_RE = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/u
+const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
 const FILENAMEISH_LINK_EXTENSIONS = new Set([
   '7z',
   'ai',
@@ -71,10 +74,6 @@ const FILENAMEISH_LINK_EXTENSIONS = new Set([
   'zsh',
 ])
 
-function isWordLikeChar(ch?: string) {
-  return !!ch && WORD_LIKE_CHAR_RE.test(ch)
-}
-
 function hasNonAsciiChar(text: string) {
   for (const char of text) {
     if ((char.codePointAt(0) ?? 0) > 0x7F)
@@ -83,8 +82,45 @@ function hasNonAsciiChar(text: string) {
   return false
 }
 
-export function shouldDemoteFilenameLikeLinkify(linkText: string, previousVisibleChar = '') {
-  if (!linkText || URL_PREFIX_HINT_RE.test(linkText) || URL_PATH_HINT_RE.test(linkText))
+function isPlausibleBareDomain(text: string) {
+  const labels = text.split('.')
+  if (labels.length < 2)
+    return false
+
+  const tld = labels[labels.length - 1]?.toLowerCase() ?? ''
+  if (!(DOMAIN_LABEL_RE.test(tld) || PUNYCODE_TLD_RE.test(tld)))
+    return false
+
+  return labels.every(label => DOMAIN_LABEL_RE.test(label))
+}
+
+function hasDomainAuthorityPrefix(text: string) {
+  const prefix = text.split(/[\\/]/)[0] ?? ''
+  return isPlausibleBareDomain(prefix)
+}
+
+function isUppercaseFilenameSegment(segment: string) {
+  const lettersOnly = segment.replace(/[^A-Za-z]/g, '')
+  return lettersOnly.length >= 2 && lettersOnly === lettersOnly.toUpperCase()
+}
+
+function hasStrongFilenameSignals(linkText: string) {
+  if (hasNonAsciiChar(linkText) || FILENAMEISH_SEGMENT_RE.test(linkText))
+    return true
+
+  if (!ASCII_DOMAIN_CHARS_RE.test(linkText))
+    return true
+
+  if (PATH_SEPARATOR_RE.test(linkText))
+    return !hasDomainAuthorityPrefix(linkText)
+
+  const extensionless = linkText.replace(FILENAMEISH_EXTENSION_RE, '')
+  const filenameLikeSegments = extensionless.split('.').filter(Boolean)
+  return filenameLikeSegments.some(isUppercaseFilenameSegment)
+}
+
+export function shouldDemoteFilenameLikeLinkify(linkText: string) {
+  if (!linkText || URL_PREFIX_HINT_RE.test(linkText) || URL_QUERY_OR_AUTH_HINT_RE.test(linkText))
     return false
 
   const extensionMatch = linkText.match(FILENAMEISH_EXTENSION_RE)
@@ -95,9 +131,5 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string, previousVisibl
   if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
     return false
 
-  return (
-    isWordLikeChar(previousVisibleChar)
-    || hasNonAsciiChar(linkText)
-    || FILENAMEISH_SIGNAL_RE.test(linkText)
-  )
+  return hasStrongFilenameSignals(linkText)
 }

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -100,7 +100,7 @@ function hasDomainAuthorityPrefix(text: string) {
 }
 
 function isUppercaseFilenameSegment(segment: string) {
-  const lettersOnly = segment.replace(/[^A-Za-z]/g, '')
+  const lettersOnly = segment.replace(/[^a-z]/gi, '')
   return lettersOnly.length >= 2 && lettersOnly === lettersOnly.toUpperCase()
 }
 

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -1,5 +1,6 @@
 import type { MarkdownIt } from 'markdown-it-ts'
 import type { MarkdownToken } from '../types'
+import { shouldDemoteFilenameLikeLinkify } from '../parser/linkifyHeuristics'
 
 // We hard-stop FULLWIDTH exclamation mark used as CJK punctuation.
 // ASCII `!` is valid in URLs (path/query/fragment), so do not stop on it.
@@ -108,6 +109,23 @@ function setHrefOnLinkOpen(token: any, href: string) {
     token.attrs.push(['href', href])
 }
 
+function getTrailingTextChar(token: MarkdownToken | undefined) {
+  if (token?.type !== 'text' || typeof token.content !== 'string' || !token.content)
+    return ''
+  return token.content[token.content.length - 1] ?? ''
+}
+
+function collectLinkifyText(tokens: MarkdownToken[], openIndex: number, closeIndex: number) {
+  let text = ''
+  for (let index = openIndex + 1; index < closeIndex; index++) {
+    const token = tokens[index]
+    if (token?.type !== 'text' || typeof token.content !== 'string')
+      return null
+    text += token.content
+  }
+  return text || null
+}
+
 export function applyFixLinkTokens(md: MarkdownIt) {
   // Run after the inline rule so markdown-it has produced inline tokens
   // for block-level tokens; we then adjust each inline token's children
@@ -162,6 +180,16 @@ function fixLinkToken(tokens: MarkdownToken[]): MarkdownToken[] {
         }
       }
       if (closeIdx !== -1) {
+        const linkText = collectLinkifyText(tokens, i, closeIdx)
+        if (
+          curToken.markup === 'linkify'
+          && linkText
+          && shouldDemoteFilenameLikeLinkify(linkText, getTrailingTextChar(tokens[i - 1]))
+        ) {
+          tokens.splice(i, closeIdx - i + 1, textToken(linkText) as any)
+          continue
+        }
+
         const href = getHrefFromLinkOpen(curToken as any)
         const hrefStop = firstIndexOfAny(href, LINKIFY_HARD_STOP_CHARS)
         // Prefer splitting by the visible text token, but also trim href if it contains stop chars.

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -109,12 +109,6 @@ function setHrefOnLinkOpen(token: any, href: string) {
     token.attrs.push(['href', href])
 }
 
-function getTrailingTextChar(token: MarkdownToken | undefined) {
-  if (token?.type !== 'text' || typeof token.content !== 'string' || !token.content)
-    return ''
-  return token.content[token.content.length - 1] ?? ''
-}
-
 function collectLinkifyText(tokens: MarkdownToken[], openIndex: number, closeIndex: number) {
   let text = ''
   for (let index = openIndex + 1; index < closeIndex; index++) {
@@ -184,7 +178,7 @@ function fixLinkToken(tokens: MarkdownToken[]): MarkdownToken[] {
         if (
           curToken.markup === 'linkify'
           && linkText
-          && shouldDemoteFilenameLikeLinkify(linkText, getTrailingTextChar(tokens[i - 1]))
+          && shouldDemoteFilenameLikeLinkify(linkText)
         ) {
           tokens.splice(i, closeIdx - i + 1, textToken(linkText) as any)
           continue

--- a/packages/markstream-vue2/src/components/ParagraphNode/ParagraphNode.vue
+++ b/packages/markstream-vue2/src/components/ParagraphNode/ParagraphNode.vue
@@ -161,12 +161,9 @@ function processChild(child: NodeChild): { child: NodeChild, component: any } {
 <template>
   <p dir="auto" class="paragraph-node">
     <template v-for="(child, index) in renderedChildren">
-      <span
-        v-if="isMediaOnlyParagraph && isWhitespaceText(child)"
-        :key="`${indexKey || 'paragraph'}-${index}`"
-      >
+      <template v-if="isMediaOnlyParagraph && isWhitespaceText(child)">
         {{ getTextContent(child) }}
-      </span>
+      </template>
       <component
         :is="processChild(child).component"
         v-else

--- a/packages/markstream-vue2/src/components/ParagraphNode/ParagraphNode.vue
+++ b/packages/markstream-vue2/src/components/ParagraphNode/ParagraphNode.vue
@@ -160,16 +160,17 @@ function processChild(child: NodeChild): { child: NodeChild, component: any } {
 
 <template>
   <p dir="auto" class="paragraph-node">
-    <template
-      v-for="(child, index) in renderedChildren"
-      :key="`${indexKey || 'paragraph'}-${index}`"
-    >
-      <template v-if="isMediaOnlyParagraph && isWhitespaceText(child)">
+    <template v-for="(child, index) in renderedChildren">
+      <span
+        v-if="isMediaOnlyParagraph && isWhitespaceText(child)"
+        :key="`${indexKey || 'paragraph'}-${index}`"
+      >
         {{ getTextContent(child) }}
-      </template>
+      </span>
       <component
         :is="processChild(child).component"
         v-else
+        :key="`${indexKey || 'paragraph'}-${index}`"
         v-bind="getChildProps(processChild(child).child, index)"
       />
     </template>

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -33,10 +33,38 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(linkNodes[0], 'example.com')).toBe(true)
   })
 
+  it('preserves bare domains whose TLDs overlap with file extensions', () => {
+    const nodes = parseMarkdownToStructure('访问 example.ai 和 OpenAI.ai 获取更多信息。', md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(2)
+    expect(linkNodes.map(link => link.href)).toEqual([
+      'http://example.ai',
+      'http://OpenAI.ai',
+    ])
+  })
+
+  it('preserves adjacent cjk bare domains when they are intended as links', () => {
+    const nodes = parseMarkdownToStructure('请访问example.ai，获取更多信息。', md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://example.ai')
+    expect(textIncludes(linkNodes[0], 'example.ai')).toBe(true)
+  })
+
   it('keeps standalone uppercase filenames as text', () => {
     const nodes = parseMarkdownToStructure('README.md', md, { final: true })
 
     expect(links(nodes)).toHaveLength(0)
     expect(textIncludes(nodes, 'README.md')).toBe(true)
+  })
+
+  it('keeps file-like paths as text instead of preserving linkify output', () => {
+    const nodes = parseMarkdownToStructure('请查看 docs/README.md 和 src/index.ts。', md, { final: true })
+
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'docs/README.md')).toBe(true)
+    expect(textIncludes(nodes, 'src/index.ts')).toBe(true)
   })
 })

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../packages/markdown-parser/src'
+import { collect, links, textIncludes } from './utils/midstate-utils'
+
+const md = getMarkdown('issue-402')
+
+describe('issue #402 filename-like linkify regression', () => {
+  it('keeps filename cells as plain text inside markdown tables', () => {
+    const input = `当前可用的文件如下:
+
+| 文件名 | 文件ID |
+|--------|--------|
+| 制度04-XX银行不良信贷资产转让实施细则.docx | f0f026a0a3b84b68af457786ac1271c4GbdC4y7vIs |
+| 制度03-XX银行呆账核销实施细则.md | 7a092ea2aabd4460917e1a8347927548jocBz0soj8 |
+| 制度02-XX银行呆账核销管理办法.md | d2b786c5ab9a48b5a4755b783a2c8668b2Tp9pCBmH |
+| 制度01-财政部文件-《金融企业呆账核销管理办法(2017年版)》.md | 511e9efd721940868eb873c1beb67e43wMl7m22Kb5 |
+`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    const tables = collect(nodes, 'table') as any[]
+    expect(tables).toHaveLength(1)
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '制度03-XX银行呆账核销实施细则.md')).toBe(true)
+    expect(textIncludes(nodes, '制度02-XX银行呆账核销管理办法.md')).toBe(true)
+  })
+
+  it('still preserves normal bare-domain autolinks', () => {
+    const nodes = parseMarkdownToStructure('访问 example.com 获取更多信息。', md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://example.com')
+    expect(textIncludes(linkNodes[0], 'example.com')).toBe(true)
+  })
+
+  it('keeps standalone uppercase filenames as text', () => {
+    const nodes = parseMarkdownToStructure('README.md', md, { final: true })
+
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'README.md')).toBe(true)
+  })
+})

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -34,12 +34,13 @@ describe('issue #402 filename-like linkify regression', () => {
   })
 
   it('preserves bare domains whose TLDs overlap with file extensions', () => {
-    const nodes = parseMarkdownToStructure('访问 example.ai 和 OpenAI.ai 获取更多信息。', md, { final: true })
+    const nodes = parseMarkdownToStructure('访问 example.ai、example.md 和 OpenAI.ai 获取更多信息。', md, { final: true })
     const linkNodes = links(nodes)
 
-    expect(linkNodes).toHaveLength(2)
+    expect(linkNodes).toHaveLength(3)
     expect(linkNodes.map(link => link.href)).toEqual([
       'http://example.ai',
+      'http://example.md',
       'http://OpenAI.ai',
     ])
   })
@@ -51,6 +52,15 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(linkNodes).toHaveLength(1)
     expect(linkNodes[0].href).toBe('http://example.ai')
     expect(textIncludes(linkNodes[0], 'example.ai')).toBe(true)
+  })
+
+  it('preserves punycoded bare domains whose tlds overlap with file extensions', () => {
+    const nodes = parseMarkdownToStructure('也可以访问 xn--fsqu00a.ai 查看说明。', md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://xn--fsqu00a.ai')
+    expect(textIncludes(linkNodes[0], 'xn--fsqu00a.ai')).toBe(true)
   })
 
   it('keeps standalone uppercase filenames as text', () => {

--- a/test/vue2-inline-image-links.test.ts
+++ b/test/vue2-inline-image-links.test.ts
@@ -116,7 +116,13 @@ describe('markstream-vue2 paragraph media-only links', () => {
 
     const paragraph = wrapper.get('p.paragraph-node')
     const childTagNames = Array.from(paragraph.element.children).map(child => child.tagName)
+    const meaningfulNodes = Array.from(paragraph.element.childNodes).filter((node) => {
+      return node.nodeType !== Node.TEXT_NODE || node.textContent === ' '
+    })
     expect(childTagNames).toEqual(['A', 'A'])
+    expect(meaningfulNodes).toHaveLength(3)
+    expect(meaningfulNodes[1]?.nodeType).toBe(Node.TEXT_NODE)
+    expect(meaningfulNodes[1]?.textContent).toBe(' ')
     expect(paragraph.findAll('.text-node')).toHaveLength(0)
     expect(paragraph.findAll('a.link-node')).toHaveLength(2)
   })


### PR DESCRIPTION
Closes #402
## Summary

This change fixes issue #402, where filename-like text such as `制度03-XX银行呆账核销实施细则.md` was being auto-linkified by the shared parser, especially inside table cells.

It adds parser-side safeguards to keep real bare domains like `example.com` linkified while preserving filename-like entries as plain text across the shared rendering pipeline. It also tightens Vue 2 paragraph rendering so the repro page keeps inline media spacing without injecting extra DOM nodes.

## Changes

- [x] Add shared parser heuristics to demote filename-like `linkify` results back to plain text
- [x] Apply the safeguard in both inline parsing and link-token post-processing paths
- [x] Add regression coverage for table filenames, `README.md`, and normal bare-domain autolinks
- [x] Fix Vue 2 media-only paragraph rendering so inline image links keep spacing without inserting an extra `<span>`

## Screenshots / Demo (if UI/behavior changes)

- [x] Added GIF/screenshot
   **before**
<img width="872" height="506" alt="image" src="https://github.com/user-attachments/assets/597e5113-9bf6-4e49-b412-e870b447eea6" />
   **after**
<img width="756" height="462" alt="image" src="https://github.com/user-attachments/assets/55eef38a-6609-488b-815b-ce68445bb06d" />

- [x] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

Repro link:
https://markstream-vue.simonhe.me/test#data=z:VVNfSxtBEH_fTzFgHjRwpkb60EAFoRYLCkGlL7U2690mWbzbO_Y2RhsCsTQKRVQI1fqnxlSioX-IiLRWrX6YZi_JU79C904N8Wlmdmd_v5n57fTAOOZzruAEWzBFXAFjeBYhuVdr3Wy3V1bler1xWZU339qFcvvraqu-BOHwywyBQYiAb6PKThCsC2WHWSpjYh4Og9zdldUt7_zUK5fkdq25875VqTXXTrxPdblx1DgvtFbO_hbeIdTTA7J80awUvIMrebWOkKbw5YeD5ulWOOwH3uZe40_JdxOUmZQR0G2DJFT8ql269taqr3vTQjhuLBJJUZHOzPbrthWZpJbNtFHy5HHE6vSnzWdIX0DpfTyRP44QalVW5XJRFr8r6n9XO6EReAqWPhMNqQl83mpeHHeuEAqF0DRl4s2jmQFYmImCsaCSp5Mc67mBfG4w7yf42OOEW5gaCCUSCevOT5p2Vk9jrqY7gQDi3LYcAZo2BHHMXcIDd4Iwg_C7IM7JPCVZHyRAbVweNg-WVFEBrnARWXBshZfMMF1Qm6mpWA7m5DnHFsnafK6XKScGqnPKUn2QU7SciAxnkAjl_Ls8CF9uB6cIUFddYmOxP4HyHcoXLGmnOHbSVA9IaVfc5YNJXaFxO6u51HJMoqVtTt_aTGBTw1ydIwMLrOipIJarLIAGJp4lJrSuS7JYDY4ADOLq4Itl2Fn2IO32G3WntY4Pvf2Nxvma_LLfXln3ds-8zZMHb2T9d7N4_ODNr5pXWfb2f3qHBa9c7bT5LBp0Z0TRsOPE7v8wuhUmFqyHXxEMT06he4liMMLSmOnEgNGp8TGkdiYGcRMvpridYUbEXyTk40GXxN0KDwVr5pfwHw

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)
