### PR TITLE
chore: migrate svelte legacy components to svelte 5 runes

### DIFF
--- a/packages/markstream-svelte/src/components/AdmonitionNode.svelte
+++ b/packages/markstream-svelte/src/components/AdmonitionNode.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext | undefined;
+  }
+
+  let { node, context = undefined }: Props = $props();
+
+  let html = $derived(renderNodeHtml(node, context));
 </script>
 {@html html}

--- a/packages/markstream-svelte/src/components/BlockquoteNode.svelte
+++ b/packages/markstream-svelte/src/components/BlockquoteNode.svelte
@@ -2,9 +2,15 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList, getString } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  $: cite = getString((node as any)?.cite)
+
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext | undefined;
+    indexKey?: string | number | undefined;
+  }
+
+  let { node, context = undefined, indexKey = undefined }: Props = $props();
+
+  let cite = $derived(getString((node as any)?.cite));
 </script>
 <blockquote class="blockquote blockquote-node" dir="auto" cite={cite || undefined}><RenderChildren nodes={getNodeList((node as any)?.children)} context={context} prefix={String(indexKey ?? 'blockquote') + '-blockquote'} /></blockquote>

--- a/packages/markstream-svelte/src/components/CheckboxNode.svelte
+++ b/packages/markstream-svelte/src/components/CheckboxNode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SvelteRenderableNode } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
+  
+  let { node }: { node: SvelteRenderableNode } = $props()
 </script>
 <input class="checkbox-node" type="checkbox" disabled checked={Boolean((node as any)?.checked)} />

--- a/packages/markstream-svelte/src/components/CheckboxNode.svelte
+++ b/packages/markstream-svelte/src/components/CheckboxNode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { SvelteRenderableNode } from './shared/node-helpers'
   
-  let { node }: { node: SvelteRenderableNode } = $props()
+  type Props = { node: SvelteRenderableNode };
+  let { node }: Props = $props()
 </script>
 <input class="checkbox-node" type="checkbox" disabled checked={Boolean((node as any)?.checked)} />

--- a/packages/markstream-svelte/src/components/CodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/CodeBlockNode.svelte
@@ -10,6 +10,30 @@
   import { copyTextToClipboard, resolveCssSize } from './shared/rich-block-helpers'
   import { getString, sanitizeClassToken } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    isDark?: boolean | undefined
+    loading?: boolean | undefined
+    stream?: boolean | undefined
+    darkTheme?: CodeBlockMonacoTheme | undefined
+    lightTheme?: CodeBlockMonacoTheme | undefined
+    themes?: CodeBlockMonacoTheme[] | undefined
+    monacoOptions?: CodeBlockMonacoOptions | undefined
+    minWidth?: string | number | undefined
+    maxWidth?: string | number | undefined
+    isShowPreview?: boolean
+    enableFontSizeControl?: boolean
+    showHeader?: boolean
+    showCopyButton?: boolean
+    showExpandButton?: boolean
+    showPreviewButton?: boolean
+    showCollapseButton?: boolean
+    showFontSizeButtons?: boolean
+    htmlPreviewAllowScripts?: boolean
+    htmlPreviewSandbox?: string | undefined
+  }
+
   let {
     node,
     context = undefined,
@@ -32,29 +56,7 @@
     showFontSizeButtons = true,
     htmlPreviewAllowScripts = false,
     htmlPreviewSandbox = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext | undefined
-    isDark?: boolean | undefined
-    loading?: boolean | undefined
-    stream?: boolean | undefined
-    darkTheme?: CodeBlockMonacoTheme | undefined
-    lightTheme?: CodeBlockMonacoTheme | undefined
-    themes?: CodeBlockMonacoTheme[] | undefined
-    monacoOptions?: CodeBlockMonacoOptions | undefined
-    minWidth?: string | number | undefined
-    maxWidth?: string | number | undefined
-    isShowPreview?: boolean
-    enableFontSizeControl?: boolean
-    showHeader?: boolean
-    showCopyButton?: boolean
-    showExpandButton?: boolean
-    showPreviewButton?: boolean
-    showCollapseButton?: boolean
-    showFontSizeButtons?: boolean
-    htmlPreviewAllowScripts?: boolean
-    htmlPreviewSandbox?: string | undefined
-  } = $props()
+  }: Props = $props()
 
   const { t } = useSafeI18n()
   const defaultDiffHideUnchangedRegions = Object.freeze({

--- a/packages/markstream-svelte/src/components/CodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/CodeBlockNode.svelte
@@ -10,27 +10,51 @@
   import { copyTextToClipboard, resolveCssSize } from './shared/rich-block-helpers'
   import { getString, sanitizeClassToken } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let isDark: boolean | undefined = undefined
-  export let loading: boolean | undefined = undefined
-  export let stream: boolean | undefined = undefined
-  export let darkTheme: CodeBlockMonacoTheme | undefined = undefined
-  export let lightTheme: CodeBlockMonacoTheme | undefined = undefined
-  export let themes: CodeBlockMonacoTheme[] | undefined = undefined
-  export let monacoOptions: CodeBlockMonacoOptions | undefined = undefined
-  export let minWidth: string | number | undefined = undefined
-  export let maxWidth: string | number | undefined = undefined
-  export let isShowPreview = true
-  export let enableFontSizeControl = true
-  export let showHeader = true
-  export let showCopyButton = true
-  export let showExpandButton = true
-  export let showPreviewButton = true
-  export let showCollapseButton = true
-  export let showFontSizeButtons = true
-  export let htmlPreviewAllowScripts = false
-  export let htmlPreviewSandbox: string | undefined = undefined
+  let {
+    node,
+    context = undefined,
+    isDark = undefined,
+    loading = undefined,
+    stream = undefined,
+    darkTheme = undefined,
+    lightTheme = undefined,
+    themes = undefined,
+    monacoOptions = undefined,
+    minWidth = undefined,
+    maxWidth = undefined,
+    isShowPreview = true,
+    enableFontSizeControl = true,
+    showHeader = true,
+    showCopyButton = true,
+    showExpandButton = true,
+    showPreviewButton = true,
+    showCollapseButton = true,
+    showFontSizeButtons = true,
+    htmlPreviewAllowScripts = false,
+    htmlPreviewSandbox = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    isDark?: boolean | undefined
+    loading?: boolean | undefined
+    stream?: boolean | undefined
+    darkTheme?: CodeBlockMonacoTheme | undefined
+    lightTheme?: CodeBlockMonacoTheme | undefined
+    themes?: CodeBlockMonacoTheme[] | undefined
+    monacoOptions?: CodeBlockMonacoOptions | undefined
+    minWidth?: string | number | undefined
+    maxWidth?: string | number | undefined
+    isShowPreview?: boolean
+    enableFontSizeControl?: boolean
+    showHeader?: boolean
+    showCopyButton?: boolean
+    showExpandButton?: boolean
+    showPreviewButton?: boolean
+    showCollapseButton?: boolean
+    showFontSizeButtons?: boolean
+    htmlPreviewAllowScripts?: boolean
+    htmlPreviewSandbox?: string | undefined
+  } = $props()
 
   const { t } = useSafeI18n()
   const defaultDiffHideUnchangedRegions = Object.freeze({
@@ -95,82 +119,86 @@
     languageRetryTimer = setTimeout(retry, 50)
   }
 
-  let editorHost: HTMLDivElement | null = null
-  let helpers: any = null
-  let runtimeMonacoOptions: Record<string, any> | null = null
-  let ensureMonacoPromise: Promise<void> | null = null
-  let editorReady = false
-  let useFallback = false
-  let fallbackLanguage = ''
-  let editorKind: 'single' | 'diff' | null = null
-  let createEditorPromise: Promise<void> | null = null
-  let mounted = false
-  let collapsed = false
-  let expanded = false
-  let copied = false
-  let previewOpen = false
-  let codeFontSize = 13
-  let copyTimer: ReturnType<typeof setTimeout> | null = null
-  let lifecycleId = 0
-  let heightSyncRaf: number | null = null
-  let heightSyncDisposables: Array<{ dispose?: () => void } | (() => void)> = []
-  let lastLayoutWidth: number | null = null
-  let lastLayoutHeight: number | null = null
-  let lastThemeRequest = ''
-  let languageRetryTimer: ReturnType<typeof setTimeout> | null = null
-  let loadingSettledRefreshPromise: Promise<void> | null = null
-  let loadingSettledRefreshTimer: ReturnType<typeof setTimeout> | null = null
-  let lastSettledRefreshSignature = ''
-  let tokenizeTimer: ReturnType<typeof setTimeout> | null = null
-  let tokenizeRaf: number | null = null
-  let tokenizeShouldRefreshModelValue = false
+  let editorHost: HTMLDivElement | null = $state(null)
+  let helpers: any = $state(null)
+  let runtimeMonacoOptions: Record<string, any> | null = $state(null)
+  let ensureMonacoPromise: Promise<void> | null = $state(null)
+  let editorReady = $state(false)
+  let useFallback = $state(false)
+  let fallbackLanguage = $state('')
+  let editorKind: 'single' | 'diff' | null = $state(null)
+  let createEditorPromise: Promise<void> | null = $state(null)
+  let mounted = $state(false)
+  let collapsed = $state(false)
+  let expanded = $state(false)
+  let copied = $state(false)
+  let previewOpen = $state(false)
+  let codeFontSize = $state(13)
+  let copyTimer: ReturnType<typeof setTimeout> | null = $state(null)
+  let lifecycleId = $state(0)
+  let heightSyncRaf: number | null = $state(null)
+  let heightSyncDisposables: Array<{ dispose?: () => void } | (() => void)> = $state([])
+  let lastLayoutWidth: number | null = $state(null)
+  let lastLayoutHeight: number | null = $state(null)
+  let lastThemeRequest = $state('')
+  let languageRetryTimer: ReturnType<typeof setTimeout> | null = $state(null)
+  let loadingSettledRefreshPromise: Promise<void> | null = $state(null)
+  let loadingSettledRefreshTimer: ReturnType<typeof setTimeout> | null = $state(null)
+  let lastSettledRefreshSignature = $state('')
+  let tokenizeTimer: ReturnType<typeof setTimeout> | null = $state(null)
+  let tokenizeRaf: number | null = $state(null)
+  let tokenizeShouldRefreshModelValue = $state(false)
 
-  $: rawLanguage = getString((node as any)?.language).trim()
-  $: canonicalLanguage = normalizeLanguageIdentifier(rawLanguage)
-  $: monacoLanguage = resolveMonacoLanguageId(canonicalLanguage || rawLanguage || 'plaintext')
-  $: code = getResolvedCode(node)
-  $: diff = Boolean((node as any)?.diff)
-  $: originalCode = getString((node as any)?.originalCode)
-  $: updatedCode = getString((node as any)?.updatedCode)
-  $: nodeLoading = (node as any)?.loading === true
-  $: resolvedLoading = loading ?? nodeLoading
-  $: resolvedStream = stream ?? context?.codeBlockStream ?? true
-  $: resolvedIsDark = isDark ?? context?.isDark ?? false
-  $: resolvedThemes = context?.codeBlockThemes
-  $: mergedMonacoOptions = { ...(resolvedThemes?.monacoOptions || {}), ...(monacoOptions || {}) }
-  $: resolvedMonacoOptions = buildResolvedMonacoOptions()
-  $: requestedTheme = getThemeName(
+  let rawLanguage = $derived(getString((node as any)?.language).trim())
+  let canonicalLanguage = $derived(normalizeLanguageIdentifier(rawLanguage))
+  let monacoLanguage = $derived(resolveMonacoLanguageId(canonicalLanguage || rawLanguage || 'plaintext'))
+  let code = $derived(getResolvedCode(node))
+  let diff = $derived(Boolean((node as any)?.diff))
+  let originalCode = $derived(getString((node as any)?.originalCode))
+  let updatedCode = $derived(getString((node as any)?.updatedCode))
+  let nodeLoading = $derived((node as any)?.loading === true)
+  let resolvedLoading = $derived(loading ?? nodeLoading)
+  let resolvedStream = $derived(stream ?? context?.codeBlockStream ?? true)
+  let resolvedIsDark = $derived(isDark ?? context?.isDark ?? false)
+  let resolvedThemes = $derived(context?.codeBlockThemes)
+  let mergedMonacoOptions = $derived({ ...(resolvedThemes?.monacoOptions || {}), ...(monacoOptions || {}) })
+  let resolvedMonacoOptions = $derived(buildResolvedMonacoOptions())
+  let requestedTheme = $derived(getThemeName(
     resolvedIsDark
       ? darkTheme ?? resolvedThemes?.darkTheme
       : lightTheme ?? resolvedThemes?.lightTheme,
     resolvedIsDark ? 'vitesse-dark' : 'vitesse-light',
-  )
-  $: defaultCodeFontSize = Number(mergedMonacoOptions.fontSize) || 13
-  $: minWidthValue = resolveCssSize(minWidth ?? resolvedThemes?.minWidth)
-  $: maxWidthValue = resolveCssSize(maxWidth ?? resolvedThemes?.maxWidth)
-  $: containerStyle = [
+  ))
+  let defaultCodeFontSize = $derived(Number(mergedMonacoOptions.fontSize) || 13)
+  let minWidthValue = $derived(resolveCssSize(minWidth ?? resolvedThemes?.minWidth))
+  let maxWidthValue = $derived(resolveCssSize(maxWidth ?? resolvedThemes?.maxWidth))
+  let containerStyle = $derived([
     minWidthValue ? `min-width: ${minWidthValue}` : '',
     maxWidthValue ? `max-width: ${maxWidthValue}` : '',
-  ].filter(Boolean).join('; ')
-  $: languageIcon = getLanguageIcon(canonicalLanguage || rawLanguage || 'plain')
-  $: displayLanguage = languageMap[canonicalLanguage] || (rawLanguage ? rawLanguage.toUpperCase() : languageMap[''])
-  $: isPreviewable = isShowPreview !== false && (canonicalLanguage === 'html' || canonicalLanguage === 'svg')
-  $: previewTitle = canonicalLanguage === 'svg' ? t('artifacts.svgPreviewTitle') : t('artifacts.htmlPreviewTitle')
-  $: shouldDelayEditor = resolvedStream === false && resolvedLoading
-  $: documentStreaming = context?.final === false || resolvedLoading
-  $: shouldDeferStreamingLanguage = resolvedStream !== false && documentStreaming && (isLikelyIncompleteLanguageIdentifier(rawLanguage) || isStreamingLanguagePrefix(rawLanguage))
-  $: shouldRender = !(resolvedLoading && !code.trim())
-  $: preLanguageClass = sanitizeClassToken(rawLanguage || monacoLanguage)
-  $: showPreWhileMonacoLoads = !useFallback && !shouldDelayEditor && !shouldDeferStreamingLanguage && !editorReady
-  $: showPreFallback = useFallback || shouldDelayEditor || shouldDeferStreamingLanguage || showPreWhileMonacoLoads
-  $: settledRefreshSignature = diff
+  ].filter(Boolean).join('; '))
+  let languageIcon = $derived(getLanguageIcon(canonicalLanguage || rawLanguage || 'plain'))
+  let displayLanguage = $derived(languageMap[canonicalLanguage] || (rawLanguage ? rawLanguage.toUpperCase() : languageMap['']))
+  let isPreviewable = $derived(isShowPreview !== false && (canonicalLanguage === 'html' || canonicalLanguage === 'svg'))
+  let previewTitle = $derived(canonicalLanguage === 'svg' ? t('artifacts.svgPreviewTitle') : t('artifacts.htmlPreviewTitle'))
+  let shouldDelayEditor = $derived(resolvedStream === false && resolvedLoading)
+  let documentStreaming = $derived(context?.final === false || resolvedLoading)
+  let shouldDeferStreamingLanguage = $derived(resolvedStream !== false && documentStreaming && (isLikelyIncompleteLanguageIdentifier(rawLanguage) || isStreamingLanguagePrefix(rawLanguage)))
+  let shouldRender = $derived(!(resolvedLoading && !code.trim()))
+  let preLanguageClass = $derived(sanitizeClassToken(rawLanguage || monacoLanguage))
+  let showPreWhileMonacoLoads = $derived(!useFallback && !shouldDelayEditor && !shouldDeferStreamingLanguage && !editorReady)
+  let showPreFallback = $derived(useFallback || shouldDelayEditor || shouldDeferStreamingLanguage || showPreWhileMonacoLoads)
+  let settledRefreshSignature = $derived(diff
     ? `${monacoLanguage}\0${originalCode}\0${updatedCode || code}`
-    : `${monacoLanguage}\0${code}`
-  $: if (useFallback && fallbackLanguage && rawLanguage !== fallbackLanguage && isLikelyIncompleteLanguageIdentifier(fallbackLanguage)) {
-    useFallback = false
-    fallbackLanguage = ''
-  }
-  $: {
+    : `${monacoLanguage}\0${code}`)
+
+  $effect(() => {
+    if (useFallback && fallbackLanguage && rawLanguage !== fallbackLanguage && isLikelyIncompleteLanguageIdentifier(fallbackLanguage)) {
+      useFallback = false
+      fallbackLanguage = ''
+    }
+  })
+
+  $effect(() => {
     void mounted
     void resolvedLoading
     void settledRefreshSignature
@@ -182,8 +210,9 @@
         queueLoadingSettledRefresh()
       }
     }
-  }
-  $: {
+  })
+
+  $effect(() => {
     void mounted
     void editorHost
     void shouldRender
@@ -201,7 +230,7 @@
     void expanded
     if (mounted)
       void syncEditor()
-  }
+  })
 
   onMount(() => {
     mounted = true

--- a/packages/markstream-svelte/src/components/D2BlockNode.svelte
+++ b/packages/markstream-svelte/src/components/D2BlockNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
-  import { afterUpdate, onDestroy, onMount } from 'svelte'
+  import { onDestroy, onMount, untrack } from 'svelte'
   import { useSafeI18n } from '../i18n/useSafeI18n'
   import { getD2 } from '../optional/d2'
   import { extractRenderedSvg, toSafeSvgMarkup } from '../sanitizeSvg'
@@ -29,50 +29,71 @@
     AB5: '#F59E0B',
   }
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let maxHeight: string | null | undefined = '500px'
-  export let loading: boolean | undefined = undefined
-  export let isDark: boolean | undefined = undefined
-  export let themeId: number | null | undefined = undefined
-  export let darkThemeId: number | null | undefined = undefined
-  export let showHeader = true
-  export let showModeToggle = true
-  export let showCopyButton = true
-  export let showExportButton = true
-  export let showCollapseButton = true
+  let {
+    node,
+    context = undefined,
+    maxHeight = '500px',
+    loading = undefined,
+    isDark = undefined,
+    themeId = undefined,
+    darkThemeId = undefined,
+    showHeader = true,
+    showModeToggle = true,
+    showCopyButton = true,
+    showExportButton = true,
+    showCollapseButton = true
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    maxHeight?: string | null | undefined
+    loading?: boolean | undefined
+    isDark?: boolean | undefined
+    themeId?: number | null | undefined
+    darkThemeId?: number | null | undefined
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showExportButton?: boolean
+    showCollapseButton?: boolean
+  } = $props()
 
   const { t } = useSafeI18n()
 
-  let mounted = false
-  let renderToken = 0
-  let lastSignature = ''
-  let activeRenderSignature = ''
-  let svgMarkup = ''
-  let renderError = ''
-  let rendering = false
-  let rerenderQueued = false
-  let rerenderForce = false
-  let copied = false
-  let collapsed = false
-  let showSource = false
+  let mounted = $state(false)
+  let renderToken = $state(0)
+  let lastSignature = $state('')
+  let activeRenderSignature = $state('')
+  let svgMarkup = $state('')
+  let renderError = $state('')
+  let rendering = $state(false)
+  let rerenderQueued = $state(false)
+  let rerenderForce = $state(false)
+  let copied = $state(false)
+  let collapsed = $state(false)
+  let showSource = $state(false)
   let copyTimer: ReturnType<typeof setTimeout> | null = null
 
-  $: source = getString((node as any)?.code)
-  $: resolvedLoading = loading ?? (node as any)?.loading === true
-  $: resolvedIsDark = isDark ?? context?.isDark ?? false
-  $: shouldRender = !(resolvedLoading && !source.trim())
-  $: showSourceFallback = showSource || !svgMarkup
-  $: renderStyle = maxHeight && maxHeight !== 'none' ? `max-height: ${maxHeight}` : ''
+  let source = $derived(getString((node as any)?.code))
+  let resolvedLoading = $derived(loading ?? (node as any)?.loading === true)
+  let resolvedIsDark = $derived(isDark ?? context?.isDark ?? false)
+  let shouldRender = $derived(!(resolvedLoading && !source.trim()))
+  let showSourceFallback = $derived(showSource || !svgMarkup)
+  let renderStyle = $derived(maxHeight && maxHeight !== 'none' ? `max-height: ${maxHeight}` : '')
 
   onMount(() => {
     mounted = true
     void renderD2(true)
   })
 
-  afterUpdate(() => {
-    if (mounted)
-      void renderD2()
+  $effect(() => {
+    if (mounted) {
+      const _sig = getRenderSignature()
+      const _collapsed = collapsed
+      const _showSource = showSource
+      untrack(() => {
+        void renderD2()
+      })
+    }
   })
 
   onDestroy(() => {

--- a/packages/markstream-svelte/src/components/D2BlockNode.svelte
+++ b/packages/markstream-svelte/src/components/D2BlockNode.svelte
@@ -29,6 +29,21 @@
     AB5: '#F59E0B',
   }
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    maxHeight?: string | null | undefined
+    loading?: boolean | undefined
+    isDark?: boolean | undefined
+    themeId?: number | null | undefined
+    darkThemeId?: number | null | undefined
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showExportButton?: boolean
+    showCollapseButton?: boolean
+  }
+
   let {
     node,
     context = undefined,
@@ -42,20 +57,7 @@
     showCopyButton = true,
     showExportButton = true,
     showCollapseButton = true
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext | undefined
-    maxHeight?: string | null | undefined
-    loading?: boolean | undefined
-    isDark?: boolean | undefined
-    themeId?: number | null | undefined
-    darkThemeId?: number | null | undefined
-    showHeader?: boolean
-    showModeToggle?: boolean
-    showCopyButton?: boolean
-    showExportButton?: boolean
-    showCollapseButton?: boolean
-  } = $props()
+  }: Props = $props()
 
   const { t } = useSafeI18n()
 

--- a/packages/markstream-svelte/src/components/DefinitionListNode.svelte
+++ b/packages/markstream-svelte/src/components/DefinitionListNode.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext | undefined;
+  }
+
+  let { node, context = undefined }: Props = $props();
+
+  let html = $derived(renderNodeHtml(node, context));
 </script>
 {@html html}

--- a/packages/markstream-svelte/src/components/EmojiNode.svelte
+++ b/packages/markstream-svelte/src/components/EmojiNode.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { getString } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  $: value = getString((node as any)?.raw || (node as any)?.markup || (node as any)?.content || (node as any)?.name)
+
+  interface Props {
+    node: SvelteRenderableNode;
+  }
+
+  let { node }: Props = $props();
+
+  let value = $derived(getString((node as any)?.raw || (node as any)?.markup || (node as any)?.content || (node as any)?.name));
 </script>
 <span class="emoji-node">{value}</span>

--- a/packages/markstream-svelte/src/components/EmphasisNode.svelte
+++ b/packages/markstream-svelte/src/components/EmphasisNode.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+  
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined,
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
 <InlineWrapNode {node} {context} {indexKey} tag="em" />

--- a/packages/markstream-svelte/src/components/EmphasisNode.svelte
+++ b/packages/markstream-svelte/src/components/EmphasisNode.svelte
@@ -2,14 +2,15 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
   
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined,
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 <InlineWrapNode {node} {context} {indexKey} tag="em" />

--- a/packages/markstream-svelte/src/components/FallbackComponent.svelte
+++ b/packages/markstream-svelte/src/components/FallbackComponent.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext | undefined;
+  }
+
+  let { node, context = undefined }: Props = $props();
+
+  let html = $derived(renderNodeHtml(node, context));
 </script>
 {@html html}

--- a/packages/markstream-svelte/src/components/FootnoteAnchorNode.svelte
+++ b/packages/markstream-svelte/src/components/FootnoteAnchorNode.svelte
@@ -2,10 +2,14 @@
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
+  interface Props {
+    node: SvelteRenderableNode
+  }
 
-  $: id = getString((node as any)?.id)
-  $: href = id ? `#fnref-${id}` : undefined
+  let { node }: Props = $props()
+
+  let id = $derived(getString((node as any)?.id))
+  let href = $derived(id ? `#fnref-${id}` : undefined)
 
   function scrollToReference(event: MouseEvent) {
     event.preventDefault()

--- a/packages/markstream-svelte/src/components/FootnoteNode.svelte
+++ b/packages/markstream-svelte/src/components/FootnoteNode.svelte
@@ -3,17 +3,21 @@
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList, getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+  interface Props {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  }
 
-  $: id = getString((node as any)?.id)
-  $: children = getNodeList((node as any)?.children)
-  $: prefix = `footnote-${indexKey ?? (id || 'node')}`
+  let { node, context = undefined, indexKey = undefined }: Props = $props()
+
+  let id = $derived(getString((node as any)?.id))
+  let children = $derived(getNodeList((node as any)?.children))
+  let prefix = $derived(`footnote-${indexKey ?? (id || 'node')}`)
 </script>
 
 <div id={id ? `fnref--${id}` : undefined} class="footnote-node">
   <div class="footnote-node__content">
-    <RenderChildren nodes={children} context={context} {prefix} />
+    <RenderChildren nodes={children} {context} {prefix} />
   </div>
 </div>

--- a/packages/markstream-svelte/src/components/FootnoteReferenceNode.svelte
+++ b/packages/markstream-svelte/src/components/FootnoteReferenceNode.svelte
@@ -2,11 +2,15 @@
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
+  interface Props {
+    node: SvelteRenderableNode
+  }
 
-  $: id = getString((node as any)?.id)
-  $: href = id ? `#fnref--${id}` : undefined
-  $: linkAttrs = href ? { href } : {}
+  let { node }: Props = $props()
+
+  let id = $derived(getString((node as any)?.id))
+  let href = $derived(id ? `#fnref--${id}` : undefined)
+  let linkAttrs = $derived(href ? { href } : {})
 
   function scrollToFootnote(event: MouseEvent) {
     event.preventDefault()

--- a/packages/markstream-svelte/src/components/HeadingNode.svelte
+++ b/packages/markstream-svelte/src/components/HeadingNode.svelte
@@ -14,6 +14,6 @@
   let tag = $derived('h' + level)
 </script>
 
-<svelte:element this={tag} class={'heading-node heading-' + level}>
+<svelte:element this={tag} class="heading-node heading-{level}">
   <RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? 'heading') + '-heading'} />
 </svelte:element>

--- a/packages/markstream-svelte/src/components/HeadingNode.svelte
+++ b/packages/markstream-svelte/src/components/HeadingNode.svelte
@@ -3,13 +3,17 @@
   import RenderChildren from './RenderChildren.svelte'
   import { clampHeadingLevel, getNodeList } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  $: level = clampHeadingLevel((node as any)?.level)
-  $: tag = 'h' + level
+  interface Props {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  }
+
+  let { node, context = undefined, indexKey = undefined }: Props = $props()
+  let level = $derived(clampHeadingLevel((node as any)?.level))
+  let tag = $derived('h' + level)
 </script>
 
 <svelte:element this={tag} class={'heading-node heading-' + level}>
-  <RenderChildren nodes={getNodeList((node as any)?.children)} context={context} prefix={String(indexKey ?? 'heading') + '-heading'} />
+  <RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? 'heading') + '-heading'} />
 </svelte:element>

--- a/packages/markstream-svelte/src/components/HighlightNode.svelte
+++ b/packages/markstream-svelte/src/components/HighlightNode.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <InlineWrapNode {node} {context} {indexKey} tag="mark" />

--- a/packages/markstream-svelte/src/components/HighlightNode.svelte
+++ b/packages/markstream-svelte/src/components/HighlightNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
+
 <InlineWrapNode {node} {context} {indexKey} tag="mark" />

--- a/packages/markstream-svelte/src/components/HtmlBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/HtmlBlockNode.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  interface Props {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  }
+
+  let { node, context = undefined }: Props = $props()
+  let html = $derived(renderNodeHtml(node, context))
 </script>
 {@html html}

--- a/packages/markstream-svelte/src/components/HtmlInlineNode.svelte
+++ b/packages/markstream-svelte/src/components/HtmlInlineNode.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+  
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext;
+  }
+  
+  let { node, context }: Props = $props();
+  
+  let html = $derived(renderNodeHtml(node, context));
 </script>
 {@html html}

--- a/packages/markstream-svelte/src/components/HtmlPreviewFrame.svelte
+++ b/packages/markstream-svelte/src/components/HtmlPreviewFrame.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
-  export let code = ''
-  export let title = 'Preview'
-  export let isDark = false
-  export let htmlPreviewAllowScripts = false
-  export let htmlPreviewSandbox: string | undefined = undefined
-  export let onClose: (() => void) | undefined = undefined
-  $: sandbox = htmlPreviewSandbox ?? (htmlPreviewAllowScripts ? 'allow-scripts' : '')
+  interface Props {
+    code?: string;
+    title?: string;
+    isDark?: boolean;
+    htmlPreviewAllowScripts?: boolean;
+    htmlPreviewSandbox?: string;
+    onClose?: () => void;
+  }
+  
+  let {
+    code = '',
+    title = 'Preview',
+    isDark = false,
+    htmlPreviewAllowScripts = false,
+    htmlPreviewSandbox,
+    onClose
+  }: Props = $props();
+  
+  let sandbox = $derived(htmlPreviewSandbox ?? (htmlPreviewAllowScripts ? 'allow-scripts' : ''));
 </script>
 <div class:is-dark={isDark} class="html-preview-frame">
   <div class="html-preview-frame__header"><span>{title}</span><button type="button" onclick={() => onClose?.()}>Close</button></div>

--- a/packages/markstream-svelte/src/components/ImageNode.svelte
+++ b/packages/markstream-svelte/src/components/ImageNode.svelte
@@ -71,11 +71,9 @@
 <span class="image-node-container">
   {#if !isLoading && !hasError}
     <img
-      class={[
-        "image-node__img",
-        (useEagerImagePath || imageLoaded) && "is-loaded",
-        (!useEagerImagePath && !imageLoaded) && "is-loading"
-      ]}
+      class="image-node__img"
+      class:is-loaded={useEagerImagePath || imageLoaded}
+      class:is-loading={!useEagerImagePath && !imageLoaded}
       src={currentSrc}
       alt={alt}
       title={title || alt || undefined}

--- a/packages/markstream-svelte/src/components/ImageNode.svelte
+++ b/packages/markstream-svelte/src/components/ImageNode.svelte
@@ -5,17 +5,19 @@
 
   import { untrack } from 'svelte'
 
+  type Props = {
+    node: SvelteRenderableNode;
+    fallbackSrc?: string;
+    lazy?: boolean;
+    usePlaceholder?: boolean;
+  }
+
   let {
     node,
     fallbackSrc = '',
     lazy = false,
     usePlaceholder = true
-  }: {
-    node: SvelteRenderableNode;
-    fallbackSrc?: string;
-    lazy?: boolean;
-    usePlaceholder?: boolean;
-  } = $props()
+  }: Props = $props()
 
   const { t } = useSafeI18n()
 

--- a/packages/markstream-svelte/src/components/ImageNode.svelte
+++ b/packages/markstream-svelte/src/components/ImageNode.svelte
@@ -3,32 +3,45 @@
   import { useSafeI18n } from '../i18n/useSafeI18n'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let fallbackSrc = ''
-  export let lazy = false
-  export let usePlaceholder = true
+  import { untrack } from 'svelte'
+
+  let {
+    node,
+    fallbackSrc = '',
+    lazy = false,
+    usePlaceholder = true
+  }: {
+    node: SvelteRenderableNode;
+    fallbackSrc?: string;
+    lazy?: boolean;
+    usePlaceholder?: boolean;
+  } = $props()
 
   const { t } = useSafeI18n()
 
-  let imageLoaded = false
-  let hasError = false
-  let fallbackTried = false
-  let currentSrc = ''
-  let previousSrc = ''
+  let src = $derived(getString((node as any)?.src))
+  let alt = $derived(getString((node as any)?.alt))
+  let title = $derived(getString((node as any)?.title))
+  let raw = $derived(getString((node as any)?.raw))
+  let isLoading = $derived(Boolean((node as any)?.loading))
+  let useEagerImagePath = $derived(!lazy)
 
-  $: src = getString((node as any)?.src)
-  $: alt = getString((node as any)?.alt)
-  $: title = getString((node as any)?.title)
-  $: raw = getString((node as any)?.raw)
-  $: isLoading = Boolean((node as any)?.loading)
-  $: useEagerImagePath = !lazy
-  $: if (src !== previousSrc) {
-    previousSrc = src
-    currentSrc = src
-    imageLoaded = false
-    hasError = false
-    fallbackTried = false
-  }
+  let initialSrc = untrack(() => getString((node as any)?.src))
+  let previousSrc = $state(initialSrc)
+  let currentSrc = $state(initialSrc)
+  let imageLoaded = $state(false)
+  let hasError = $state(false)
+  let fallbackTried = $state(false)
+
+  $effect.pre(() => {
+    if (src !== previousSrc) {
+      previousSrc = src
+      currentSrc = src
+      imageLoaded = false
+      hasError = false
+      fallbackTried = false
+    }
+  })
 
   function handleImageError() {
     if (fallbackSrc && !fallbackTried) {
@@ -56,9 +69,11 @@
 <span class="image-node-container">
   {#if !isLoading && !hasError}
     <img
-      class:is-loaded={useEagerImagePath || imageLoaded}
-      class:is-loading={!useEagerImagePath && !imageLoaded}
-      class="image-node__img"
+      class={[
+        "image-node__img",
+        (useEagerImagePath || imageLoaded) && "is-loaded",
+        (!useEagerImagePath && !imageLoaded) && "is-loading"
+      ]}
       src={currentSrc}
       alt={alt}
       title={title || alt || undefined}

--- a/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
@@ -9,6 +9,22 @@
   import { clearElement, copyTextToClipboard, downloadSvgMarkup } from './shared/rich-block-helpers'
   import { getString } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    maxHeight?: string | null | undefined
+    estimatedPreviewHeightPx?: number | undefined
+    loading?: boolean | undefined
+    isDark?: boolean | undefined
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showCollapseButton?: boolean
+    showExportButton?: boolean
+    showFullscreenButton?: boolean
+    showZoomControls?: boolean
+  }
+
   let {
     node,
     context = undefined,
@@ -23,21 +39,7 @@
     showExportButton = true,
     showFullscreenButton = true,
     showZoomControls = true
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext | undefined
-    maxHeight?: string | null | undefined
-    estimatedPreviewHeightPx?: number | undefined
-    loading?: boolean | undefined
-    isDark?: boolean | undefined
-    showHeader?: boolean
-    showModeToggle?: boolean
-    showCopyButton?: boolean
-    showCollapseButton?: boolean
-    showExportButton?: boolean
-    showFullscreenButton?: boolean
-    showZoomControls?: boolean
-  } = $props()
+  }: Props = $props()
 
   const { t } = useSafeI18n()
   const infographicIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="#5b8ff9" d="M5 4.25A2.25 2.25 0 0 1 7.25 2h2.5A2.25 2.25 0 0 1 12 4.25v2.5A2.25 2.25 0 0 1 9.75 9h-2.5A2.25 2.25 0 0 1 5 6.75z"/><path fill="#61d9a6" d="M12 17.25A2.25 2.25 0 0 1 14.25 15h2.5A2.25 2.25 0 0 1 19 17.25v2.5A2.25 2.25 0 0 1 16.75 22h-2.5A2.25 2.25 0 0 1 12 19.75z"/><path fill="#f6bd16" d="M12 4.25A2.25 2.25 0 0 1 14.25 2h2.5A2.25 2.25 0 0 1 19 4.25v2.5A2.25 2.25 0 0 1 16.75 9h-2.5A2.25 2.25 0 0 1 12 6.75z"/><path fill="#5ad8a6" d="M7.5 10.75h1.75a6.25 6.25 0 0 1 6.25 6.25v.25h-2V17a4.25 4.25 0 0 0-4.25-4.25H7.5z"/><path fill="#7262fd" d="M15.5 11.1l3.75 2.16v4.33l-3.75 2.16l-3.75-2.16v-4.33z"/></svg>'

--- a/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
-  import { afterUpdate, onDestroy, onMount, tick } from 'svelte'
+  import { onDestroy, onMount, tick, untrack } from 'svelte'
   import { useSafeI18n } from '../i18n/useSafeI18n'
   import { getInfographic } from '../optional/infographic'
   import { toSafeSvgMarkup } from '../sanitizeSvg'
@@ -9,70 +9,92 @@
   import { clearElement, copyTextToClipboard, downloadSvgMarkup } from './shared/rich-block-helpers'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let maxHeight: string | null | undefined = '500px'
-  export let estimatedPreviewHeightPx: number | undefined = undefined
-  export let loading: boolean | undefined = undefined
-  export let isDark: boolean | undefined = undefined
-  export let showHeader = true
-  export let showModeToggle = true
-  export let showCopyButton = true
-  export let showCollapseButton = true
-  export let showExportButton = true
-  export let showFullscreenButton = true
-  export let showZoomControls = true
+  let {
+    node,
+    context = undefined,
+    maxHeight = '500px',
+    estimatedPreviewHeightPx = undefined,
+    loading = undefined,
+    isDark = undefined,
+    showHeader = true,
+    showModeToggle = true,
+    showCopyButton = true,
+    showCollapseButton = true,
+    showExportButton = true,
+    showFullscreenButton = true,
+    showZoomControls = true
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext | undefined
+    maxHeight?: string | null | undefined
+    estimatedPreviewHeightPx?: number | undefined
+    loading?: boolean | undefined
+    isDark?: boolean | undefined
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showCollapseButton?: boolean
+    showExportButton?: boolean
+    showFullscreenButton?: boolean
+    showZoomControls?: boolean
+  } = $props()
 
   const { t } = useSafeI18n()
   const infographicIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="#5b8ff9" d="M5 4.25A2.25 2.25 0 0 1 7.25 2h2.5A2.25 2.25 0 0 1 12 4.25v2.5A2.25 2.25 0 0 1 9.75 9h-2.5A2.25 2.25 0 0 1 5 6.75z"/><path fill="#61d9a6" d="M12 17.25A2.25 2.25 0 0 1 14.25 15h2.5A2.25 2.25 0 0 1 19 17.25v2.5A2.25 2.25 0 0 1 16.75 22h-2.5A2.25 2.25 0 0 1 12 19.75z"/><path fill="#f6bd16" d="M12 4.25A2.25 2.25 0 0 1 14.25 2h2.5A2.25 2.25 0 0 1 19 4.25v2.5A2.25 2.25 0 0 1 16.75 9h-2.5A2.25 2.25 0 0 1 12 6.75z"/><path fill="#5ad8a6" d="M7.5 10.75h1.75a6.25 6.25 0 0 1 6.25 6.25v.25h-2V17a4.25 4.25 0 0 0-4.25-4.25H7.5z"/><path fill="#7262fd" d="M15.5 11.1l3.75 2.16v4.33l-3.75 2.16l-3.75-2.16v-4.33z"/></svg>'
 
-  let renderHost: HTMLDivElement | null = null
-  let mounted = false
-  let renderToken = 0
-  let lastCompletedRenderSignature = ''
-  let activeRenderSignature = ''
-  let lastSuppressedErrorSignature = ''
-  let instance: any = null
-  let renderError = ''
-  let rendering = false
-  let rerenderQueued = false
-  let rerenderForce = false
-  let hasPreview = false
-  let copied = false
-  let collapsed = false
-  let showSource = false
-  let modalOpen = false
-  let modalMarkup = ''
-  let zoom = 1
+  let renderHost: HTMLDivElement | null = $state(null)
+  let mounted = $state(false)
+  let renderToken = $state(0)
+  let lastCompletedRenderSignature = $state('')
+  let activeRenderSignature = $state('')
+  let lastSuppressedErrorSignature = $state('')
+  let instance: any = $state(null)
+  let renderError = $state('')
+  let rendering = $state(false)
+  let rerenderQueued = $state(false)
+  let rerenderForce = $state(false)
+  let hasPreview = $state(false)
+  let copied = $state(false)
+  let collapsed = $state(false)
+  let showSource = $state(false)
+  let modalOpen = $state(false)
+  let modalMarkup = $state('')
+  let zoom = $state(1)
   let copyTimer: ReturnType<typeof setTimeout> | null = null
 
-  $: source = getString((node as any)?.code)
-  $: nodeLoading = typeof (node as any)?.loading === 'boolean' ? Boolean((node as any)?.loading) : true
-  $: resolvedLoading = loading ?? nodeLoading
-  $: final = context?.final ?? resolvedLoading === false
-  $: progressivePreview = resolvedLoading !== false || final === false
-  $: resolvedIsDark = isDark ?? context?.isDark ?? false
-  $: maxPreviewHeight = maxHeight === 'none' ? null : parsePositiveNumber(maxHeight)
-  $: previewHeight = clampPreviewHeight(
+  let source = $derived(getString((node as any)?.code))
+  let nodeLoading = $derived(typeof (node as any)?.loading === 'boolean' ? Boolean((node as any)?.loading) : true)
+  let resolvedLoading = $derived(loading ?? nodeLoading)
+  let final = $derived(context?.final ?? resolvedLoading === false)
+  let progressivePreview = $derived(resolvedLoading !== false || final === false)
+  let resolvedIsDark = $derived(isDark ?? context?.isDark ?? false)
+  let maxPreviewHeight = $derived(maxHeight === 'none' ? null : parsePositiveNumber(maxHeight))
+  let previewHeight = $derived(clampPreviewHeight(
     parsePositiveNumber(estimatedPreviewHeightPx) ?? estimateInfographicPreviewHeight(source),
     320,
     maxPreviewHeight ?? undefined,
-  )
-  $: previewStyle = [
+  ))
+  let previewStyle = $derived([
     `min-height: ${previewHeight}px`,
     maxHeight && maxHeight !== 'none' ? `max-height: ${maxHeight}` : '',
-  ].filter(Boolean).join('; ')
-  $: transformStyle = `transform: scale(${zoom}); transform-origin: center center;`
-  $: shouldRender = !(resolvedLoading && !source.trim())
+  ].filter(Boolean).join('; '))
+  let transformStyle = $derived(`transform: scale(${zoom}); transform-origin: center center;`)
+  let shouldRender = $derived(!(resolvedLoading && !source.trim()))
 
   onMount(() => {
     mounted = true
     queueInfographicRender(true)
   })
 
-  afterUpdate(() => {
-    if (mounted)
-      queueInfographicRender()
+  $effect(() => {
+    if (mounted) {
+      const _sig = `${source}\n${resolvedIsDark}\n${final}\n${progressivePreview}`
+      const _collapsed = collapsed
+      const _showSource = showSource
+      untrack(() => {
+        queueInfographicRender()
+      })
+    }
   })
 
   onDestroy(() => {

--- a/packages/markstream-svelte/src/components/InlineCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/InlineCodeNode.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { getString } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  $: code = getString((node as any)?.code ?? (node as any)?.content ?? (node as any)?.raw)
+  
+  interface Props {
+    node: SvelteRenderableNode;
+  }
+  
+  let { node }: Props = $props();
+  
+  let code = $derived(getString((node as any)?.code ?? (node as any)?.content ?? (node as any)?.raw));
 </script>
 <code class="inline-code-node">{code}</code>

--- a/packages/markstream-svelte/src/components/InlineWrapNode.svelte
+++ b/packages/markstream-svelte/src/components/InlineWrapNode.svelte
@@ -2,9 +2,18 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  export let tag = 'span'
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined,
+    tag = 'span'
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+    tag?: string
+  } = $props()
 </script>
-<svelte:element this={tag}><RenderChildren nodes={getNodeList((node as any)?.children)} context={context} prefix={String(indexKey ?? tag) + '-' + tag} /></svelte:element>
+
+<svelte:element this={tag}><RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? tag) + '-' + tag} /></svelte:element>

--- a/packages/markstream-svelte/src/components/InlineWrapNode.svelte
+++ b/packages/markstream-svelte/src/components/InlineWrapNode.svelte
@@ -3,17 +3,18 @@
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+    tag?: string
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined,
     tag = 'span'
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-    tag?: string
-  } = $props()
+  }: Props = $props()
 </script>
 
 <svelte:element this={tag}><RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? tag) + '-' + tag} /></svelte:element>

--- a/packages/markstream-svelte/src/components/InsertNode.svelte
+++ b/packages/markstream-svelte/src/components/InsertNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
+
 <InlineWrapNode {node} {context} {indexKey} tag="ins" />

--- a/packages/markstream-svelte/src/components/InsertNode.svelte
+++ b/packages/markstream-svelte/src/components/InsertNode.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <InlineWrapNode {node} {context} {indexKey} tag="ins" />

--- a/packages/markstream-svelte/src/components/LinkNode.svelte
+++ b/packages/markstream-svelte/src/components/LinkNode.svelte
@@ -3,15 +3,21 @@
   import { hideTooltip, showTooltipForAnchor } from '../tooltip/singletonTooltip'
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList, getString } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  export let showTooltip: boolean | undefined = undefined
-  $: href = getString((node as any)?.href)
-  $: title = getString((node as any)?.title || href)
-  $: children = getNodeList((node as any)?.children)
-  $: tooltipEnabled = showTooltip ?? context?.showTooltips ?? true
-  $: isHashLink = href.startsWith('#') && href.length > 1
+  
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext;
+    indexKey?: string | number;
+    showTooltip?: boolean;
+  }
+  
+  let { node, context, indexKey, showTooltip }: Props = $props();
+
+  let href = $derived(getString((node as any)?.href));
+  let title = $derived(getString((node as any)?.title || href));
+  let children = $derived(getNodeList((node as any)?.children));
+  let tooltipEnabled = $derived(showTooltip ?? context?.showTooltips ?? true);
+  let isHashLink = $derived(href.startsWith('#') && href.length > 1);
 
   function showLinkTooltip(event: MouseEvent | FocusEvent) {
     if (!tooltipEnabled || !title)

--- a/packages/markstream-svelte/src/components/ListItemNode.svelte
+++ b/packages/markstream-svelte/src/components/ListItemNode.svelte
@@ -3,15 +3,16 @@
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <li><RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? 'li') + '-li'} /></li>

--- a/packages/markstream-svelte/src/components/ListItemNode.svelte
+++ b/packages/markstream-svelte/src/components/ListItemNode.svelte
@@ -2,8 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
-<li><RenderChildren nodes={getNodeList((node as any)?.children)} context={context} prefix={String(indexKey ?? 'li') + '-li'} /></li>
+
+<li><RenderChildren nodes={getNodeList((node as any)?.children)} {context} prefix={String(indexKey ?? 'li') + '-li'} /></li>

--- a/packages/markstream-svelte/src/components/ListNode.svelte
+++ b/packages/markstream-svelte/src/components/ListNode.svelte
@@ -2,12 +2,18 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import RenderChildren from './RenderChildren.svelte'
   import { getNodeList } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  $: ordered = Boolean((node as any)?.ordered)
-  $: start = Number((node as any)?.start)
-  $: tag = ordered ? 'ol' : 'ul'
+  
+  interface Props {
+    node: SvelteRenderableNode;
+    context?: SvelteRenderContext;
+    indexKey?: string | number;
+  }
+  
+  let { node, context, indexKey }: Props = $props();
+  
+  let ordered = $derived(Boolean((node as any)?.ordered));
+  let start = $derived(Number((node as any)?.start));
+  let tag = $derived(ordered ? 'ol' : 'ul');
 </script>
 {#if ordered}
   <ol start={Number.isFinite(start) ? start : undefined}><RenderChildren nodes={getNodeList((node as any)?.items)} context={context} prefix={String(indexKey ?? 'list') + '-list'} /></ol>

--- a/packages/markstream-svelte/src/components/MarkdownCodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MarkdownCodeBlockNode.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import CodeBlockNode from './CodeBlockNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
+
+  let {
+    node,
+    context = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  } = $props()
 </script>
+
 <CodeBlockNode {node} {context} />

--- a/packages/markstream-svelte/src/components/MarkdownCodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MarkdownCodeBlockNode.svelte
@@ -2,13 +2,14 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import CodeBlockNode from './CodeBlockNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  };
   let {
     node,
     context = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-  } = $props()
+  }: Props = $props()
 </script>
 
 <CodeBlockNode {node} {context} />

--- a/packages/markstream-svelte/src/components/MathBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MathBlockNode.svelte
@@ -6,27 +6,30 @@
   import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../workers/katexWorkerClient'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
+  let { node }: { node: SvelteRenderableNode } = $props()
 
-  let mathEl: HTMLDivElement | null = null
-  let rendering = true
+  let mathEl: HTMLDivElement | null = $state(null)
+  let rendering = $state(true)
   let destroyed = false
   let renderVersion = 0
   let hasRenderedOnce = false
 
-  $: source = getString((node as any)?.content || (node as any)?.markup || (node as any)?.raw)
-  $: raw = getString((node as any)?.raw || source)
-  $: nodeLoading = (node as any)?.loading === true
-  $: renderKey = `${source}\n${raw}\n${nodeLoading ? '1' : '0'}`
-  $: if (mathEl)
-    void renderMath(renderKey, source, raw, nodeLoading)
+  let source = $derived(getString((node as any)?.content || (node as any)?.markup || (node as any)?.raw))
+  let raw = $derived(getString((node as any)?.raw || source))
+  let nodeLoading = $derived((node as any)?.loading === true)
+
+  $effect(() => {
+    if (mathEl) {
+      void renderMath(source, raw, nodeLoading)
+    }
+  })
 
   onDestroy(() => {
     destroyed = true
     renderVersion += 1
   })
 
-  async function renderMath(_renderKey: string, currentSource: string, currentRaw: string, currentLoading: boolean) {
+  async function renderMath(currentSource: string, currentRaw: string, currentLoading: boolean) {
     const target = mathEl
     if (!target)
       return
@@ -92,5 +95,5 @@
 </script>
 
 <div class="math-block markstream-nested-math-block" data-markstream-katex-managed="1">
-  <div bind:this={mathEl} class:math-rendering={rendering} class="markstream-nested-math-block__render"></div>
+  <div bind:this={mathEl} class={['markstream-nested-math-block__render', rendering && 'math-rendering']}></div>
 </div>

--- a/packages/markstream-svelte/src/components/MathBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MathBlockNode.svelte
@@ -6,7 +6,8 @@
   import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../workers/katexWorkerClient'
   import { getString } from './shared/node-helpers'
 
-  let { node }: { node: SvelteRenderableNode } = $props()
+  type Props = { node: SvelteRenderableNode }
+  let { node }: Props = $props()
 
   let mathEl: HTMLDivElement | null = $state(null)
   let rendering = $state(true)

--- a/packages/markstream-svelte/src/components/MathBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MathBlockNode.svelte
@@ -96,5 +96,5 @@
 </script>
 
 <div class="math-block markstream-nested-math-block" data-markstream-katex-managed="1">
-  <div bind:this={mathEl} class={['markstream-nested-math-block__render', rendering && 'math-rendering']}></div>
+  <div bind:this={mathEl} class="markstream-nested-math-block__render" class:math-rendering={rendering}></div>
 </div>

--- a/packages/markstream-svelte/src/components/MathInlineNode.svelte
+++ b/packages/markstream-svelte/src/components/MathInlineNode.svelte
@@ -6,7 +6,8 @@
   import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../workers/katexWorkerClient'
   import { getString } from './shared/node-helpers'
 
-  let { node }: { node: SvelteRenderableNode } = $props()
+  type Props = { node: SvelteRenderableNode }
+  let { node }: Props = $props()
 
   let mathEl: HTMLSpanElement | null = $state(null)
   let loading = $state(true)

--- a/packages/markstream-svelte/src/components/MathInlineNode.svelte
+++ b/packages/markstream-svelte/src/components/MathInlineNode.svelte
@@ -6,28 +6,31 @@
   import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../workers/katexWorkerClient'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
+  let { node }: { node: SvelteRenderableNode } = $props()
 
-  let mathEl: HTMLSpanElement | null = null
-  let loading = true
+  let mathEl: HTMLSpanElement | null = $state(null)
+  let loading = $state(true)
   let destroyed = false
   let renderVersion = 0
   let hasRenderedOnce = false
 
-  $: source = getString((node as any)?.content || (node as any)?.markup || (node as any)?.raw)
-  $: raw = getString((node as any)?.raw || source)
-  $: nodeLoading = (node as any)?.loading === true
-  $: displayMode = String((node as any)?.markup || '') === '$$'
-  $: renderKey = `${source}\n${raw}\n${nodeLoading ? '1' : '0'}\n${displayMode ? '1' : '0'}`
-  $: if (mathEl)
-    void renderMath(renderKey, source, raw, nodeLoading, displayMode)
+  let source = $derived(getString((node as any)?.content || (node as any)?.markup || (node as any)?.raw))
+  let raw = $derived(getString((node as any)?.raw || source))
+  let nodeLoading = $derived((node as any)?.loading === true)
+  let displayMode = $derived(String((node as any)?.markup || '') === '$$')
+
+  $effect(() => {
+    if (mathEl) {
+      void renderMath(source, raw, nodeLoading, displayMode)
+    }
+  })
 
   onDestroy(() => {
     destroyed = true
     renderVersion += 1
   })
 
-  async function renderMath(_renderKey: string, currentSource: string, currentRaw: string, currentLoading: boolean, currentDisplayMode: boolean) {
+  async function renderMath(currentSource: string, currentRaw: string, currentLoading: boolean, currentDisplayMode: boolean) {
     const target = mathEl
     if (!target)
       return
@@ -93,7 +96,7 @@
 </script>
 
 <span class="math-inline-wrapper markstream-nested-math" data-display="inline" data-markstream-katex-managed="1">
-  <span bind:this={mathEl} class={'math-inline' + (loading ? ' math-inline--hidden' : '')}></span>
+  <span bind:this={mathEl} class={['math-inline', loading && 'math-inline--hidden']}></span>
   {#if loading}
     <span class="math-inline__loading" role="status" aria-live="polite">
       <span class="math-inline__spinner" aria-hidden="true"></span>

--- a/packages/markstream-svelte/src/components/MathInlineNode.svelte
+++ b/packages/markstream-svelte/src/components/MathInlineNode.svelte
@@ -97,7 +97,7 @@
 </script>
 
 <span class="math-inline-wrapper markstream-nested-math" data-display="inline" data-markstream-katex-managed="1">
-  <span bind:this={mathEl} class={['math-inline', loading && 'math-inline--hidden']}></span>
+  <span bind:this={mathEl} class="math-inline" class:math-inline--hidden={loading}></span>
   {#if loading}
     <span class="math-inline__loading" role="status" aria-live="polite">
       <span class="math-inline__spinner" aria-hidden="true"></span>

--- a/packages/markstream-svelte/src/components/MermaidBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MermaidBlockNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
-  import { afterUpdate, onDestroy, onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
   import { useSafeI18n } from '../i18n/useSafeI18n'
   import { getMermaid } from '../optional/mermaid'
   import { toSafeSvgMarkup } from '../sanitizeSvg'
@@ -13,84 +13,110 @@
 
   type MermaidTheme = 'light' | 'dark'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let maxHeight: string | null | undefined = '500px'
-  export let estimatedPreviewHeightPx: number | undefined = undefined
-  export let loading: boolean | undefined = undefined
-  export let isDark: boolean | undefined = undefined
-  export let workerTimeoutMs = 1400
-  export let parseTimeoutMs = 1800
-  export let renderTimeoutMs = 2500
-  export let fullRenderTimeoutMs = 4000
-  export let renderDebounceMs = 300
-  export let showHeader = true
-  export let showModeToggle = true
-  export let showCopyButton = true
-  export let showExportButton = true
-  export let showFullscreenButton = true
-  export let showCollapseButton = true
-  export let showZoomControls = true
-  export let isStrict = true
+  let {
+    node,
+    context = undefined,
+    maxHeight = '500px',
+    estimatedPreviewHeightPx = undefined,
+    loading = undefined,
+    isDark = undefined,
+    workerTimeoutMs = 1400,
+    parseTimeoutMs = 1800,
+    renderTimeoutMs = 2500,
+    fullRenderTimeoutMs = 4000,
+    renderDebounceMs = 300,
+    showHeader = true,
+    showModeToggle = true,
+    showCopyButton = true,
+    showExportButton = true,
+    showFullscreenButton = true,
+    showCollapseButton = true,
+    showZoomControls = true,
+    isStrict = true,
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    maxHeight?: string | null
+    estimatedPreviewHeightPx?: number
+    loading?: boolean
+    isDark?: boolean
+    workerTimeoutMs?: number
+    parseTimeoutMs?: number
+    renderTimeoutMs?: number
+    fullRenderTimeoutMs?: number
+    renderDebounceMs?: number
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showExportButton?: boolean
+    showFullscreenButton?: boolean
+    showCollapseButton?: boolean
+    showZoomControls?: boolean
+    isStrict?: boolean
+  } = $props()
 
   const { t } = useSafeI18n()
   const mermaidIcon = getLanguageIcon('mermaid')
 
-  let mounted = false
-  let renderToken = 0
-  let lastRenderSignature = ''
-  let lastProgressiveMissSignature = ''
-  let lastRenderedCode = ''
-  let svgMarkup = ''
-  let svgCache: Partial<Record<MermaidTheme, string>> = {}
-  let renderError = ''
-  let rendering = false
-  let hasRenderedOnce = false
-  let copied = false
-  let collapsed = false
-  let showSource = false
-  let modalOpen = false
-  let zoom = 1
-  let renderTimer: ReturnType<typeof setTimeout> | null = null
-  let copyTimer: ReturnType<typeof setTimeout> | null = null
+  let mounted = $state(false)
+  let renderToken = $state(0)
+  let lastRenderSignature = $state('')
+  let lastProgressiveMissSignature = $state('')
+  let lastRenderedCode = $state('')
+  let svgMarkup = $state('')
+  let svgCache: Partial<Record<MermaidTheme, string>> = $state({})
+  let renderError = $state('')
+  let rendering = $state(false)
+  let hasRenderedOnce = $state(false)
+  let copied = $state(false)
+  let collapsed = $state(false)
+  let showSource = $state(false)
+  let modalOpen = $state(false)
+  let zoom = $state(1)
+  let renderTimer: ReturnType<typeof setTimeout> | null = $state(null)
+  let copyTimer: ReturnType<typeof setTimeout> | null = $state(null)
 
-  $: source = normalizeMermaidSource(getString((node as any)?.code))
-  $: nodeLoading = typeof (node as any)?.loading === 'boolean' ? Boolean((node as any)?.loading) : true
-  $: resolvedLoading = loading ?? nodeLoading
-  $: resolvedIsDark = isDark ?? context?.isDark ?? false
-  $: theme = (resolvedIsDark ? 'dark' : 'light') as MermaidTheme
-  $: final = context?.final ?? resolvedLoading === false
-  $: progressivePreview = resolvedLoading !== false || final === false
-  $: maxPreviewHeight = maxHeight === 'none' ? null : parsePositiveNumber(maxHeight)
-  $: previewHeight = clampPreviewHeight(
+  let source = $derived(normalizeMermaidSource(getString((node as any)?.code)))
+  let nodeLoading = $derived(typeof (node as any)?.loading === 'boolean' ? Boolean((node as any)?.loading) : true)
+  let resolvedLoading = $derived(loading ?? nodeLoading)
+  let resolvedIsDark = $derived(isDark ?? context?.isDark ?? false)
+  let theme = $derived((resolvedIsDark ? 'dark' : 'light') as MermaidTheme)
+  let final = $derived(context?.final ?? resolvedLoading === false)
+  let progressivePreview = $derived(resolvedLoading !== false || final === false)
+  let maxPreviewHeight = $derived(maxHeight === 'none' ? null : parsePositiveNumber(maxHeight))
+  let previewHeight = $derived(clampPreviewHeight(
     parsePositiveNumber(estimatedPreviewHeightPx) ?? estimateMermaidPreviewHeight(source),
     undefined,
     maxPreviewHeight ?? undefined,
-  )
-  $: previewStyle = [
+  ))
+  let previewStyle = $derived([
     `min-height: ${previewHeight}px`,
     maxHeight && maxHeight !== 'none' ? `max-height: ${maxHeight}` : '',
     `transform: scale(${zoom})`,
-  ].filter(Boolean).join('; ')
-  $: shouldRender = !(resolvedLoading && !source.trim())
-  $: canUsePreview = Boolean(svgMarkup && !showSource)
+  ].filter(Boolean).join('; '))
+  let shouldRender = $derived(!(resolvedLoading && !source.trim()))
+  let canUsePreview = $derived(Boolean(svgMarkup && !showSource))
 
   onMount(() => {
     mounted = true
     scheduleRender(true)
+
+    return () => {
+      mounted = false
+      renderToken += 1
+      clearRenderTimer()
+      if (copyTimer)
+        clearTimeout(copyTimer)
+    }
   })
 
-  afterUpdate(() => {
-    if (mounted)
-      scheduleRender()
-  })
-
-  onDestroy(() => {
-    mounted = false
-    renderToken += 1
-    clearRenderTimer()
-    if (copyTimer)
-      clearTimeout(copyTimer)
+  $effect(() => {
+    if (mounted) {
+      getRenderSignature()
+      showSource
+      collapsed
+      untrack(() => scheduleRender())
+    }
   })
 
   function clearRenderTimer() {

--- a/packages/markstream-svelte/src/components/MermaidBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/MermaidBlockNode.svelte
@@ -13,6 +13,28 @@
 
   type MermaidTheme = 'light' | 'dark'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    maxHeight?: string | null
+    estimatedPreviewHeightPx?: number
+    loading?: boolean
+    isDark?: boolean
+    workerTimeoutMs?: number
+    parseTimeoutMs?: number
+    renderTimeoutMs?: number
+    fullRenderTimeoutMs?: number
+    renderDebounceMs?: number
+    showHeader?: boolean
+    showModeToggle?: boolean
+    showCopyButton?: boolean
+    showExportButton?: boolean
+    showFullscreenButton?: boolean
+    showCollapseButton?: boolean
+    showZoomControls?: boolean
+    isStrict?: boolean
+  }
+
   let {
     node,
     context = undefined,
@@ -33,27 +55,7 @@
     showCollapseButton = true,
     showZoomControls = true,
     isStrict = true,
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    maxHeight?: string | null
-    estimatedPreviewHeightPx?: number
-    loading?: boolean
-    isDark?: boolean
-    workerTimeoutMs?: number
-    parseTimeoutMs?: number
-    renderTimeoutMs?: number
-    fullRenderTimeoutMs?: number
-    renderDebounceMs?: number
-    showHeader?: boolean
-    showModeToggle?: boolean
-    showCopyButton?: boolean
-    showExportButton?: boolean
-    showFullscreenButton?: boolean
-    showCollapseButton?: boolean
-    showZoomControls?: boolean
-    isStrict?: boolean
-  } = $props()
+  }: Props = $props()
 
   const { t } = useSafeI18n()
   const mermaidIcon = getLanguageIcon('mermaid')

--- a/packages/markstream-svelte/src/components/NodeOutlet.svelte
+++ b/packages/markstream-svelte/src/components/NodeOutlet.svelte
@@ -50,15 +50,16 @@
     resolveNodeOutletCustomInputs,
   } from './shared/node-outlet-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined,
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 
   let resolvedType = $derived(String((node as any)?.type || ''))
   let customComponentMap = $derived(context?.customComponents || getCustomNodeComponents(context?.customId))

--- a/packages/markstream-svelte/src/components/NodeRenderer.svelte
+++ b/packages/markstream-svelte/src/components/NodeRenderer.svelte
@@ -353,7 +353,8 @@
 <!-- svelte-ignore a11y_mouse_events_have_key_events -->
 <div
   bind:this={rootEl}
-  class={'markstream-svelte markdown-renderer' + (isDark ? ' dark' : '') + (className ? ' ' + className : '')}
+  class="markstream-svelte markdown-renderer {className}"
+  class:dark={isDark}
   data-custom-id={customId}
   onclick={onClick}
   onmouseover={handleMouseover}

--- a/packages/markstream-svelte/src/components/ParagraphNode.svelte
+++ b/packages/markstream-svelte/src/components/ParagraphNode.svelte
@@ -4,15 +4,16 @@
   import NodeOutlet from './NodeOutlet.svelte'
   import { getNodeList, splitParagraphChildren } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 
   let prefix = $derived(String(indexKey ?? 'p'))
   let parts = $derived(splitParagraphChildren(getNodeList((node as any)?.children)))

--- a/packages/markstream-svelte/src/components/ParagraphNode.svelte
+++ b/packages/markstream-svelte/src/components/ParagraphNode.svelte
@@ -4,18 +4,24 @@
   import NodeOutlet from './NodeOutlet.svelte'
   import { getNodeList, splitParagraphChildren } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 
-  $: prefix = String(indexKey ?? 'p')
-  $: parts = splitParagraphChildren(getNodeList((node as any)?.children))
+  let prefix = $derived(String(indexKey ?? 'p'))
+  let parts = $derived(splitParagraphChildren(getNodeList((node as any)?.children)))
 </script>
 
 {#each parts as part, index (prefix + '-' + index)}
   {#if part.kind === 'inline'}
-    <p class="paragraph-node"><RenderChildren nodes={part.nodes} context={context} prefix={prefix + '-' + index} /></p>
+    <p class="paragraph-node"><RenderChildren nodes={part.nodes} {context} prefix={prefix + '-' + index} /></p>
   {:else}
-    <NodeOutlet node={part.node} context={context} indexKey={prefix + '-' + index} />
+    <NodeOutlet node={part.node} {context} indexKey={prefix + '-' + index} />
   {/if}
 {/each}

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -2,11 +2,12 @@
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { encodeDataPayload, getString, sanitizeClassToken } from './shared/node-helpers'
 
+  type Props = {
+    node: SvelteRenderableNode
+  };
   let {
     node
-  }: {
-    node: SvelteRenderableNode
-  } = $props()
+  }: Props = $props()
 
   let languageRaw = $derived(getString((node as any)?.language).trim())
   let language = $derived(sanitizeClassToken(languageRaw))

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -17,5 +17,5 @@
 </script>
 
 {#if !(loading && !code.trim())}
-  <pre data-markstream-code-block="1" data-markstream-language={languageRaw || undefined} data-markstream-loading={loading ? '1' : undefined} data-markstream-diff={diff ? '1' : undefined} data-markstream-original={diff ? encodeDataPayload(getString((node as any)?.originalCode)) : undefined} data-markstream-updated={diff ? encodeDataPayload(getString((node as any)?.updatedCode)) : undefined} aria-busy={loading ? 'true' : undefined}><code class={language ? 'language-' + language : undefined}>{code}</code></pre>
+  <pre data-markstream-code-block="1" data-markstream-language={languageRaw || undefined} data-markstream-loading={loading ? '1' : undefined} data-markstream-diff={diff ? '1' : undefined} data-markstream-original={diff ? encodeDataPayload(getString((node as any)?.originalCode)) : undefined} data-markstream-updated={diff ? encodeDataPayload(getString((node as any)?.updatedCode)) : undefined} aria-busy={loading ? 'true' : undefined}><code class={language ? `language-${language}` : undefined}>{code}</code></pre>
 {/if}

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
   import type { SvelteRenderableNode } from './shared/node-helpers'
   import { encodeDataPayload, getString, sanitizeClassToken } from './shared/node-helpers'
-  export let node: SvelteRenderableNode
-  $: languageRaw = getString((node as any)?.language).trim()
-  $: language = sanitizeClassToken(languageRaw)
-  $: code = getString((node as any)?.code)
-  $: diff = Boolean((node as any)?.diff)
-  $: loading = (node as any)?.loading === true
+
+  let {
+    node
+  }: {
+    node: SvelteRenderableNode
+  } = $props()
+
+  let languageRaw = $derived(getString((node as any)?.language).trim())
+  let language = $derived(sanitizeClassToken(languageRaw))
+  let code = $derived(getString((node as any)?.code))
+  let diff = $derived(Boolean((node as any)?.diff))
+  let loading = $derived((node as any)?.loading === true)
 </script>
+
 {#if !(loading && !code.trim())}
   <pre data-markstream-code-block="1" data-markstream-language={languageRaw || undefined} data-markstream-loading={loading ? '1' : undefined} data-markstream-diff={diff ? '1' : undefined} data-markstream-original={diff ? encodeDataPayload(getString((node as any)?.originalCode)) : undefined} data-markstream-updated={diff ? encodeDataPayload(getString((node as any)?.updatedCode)) : undefined} aria-busy={loading ? 'true' : undefined}><code class={language ? 'language-' + language : undefined}>{code}</code></pre>
 {/if}

--- a/packages/markstream-svelte/src/components/ReferenceNode.svelte
+++ b/packages/markstream-svelte/src/components/ReferenceNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  let {
+    node,
+    context = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  } = $props()
+
+  let html = $derived(renderNodeHtml(node, context))
 </script>
+
 {@html html}

--- a/packages/markstream-svelte/src/components/ReferenceNode.svelte
+++ b/packages/markstream-svelte/src/components/ReferenceNode.svelte
@@ -2,13 +2,14 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  };
   let {
     node,
     context = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-  } = $props()
+  }: Props = $props()
 
   let html = $derived(renderNodeHtml(node, context))
 </script>

--- a/packages/markstream-svelte/src/components/RenderChildren.svelte
+++ b/packages/markstream-svelte/src/components/RenderChildren.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import NodeOutlet from './NodeOutlet.svelte'
 
+  type Props = {
+    nodes?: readonly SvelteRenderableNode[] | null
+    context?: SvelteRenderContext
+    prefix?: string
+  };
   let {
     nodes = [],
     context = undefined,
     prefix = 'child',
-  }: {
-    nodes?: readonly SvelteRenderableNode[] | null
-    context?: SvelteRenderContext
-    prefix?: string
-  } = $props()
+  }: Props = $props()
 </script>
 
 {#each nodes || [] as child, index (prefix + '-' + index)}

--- a/packages/markstream-svelte/src/components/StrikethroughNode.svelte
+++ b/packages/markstream-svelte/src/components/StrikethroughNode.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <InlineWrapNode {node} {context} {indexKey} tag="del" />

--- a/packages/markstream-svelte/src/components/StrikethroughNode.svelte
+++ b/packages/markstream-svelte/src/components/StrikethroughNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
+
 <InlineWrapNode {node} {context} {indexKey} tag="del" />

--- a/packages/markstream-svelte/src/components/StrongNode.svelte
+++ b/packages/markstream-svelte/src/components/StrongNode.svelte
@@ -2,14 +2,15 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
   
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined,
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 <InlineWrapNode {node} {context} {indexKey} tag="strong" />

--- a/packages/markstream-svelte/src/components/StrongNode.svelte
+++ b/packages/markstream-svelte/src/components/StrongNode.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+  
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined,
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
 <InlineWrapNode {node} {context} {indexKey} tag="strong" />

--- a/packages/markstream-svelte/src/components/SubscriptNode.svelte
+++ b/packages/markstream-svelte/src/components/SubscriptNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
+
 <InlineWrapNode {node} {context} {indexKey} tag="sub" />

--- a/packages/markstream-svelte/src/components/SubscriptNode.svelte
+++ b/packages/markstream-svelte/src/components/SubscriptNode.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <InlineWrapNode {node} {context} {indexKey} tag="sub" />

--- a/packages/markstream-svelte/src/components/SuperscriptNode.svelte
+++ b/packages/markstream-svelte/src/components/SuperscriptNode.svelte
@@ -2,15 +2,16 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  };
   let {
     node,
     context = undefined,
     indexKey = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-    indexKey?: string | number
-  } = $props()
+  }: Props = $props()
 </script>
 
 <InlineWrapNode {node} {context} {indexKey} tag="sup" />

--- a/packages/markstream-svelte/src/components/SuperscriptNode.svelte
+++ b/packages/markstream-svelte/src/components/SuperscriptNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import InlineWrapNode from './InlineWrapNode.svelte'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+  } = $props()
 </script>
+
 <InlineWrapNode {node} {context} {indexKey} tag="sup" />

--- a/packages/markstream-svelte/src/components/TableNode.svelte
+++ b/packages/markstream-svelte/src/components/TableNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  let {
+    node,
+    context = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  } = $props()
+
+  let html = $derived(renderNodeHtml(node, context))
 </script>
+
 {@html html}

--- a/packages/markstream-svelte/src/components/TableNode.svelte
+++ b/packages/markstream-svelte/src/components/TableNode.svelte
@@ -2,13 +2,14 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  };
   let {
     node,
     context = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-  } = $props()
+  }: Props = $props()
 
   let html = $derived(renderNodeHtml(node, context))
 </script>

--- a/packages/markstream-svelte/src/components/TextNode.svelte
+++ b/packages/markstream-svelte/src/components/TextNode.svelte
@@ -49,4 +49,4 @@
   })
 </script>
 
-<span data-typewriter={typewriter !== false ? '1' : undefined} class:markstream-svelte-text--centered={centered} class="markstream-svelte-text-node text-node">{streamInfo.stableContent}{#if streamInfo.deltaContent}<span class={'markstream-svelte-text__stream-delta text-node-stream-delta ' + streamInfo.deltaClass}>{streamInfo.deltaContent}</span>{/if}</span>
+<span data-typewriter={typewriter !== false ? '1' : undefined} class:markstream-svelte-text--centered={centered} class="markstream-svelte-text-node text-node">{streamInfo.stableContent}{#if streamInfo.deltaContent}<span class="markstream-svelte-text__stream-delta text-node-stream-delta {streamInfo.deltaClass}">{streamInfo.deltaContent}</span>{/if}</span>

--- a/packages/markstream-svelte/src/components/TextNode.svelte
+++ b/packages/markstream-svelte/src/components/TextNode.svelte
@@ -2,23 +2,35 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { getString } from './shared/node-helpers'
 
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  export let indexKey: string | number | undefined = undefined
-  export let typewriter: boolean | undefined = undefined
+  interface Props {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+    indexKey?: string | number
+    typewriter?: boolean
+  }
+
+  let {
+    node,
+    context = undefined,
+    indexKey = undefined,
+    typewriter = undefined
+  }: Props = $props()
 
   let previousKey = ''
   let previousContent = ''
-  let stableContent = ''
-  let deltaContent = ''
   let deltaClass = 'markstream-svelte-text__stream-delta--a'
 
-  $: content = getString((node as any)?.content ?? (node as any)?.raw)
-  $: centered = Boolean((node as any)?.center)
-  $: streamKey = String(context?.customId ?? 'global') + ':' + String(context?.streamRenderVersion ?? 0) + ':' + String(indexKey ?? 'node')
-  $: {
+  const content = $derived(getString((node as any)?.content ?? (node as any)?.raw))
+  const centered = $derived(Boolean((node as any)?.center))
+  const streamKey = $derived(String(context?.customId ?? 'global') + ':' + String(context?.streamRenderVersion ?? 0) + ':' + String(indexKey ?? 'node'))
+
+  const streamInfo = $derived.by(() => {
     const state = context?.textStreamState
     const previous = streamKey === previousKey ? previousContent : (state?.get(streamKey) ?? '')
+    
+    let stableContent = ''
+    let deltaContent = ''
+
     if (previous && content.startsWith(previous) && content.length > previous.length) {
       stableContent = previous
       deltaContent = content.slice(previous.length)
@@ -28,10 +40,13 @@
       stableContent = content
       deltaContent = ''
     }
+    
     previousKey = streamKey
     previousContent = content
     state?.set(streamKey, content)
-  }
+
+    return { stableContent, deltaContent, deltaClass }
+  })
 </script>
 
-<span data-typewriter={typewriter !== false ? '1' : undefined} class:markstream-svelte-text--centered={centered} class="markstream-svelte-text-node text-node">{stableContent}{#if deltaContent}<span class={'markstream-svelte-text__stream-delta text-node-stream-delta ' + deltaClass}>{deltaContent}</span>{/if}</span>
+<span data-typewriter={typewriter !== false ? '1' : undefined} class:markstream-svelte-text--centered={centered} class="markstream-svelte-text-node text-node">{streamInfo.stableContent}{#if streamInfo.deltaContent}<span class={'markstream-svelte-text__stream-delta text-node-stream-delta ' + streamInfo.deltaClass}>{streamInfo.deltaContent}</span>{/if}</span>

--- a/packages/markstream-svelte/src/components/Tooltip.svelte
+++ b/packages/markstream-svelte/src/components/Tooltip.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
-  let { text = '' }: { text?: string } = $props()
+  type Props = { text?: string };
+  let { text = '' }: Props = $props()
 </script>
 <span class="tooltip-element">{text}</span>

--- a/packages/markstream-svelte/src/components/Tooltip.svelte
+++ b/packages/markstream-svelte/src/components/Tooltip.svelte
@@ -1,4 +1,4 @@
 <script lang="ts">
-  export let text = ''
+  let { text = '' }: { text?: string } = $props()
 </script>
 <span class="tooltip-element">{text}</span>

--- a/packages/markstream-svelte/src/components/VmrContainerNode.svelte
+++ b/packages/markstream-svelte/src/components/VmrContainerNode.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
-  export let node: SvelteRenderableNode
-  export let context: SvelteRenderContext | undefined = undefined
-  $: html = renderNodeHtml(node, context)
+
+  let {
+    node,
+    context = undefined
+  }: {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  } = $props()
+
+  let html = $derived(renderNodeHtml(node, context))
 </script>
+
 {@html html}

--- a/packages/markstream-svelte/src/components/VmrContainerNode.svelte
+++ b/packages/markstream-svelte/src/components/VmrContainerNode.svelte
@@ -2,13 +2,14 @@
   import type { SvelteRenderableNode, SvelteRenderContext } from './shared/node-helpers'
   import { renderNodeHtml } from './shared/renderNodeHtml'
 
+  type Props = {
+    node: SvelteRenderableNode
+    context?: SvelteRenderContext
+  };
   let {
     node,
     context = undefined
-  }: {
-    node: SvelteRenderableNode
-    context?: SvelteRenderContext
-  } = $props()
+  }: Props = $props()
 
   let html = $derived(renderNodeHtml(node, context))
 </script>

--- a/packages/markstream-svelte/tsconfig.json
+++ b/packages/markstream-svelte/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "paths": {},
     "types": ["svelte", "vite/client", "node"],
     "declaration": true,
     "declarationMap": false,


### PR DESCRIPTION
## Summary

Please explain the goal of this change in 2–3 lines.

## Changes

migrate svelte legacy components to svelte 5 runes

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

## Checklist

- [ ] Lint: `pnpm lint`
- [ ] Typecheck: `pnpm typecheck`
- [ ] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [ ] Build: `pnpm build` (library + CSS)
