### PR TITLE
feat: make markstream-svelte Svelte 5 only

### DIFF
--- a/.agents/skills/markstream-install/SKILL.md
+++ b/.agents/skills/markstream-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markstream-install
-description: Install and wire markstream-vue, markstream-react, markstream-vue2, or markstream-angular into an existing repository. Use when Codex needs to choose the right package, install the smallest peer-dependency set, fix CSS/reset order, decide between `content` and `nodes`, or add a minimal working renderer example.
+description: Install and wire markstream-vue, markstream-react, markstream-vue2, markstream-angular, or markstream-svelte into an existing repository. Use when Codex needs to choose the right package, install the smallest peer-dependency set, fix CSS/reset order, decide between `content` and `nodes`, or add a minimal working renderer example.
 ---
 
 # Markstream Install
@@ -13,7 +13,8 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
 
 1. Detect the target framework and CSS stack.
    - Check `package.json`, app entry files, Tailwind or UnoCSS config, and whether the repo is SSR or streaming-focused.
-   - Choose the package that matches the host app: `markstream-vue`, `markstream-vue2`, `markstream-react`, or `markstream-angular`.
+   - Choose the package that matches the host app: `markstream-vue`, `markstream-vue2`, `markstream-react`, `markstream-angular`, or `markstream-svelte`.
+   - Use `markstream-svelte` only for Svelte 5 apps.
 2. Install the smallest peer set that matches the requested features.
    - Add peers only for features the user actually needs: Monaco, Mermaid, D2, KaTeX, or lightweight highlighting via `stream-markdown`.
    - Do not install every optional peer by default.

--- a/.agents/skills/markstream-install/references/scenarios.md
+++ b/.agents/skills/markstream-install/references/scenarios.md
@@ -8,6 +8,7 @@
 | Vue 2.6 / 2.7 | `markstream-vue2` |
 | React 18+ | `markstream-react` |
 | Angular 20+ | `markstream-angular` |
+| Svelte 5 | `markstream-svelte` |
 
 ## Peer selection
 
@@ -25,7 +26,7 @@
 - Markstream CSS after reset
 - in Tailwind or UnoCSS projects, keep Markstream CSS inside `@layer components`
 - import KaTeX CSS when math is used
-- when standalone node components are rendered directly, wrap them with `.markstream-vue`
+- when standalone node components are rendered directly, wrap them with the package root class such as `.markstream-vue`, `.markstream-react`, or `.markstream-svelte`
 
 ## Input choice
 

--- a/.agents/skills/markstream-svelte/SKILL.md
+++ b/.agents/skills/markstream-svelte/SKILL.md
@@ -1,49 +1,15 @@
 ---
 name: markstream-svelte
-description: Integrate markstream-svelte into a Svelte 5 app. Use when Codex needs to add the Svelte renderer, import CSS correctly, choose between `content` and `nodes`, wire worker helpers, add scoped custom components or trusted custom tags, or update a Svelte repository away from Svelte 4 assumptions.
+description: Integrate markstream-svelte in Svelte 5 apps. Svelte 4 unsupported.
 ---
 
 # Markstream Svelte
 
-Use this skill when the host app is Svelte 5. Do not use it for Svelte 4; `markstream-svelte` is Svelte 5-only.
-
-## Workflow
-
-1. Confirm the repo is Svelte 5.
-   - Check `package.json`, `svelte.config.*`, and the app entry.
-   - If the app is still Svelte 4, report that the current package requires Svelte 5 instead of adding compatibility shims.
-2. Install `markstream-svelte` plus only the requested optional peers.
-   - Add peers only for features the user actually needs: Monaco, Mermaid, D2, KaTeX, or lightweight highlighting via `stream-markdown`.
-3. Import `markstream-svelte/index.css` from the app entry or root layout.
-   - Add `katex/dist/katex.min.css` when math is enabled.
-   - Keep reset styles before Markstream styles.
-4. Start with `<MarkdownRender {content} />`.
-   - Use `nodes` plus `final` only for streaming, worker-preparsed nodes, or high-frequency updates.
-   - Keep `htmlPolicy="safe"` and Mermaid strict mode unless the user explicitly needs trusted legacy behavior.
-5. Use Svelte 5 component patterns.
-   - Write examples with `$props()` instead of `export let`.
-   - Use callback props such as `onCopy` instead of legacy event dispatch patterns unless the host code already requires a wrapper.
-6. Wire optional workers when requested.
-   - Import `setKaTeXWorker` and `setMermaidWorker` from `markstream-svelte`.
-   - Import workers from `markstream-svelte/workers/*` with the bundler's worker query.
-7. Add custom components through scoped mappings.
-   - Use `setCustomComponents(customId, mapping)` and pass the same `customId` to `MarkdownRender`.
-   - For trusted custom tags, pass `customHtmlTags` and render nested Markdown with `MarkdownRender`.
-8. Validate with the smallest useful Svelte command.
-   - Prefer `svelte-check`, app build, or a local playground/e2e case.
-
-## Default Decisions
-
-- Prefer `content` for static pages and low-frequency updates.
-- Prefer `nodes` plus `final` for SSE, token streaming, AI chat, and worker-preparsed content.
-- Keep optional peers minimal and explicit.
-- Keep custom components scoped with `customId` unless the whole app truly needs a global mapping.
-- Treat Svelte 4 support as out of scope; upgrade the host app to Svelte 5 instead of adding compatibility wrappers.
-
-## Useful Doc Targets
-
-- `docs/guide/svelte.md`
-- `docs/guide/installation.md`
-- `docs/guide/usage.md`
-- `docs/guide/custom-components.md`
-- `docs/guide/troubleshooting.md`
+- Confirm Svelte 5; ask Svelte 4 users to upgrade.
+- Add package and only requested peers.
+- Import CSS after resets; KaTeX CSS for math.
+- Default to `<MarkdownRender {content} />`; use `nodes`+`final` for streaming/workers.
+- Use `$props()` and callbacks.
+- Workers: `setKaTeXWorker`, `setMermaidWorker`, `workers/*?worker`.
+- Custom UI: scoped `setCustomComponents`, `customId`, `customHtmlTags`.
+- Verify with `svelte-check`, build, or e2e.

--- a/.agents/skills/markstream-svelte/SKILL.md
+++ b/.agents/skills/markstream-svelte/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: markstream-svelte
+description: Integrate markstream-svelte into a Svelte 5 app. Use when Codex needs to add the Svelte renderer, import CSS correctly, choose between `content` and `nodes`, wire worker helpers, add scoped custom components or trusted custom tags, or update a Svelte repository away from Svelte 4 assumptions.
+---
+
+# Markstream Svelte
+
+Use this skill when the host app is Svelte 5. Do not use it for Svelte 4; `markstream-svelte` is Svelte 5-only.
+
+## Workflow
+
+1. Confirm the repo is Svelte 5.
+   - Check `package.json`, `svelte.config.*`, and the app entry.
+   - If the app is still Svelte 4, report that the current package requires Svelte 5 instead of adding compatibility shims.
+2. Install `markstream-svelte` plus only the requested optional peers.
+   - Add peers only for features the user actually needs: Monaco, Mermaid, D2, KaTeX, or lightweight highlighting via `stream-markdown`.
+3. Import `markstream-svelte/index.css` from the app entry or root layout.
+   - Add `katex/dist/katex.min.css` when math is enabled.
+   - Keep reset styles before Markstream styles.
+4. Start with `<MarkdownRender {content} />`.
+   - Use `nodes` plus `final` only for streaming, worker-preparsed nodes, or high-frequency updates.
+   - Keep `htmlPolicy="safe"` and Mermaid strict mode unless the user explicitly needs trusted legacy behavior.
+5. Use Svelte 5 component patterns.
+   - Write examples with `$props()` instead of `export let`.
+   - Use callback props such as `onCopy` instead of legacy event dispatch patterns unless the host code already requires a wrapper.
+6. Wire optional workers when requested.
+   - Import `setKaTeXWorker` and `setMermaidWorker` from `markstream-svelte`.
+   - Import workers from `markstream-svelte/workers/*` with the bundler's worker query.
+7. Add custom components through scoped mappings.
+   - Use `setCustomComponents(customId, mapping)` and pass the same `customId` to `MarkdownRender`.
+   - For trusted custom tags, pass `customHtmlTags` and render nested Markdown with `MarkdownRender`.
+8. Validate with the smallest useful Svelte command.
+   - Prefer `svelte-check`, app build, or a local playground/e2e case.
+
+## Default Decisions
+
+- Prefer `content` for static pages and low-frequency updates.
+- Prefer `nodes` plus `final` for SSE, token streaming, AI chat, and worker-preparsed content.
+- Keep optional peers minimal and explicit.
+- Keep custom components scoped with `customId` unless the whole app truly needs a global mapping.
+- Treat Svelte 4 support as out of scope; upgrade the host app to Svelte 5 instead of adding compatibility wrappers.
+
+## Useful Doc Targets
+
+- `docs/guide/svelte.md`
+- `docs/guide/installation.md`
+- `docs/guide/usage.md`
+- `docs/guide/custom-components.md`
+- `docs/guide/troubleshooting.md`

--- a/.agents/skills/markstream-svelte/agents/openai.yaml
+++ b/.agents/skills/markstream-svelte/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Markstream Svelte"
-  short_description: "Install and wire markstream-svelte in Svelte 5"
-  default_prompt: "Use $markstream-svelte to integrate markstream-svelte into this Svelte 5 repository with the right CSS, optional peers, and custom component setup."
+  display_name: Markstream Svelte
+  short_description: Install and wire markstream-svelte in Svelte 5
+  default_prompt: Use $markstream-svelte to integrate markstream-svelte into this Svelte 5 repository with the right CSS, optional peers, and custom component setup.

--- a/.agents/skills/markstream-svelte/agents/openai.yaml
+++ b/.agents/skills/markstream-svelte/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Markstream Svelte"
+  short_description: "Install and wire markstream-svelte in Svelte 5"
+  default_prompt: "Use $markstream-svelte to integrate markstream-svelte into this Svelte 5 repository with the right CSS, optional peers, and custom component setup."

--- a/.agents/skills/markstream-svelte/agents/openai.yaml
+++ b/.agents/skills/markstream-svelte/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: Markstream Svelte
-  short_description: Install and wire markstream-svelte in Svelte 5
-  default_prompt: Use $markstream-svelte to integrate markstream-svelte into this Svelte 5 repository with the right CSS, optional peers, and custom component setup.
+  short_description: Svelte 5 setup
+  default_prompt: Use $markstream-svelte.

--- a/docs/guide/ai-workflows.md
+++ b/docs/guide/ai-workflows.md
@@ -76,20 +76,20 @@ That is usually the easiest way for npm users to discover the maintained prompt 
 This repository now includes reusable assets you can version with the codebase:
 
 - Task skills: `markstream-install`, `markstream-custom-components`, `markstream-migration`
-- Framework entry skills: `markstream-vue`, `markstream-nuxt`, `markstream-vue2`, `markstream-vue2-cli`, `markstream-vue2-vite`, `markstream-react`, `markstream-angular`
+- Framework entry skills: `markstream-vue`, `markstream-nuxt`, `markstream-vue2`, `markstream-vue2-cli`, `markstream-vue2-vite`, `markstream-react`, `markstream-angular`, `markstream-svelte`
 - `prompts/install-markstream.md`
 - `prompts/override-built-in-components.md`
 - `prompts/add-custom-tag-thinking.md`
 - `prompts/migrate-react-markdown.md`
 - `prompts/audit-markstream-integration.md`
 
-Use `.agents/skills/` when you want reusable Codex workflow assets that GitHub-based installers can discover automatically. The task skills cover cross-framework work; the framework entry skills make Vue 3, Nuxt, Vue 2, Vue 2 CLI, Vue 2 Vite, React, and Angular scenarios directly discoverable. Use `prompts/` when you want copyable starting prompts for humans or other assistants.
+Use `.agents/skills/` when you want reusable Codex workflow assets that GitHub-based installers can discover automatically. The task skills cover cross-framework work; the framework entry skills make Vue 3, Nuxt, Vue 2, Vue 2 CLI, Vue 2 Vite, React, Angular, and Svelte 5 scenarios directly discoverable. Use `prompts/` when you want copyable starting prompts for humans or other assistants.
 
 ## 1. Give the AI these five facts first
 
 Before you ask for code changes, include:
 
-- framework and version, for example Vue 3, Nuxt 3, React 18, or Angular 20
+- framework and version, for example Vue 3, Nuxt 3, React 18, Angular 20, or Svelte 5
 - CSS stack, for example Tailwind, UnoCSS, reset libraries, or a design system
 - rendering mode: static article, docs site, SSR, or streaming chat
 - required peers: Monaco, Mermaid, D2, KaTeX, or Shiki

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -75,7 +75,7 @@ This guide is organized by task first, framework second. Start with the shortest
 
 | Page | Description |
 |------|-------------|
-| [Quick Start](/guide/svelte) | Svelte 5 renderer usage, workers, and custom components |
+| [Quick Start](/guide/svelte) | Svelte 5-only renderer usage, workers, and custom components |
 
 ### Nuxt
 

--- a/docs/guide/svelte.md
+++ b/docs/guide/svelte.md
@@ -1,13 +1,19 @@
 # Svelte
 
-`markstream-svelte` provides the Svelte 5 renderer with the same component names, worker helpers, and playground fixtures as the Vue and React packages.
+`markstream-svelte` provides the Svelte 5-only renderer with the same component names, worker helpers, and playground fixtures as the Vue and React packages. Svelte 4 is not supported.
+
+Install the package with Svelte 5:
+
+```bash
+pnpm add markstream-svelte svelte@^5
+```
 
 ```svelte
 <script lang="ts">
   import MarkdownRender from 'markstream-svelte'
   import 'markstream-svelte/index.css'
 
-  export let content = '# markstream-svelte'
+  let { content = '# markstream-svelte' }: { content?: string } = $props()
 </script>
 
 <MarkdownRender
@@ -28,7 +34,7 @@ For KaTeX and Mermaid worker parity:
   import MermaidWorker from 'markstream-svelte/workers/mermaidParser.worker?worker&inline'
 
   setKaTeXWorker(new KatexWorker())
-setMermaidWorker(new MermaidWorker())
+  setMermaidWorker(new MermaidWorker())
 </script>
 ```
 
@@ -51,6 +57,30 @@ Custom HTML tags use the same scoped component registry:
   {customId}
   customHtmlTags={['thinking']}
 />
+```
+
+Example `ThinkingNode.svelte`:
+
+```svelte
+<script lang="ts">
+  import MarkdownRender from 'markstream-svelte'
+
+  let {
+    node,
+    customId = undefined,
+  }: {
+    node: any
+    customId?: string
+  } = $props()
+</script>
+
+<section class="thinking-node">
+  <MarkdownRender
+    content={String(node?.content ?? '')}
+    {customId}
+    customHtmlTags={['thinking']}
+  />
+</section>
 ```
 
 Local playground:

--- a/docs/zh/guide/ai-workflows.md
+++ b/docs/zh/guide/ai-workflows.md
@@ -76,20 +76,20 @@ npx markstream-vue prompts show install-markstream
 这个仓库现在已经有可版本化、可复用的资产：
 
 - 任务型 skills：`markstream-install`、`markstream-custom-components`、`markstream-migration`
-- 框架入口 skills：`markstream-vue`、`markstream-nuxt`、`markstream-vue2`、`markstream-vue2-cli`、`markstream-vue2-vite`、`markstream-react`、`markstream-angular`
+- 框架入口 skills：`markstream-vue`、`markstream-nuxt`、`markstream-vue2`、`markstream-vue2-cli`、`markstream-vue2-vite`、`markstream-react`、`markstream-angular`、`markstream-svelte`
 - `prompts/install-markstream.md`
 - `prompts/override-built-in-components.md`
 - `prompts/add-custom-tag-thinking.md`
 - `prompts/migrate-react-markdown.md`
 - `prompts/audit-markstream-integration.md`
 
-`.agents/skills/` 适合放可复用、并且能被 GitHub 安装器自动发现的 Codex 工作流资产。任务型 skills 负责跨框架工作流，框架入口 skills 则让 Vue 3、Nuxt、Vue 2、Vue 2 CLI、Vue 2 Vite、React、Angular 这些场景更容易被直接发现；`prompts/` 适合放给人类或其他助手直接复制使用的提示词模板。
+`.agents/skills/` 适合放可复用、并且能被 GitHub 安装器自动发现的 Codex 工作流资产。任务型 skills 负责跨框架工作流，框架入口 skills 则让 Vue 3、Nuxt、Vue 2、Vue 2 CLI、Vue 2 Vite、React、Angular、Svelte 5 这些场景更容易被直接发现；`prompts/` 适合放给人类或其他助手直接复制使用的提示词模板。
 
 ## 1. 先把这五类信息告诉 AI
 
 在让 AI 开始改代码前，尽量先说明：
 
-- 框架和版本，例如 Vue 3、Nuxt 3、React 18、Angular 20
+- 框架和版本，例如 Vue 3、Nuxt 3、React 18、Angular 20、Svelte 5
 - CSS 技术栈，例如 Tailwind、UnoCSS、reset 库、设计系统
 - 渲染模式：静态文章、文档站、SSR，还是流式聊天
 - 需要哪些可选能力：Monaco、Mermaid、D2、KaTeX、Shiki

--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -75,7 +75,7 @@ description: 按任务组织的 markstream-vue 指南，帮助你在安装、流
 
 | 页面 | 描述 |
 |------|------|
-| [快速开始](/zh/guide/svelte) | Svelte 5 渲染器、workers 与自定义组件示例 |
+| [快速开始](/zh/guide/svelte) | Svelte 5-only 渲染器、workers 与自定义组件示例 |
 
 ### Nuxt
 

--- a/docs/zh/guide/svelte.md
+++ b/docs/zh/guide/svelte.md
@@ -1,13 +1,19 @@
 # Svelte
 
-`markstream-svelte` 提供 Svelte 5 渲染器，组件名、worker helpers 和 playground fixtures 与 Vue / React / Angular 包保持一致。
+`markstream-svelte` 提供 Svelte 5-only 渲染器，组件名、worker helpers 和 playground fixtures 与 Vue / React / Angular 包保持一致。不支持 Svelte 4。
+
+使用 Svelte 5 安装：
+
+```bash
+pnpm add markstream-svelte svelte@^5
+```
 
 ```svelte
 <script lang="ts">
   import MarkdownRender from 'markstream-svelte'
   import 'markstream-svelte/index.css'
 
-  export let content = '# markstream-svelte'
+  let { content = '# markstream-svelte' }: { content?: string } = $props()
 </script>
 
 <MarkdownRender
@@ -51,6 +57,30 @@ KaTeX 和 Mermaid worker 入口与其它框架一致：
   {customId}
   customHtmlTags={['thinking']}
 />
+```
+
+示例 `ThinkingNode.svelte`：
+
+```svelte
+<script lang="ts">
+  import MarkdownRender from 'markstream-svelte'
+
+  let {
+    node,
+    customId = undefined,
+  }: {
+    node: any
+    customId?: string
+  } = $props()
+</script>
+
+<section class="thinking-node">
+  <MarkdownRender
+    content={String(node?.content ?? '')}
+    {customId}
+    customHtmlTags={['thinking']}
+  />
+</section>
 ```
 
 本地 playground：

--- a/packages/markstream-svelte/README.md
+++ b/packages/markstream-svelte/README.md
@@ -1,11 +1,11 @@
 # markstream-svelte
 
-Svelte 5 renderer aligned with `markstream-vue`, `markstream-vue2`, and `markstream-react`.
+Svelte 5-only renderer aligned with `markstream-vue`, `markstream-vue2`, and `markstream-react`. Svelte 4 is not supported.
 
 ## Install
 
 ```bash
-pnpm add markstream-svelte svelte
+pnpm add markstream-svelte svelte@^5
 ```
 
 Optional heavy renderers stay as peer dependencies, matching the Vue and React packages:
@@ -52,6 +52,8 @@ flowchart LR
 
 ## Custom Components
 
+Register Svelte 5 components with the scoped registry:
+
 ```svelte
 <script lang="ts">
   import MarkdownRender, { setCustomComponents } from 'markstream-svelte'
@@ -68,6 +70,29 @@ flowchart LR
   {customId}
   customHtmlTags={['thinking']}
 />
+```
+
+```svelte
+<!-- ThinkingNode.svelte -->
+<script lang="ts">
+  import MarkdownRender from 'markstream-svelte'
+
+  let {
+    node,
+    customId = undefined,
+  }: {
+    node: any
+    customId?: string
+  } = $props()
+</script>
+
+<section class="thinking-node">
+  <MarkdownRender
+    content={String(node?.content ?? '')}
+    {customId}
+    customHtmlTags={['thinking']}
+  />
+</section>
 ```
 
 Run the local playground with:

--- a/packages/markstream-svelte/package.json
+++ b/packages/markstream-svelte/package.json
@@ -58,7 +58,7 @@
     "katex": ">=0.16.22",
     "mermaid": ">=11",
     "stream-monaco": ">=0.0.40",
-    "svelte": ">=5"
+    "svelte": ">=5 <6"
   },
   "peerDependenciesMeta": {
     "@antv/infographic": {

--- a/packages/markstream-svelte/src/components/NodeOutlet.svelte
+++ b/packages/markstream-svelte/src/components/NodeOutlet.svelte
@@ -50,25 +50,31 @@
     resolveNodeOutletCustomInputs,
   } from './shared/node-outlet-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined,
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 
-  $: resolvedType = String((node as any)?.type || '')
-  $: customComponentMap = context?.customComponents || getCustomNodeComponents(context?.customId)
-  $: CustomComponent = resolveNodeOutletCustomComponent(node, context, customComponentMap)
-  $: customNode = coerceCustomHtmlNode(node)
-  $: customInputs = resolveNodeOutletCustomInputs(node, context) || {}
-  $: codeMode = resolveNodeOutletCodeMode(node, context)
-  $: htmlTag = resolveHtmlTag(node)
-  $: shouldEscapeHtmlTag = resolveShouldEscapeHtmlTag()
-  $: htmlRenderNode = coerceBuiltinHtmlNode(node, resolvedType)
-  $: codeBlockInstanceKey = `${String(indexKey ?? 'code-block')}:${String((node as any)?.language ?? '')}:${(node as any)?.diff ? 'diff' : 'code'}`
-  $: escapedTextNode = {
+  let resolvedType = $derived(String((node as any)?.type || ''))
+  let customComponentMap = $derived(context?.customComponents || getCustomNodeComponents(context?.customId))
+  let CustomComponent = $derived(resolveNodeOutletCustomComponent(node, context, customComponentMap))
+  let customNode = $derived(coerceCustomHtmlNode(node))
+  let customInputs = $derived(resolveNodeOutletCustomInputs(node, context) || {})
+  let codeMode = $derived(resolveNodeOutletCodeMode(node, context))
+  let htmlTag = $derived(resolveHtmlTag(node))
+  let shouldEscapeHtmlTag = $derived(resolveShouldEscapeHtmlTag())
+  let htmlRenderNode = $derived(coerceBuiltinHtmlNode(node, resolvedType))
+  let codeBlockInstanceKey = $derived(`${String(indexKey ?? 'code-block')}:${String((node as any)?.language ?? '')}:${(node as any)?.diff ? 'diff' : 'code'}`)
+  let escapedTextNode = $derived({
     type: 'text',
     content: String((node as any)?.content ?? (node as any)?.raw ?? ''),
     raw: String((node as any)?.content ?? (node as any)?.raw ?? ''),
-  } as SvelteRenderableNode
+  } as SvelteRenderableNode)
 
   function resolveShouldEscapeHtmlTag() {
     if (resolvedType !== 'html_block' && resolvedType !== 'html_inline')
@@ -88,8 +94,7 @@
 </script>
 
 {#if CustomComponent}
-  <svelte:component
-    this={CustomComponent}
+  <CustomComponent
     node={customNode}
     context={context}
     ctx={context}

--- a/packages/markstream-svelte/src/components/NodeRenderer.svelte
+++ b/packages/markstream-svelte/src/components/NodeRenderer.svelte
@@ -5,73 +5,80 @@
     SvelteRenderableNode,
     SvelteRenderContext,
   } from './shared/node-helpers'
-  import { afterUpdate, onDestroy, onMount, tick } from 'svelte'
+  import { onDestroy, onMount, tick } from 'svelte'
   import { getCustomNodeComponents, subscribeCustomComponents } from '../customComponents'
   import { disposeRenderedHtmlEnhancements, enhanceRenderedHtml } from '../enhanceRenderedHtml'
   import NodeOutlet from './NodeOutlet.svelte'
   import { buildRenderContext, resolveParsedNodes } from './shared/node-helpers'
 
-  export let content: NodeRendererProps['content'] = ''
-  export let nodes: NodeRendererProps['nodes'] = null
-  export let final: NodeRendererProps['final'] = undefined
-  export let parseOptions: NodeRendererProps['parseOptions'] = undefined
-  export let customMarkdownIt: NodeRendererProps['customMarkdownIt'] = undefined
-  export let debugPerformance = false
-  export let customHtmlTags: NodeRendererProps['customHtmlTags'] = undefined
-  export let htmlPolicy: NodeRendererProps['htmlPolicy'] = 'safe'
-  export let viewportPriority: NodeRendererProps['viewportPriority'] = true
-  export let codeBlockStream = true
-  export let codeBlockDarkTheme: NodeRendererProps['codeBlockDarkTheme'] = undefined
-  export let codeBlockLightTheme: NodeRendererProps['codeBlockLightTheme'] = undefined
-  export let codeBlockMonacoOptions: NodeRendererProps['codeBlockMonacoOptions'] = undefined
-  export let renderCodeBlocksAsPre = false
-  export let codeBlockMinWidth: NodeRendererProps['codeBlockMinWidth'] = undefined
-  export let codeBlockMaxWidth: NodeRendererProps['codeBlockMaxWidth'] = undefined
-  export let codeBlockProps: NodeRendererProps['codeBlockProps'] = undefined
-  export let mermaidProps: NodeRendererProps['mermaidProps'] = undefined
-  export let d2Props: NodeRendererProps['d2Props'] = undefined
-  export let infographicProps: NodeRendererProps['infographicProps'] = undefined
-  export let customComponents: NodeRendererProps['customComponents'] = undefined
-  export let showTooltips = true
-  export let themes: NodeRendererProps['themes'] = undefined
-  export let isDark = false
-  export let customId: NodeRendererProps['customId'] = undefined
-  export let indexKey: NodeRendererProps['indexKey'] = undefined
-  export let typewriter = true
-  export let batchRendering = true
-  export let initialRenderBatchSize = 40
-  export let renderBatchSize = 80
-  export let renderBatchDelay = 16
-  export let renderBatchBudgetMs = 6
-  export let renderBatchIdleTimeoutMs = 120
-  export let deferNodesUntilVisible = true
-  export let maxLiveNodes = 320
-  export let liveNodeBuffer = 60
-  export let allowHtml = true
-  export let className = ''
-  export let onCopy: NodeRendererEvents['onCopy'] = undefined
-  export let onHandleArtifactClick: NodeRendererEvents['onHandleArtifactClick'] = undefined
-  export let onClick: ((event: MouseEvent) => void) | undefined = undefined
-  export let onMouseover: ((event: MouseEvent) => void) | undefined = undefined
-  export let onMouseout: ((event: MouseEvent) => void) | undefined = undefined
+  type NodeRendererComponentProps = NodeRendererProps & NodeRendererEvents & {
+    className?: string
+    onClick?: (event: MouseEvent) => void
+    onMouseover?: (event: MouseEvent) => void
+    onMouseout?: (event: MouseEvent) => void
+  }
 
-  let rootEl: HTMLDivElement | null = null
-  let parsedNodes: SvelteRenderableNode[] = []
-  let renderContext: SvelteRenderContext = { events: {} }
-  let customComponentsRevision = 0
-  let streamRenderVersion = 0
-  let previousContent: typeof content = undefined
-  let previousNodes: typeof nodes = undefined
+  let {
+    content = '',
+    nodes = null,
+    final = undefined,
+    parseOptions = undefined,
+    customMarkdownIt = undefined,
+    debugPerformance = false,
+    customHtmlTags = undefined,
+    htmlPolicy = 'safe',
+    viewportPriority = true,
+    codeBlockStream = true,
+    codeBlockDarkTheme = undefined,
+    codeBlockLightTheme = undefined,
+    codeBlockMonacoOptions = undefined,
+    renderCodeBlocksAsPre = false,
+    codeBlockMinWidth = undefined,
+    codeBlockMaxWidth = undefined,
+    codeBlockProps = undefined,
+    mermaidProps = undefined,
+    d2Props = undefined,
+    infographicProps = undefined,
+    customComponents = undefined,
+    showTooltips = true,
+    themes = undefined,
+    isDark = false,
+    customId = undefined,
+    indexKey = undefined,
+    typewriter = true,
+    batchRendering = true,
+    initialRenderBatchSize = 40,
+    renderBatchSize = 80,
+    renderBatchDelay = 16,
+    renderBatchBudgetMs = 6,
+    renderBatchIdleTimeoutMs = 120,
+    deferNodesUntilVisible = true,
+    maxLiveNodes = 320,
+    liveNodeBuffer = 60,
+    allowHtml = true,
+    className = '',
+    onCopy = undefined,
+    onHandleArtifactClick = undefined,
+    onClick = undefined,
+    onMouseover = undefined,
+    onMouseout = undefined,
+  }: NodeRendererComponentProps = $props()
+
+  let rootEl: HTMLDivElement | null = $state(null)
+  let customComponentsRevision = $state(0)
+  let streamRenderVersion = $state(0)
+  let previousContent = $state<NodeRendererProps['content']>()
+  let previousNodes = $state<NodeRendererProps['nodes']>()
   let enhancementToken = 0
   let enhancementHandle: { dispose: () => void } | null = null
-  let renderedNodeCount = 0
+  let renderedNodeCount = $state(0)
   let renderBatchTimer: ReturnType<typeof setTimeout> | null = null
   let renderBatchFrame: number | null = null
   let renderBatchIdle: number | null = null
   let renderBatchToken = 0
   const textStreamState = new Map<string, string>()
 
-  $: props = {
+  let rendererProps = $derived({
     content,
     nodes,
     final,
@@ -109,37 +116,38 @@
     maxLiveNodes,
     liveNodeBuffer,
     allowHtml,
-  } satisfies NodeRendererProps
+  } satisfies NodeRendererProps)
 
-  $: {
+  $effect.pre(() => {
     if (previousContent !== content || previousNodes !== nodes) {
       streamRenderVersion += 1
       previousContent = content
       previousNodes = nodes
     }
-  }
+  })
 
-  $: {
+  let parsedNodes = $derived.by<SvelteRenderableNode[]>(() => {
     const start = debugPerformance && typeof performance !== 'undefined' ? performance.now() : 0
-    parsedNodes = resolveParsedNodes(props)
+    const nextParsedNodes = resolveParsedNodes(rendererProps)
     if (debugPerformance && typeof console !== 'undefined' && typeof performance !== 'undefined') {
       console.info('[markstream-svelte][perf] parse(sync)', {
         ms: Math.round(performance.now() - start),
-        nodes: parsedNodes.length,
+        nodes: nextParsedNodes.length,
         contentLength: content?.length ?? 0,
       })
     }
-  }
+    return nextParsedNodes
+  })
 
-  $: {
+  let renderContext = $derived.by<SvelteRenderContext>(() => {
     void customComponentsRevision
     const scopedCustomComponents = getCustomNodeComponents(customId)
     const mergedCustomComponents = customComponents
       ? { ...scopedCustomComponents, ...customComponents }
       : scopedCustomComponents
-    renderContext = buildRenderContext(
+    return buildRenderContext(
       {
-        ...props,
+        ...rendererProps,
         customComponents: mergedCustomComponents,
       },
       {
@@ -149,9 +157,9 @@
       textStreamState,
       streamRenderVersion,
     )
-  }
+  })
 
-  $: {
+  $effect(() => {
     void parsedNodes.length
     void batchRendering
     void initialRenderBatchSize
@@ -162,19 +170,31 @@
     void final
     void renderedNodeCount
     syncRenderedNodeWindow()
-  }
-  $: renderedNodes = parsedNodes.slice(0, Math.min(renderedNodeCount, parsedNodes.length))
+  })
+  let renderedNodes = $derived(parsedNodes.slice(0, Math.min(renderedNodeCount, parsedNodes.length)))
+
+  $effect(() => {
+    void rootEl
+    void final
+    void parsedNodes
+    void renderedNodes
+    void isDark
+    void renderCodeBlocksAsPre
+    void codeBlockMonacoOptions
+    void codeBlockProps
+    void mermaidProps
+    void d2Props
+    void infographicProps
+    void showTooltips
+    void onCopy
+    scheduleEnhancement()
+  })
 
   onMount(() => {
     const unsubscribe = subscribeCustomComponents(() => {
       customComponentsRevision += 1
     })
-    scheduleEnhancement()
     return unsubscribe
-  })
-
-  afterUpdate(() => {
-    scheduleEnhancement()
   })
 
   onDestroy(() => {

--- a/packages/markstream-svelte/src/components/RenderChildren.svelte
+++ b/packages/markstream-svelte/src/components/RenderChildren.svelte
@@ -2,9 +2,15 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import NodeOutlet from './NodeOutlet.svelte'
 
-  export let nodes: readonly SvelteRenderableNode[] | null | undefined = []
-  export let context: SvelteRenderContext | undefined = undefined
-  export let prefix = 'child'
+  let {
+    nodes = [],
+    context = undefined,
+    prefix = 'child',
+  }: {
+    nodes?: readonly SvelteRenderableNode[] | null
+    context?: SvelteRenderContext
+    prefix?: string
+  } = $props()
 </script>
 
 {#each nodes || [] as child, index (prefix + '-' + index)}

--- a/packages/markstream-svelte/src/customComponents.ts
+++ b/packages/markstream-svelte/src/customComponents.ts
@@ -1,4 +1,6 @@
-export type MarkstreamSvelteComponent = any
+import type { Component } from 'svelte'
+
+export type MarkstreamSvelteComponent = Component<Record<string, any>>
 export type CustomComponentMap = Record<string, MarkstreamSvelteComponent>
 
 const GLOBAL_KEY = '__global__'

--- a/playground-svelte/src/components/ThinkingNode.svelte
+++ b/playground-svelte/src/components/ThinkingNode.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import MarkdownRender from 'markstream-svelte'
 
-  export let node: any
-  export let customId: string | undefined = undefined
-  export let isDark = false
-  export let typewriter = true
+  let {
+    node,
+    customId = undefined,
+    isDark = false,
+    typewriter = true,
+  }: {
+    node: any
+    customId?: string
+    isDark?: boolean
+    typewriter?: boolean
+  } = $props()
 </script>
 
 <section class="thinking-node">

--- a/prompts/install-markstream.md
+++ b/prompts/install-markstream.md
@@ -6,7 +6,7 @@ Use when you want an AI coding assistant to add Markstream to an existing reposi
 
 ```text
 请把 Markstream 接入到这个仓库。
-先识别当前框架和版本，然后选择正确的包：markstream-vue、markstream-vue2、markstream-react 或 markstream-angular。
+先识别当前框架和版本，然后选择正确的包：markstream-vue、markstream-vue2、markstream-react、markstream-angular 或 markstream-svelte。Svelte 项目请确认是 Svelte 5。
 只安装满足这些能力所需的最小 peer 依赖：[填写 Monaco / Mermaid / D2 / KaTeX / Shiki]。
 结合现有 CSS 技术栈处理样式顺序：[填写 Tailwind / UnoCSS / reset / design system]。
 补一个最小可运行示例，并说明这里应该用 `content` 还是 `nodes`。
@@ -18,7 +18,7 @@ Use when you want an AI coding assistant to add Markstream to an existing reposi
 
 ```text
 Add Markstream to this repository.
-Detect the current framework and version first, then choose the correct package: markstream-vue, markstream-vue2, markstream-react, or markstream-angular.
+Detect the current framework and version first, then choose the correct package: markstream-vue, markstream-vue2, markstream-react, markstream-angular, or markstream-svelte. For Svelte projects, confirm the app is on Svelte 5.
 Install only the smallest peer-dependency set needed for these features: [fill in Monaco / Mermaid / D2 / KaTeX / Shiki].
 Handle CSS order safely with the current stack: [fill in Tailwind / UnoCSS / reset / design system].
 Add one minimal working example and explain whether this repo should use `content` or `nodes`.


### PR DESCRIPTION
## Summary
- Make `markstream-svelte` explicitly Svelte 5-only with peer range `>=5 <6`.
- Migrate core Svelte renderer entry components toward Svelte 5 runes and dynamic component syntax.
- Update Svelte docs, README, prompts, and skills with Svelte 5-only guidance.
- Add a `markstream-svelte` skill and update the generic install skill to detect Svelte 5.

## Verification
- `pnpm run -C packages/markstream-svelte typecheck`
- `pnpm run -C packages/markstream-svelte build`
- `pnpm run -C playground-svelte typecheck`
- `pnpm run -C playground-svelte build`
- `pnpm docs:build`
- `pnpm test:e2e:svelte-playground`
- Skill validation via `quick_validate.py` with temporary PyYAML install
