### PR TITLE
fix: improve math block height handling

### DIFF
--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -702,6 +702,15 @@ onBeforeUnmount(() => {
             </button>
 
             <button
+              class="nav-btn nav-btn--retry"
+              :disabled="isStreaming && !isPaused"
+              @click="() => { stopStreamSimulation(); startStreamSimulation() }"
+            >
+              <Icon icon="carbon:restart" class="nav-btn__icon" />
+              <span class="nav-btn__text">Retry</span>
+            </button>
+
+            <button
               class="nav-btn nav-btn--stream"
               :disabled="!isStreaming"
               @click="toggleStreamPause"
@@ -1323,6 +1332,7 @@ onBeforeUnmount(() => {
 .nav-btn--github { background: #24292f; }
 .nav-btn--docs { background: #0f766e; }
 .nav-btn--themes { background: #0e7490; }
+.nav-btn--retry { background: #0f766e; }
 .nav-btn--stream { background: #c2410c; }
 .nav-btn--test { background: #0369a1; }
 .nav-btn--cdn { background: #475569; }

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import type { MathBlockNodeProps } from '../../types/component-props'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
 import { getKatex, getKatexSync } from '../MathInlineNode/katex'
+import { mathBlockMinHeightCache } from './minHeightCache'
 
 const props = defineProps<MathBlockNodeProps>()
 const containerEl = ref<HTMLElement | null>(null)
@@ -59,10 +60,43 @@ let isUnmounted = false
 let currentAbortController: AbortController | null = null
 const registerVisibility = useViewportPriority()
 let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
+let resizeObserver: ResizeObserver | null = null
 const renderingLoading = ref(initialState.loading)
+const lockedMinHeight = ref(resolveCachedMinHeight())
 
 if (initialState.html || initialState.text)
   hasRenderedOnce = true
+
+function getHeightCacheKey() {
+  return props.indexKey != null
+    ? `math-block:${String(props.indexKey)}`
+    : ''
+}
+
+function resolveCachedMinHeight() {
+  const cacheKey = getHeightCacheKey()
+  return cacheKey ? (mathBlockMinHeightCache.get(cacheKey) ?? 0) : 0
+}
+
+function updateLockedMinHeight(height: number) {
+  if (!Number.isFinite(height) || height <= 0)
+    return
+
+  const nextMinHeight = Math.max(lockedMinHeight.value, height)
+  if (nextMinHeight === lockedMinHeight.value)
+    return
+
+  lockedMinHeight.value = nextMinHeight
+  const cacheKey = getHeightCacheKey()
+  if (cacheKey)
+    mathBlockMinHeightCache.set(cacheKey, nextMinHeight)
+}
+
+function captureHeight() {
+  nextTick(() => {
+    updateLockedMinHeight(containerEl.value?.offsetHeight ?? 0)
+  })
+}
 
 // Function to render math using KaTeX
 async function renderMath() {
@@ -73,6 +107,7 @@ async function renderMath() {
     renderedHtml.value = ''
     renderedText.value = props.node.raw
     hasRenderedOnce = true
+    captureHeight()
     return
   }
 
@@ -114,6 +149,7 @@ async function renderMath() {
       renderedText.value = ''
       hasRenderedOnce = true
       renderingLoading.value = false
+      captureHeight()
     })
     .catch(async (err: any) => {
       // ignore if a newer render was requested or component unmounted
@@ -145,6 +181,7 @@ async function renderMath() {
             renderedText.value = ''
             hasRenderedOnce = true
             renderingLoading.value = false
+            captureHeight()
             // populate worker client cache so future calls hit cache
             setKaTeXCache(mathContent.value, true, html)
           }
@@ -160,6 +197,7 @@ async function renderMath() {
         renderingLoading.value = false
         renderedHtml.value = ''
         renderedText.value = props.node.raw
+        captureHeight()
         return
       }
 
@@ -170,6 +208,7 @@ async function renderMath() {
         renderingLoading.value = false
         renderedHtml.value = ''
         renderedText.value = props.node.raw
+        captureHeight()
       }
     })
 }
@@ -180,7 +219,25 @@ watch(
     renderMath()
   },
 )
+
+watch(
+  () => props.indexKey,
+  () => {
+    lockedMinHeight.value = resolveCachedMinHeight()
+    captureHeight()
+  },
+)
+
 onMounted(() => {
+  if (typeof ResizeObserver !== 'undefined' && containerEl.value) {
+    resizeObserver = new ResizeObserver(() => {
+      updateLockedMinHeight(containerEl.value?.offsetHeight ?? 0)
+    })
+    resizeObserver.observe(containerEl.value)
+  }
+
+  captureHeight()
+
   if (renderedHtml.value)
     return
   renderMath()
@@ -193,6 +250,8 @@ onBeforeUnmount(() => {
     currentAbortController.abort()
     currentAbortController = null
   }
+  resizeObserver?.disconnect()
+  resizeObserver = null
   visibilityHandle?.destroy?.()
   visibilityHandle = null
 })
@@ -204,6 +263,7 @@ onBeforeUnmount(() => {
     class="math-block text-center overflow-x-auto relative"
     data-markstream-math="block"
     :data-markstream-mode="renderedHtml ? 'katex' : renderedText ? 'fallback' : 'loading'"
+    :style="lockedMinHeight ? { minHeight: `${lockedMinHeight}px` } : undefined"
   >
     <Transition name="math-fade">
       <div v-if="renderingLoading && !renderedHtml && !renderedText" class="math-loading-overlay">
@@ -224,6 +284,7 @@ onBeforeUnmount(() => {
 <style scoped>
 .math-block {
   min-height: var(--ms-size-math-min-height);
+  transition: min-height var(--ms-duration-overlay) var(--ms-ease-standard);
 }
 
 .math-loading-overlay {
@@ -267,7 +328,7 @@ onBeforeUnmount(() => {
 
 .math-fade-enter-active,
 .math-fade-leave-active {
-  transition: opacity var(--ms-duration-slow) var(--ms-ease-standard);
+  transition: all var(--ms-duration-slow) var(--ms-ease-standard);
 }
 
 .math-fade-enter-from,

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -6,7 +6,7 @@ import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
 import { getKatex, getKatexSync } from '../MathInlineNode/katex'
-import { mathBlockMinHeightCache } from './minHeightCache'
+import { useMathBlockMinHeightCache } from './minHeightCache'
 
 const props = defineProps<MathBlockNodeProps>()
 const containerEl = ref<HTMLElement | null>(null)
@@ -58,6 +58,7 @@ let hasRenderedOnce = false
 let currentRenderId = 0
 let isUnmounted = false
 let currentAbortController: AbortController | null = null
+const minHeightCacheContext = useMathBlockMinHeightCache()
 const registerVisibility = useViewportPriority()
 let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
 let resizeObserver: ResizeObserver | null = null
@@ -68,14 +69,19 @@ if (initialState.html || initialState.text)
   hasRenderedOnce = true
 
 function getHeightCacheKey() {
-  return props.indexKey != null
-    ? `math-block:${String(props.indexKey)}`
+  if (props.indexKey == null)
+    return ''
+
+  const scope = props.cacheScope ?? minHeightCacheContext?.scope
+  const scopedPrefix = scope != null && String(scope).length > 0
+    ? `${String(scope)}:`
     : ''
+  return `${scopedPrefix}math-block:${String(props.indexKey)}`
 }
 
 function resolveCachedMinHeight() {
   const cacheKey = getHeightCacheKey()
-  return cacheKey ? (mathBlockMinHeightCache.get(cacheKey) ?? 0) : 0
+  return cacheKey ? (minHeightCacheContext?.cache.get(cacheKey) ?? 0) : 0
 }
 
 function updateLockedMinHeight(height: number) {
@@ -89,7 +95,7 @@ function updateLockedMinHeight(height: number) {
   lockedMinHeight.value = nextMinHeight
   const cacheKey = getHeightCacheKey()
   if (cacheKey)
-    mathBlockMinHeightCache.set(cacheKey, nextMinHeight)
+    minHeightCacheContext?.cache.set(cacheKey, nextMinHeight)
 }
 
 function captureHeight() {
@@ -221,7 +227,7 @@ watch(
 )
 
 watch(
-  () => props.indexKey,
+  [() => props.indexKey, () => props.cacheScope],
   () => {
     lockedMinHeight.value = resolveCachedMinHeight()
     captureHeight()

--- a/src/components/MathBlockNode/minHeightCache.ts
+++ b/src/components/MathBlockNode/minHeightCache.ts
@@ -1,0 +1,1 @@
+export const mathBlockMinHeightCache = new Map<string, number>()

--- a/src/components/MathBlockNode/minHeightCache.ts
+++ b/src/components/MathBlockNode/minHeightCache.ts
@@ -1,1 +1,27 @@
-export const mathBlockMinHeightCache = new Map<string, number>()
+import type { InjectionKey } from 'vue'
+import { inject, provide } from 'vue'
+
+export interface MathBlockMinHeightCacheContext {
+  scope: string
+  cache: Map<string, number>
+  clear: () => void
+}
+
+export const MATH_BLOCK_MIN_HEIGHT_CACHE = Symbol('MarkstreamMathBlockMinHeightCache') as InjectionKey<MathBlockMinHeightCacheContext>
+
+export function createMathBlockMinHeightCache(scope: string): MathBlockMinHeightCacheContext {
+  const cache = new Map<string, number>()
+  return {
+    scope,
+    cache,
+    clear: () => cache.clear(),
+  }
+}
+
+export function provideMathBlockMinHeightCache(ctx: MathBlockMinHeightCacheContext) {
+  provide(MATH_BLOCK_MIN_HEIGHT_CACHE, ctx)
+}
+
+export function useMathBlockMinHeightCache() {
+  return inject(MATH_BLOCK_MIN_HEIGHT_CACHE, null)
+}

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -51,6 +51,7 @@ import { customComponentsRevision, getCustomNodeComponents } from '../../utils/n
 import HtmlBlockNode from '../HtmlBlockNode/HtmlBlockNode.vue'
 import HtmlInlineNode from '../HtmlInlineNode/HtmlInlineNode.vue'
 import MarkdownCodeBlockNode from '../MarkdownCodeBlockNode'
+import { createMathBlockMinHeightCache, provideMathBlockMinHeightCache } from '../MathBlockNode/minHeightCache'
 import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
 import FallbackComponent from './FallbackComponent.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
@@ -159,6 +160,7 @@ provide('markstreamStreamVersion', streamRenderVersion)
 watch(
   [() => props.content, () => props.nodes],
   () => {
+    mathBlockMinHeightCache.clear()
     streamRenderVersion.value += 1
   },
   { immediate: true },
@@ -206,6 +208,9 @@ function resolveViewportRoot(node?: HTMLElement | null) {
 const instanceMsgId = props.customId
   ? `renderer-${props.customId}`
   : `renderer-${Date.now()}-${Math.random().toString(36).slice(2)}`
+const mathBlockMinHeightCache = createMathBlockMinHeightCache(instanceMsgId)
+const mathBlockCacheScope = computed(() => `${instanceMsgId}:${streamRenderVersion.value}`)
+provideMathBlockMinHeightCache(mathBlockMinHeightCache)
 const defaultMd = getMarkdown(instanceMsgId)
 const customTagCache = new Map<string, MarkdownIt>()
 const customComponentsMap = computed<Partial<CustomComponents>>(() => {
@@ -2192,6 +2197,12 @@ const renderedItems = computed(() => {
         ),
       }
     }
+    if (node.type === 'math_block') {
+      bindings = {
+        ...bindings,
+        cacheScope: mathBlockCacheScope.value,
+      }
+    }
 
     return {
       ...item,
@@ -2460,6 +2471,7 @@ watch(
 
 onBeforeUnmount(() => {
   clearTypewriterCursorTimeout()
+  mathBlockMinHeightCache.clear()
 })
 </script>
 

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -157,15 +157,6 @@ provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
 provide('markstreamStreamVersion', streamRenderVersion)
 
-watch(
-  [() => props.content, () => props.nodes],
-  () => {
-    mathBlockMinHeightCache.clear()
-    streamRenderVersion.value += 1
-  },
-  { immediate: true },
-)
-
 function logPerf(label: string, data: Record<string, unknown>) {
   if (!debugPerformanceEnabled.value)
     return
@@ -211,6 +202,14 @@ const instanceMsgId = props.customId
 const mathBlockMinHeightCache = createMathBlockMinHeightCache(instanceMsgId)
 const mathBlockCacheScope = computed(() => `${instanceMsgId}:${streamRenderVersion.value}`)
 provideMathBlockMinHeightCache(mathBlockMinHeightCache)
+watch(
+  [() => props.content, () => props.nodes],
+  () => {
+    mathBlockMinHeightCache.clear()
+    streamRenderVersion.value += 1
+  },
+  { immediate: true },
+)
 const defaultMd = getMarkdown(instanceMsgId)
 const customTagCache = new Map<string, MarkdownIt>()
 const customComponentsMap = computed<Partial<CustomComponents>>(() => {

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -244,6 +244,7 @@ export interface MathBlockNodeProps {
     raw: string
     loading?: boolean
   }
+  indexKey?: number | string
 }
 
 export interface MathInlineNodeProps {

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -245,6 +245,7 @@ export interface MathBlockNodeProps {
     loading?: boolean
   }
   indexKey?: number | string
+  cacheScope?: string | number
 }
 
 export interface MathInlineNodeProps {

--- a/test/math-block-min-height-cache-scope.test.ts
+++ b/test/math-block-min-height-cache-scope.test.ts
@@ -1,0 +1,83 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import MathBlockNode from '../src/components/MathBlockNode/MathBlockNode.vue'
+import { createMathBlockMinHeightCache, MATH_BLOCK_MIN_HEIGHT_CACHE } from '../src/components/MathBlockNode/minHeightCache'
+import { flushAll } from './setup/flush-all'
+
+vi.mock('../src/components/MathInlineNode/katex', () => ({
+  getKatexSync: () => null,
+  getKatex: async () => null,
+}))
+
+vi.mock('../src/workers/katexWorkerClient', async () => {
+  const actual: any = await vi.importActual('../src/workers/katexWorkerClient')
+  return {
+    ...actual,
+    renderKaTeXWithBackpressure: vi.fn(() => new Promise<string>(() => {})),
+  }
+})
+
+const originalOffsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+
+function mockOffsetHeight(height: number) {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return height
+    },
+  })
+}
+
+describe('mathBlockNode min-height cache scope', () => {
+  afterEach(() => {
+    if (originalOffsetHeightDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeightDescriptor)
+    }
+  })
+
+  it('isolates cached min-height across different scopes for the same indexKey', async () => {
+    const rendererCache = createMathBlockMinHeightCache('renderer-test')
+
+    mockOffsetHeight(120)
+    const first = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: '',
+          raw: '$$x$$',
+        },
+        indexKey: 'same-index',
+        cacheScope: 'msg-a',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+        },
+      },
+    })
+    await flushAll()
+    expect(first.attributes('style')).toContain('min-height: 120px;')
+    first.unmount()
+
+    mockOffsetHeight(40)
+    const second = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: '',
+          raw: '$$y$$',
+        },
+        indexKey: 'same-index',
+        cacheScope: 'msg-b',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+        },
+      },
+    })
+    await flushAll()
+    expect(second.attributes('style')).toContain('min-height: 40px;')
+    second.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

 Enhance the handling of minimum height for math blocks to ensure consistent rendering and performance. Introduce caching for minimum heights and adjust the component's behavior based on viewport changes.
 
 ## Changes

 * [x]  Implemented a cache for minimum heights in math blocks.
 * [x] Updated rendering logic to capture and adjust height dynamically.
 
 ## Screenshots / Demo (if UI/behavior changes)

 * [ ]  Added GIF/screenshot
 * [ ]  Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)
 
 ## Checklist

 * [x]  Lint: `pnpm lint`
 * [x]  Typecheck: `pnpm typecheck`
 * [x]  Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
 * [x]  Build: `pnpm build` (library + CSS)

