### PR TITLE
fix: align footnote anchor links

### DIFF
--- a/packages/markstream-angular/src/components/FootnoteReferenceNode/FootnoteReferenceNode.component.ts
+++ b/packages/markstream-angular/src/components/FootnoteReferenceNode/FootnoteReferenceNode.component.ts
@@ -6,7 +6,7 @@ import { getString } from '../shared/node-helpers'
   selector: 'markstream-angular-footnote-reference-node',
   standalone: true,
   template: `
-    <sup class="markstream-nested-footnote-ref">
+    <sup [attr.id]="referenceId" class="markstream-nested-footnote-ref">
       <a [attr.href]="href">[{{ id }}]</a>
     </sup>
   `,
@@ -21,5 +21,9 @@ export class FootnoteReferenceNodeComponent {
 
   get href() {
     return `#fnref--${this.id}`
+  }
+
+  get referenceId() {
+    return `fnref-${this.id}`
   }
 }

--- a/packages/markstream-vue2/src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue
+++ b/packages/markstream-vue2/src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue
@@ -10,7 +10,7 @@ interface FootnoteReferenceNode {
 const props = defineProps<{
   node: FootnoteReferenceNode
 }>()
-const href = `#footnote-${props.node.id}`
+const href = `#fnref--${props.node.id}`
 function handleScroll() {
   if (typeof document === 'undefined') {
     // SSR: nothing to do

--- a/src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue
+++ b/src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue
@@ -10,7 +10,7 @@ interface FootnoteReferenceNode {
 const props = defineProps<{
   node: FootnoteReferenceNode
 }>()
-const href = `#footnote-${props.node.id}`
+const href = `#fnref--${props.node.id}`
 function handleScroll() {
   if (typeof document === 'undefined') {
     // SSR: nothing to do

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -262,7 +262,7 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="typewriter" appear="true" persisted="false" css="true">
         <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">A footnote reference</span>
-          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#footnote-1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -304,7 +304,7 @@ exports[`markdownRender node e2e coverage > renders footnote reference node 1`] 
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="footnote_reference">
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-      <transition-stub data-v-8dfe8a80="" name="typewriter" appear="true" persisted="false" css="true"><sup data-v-ba0412bc="" data-v-8dfe8a80="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0" typewriter="true" is-dark="false"><span data-v-ba0412bc="" href="#footnote-1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup></transition-stub>
+      <transition-stub data-v-8dfe8a80="" name="typewriter" appear="true" persisted="false" css="true"><sup data-v-ba0412bc="" data-v-8dfe8a80="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0" typewriter="true" is-dark="false"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup></transition-stub>
     </div>
   </div>
   <!--v-if-->

--- a/test/e2e/node-renderer.e2e.test.ts
+++ b/test/e2e/node-renderer.e2e.test.ts
@@ -397,12 +397,37 @@ After`,
       name: 'footnote nodes',
       markdown: 'A footnote reference[^1].\n\n[^1]: Footnote explanation',
       expectedText: ['A footnote reference', 'Footnote explanation'],
-      assert: (wrapper) => {
-        const footnoteBlock = wrapper.find('[id="fnref-1"]')
+      assert: async (wrapper) => {
+        const reference = wrapper.find('sup.footnote-reference')
+        expect(reference.exists()).toBe(true)
+        expect(reference.attributes('id')).toBe('fnref-1')
+        expect(reference.find('.footnote-link').attributes('href')).toBe('#fnref--1')
+
+        const footnoteBlock = wrapper.find('[id="fnref--1"]')
         expect(footnoteBlock.exists()).toBe(true)
-        expect(footnoteBlock.text()).toBe('[1]')
         const footerAnchor = wrapper.find('.footnote-anchor')
         expect(footerAnchor.exists()).toBe(true)
+        expect(footerAnchor.attributes('href')).toBe('#fnref-1')
+
+        const originalScrollIntoView = Element.prototype.scrollIntoView
+        const scrollIntoView = vi.fn()
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        ;(Element.prototype as any).scrollIntoView = scrollIntoView
+        document.body.appendChild(wrapper.element)
+        try {
+          await reference.trigger('click')
+          expect(scrollIntoView).toHaveBeenCalled()
+          expect(warnSpy).not.toHaveBeenCalled()
+        }
+        finally {
+          if (wrapper.element.parentNode === document.body)
+            document.body.removeChild(wrapper.element)
+          if (originalScrollIntoView)
+            Element.prototype.scrollIntoView = originalScrollIntoView
+          else
+            delete (Element.prototype as any).scrollIntoView
+          warnSpy.mockRestore()
+        }
       },
     },
     {

--- a/test/markstream-angular-api.test.ts
+++ b/test/markstream-angular-api.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { resolveParsedNodes } from '../packages/markstream-angular/src/components/shared/node-helpers'
 import {
@@ -80,6 +82,18 @@ describe('markstream-angular api parity helpers', () => {
     expect((nodes[0] as any)?.type).toBe('thinking')
     expect((nodes[0] as any)?.loading).toBe(true)
     expect(String((nodes[0] as any)?.content || '')).toContain('全面的回答')
+  })
+
+  it('keeps footnote ids and anchors in sync', () => {
+    const footnoteSource = readFileSync(resolve(process.cwd(), 'packages/markstream-angular/src/components/FootnoteNode/FootnoteNode.component.ts'), 'utf8')
+    const referenceSource = readFileSync(resolve(process.cwd(), 'packages/markstream-angular/src/components/FootnoteReferenceNode/FootnoteReferenceNode.component.ts'), 'utf8')
+    const anchorSource = readFileSync(resolve(process.cwd(), 'packages/markstream-angular/src/components/FootnoteAnchorNode/FootnoteAnchorNode.component.ts'), 'utf8')
+
+    expect(footnoteSource).toMatch(/return `fnref--\$\{getString\(\(this\.node as any\)\?\.id\)\}`/)
+    expect(referenceSource).toContain('[attr.id]="referenceId"')
+    expect(referenceSource).toMatch(/return `#fnref--\$\{this\.id\}`/)
+    expect(referenceSource).toMatch(/return `fnref-\$\{this\.id\}`/)
+    expect(anchorSource).toMatch(/return `#fnref-\$\{this\.id\}`/)
   })
 
   it('keeps streaming thinking content grouped across mixed markdown prefixes', () => {


### PR DESCRIPTION
## Summary
- Align Vue and Vue2 footnote references with the rendered footnote body id
- Add Angular reference ids so footnote backlinks resolve
- Add focused coverage for footnote href/id consistency and click behavior

## Tests
- pnpm test test/e2e/node-renderer.e2e.test.ts --run
- pnpm test test/markstream-angular-api.test.ts --run
- pnpm test test/markstream-react-next-ssr.test.tsx test/ssr-render-to-string.test.ts --run
- pnpm test test/markstream-angular-api.test.ts test/markstream-angular-issue386-regression.test.ts --run
- pnpm exec eslint src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue packages/markstream-vue2/src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue packages/markstream-angular/src/components/FootnoteReferenceNode/FootnoteReferenceNode.component.ts test/e2e/node-renderer.e2e.test.ts test/markstream-angular-api.test.ts