### PR TITLE
feat: enable smooth streaming by default with toggle

### DIFF
--- a/.agents/skills/markstream-custom-components/SKILL.md
+++ b/.agents/skills/markstream-custom-components/SKILL.md
@@ -24,6 +24,7 @@ Read [references/patterns.md](references/patterns.md) before choosing an overrid
 4. Preserve nested Markdown when needed.
    - For trusted custom tags with inner Markdown, render `node.content` with a nested renderer.
    - Pass the same custom-tag allowlist to nested renderers.
+   - Nested renderers inside a smooth-streaming parent are automatically suppressed from double pacing — do not add `smooth-streaming` to child renderers.
 5. Keep props and cleanup intact.
    - Preserve `node`, `loading`, `indexKey`, `customId`, and `isDark`.
    - For `mermaid` and `infographic` overrides, preserve `estimatedPreviewHeightPx` so async preview shells keep stable height during remounts.

--- a/.agents/skills/markstream-install/SKILL.md
+++ b/.agents/skills/markstream-install/SKILL.md
@@ -25,7 +25,9 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
    - Import `katex/dist/katex.min.css` when math is enabled.
 4. Add the smallest working render example.
     - Use `content` for static or low-frequency rendering.
-    - Use `nodes` plus `final` when the app receives streaming updates.
+    - For streaming AI chat, use `typewriter` or `:max-live-nodes="0"` — smooth streaming (`smooth-streaming="auto"`) paces visible output automatically. Pair with `:fade="false"`.
+    - Use `nodes` plus `final` when the app needs custom AST control, worker preparsing, or structural updates beyond pacing.
+    - For manual pacing with `nodes`, use `useSmoothMarkdownStream`: `enqueue()` chunks, `finish()` when done, render from `visible`, wait for `caughtUp` before final parsing.
     - Preserve the default hardening: HTML policies now default to `safe`, and Mermaid runs in strict mode by default.
 5. Keep customization scoped.
     - If the task requires overrides, prefer `customId` / `custom-id` plus scoped `setCustomComponents(...)`.
@@ -37,6 +39,7 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
 
 - Prefer the minimal peer set over "install everything".
 - Prefer `content` unless the app is clearly SSE, chat, token-streaming, or worker-preparsed.
+- When using `content` for streaming, smooth streaming (`smooth-streaming="auto"`) is on by default for `typewriter` or `max-live-nodes <= 0`. Set `:smooth-streaming="false"` to preserve raw chunk cadence.
 - Treat CSS order as a first-class part of installation, not a later cleanup.
 - When the request includes SSR, explicitly gate browser-only peers behind client-only boundaries.
 - Do not widen HTML or Mermaid security defaults unless the user explicitly needs trusted legacy compatibility.

--- a/.agents/skills/markstream-migration/SKILL.md
+++ b/.agents/skills/markstream-migration/SKILL.md
@@ -29,8 +29,10 @@ Read [references/adoption-checklist.md](references/adoption-checklist.md) before
 5. Review gaps honestly.
    - Do not claim 1:1 parity where none exists.
    - Call out parser, plugin, security, or HTML behavior that still needs manual review.
-6. Treat streaming as a second pass unless clearly required now.
-   - Move to `nodes` only when the app receives streaming or high-frequency updates.
+6. Consider smooth streaming before jumping to `nodes`.
+   - If the app streams `content` and only needs pacing, `smooth-streaming="auto"` (the default) handles it without requiring `nodes`.
+   - Move to `nodes` only when the app needs custom AST control, worker preparsing, or high-frequency structural updates.
+   - When smooth streaming is on, pair it with `:fade="false"`.
 7. Validate and summarize.
    - Run the smallest relevant tests or build.
    - Report direct mappings, TODOs, and remaining verification work.
@@ -38,6 +40,7 @@ Read [references/adoption-checklist.md](references/adoption-checklist.md) before
 ## Default Decisions
 
 - Renderer swap first, streaming optimization second.
+- Smooth streaming is an intermediate option between "just content" and "full nodes migration": it paces visible output without requiring AST control.
 - Preserve safety over feature parity when HTML or security rules are involved.
 - Prefer explicit TODOs over vague claims.
 - Recommend against migration when the current stack depends heavily on transforms that Markstream does not mirror directly.
@@ -47,6 +50,7 @@ Read [references/adoption-checklist.md](references/adoption-checklist.md) before
 
 - `docs/guide/react-markdown-migration.md`
 - `docs/guide/react-markdown-migration-cookbook.md`
+- `docs/guide/ai-chat-streaming.md`
 - `docs/guide/installation.md`
 - `docs/guide/component-overrides.md`
 - `docs/guide/advanced.md`

--- a/.agents/skills/markstream-nuxt/SKILL.md
+++ b/.agents/skills/markstream-nuxt/SKILL.md
@@ -14,13 +14,17 @@ Use this skill when the host app is Nuxt and SSR boundaries matter.
 3. Keep browser-only peers behind client-only boundaries.
    - Prefer `<client-only>` wrappers, `.client` plugins, or guarded setup paths.
 4. Import `markstream-vue/index.css` from a client-safe app shell or plugin.
-5. Start with `content`, and move to `nodes` plus `final` only when the UI is streaming.
+5. Start with `content`, and move to `nodes` plus `final` only when the UI needs custom AST control.
+   - For streaming AI chat, use `typewriter` or `:max-live-nodes="0"` — smooth streaming (`smooth-streaming="auto"`) paces visible output automatically.
+   - When smooth streaming is on, pair it with `:fade="false"` to avoid delta fade stacking with high-commit pacing.
+   - In SSR, avoid `smooth-streaming="true"` on first-screen content; the mounted gate inside `auto` prevents hydration mismatch.
    - Remember that `html-policy` now defaults to `safe`, and Mermaid strict mode is on by default through `mermaid-props`.
 6. Validate with the smallest relevant Nuxt dev, build, or typecheck command.
 
 ## Default Decisions
 
 - SSR safety comes before feature completeness.
+- Smooth streaming is SSR-safe in `auto` mode (the default) because it gates on mount. Do not use `smooth-streaming="true"` for first-screen SSR content — it bypasses the mounted gate and can cause hydration mismatch or blank flash.
 - Avoid import-time access to browser globals from server code paths.
 - Treat Monaco, Mermaid workers, and similar heavy peers as client-only unless the repo already has a proven SSR pattern.
 - Keep `html-policy="safe"` and Mermaid strict mode unless the task is preserving trusted legacy rendering.

--- a/.agents/skills/markstream-vue/SKILL.md
+++ b/.agents/skills/markstream-vue/SKILL.md
@@ -14,7 +14,10 @@ Use this skill when the host app is plain Vue 3, typically Vite-based, and not N
 3. Import `markstream-vue/index.css` after resets.
    - In Tailwind or UnoCSS projects, keep Markstream styles inside `@layer components`.
 4. Start with `<MarkdownRender :content="markdown" />`.
-   - Switch to `nodes` plus `final` only for streaming, SSE, or high-frequency updates.
+   - For AI chat or streaming UIs, use `typewriter` or `:max-live-nodes="0"` — smooth streaming is auto-enabled (`smooth-streaming="auto"`, the default) and paces visible output so bursty chunks appear steadily.
+   - Set `:smooth-streaming="false"` to preserve raw chunk cadence; set `:smooth-streaming="true"` to force smooth pacing even on first-screen content (may cause hydration mismatch in SSR).
+   - When smooth streaming is on, pair it with `:fade="false"` to avoid delta fade (280 ms) stacking with high-commit pacing.
+   - Switch to `nodes` plus `final` only when the app needs custom AST control, worker preparsing, or structural updates beyond pacing.
    - Remember that `html-policy` now defaults to `safe`, and Mermaid strict mode is on by default through `mermaid-props`.
 5. Use `custom-id` plus scoped `setCustomComponents(...)` for overrides.
 6. Validate with the smallest useful dev, build, or typecheck command.
@@ -22,6 +25,8 @@ Use this skill when the host app is plain Vue 3, typically Vite-based, and not N
 ## Default Decisions
 
 - Vue 3 apps default to `content`.
+- Smooth streaming (`smooth-streaming="auto"`) is on by default when `typewriter` or `max-live-nodes <= 0`. It only paces the `content` path; `nodes` mode is never affected.
+- For manual pacing with `nodes`, use `useSmoothMarkdownStream` directly: `enqueue()` chunks, `finish()` when done, render from `visible`, and wait for `caughtUp` before final parsing.
 - Prefer local component registration unless the repo already uses a shared plugin entry.
 - When Monaco code blocks need app-level preloading, import `preloadCodeBlockRuntime` from `markstream-vue`. Existing `getUseMonaco()` preloads remain valid; do not import `stream-monaco` directly just to warm workers.
 - Keep `html-policy="safe"` and Mermaid strict mode unless the task is explicitly preserving trusted legacy behavior.
@@ -33,4 +38,5 @@ Use this skill when the host app is plain Vue 3, typically Vite-based, and not N
 - `docs/guide/quick-start.md`
 - `docs/guide/installation.md`
 - `docs/guide/usage.md`
+- `docs/guide/ai-chat-streaming.md`
 - `docs/guide/component-overrides.md`

--- a/README.md
+++ b/README.md
@@ -258,35 +258,37 @@ Then use `<MarkdownRender :content="md" />` in your pages.
 
 ## ⏱️ Streaming in 30 seconds
 
-Render streamed Markdown (SSE/websocket) with incremental updates:
+Render streamed Markdown (SSE/websocket) with built-in smooth pacing:
 
 ```ts
-import type { ParsedNode } from 'markstream-vue'
-import MarkdownRender, { getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import MarkdownRender from 'markstream-vue'
 import { ref } from 'vue'
 
-const nodes = ref<ParsedNode[]>([])
-const buffer = ref('')
-const md = getMarkdown()
+const content = ref('')
+const final = ref(false)
 
-function addChunk(chunk: string) {
-  buffer.value += chunk
-  nodes.value = parseMarkdownToStructure(buffer.value, md)
+eventSource.onmessage = (event) => {
+  content.value += event.data
 }
-
-// e.g., inside your SSE/onmessage handler
-eventSource.onmessage = event => addChunk(event.data)
+eventSource.addEventListener('done', () => {
+  final.value = true
+})
 
 // template
 // <MarkdownRender
-//   :nodes="nodes"
+//   :content="content"
+//   :final="final"
 //   :max-live-nodes="0"
-//   :batch-rendering="{
-//     renderBatchSize: 16,
-//     renderBatchDelay: 8,
-//   }"
+//   :batch-rendering="true"
+//   :render-batch-size="16"
+//   :render-batch-delay="8"
+//   :render-batch-budget-ms="4"
+//   :fade="false"
+//   :typewriter="true"
 // />
 ```
+
+`smooth-streaming` is enabled by default in typewriter/incremental mode (`typewriter` or `max-live-nodes <= 0`). Disable per surface with `:smooth-streaming="false"` if you want raw chunk cadence.
 
 Switch rendering style per surface:
 
@@ -332,7 +334,7 @@ const md = getMarkdown() // match server setup
 
 function addChunk(chunk: string) {
   buffer.value += chunk
-  nodes.value = parseMarkdownToStructure(buffer.value, md)
+  nodes.value = parseMarkdownToStructure(buffer.value, md, { final: false })
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -259,35 +259,37 @@ export default defineNuxtPlugin((nuxtApp) => {
 
 ## ⏱️ 30 秒流式接入
 
-用 SSE / WebSocket 增量渲染 Markdown：
+用 SSE / WebSocket 结合内置平滑节奏渲染 Markdown：
 
 ```ts
-import type { ParsedNode } from 'markstream-vue'
-import MarkdownRender, { getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import MarkdownRender from 'markstream-vue'
 import { ref } from 'vue'
 
-const nodes = ref<ParsedNode[]>([])
-const buffer = ref('')
-const md = getMarkdown()
+const content = ref('')
+const final = ref(false)
 
-function addChunk(chunk: string) {
-  buffer.value += chunk
-  nodes.value = parseMarkdownToStructure(buffer.value, md)
+eventSource.onmessage = (event) => {
+  content.value += event.data
 }
-
-// 例如在 SSE / onmessage 处理器中
-eventSource.onmessage = event => addChunk(event.data)
+eventSource.addEventListener('done', () => {
+  final.value = true
+})
 
 // template
 // <MarkdownRender
-//   :nodes="nodes"
+//   :content="content"
+//   :final="final"
 //   :max-live-nodes="0"
-//   :batch-rendering="{
-//     renderBatchSize: 16,
-//     renderBatchDelay: 8,
-//   }"
+//   :batch-rendering="true"
+//   :render-batch-size="16"
+//   :render-batch-delay="8"
+//   :render-batch-budget-ms="4"
+//   :fade="false"
+//   :typewriter="true"
 // />
 ```
+
+`smooth-streaming` 在打字机/增量模式（`typewriter` 或 `max-live-nodes <= 0`）默认开启；如果希望严格按原始 chunk 节奏显示，可按实例设置 `:smooth-streaming="false"`。
 
 按页面需要切换渲染风格：
 

--- a/docs/guide/ai-chat-streaming.md
+++ b/docs/guide/ai-chat-streaming.md
@@ -38,7 +38,6 @@ const final = ref(false)
     :content="streamedText"
     :final="final"
     :max-live-nodes="0"
-    :smooth-streaming="true"
     :batch-rendering="true"
     :render-batch-size="16"
     :render-batch-delay="8"
@@ -55,6 +54,7 @@ Why this path works better:
 - Backlog-aware pacing speeds up automatically when pending text grows.
 - Final parsing waits for visible content to catch up, so end-of-stream settling is stable.
 - `custom-id="chat"` gives you a scoped place to theme the chat surface or override one renderer safely.
+- The default `smooth-streaming="auto"` already enables smooth pacing when `typewriter` is on or `max-live-nodes <= 0`. Only use `:smooth-streaming="true"` if you want first-screen content to also start from blank with the typewriter effect—this bypasses the mounted gate and can cause hydration mismatch or blank flash in SSR scenarios.
 
 Turn it off per surface with `:smooth-streaming="false"` if you want raw chunk cadence. If you already parse in a worker/store and need AST control, keep using `nodes` + `final`.
 

--- a/docs/guide/ai-chat-streaming.md
+++ b/docs/guide/ai-chat-streaming.md
@@ -100,7 +100,7 @@ Start here when visuals look wrong: [Troubleshooting](/guide/troubleshooting#css
 If you parse `nodes` yourself (worker, store, or custom AST pipeline), the built-in smooth streaming inside `MarkdownRender` does **not** activate — it only applies to the `content` path. Use `useSmoothMarkdownStream` directly to pace the raw text before parsing.
 
 ```ts
-import { useSmoothMarkdownStream, getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import { getMarkdown, parseMarkdownToStructure, useSmoothMarkdownStream } from 'markstream-vue'
 import { ref, watch } from 'vue'
 
 const stream = useSmoothMarkdownStream()
@@ -108,7 +108,7 @@ const stream = useSmoothMarkdownStream()
 // Feed incoming chunks from your event source
 eventSource.onmessage = (event) => {
   stream.enqueue(event.data)
-})
+}
 
 eventSource.addEventListener('done', () => {
   stream.finish()

--- a/docs/guide/ai-chat-streaming.md
+++ b/docs/guide/ai-chat-streaming.md
@@ -21,36 +21,42 @@ Install only the peers you actually expect to show up in responses.
 
 ## 2. Recommended data flow
 
-For frequent updates, keep parsing outside `MarkdownRender` and pass `nodes` + `final`.
+For jittery token streams, use built-in smooth pacing on `MarkdownRender`.
 
 ```vue
 <script setup lang="ts">
-import MarkdownRender, { getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
-import { computed, ref } from 'vue'
+import MarkdownRender from 'markstream-vue'
+import { ref } from 'vue'
 
 const streamedText = ref('')
 const final = ref(false)
-const md = getMarkdown('chat-message')
-
-const nodes = computed(() =>
-  parseMarkdownToStructure(streamedText.value, md, { final: final.value }),
-)
 </script>
 
 <template>
   <MarkdownRender
     custom-id="chat"
-    :nodes="nodes"
+    :content="streamedText"
     :final="final"
+    :max-live-nodes="0"
+    :smooth-streaming="true"
+    :batch-rendering="true"
+    :render-batch-size="16"
+    :render-batch-delay="8"
+    :render-batch-budget-ms="4"
+    :fade="false"
+    :typewriter="true"
   />
 </template>
 ```
 
 Why this path works better:
 
-- `MarkdownRender` does not need to reparse the full string on every tiny token update.
-- You can move parsing into a store, worker, or message pipeline later without changing the renderer contract.
+- Incoming chunks can be bursty while visible output remains steady.
+- Backlog-aware pacing speeds up automatically when pending text grows.
+- Final parsing waits for visible content to catch up, so end-of-stream settling is stable.
 - `custom-id="chat"` gives you a scoped place to theme the chat surface or override one renderer safely.
+
+Turn it off per surface with `:smooth-streaming="false"` if you want raw chunk cadence. If you already parse in a worker/store and need AST control, keep using `nodes` + `final`.
 
 ## 3. Renderer settings that usually work well
 

--- a/docs/guide/ai-chat-streaming.md
+++ b/docs/guide/ai-chat-streaming.md
@@ -95,7 +95,39 @@ See [Override Built-in Components](/guide/component-overrides).
 
 Start here when visuals look wrong: [Troubleshooting](/guide/troubleshooting#css-looks-wrong-start-here)
 
-## 6. When not to use this path
+## 6. Manual composable usage with `nodes`
+
+If you parse `nodes` yourself (worker, store, or custom AST pipeline), the built-in smooth streaming inside `MarkdownRender` does **not** activate — it only applies to the `content` path. Use `useSmoothMarkdownStream` directly to pace the raw text before parsing.
+
+```ts
+import { useSmoothMarkdownStream, getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import { ref, watch } from 'vue'
+
+const stream = useSmoothMarkdownStream()
+
+// Feed incoming chunks from your event source
+eventSource.onmessage = (event) => {
+  stream.enqueue(event.data)
+})
+
+eventSource.addEventListener('done', () => {
+  stream.finish()
+})
+
+// Parse only the visible portion; final parsing waits until caught up
+const md = getMarkdown('chat')
+const nodes = ref([])
+
+watch([stream.visible, stream.final], () => {
+  nodes.value = parseMarkdownToStructure(stream.visible.value, md, {
+    final: stream.final.value,
+  })
+})
+```
+
+The composable returns reactive refs: `visible`, `source`, `caughtUp`, and `final`. Use `visible` for rendering and wait until `caughtUp` is `true` before considering the stream complete.
+
+## 7. When not to use this path
 
 - Use `content` when updates are infrequent or the page is basically static.
 - Use server-side preparse + `nodes` when another layer already owns Markdown parsing.

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -107,6 +107,7 @@ Hooks remain useful if you want to reshape the emitted `thinking` node (strip wr
 Besides the core renderer and parser helpers, the package exposes:
 
 - `CodeBlockNode`, `MarkdownCodeBlockNode`, `MermaidBlockNode`, `MathBlockNode`, `ImageNode`, etc. — see [Components](/guide/components) for their props and CSS requirements.
+- `useSmoothMarkdownStream(options?)` — adapts bursty source chunks into a stable `visible` Markdown stream with `final`/`pendingChars` state.
 - `VueRendererMarkdown` (global component plugin) and shared type exports (component prop interfaces, parser types).
 
 For parser types and hooks, see [/guide/parser-api](/guide/parser-api) (or the `stream-markdown-parser` README on npm).

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -22,7 +22,7 @@ Use this page when you need to fine-tune streaming behaviour, control heavy node
 | `custom-markdown-it` | `(md: MarkdownIt) => MarkdownIt` | – | Customize the internal MarkdownIt instance (add plugins, tweak options). |
 | `debug-performance` | `boolean` | `false` | Logs parse/render timing and virtualization stats (dev only). |
 | `typewriter` | `boolean` | `false` | Shows the blinking typewriter cursor while streamed content grows. |
-| `smooth-streaming` | `boolean` | `true` | Enables built-in pacing for streaming `content` updates in typewriter/incremental mode. Set `false` to render with raw chunk cadence. |
+| `smooth-streaming` | `boolean \| 'auto'` | `'auto'` | Enables built-in pacing for streaming `content` updates. `'auto'` only enables when `typewriter=true` or `max-live-nodes<=0`. Set `true` to force-enable, `false` to render with raw chunk cadence. |
 | `fade` | `boolean` | `true` | Enables non-code-node enter fade and appended-text fade. Disable if you need zero animation for SSR snapshots. |
 
 ### Security defaults and compatibility opt-outs
@@ -75,7 +75,7 @@ Use `html-policy="escape"` when you want literal HTML text to stay visible inste
 | `max-live-nodes` | `320` | Virtualization threshold; set `0` to disable virtualization (renders everything). |
 | `live-node-buffer` | `60` | Overscan window (how many nodes to keep before/after the focus range). |
 | `batch-rendering` | `true` | Incremental rendering batches (only when `max-live-nodes <= 0`). |
-| `smooth-streaming` | `true` | Built-in stream pacing in typewriter/incremental mode (`typewriter` or `max-live-nodes <= 0`). |
+| `smooth-streaming` | `'auto'` | Built-in stream pacing in typewriter/incremental mode (`typewriter` or `max-live-nodes <= 0`). Set `true` to force-enable, `false` for raw chunk cadence. |
 | `initial-render-batch-size` | `40` | How many nodes render immediately before batching begins. |
 | `render-batch-size` | `80` | How many nodes render per batch tick. |
 | `render-batch-delay` | `16` | Extra delay (ms) before each batch after rAF. |

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -23,7 +23,30 @@ Use this page when you need to fine-tune streaming behaviour, control heavy node
 | `debug-performance` | `boolean` | `false` | Logs parse/render timing and virtualization stats (dev only). |
 | `typewriter` | `boolean` | `false` | Shows the blinking typewriter cursor while streamed content grows. |
 | `smooth-streaming` | `boolean \| 'auto'` | `'auto'` | Enables built-in pacing for streaming `content` updates. `'auto'` only enables when `typewriter=true` or `max-live-nodes<=0`. Set `true` to force-enable, `false` to render with raw chunk cadence. |
+| `smooth-streaming-options` | `SmoothMarkdownStreamOptions` | – | Options for built-in stream pacing (`minCharsPerSecond`, `maxCharsPerSecond`, `targetLatencyMs`, `catchUpLatencyMs`, `catchUpThreshold`, `maxCommitFps`, `startDelayMs`, `maxCharsPerCommit`, `flushOnFinish`). Read when the renderer is created; recreate the renderer with a different `key` if you need to change them dynamically. |
 | `fade` | `boolean` | `true` | Enables non-code-node enter fade and appended-text fade. Disable if you need zero animation for SSR snapshots. |
+
+::: tip SSR and smooth streaming
+For SSR with static initial content, prefer `smooth-streaming="auto"` (the default). The `auto` mode includes a mounted gate that prevents pacing initial content from blank on the first client render. Use `smooth-streaming=true` only when you explicitly want to pace the first client-side content as well — this can cause a hydration mismatch or a first-paint flash of empty content in SSR setups.
+:::
+
+### Advanced smooth streaming configuration
+
+Use `smooth-streaming-options` to fine-tune pacing behaviour:
+
+```vue
+<MarkdownRender
+  :content="content"
+  :smooth-streaming-options="{
+    minCharsPerSecond: 45,
+    maxCharsPerSecond: 1200,
+    targetLatencyMs: 900,
+    catchUpLatencyMs: 350,
+  }"
+/>
+```
+
+Available keys: `minCharsPerSecond`, `maxCharsPerSecond`, `targetLatencyMs`, `catchUpLatencyMs`, `catchUpThreshold`, `maxCommitFps`, `startDelayMs`, `maxCharsPerCommit`, `flushOnFinish`. These are read once when the renderer is created; change the component `key` to apply new options dynamically.
 
 ### Security defaults and compatibility opt-outs
 
@@ -76,6 +99,7 @@ Use `html-policy="escape"` when you want literal HTML text to stay visible inste
 | `live-node-buffer` | `60` | Overscan window (how many nodes to keep before/after the focus range). |
 | `batch-rendering` | `true` | Incremental rendering batches (only when `max-live-nodes <= 0`). |
 | `smooth-streaming` | `'auto'` | Built-in stream pacing in typewriter/incremental mode (`typewriter` or `max-live-nodes <= 0`). Set `true` to force-enable, `false` for raw chunk cadence. |
+| `smooth-streaming-options` | – | Fine-tune pacing: `minCharsPerSecond`, `maxCharsPerSecond`, `targetLatencyMs`, `catchUpLatencyMs`, `catchUpThreshold`, `maxCommitFps`, `startDelayMs`, `maxCharsPerCommit`, `flushOnFinish`. Read once when the renderer is created; use a different component `key` to apply new options dynamically. |
 | `initial-render-batch-size` | `40` | How many nodes render immediately before batching begins. |
 | `render-batch-size` | `80` | How many nodes render per batch tick. |
 | `render-batch-delay` | `16` | Extra delay (ms) before each batch after rAF. |

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -22,6 +22,7 @@ Use this page when you need to fine-tune streaming behaviour, control heavy node
 | `custom-markdown-it` | `(md: MarkdownIt) => MarkdownIt` | – | Customize the internal MarkdownIt instance (add plugins, tweak options). |
 | `debug-performance` | `boolean` | `false` | Logs parse/render timing and virtualization stats (dev only). |
 | `typewriter` | `boolean` | `false` | Shows the blinking typewriter cursor while streamed content grows. |
+| `smooth-streaming` | `boolean` | `true` | Enables built-in pacing for streaming `content` updates in typewriter/incremental mode. Set `false` to render with raw chunk cadence. |
 | `fade` | `boolean` | `true` | Enables non-code-node enter fade and appended-text fade. Disable if you need zero animation for SSR snapshots. |
 
 ### Security defaults and compatibility opt-outs
@@ -74,6 +75,7 @@ Use `html-policy="escape"` when you want literal HTML text to stay visible inste
 | `max-live-nodes` | `320` | Virtualization threshold; set `0` to disable virtualization (renders everything). |
 | `live-node-buffer` | `60` | Overscan window (how many nodes to keep before/after the focus range). |
 | `batch-rendering` | `true` | Incremental rendering batches (only when `max-live-nodes <= 0`). |
+| `smooth-streaming` | `true` | Built-in stream pacing in typewriter/incremental mode (`typewriter` or `max-live-nodes <= 0`). |
 | `initial-render-batch-size` | `40` | How many nodes render immediately before batching begins. |
 | `render-batch-size` | `80` | How many nodes render per batch tick. |
 | `render-batch-delay` | `16` | Extra delay (ms) before each batch after rAF. |

--- a/docs/zh/guide/ai-chat-streaming.md
+++ b/docs/zh/guide/ai-chat-streaming.md
@@ -94,7 +94,7 @@ const nodes = computed(() =>
 如果你自己在 worker、store 或自定义 AST 管线中解析 `nodes`，`MarkdownRender` 内置的 smooth streaming **不会**启用——它只作用于 `content` 路径。你可以直接使用 `useSmoothMarkdownStream`，在解析前对原始文本做 pacing。
 
 ```ts
-import { useSmoothMarkdownStream, getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import { getMarkdown, parseMarkdownToStructure, useSmoothMarkdownStream } from 'markstream-vue'
 import { ref, watch } from 'vue'
 
 const stream = useSmoothMarkdownStream()
@@ -102,7 +102,7 @@ const stream = useSmoothMarkdownStream()
 // 从事件源喂入新 chunk
 eventSource.onmessage = (event) => {
   stream.enqueue(event.data)
-})
+}
 
 eventSource.addEventListener('done', () => {
   stream.finish()

--- a/docs/zh/guide/ai-chat-streaming.md
+++ b/docs/zh/guide/ai-chat-streaming.md
@@ -89,7 +89,39 @@ const nodes = computed(() =>
 
 页面效果不对时，先从这里开始排： [故障排除](/zh/guide/troubleshooting#css-looks-wrong-start-here)
 
-## 6. 什么时候不该走这条路径
+## 6. 手动使用 composable 搭配 `nodes`
+
+如果你自己在 worker、store 或自定义 AST 管线中解析 `nodes`，`MarkdownRender` 内置的 smooth streaming **不会**启用——它只作用于 `content` 路径。你可以直接使用 `useSmoothMarkdownStream`，在解析前对原始文本做 pacing。
+
+```ts
+import { useSmoothMarkdownStream, getMarkdown, parseMarkdownToStructure } from 'markstream-vue'
+import { ref, watch } from 'vue'
+
+const stream = useSmoothMarkdownStream()
+
+// 从事件源喂入新 chunk
+eventSource.onmessage = (event) => {
+  stream.enqueue(event.data)
+})
+
+eventSource.addEventListener('done', () => {
+  stream.finish()
+})
+
+// 只解析可见部分；最终解析等 caughtUp 后再触发
+const md = getMarkdown('chat')
+const nodes = ref([])
+
+watch([stream.visible, stream.final], () => {
+  nodes.value = parseMarkdownToStructure(stream.visible.value, md, {
+    final: stream.final.value,
+  })
+})
+```
+
+该 composable 返回响应式 ref：`visible`、`source`、`caughtUp` 和 `final`。用 `visible` 渲染，等 `caughtUp` 为 `true` 后再认为流结束。
+
+## 7. 什么时候不该走这条路径
 
 - 更新频率不高、页面基本静态时，用 `content` 更简单
 - 如果服务端或别的层已经接管 Markdown 解析，就直接用预解析后的 `nodes`

--- a/playground/src/components/ThinkingNode.vue
+++ b/playground/src/components/ThinkingNode.vue
@@ -32,7 +32,15 @@ function toOptionalBoolean(value: unknown) {
 }
 
 const resolvedTypewriter = computed(() => toOptionalBoolean(props.typewriter) ?? inheritedTypewriter?.value ?? true)
-const resolvedSmoothStreaming = computed(() => inheritedSmoothStreaming?.value)
+const resolvedSmoothStreaming = computed<boolean | 'auto' | undefined>(() => {
+  if (inheritedSmoothStreaming?.value === true)
+    return 'auto'
+
+  if (inheritedSmoothStreaming?.value === false)
+    return false
+
+  return undefined
+})
 </script>
 
 <template>

--- a/playground/src/components/ThinkingNode.vue
+++ b/playground/src/components/ThinkingNode.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
 }>()
 
 const inheritedTypewriter = inject<{ value?: boolean } | undefined>('markstreamTypewriter', undefined)
+const inheritedSmoothStreaming = inject<{ value?: boolean } | undefined>('markstreamSmoothStreaming', undefined)
 const resolvedContent = computed(() => String(props.node.content ?? ''))
 const resolvedCustomHtmlTags = computed(() => props.customHtmlTags?.length ? props.customHtmlTags : ['thinking', 'think'])
 const resolvedFinal = computed(() => typeof props.node.loading === 'boolean' ? !props.node.loading : undefined)
@@ -31,6 +32,7 @@ function toOptionalBoolean(value: unknown) {
 }
 
 const resolvedTypewriter = computed(() => toOptionalBoolean(props.typewriter) ?? inheritedTypewriter?.value ?? true)
+const resolvedSmoothStreaming = computed(() => inheritedSmoothStreaming?.value)
 </script>
 
 <template>
@@ -43,6 +45,7 @@ const resolvedTypewriter = computed(() => toOptionalBoolean(props.typewriter) ??
       :index-key="nestedIndexKey"
       :is-dark="isDark"
       :typewriter="resolvedTypewriter"
+      :smooth-streaming="resolvedSmoothStreaming"
       :viewport-priority="false"
       :defer-nodes-until-visible="false"
       :batch-rendering="false"

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -57,6 +57,7 @@ const streamChunkSizeMax = useLocalStorage<number>('vmr-settings-stream-chunk-si
 const streamBurstiness = useLocalStorage<number>('vmr-settings-stream-burstiness', 35)
 const streamTransportMode = useLocalStorage<StreamTransportMode>('vmr-settings-stream-transport-mode', 'readable-stream')
 const streamSliceMode = useLocalStorage<StreamSliceMode>('vmr-settings-stream-slice-mode', 'pure-random')
+const smoothStreaming = useLocalStorage<boolean>('vmr-settings-smooth-streaming', true)
 const normalizedChunkDelayRange = computed(() => normalizeStreamRange(
   Number(streamChunkDelayMin.value),
   Number(streamChunkDelayMax.value),
@@ -647,6 +648,30 @@ onBeforeUnmount(() => {
             </div>
           </button>
         </div>
+
+        <div class="setting-row-inline">
+          <label class="setting-label">Smooth Stream</label>
+          <button
+            class="theme-toggle"
+            :class="{ 'theme-toggle--dark': smoothStreaming }"
+            @click.stop="smoothStreaming = !smoothStreaming"
+          >
+            <div class="theme-toggle__thumb">
+              <Transition
+                enter-active-class="transition-all duration-300 ease-out"
+                leave-active-class="transition-all duration-200 ease-in"
+                enter-from-class="opacity-0 scale-0 rotate-90"
+                enter-to-class="opacity-100 scale-100 rotate-0"
+                leave-from-class="opacity-100 scale-100 rotate-0"
+                leave-to-class="opacity-0 scale-0 rotate-90"
+                mode="out-in"
+              >
+                <Icon v-if="smoothStreaming" key="smooth-on" icon="carbon:checkmark" class="theme-toggle__icon theme-toggle__icon--moon" />
+                <Icon v-else key="smooth-off" icon="carbon:close" class="theme-toggle__icon theme-toggle__icon--sun" />
+              </Transition>
+            </div>
+          </button>
+        </div>
       </aside>
     </Transition>
 
@@ -763,11 +788,11 @@ onBeforeUnmount(() => {
         <main ref="messagesContainer" class="chat-messages chatbot-messages">
           <MarkdownRender
             :content="content"
+            :smooth-streaming="smoothStreaming"
             :code-block-dark-theme="selectedTheme || undefined"
             :code-block-light-theme="selectedTheme || undefined"
             :code-block-monaco-options="playgroundMonacoOptions"
             :themes="themes"
-            typewriter
             :custom-html-tags="['thinking']"
             :escape-html-tags="['question', 'answer']"
             :is-dark="isDark"

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -789,6 +789,7 @@ onBeforeUnmount(() => {
           <MarkdownRender
             :content="content"
             :smooth-streaming="smoothStreaming"
+            :fade="!smoothStreaming"
             typewriter
             :code-block-dark-theme="selectedTheme || undefined"
             :code-block-light-theme="selectedTheme || undefined"

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -789,6 +789,7 @@ onBeforeUnmount(() => {
           <MarkdownRender
             :content="content"
             :smooth-streaming="smoothStreaming"
+            typewriter
             :code-block-dark-theme="selectedTheme || undefined"
             :code-block-light-theme="selectedTheme || undefined"
             :code-block-monaco-options="playgroundMonacoOptions"

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -790,7 +790,6 @@ onBeforeUnmount(() => {
             :content="content"
             :smooth-streaming="smoothStreaming"
             :fade="!smoothStreaming"
-            typewriter
             :code-block-dark-theme="selectedTheme || undefined"
             :code-block-light-theme="selectedTheme || undefined"
             :code-block-monaco-options="playgroundMonacoOptions"

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -10,7 +10,7 @@ const budgets = {
   maxDistBytes: Number(process.env.MAX_DIST_BYTES || 800 * 1024),
   maxJsChunkBytes: Number(process.env.MAX_JS_CHUNK_BYTES || 300 * 1024),
   maxPackSizeBytes: Number(process.env.MAX_PACK_TGZ_BYTES || 250 * 1024),
-  maxPackUnpackedBytes: Number(process.env.MAX_PACK_UNPACKED_BYTES || 750 * 1024),
+  maxPackUnpackedBytes: Number(process.env.MAX_PACK_UNPACKED_BYTES || 800 * 1024),
 }
 
 function formatBytes(bytes) {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -35,6 +35,7 @@ import TableNode from '../../components/TableNode'
 import TextNode from '../../components/TextNode'
 import ThematicBreakNode from '../../components/ThematicBreakNode'
 import VmrContainerNode from '../../components/VmrContainerNode'
+import { useSmoothMarkdownStream } from '../../composables/useSmoothMarkdownStream'
 import { provideViewportPriority } from '../../composables/viewportPriority'
 import {
   buildBlockTextProfile,
@@ -89,6 +90,7 @@ const props = withDefaults(defineProps<NodeRendererProps>(), {
   codeBlockStream: true,
   showTooltips: true,
   typewriter: false,
+  smoothStreaming: true,
   fade: true,
   batchRendering: true,
   debugPerformance: false,
@@ -133,6 +135,7 @@ const debugPerformanceEnabled = computed(() => props.debugPerformance && isClien
 const attrs = useAttrs() as RendererAttrs
 const textStreamState = new Map<string, string>()
 const streamRenderVersion = ref(0)
+const smoothStream = useSmoothMarkdownStream()
 const experimentContainerWidth = ref(0)
 const simpleTextProbeProfile = ref(createEmptySimpleTextProbeProfile())
 const resolvedShowTooltips = computed<boolean | undefined>(() => {
@@ -152,10 +155,64 @@ const ownsTypewriterCursor = computed(() => inheritedTypewriterCursor?.value !==
 provide('markstreamShowTooltips', resolvedShowTooltips)
 provide('markstreamHtmlPolicy', resolvedHtmlPolicy)
 provide('markstreamTypewriter', computed(() => props.typewriter !== false))
+provide('markstreamSmoothStreaming', computed(() => props.smoothStreaming !== false))
 provide('markstreamFade', computed(() => props.fade !== false))
 provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
 provide('markstreamStreamVersion', streamRenderVersion)
+
+const smoothStreamingEnabled = computed(() => (
+  props.smoothStreaming !== false
+  && !props.nodes?.length
+  && (props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0)
+))
+const renderContent = computed(() => (
+  smoothStreamingEnabled.value
+    ? smoothStream.visible.value
+    : (props.content ?? '')
+))
+
+const requestedFinal = computed<boolean | undefined>(() => {
+  const base = (props.parseOptions ?? {}) as RendererParseOptions
+  return props.final ?? base.final
+})
+
+watch(
+  [() => props.content, () => props.nodes, smoothStreamingEnabled, requestedFinal],
+  ([content, nodes, enabled, finalRequested]) => {
+    if (nodes?.length) {
+      smoothStream.reset('')
+      return
+    }
+
+    const nextContent = content ?? ''
+
+    if (!enabled) {
+      smoothStream.reset(nextContent)
+      if (finalRequested)
+        smoothStream.finish({ flush: true })
+      return
+    }
+
+    const source = smoothStream.source.value
+    if (!nextContent) {
+      smoothStream.reset('')
+    }
+    else if (nextContent === source) {
+      // no-op
+    }
+    else if (nextContent.startsWith(source)) {
+      smoothStream.enqueue(nextContent.slice(source.length))
+    }
+    else {
+      smoothStream.reset(nextContent)
+    }
+
+    if (finalRequested)
+      smoothStream.finish()
+  },
+  { immediate: true },
+)
 
 function logPerf(label: string, data: Record<string, unknown>) {
   if (!debugPerformanceEnabled.value)
@@ -237,7 +294,9 @@ const mdInstance = computed(() => {
 
 const mergedParseOptions = computed(() => {
   const base = (props.parseOptions ?? {}) as RendererParseOptions
-  const resolvedFinal = props.final ?? base.final
+  let resolvedFinal = requestedFinal.value
+  if (smoothStreamingEnabled.value && resolvedFinal != null)
+    resolvedFinal = resolvedFinal ? smoothStream.caughtUp.value : false
   const merged = effectiveCustomHtmlTags.value
   const hasFinal = resolvedFinal != null
   const hasCustom = merged.length > 0
@@ -269,17 +328,18 @@ const parsedNodes = computed<ParsedNode[]>(() => {
   // the array length doesn't change.
   if (props.nodes?.length)
     return markRaw((props.nodes as unknown as ParsedNode[]).slice())
-  if (props.content) {
+  const contentToParse = renderContent.value
+  if (contentToParse) {
     // Prefer an explicitly passed `markdown` prop, then a globally
     // provided markdown via `setGlobalMarkdown`, otherwise fall back
     // to the legacy `getMarkdown()` factory.
     const parseStart = debugPerformanceEnabled.value ? performance.now() : 0
-    const parsed = parseMarkdownToStructure(props.content, mdInstance.value, mergedParseOptions.value)
+    const parsed = parseMarkdownToStructure(contentToParse, mdInstance.value, mergedParseOptions.value)
     if (debugPerformanceEnabled.value) {
       logPerf('parse(sync)', {
         ms: Math.round(performance.now() - parseStart),
         nodes: parsed.length,
-        contentLength: props.content.length,
+        contentLength: contentToParse.length,
       })
     }
     return markRaw(parsed)
@@ -2358,9 +2418,9 @@ function getNodeTextLength(node: unknown): number {
 }
 
 function getTypewriterContentLength() {
-  if (typeof props.content === 'string')
-    return props.content.length
-  return (props.nodes ?? []).reduce((total, node) => total + getNodeTextLength(node), 0)
+  if (props.nodes?.length)
+    return props.nodes.reduce((total, node) => total + getNodeTextLength(node), 0)
+  return renderContent.value.length
 }
 
 function clearTypewriterCursorTimeout() {
@@ -2431,7 +2491,7 @@ function updateTypewriterCursorPosition() {
 }
 
 watch(
-  [() => props.content, () => props.nodes, () => props.typewriter],
+  [renderContent, () => props.nodes, () => props.typewriter],
   async () => {
     if (!isClient || renderAsFragment.value || !ownsTypewriterCursor.value)
       return

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5,7 +5,7 @@ import type { CustomComponents } from '../../types'
 import type { CodeBlockPreviewPayload } from '../../types/component-props'
 import type { NodeRendererProps } from '../../types/node-renderer-props'
 import { getMarkdown, mergeCustomHtmlTags, parseMarkdownToStructure, resolveCustomHtmlTags } from 'stream-markdown-parser'
-import { computed, defineAsyncComponent, inject, markRaw, nextTick, onBeforeUnmount, provide, reactive, ref, useAttrs, watch } from 'vue'
+import { computed, defineAsyncComponent, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, useAttrs, watch } from 'vue'
 import AdmonitionNode from '../../components/AdmonitionNode'
 import BlockquoteNode from '../../components/BlockquoteNode'
 import CheckboxNode from '../../components/CheckboxNode'
@@ -90,7 +90,7 @@ const props = withDefaults(defineProps<NodeRendererProps>(), {
   codeBlockStream: true,
   showTooltips: true,
   typewriter: false,
-  smoothStreaming: true,
+  smoothStreaming: 'auto',
   fade: true,
   batchRendering: true,
   debugPerformance: false,
@@ -135,7 +135,7 @@ const debugPerformanceEnabled = computed(() => props.debugPerformance && isClien
 const attrs = useAttrs() as RendererAttrs
 const textStreamState = new Map<string, string>()
 const streamRenderVersion = ref(0)
-const smoothStream = useSmoothMarkdownStream()
+const smoothStream = useSmoothMarkdownStream(props.smoothStreamingOptions)
 const experimentContainerWidth = ref(0)
 const simpleTextProbeProfile = ref(createEmptySimpleTextProbeProfile())
 const resolvedShowTooltips = computed<boolean | undefined>(() => {
@@ -161,10 +161,30 @@ provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
 provide('markstreamStreamVersion', streamRenderVersion)
 
+const smoothStreamingEligible = computed(() => {
+  if (props.smoothStreaming === false)
+    return false
+  if (props.nodes?.length)
+    return false
+  if (props.smoothStreaming === true)
+    return true
+  // 'auto': only enable when typewriter/incremental mode is active
+  return props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0
+})
+
+// Mounted gate: prevent smooth streaming from pacing initial static content
+// on the first client render (avoids SSR hydration mismatch and blank flash).
+// Only applies in 'auto' mode — when smoothStreaming === true, the user
+// explicitly opted in and the gate is always open.
+const hasMountedForSmoothStreaming = ref(!isClient || props.smoothStreaming === true)
+
+onMounted(() => {
+  hasMountedForSmoothStreaming.value = true
+})
+
 const smoothStreamingEnabled = computed(() => (
-  props.smoothStreaming !== false
-  && !props.nodes?.length
-  && (props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0)
+  hasMountedForSmoothStreaming.value
+  && smoothStreamingEligible.value
 ))
 const renderContent = computed(() => (
   smoothStreamingEnabled.value

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -150,12 +150,12 @@ const resolvedShowTooltips = computed<boolean | undefined>(() => {
 })
 const inheritedHtmlPolicy = inject<{ value?: HtmlPolicy } | undefined>('markstreamHtmlPolicy', undefined)
 const inheritedTypewriterCursor = inject<{ value?: boolean } | undefined>('markstreamTypewriterCursor', undefined)
+const inheritedSmoothStreaming = inject<{ value?: boolean } | undefined>('markstreamSmoothStreaming', undefined)
 const resolvedHtmlPolicy = computed<HtmlPolicy>(() => props.htmlPolicy ?? inheritedHtmlPolicy?.value ?? 'safe')
 const ownsTypewriterCursor = computed(() => inheritedTypewriterCursor?.value !== true)
 provide('markstreamShowTooltips', resolvedShowTooltips)
 provide('markstreamHtmlPolicy', resolvedHtmlPolicy)
 provide('markstreamTypewriter', computed(() => props.typewriter !== false))
-provide('markstreamSmoothStreaming', computed(() => props.smoothStreaming !== false))
 provide('markstreamFade', computed(() => props.fade !== false))
 provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
@@ -165,6 +165,11 @@ const smoothStreamingEligible = computed(() => {
   if (props.smoothStreaming === false)
     return false
   if (props.nodes?.length)
+    return false
+  // When the parent renderer is already pacing content, avoid double-pacing
+  // in nested renderers (e.g. thinking blocks, custom tag content).
+  // Only applies in 'auto' mode — smoothStreaming === true explicitly opts in.
+  if (props.smoothStreaming !== true && inheritedSmoothStreaming?.value)
     return false
   if (props.smoothStreaming === true)
     return true
@@ -186,6 +191,7 @@ const smoothStreamingEnabled = computed(() => (
   hasMountedForSmoothStreaming.value
   && smoothStreamingEligible.value
 ))
+provide('markstreamSmoothStreaming', smoothStreamingEnabled)
 const renderContent = computed(() => (
   smoothStreamingEnabled.value
     ? smoothStream.visible.value
@@ -279,8 +285,14 @@ const instanceMsgId = props.customId
 const mathBlockMinHeightCache = createMathBlockMinHeightCache(instanceMsgId)
 const mathBlockCacheScope = computed(() => `${instanceMsgId}:${streamRenderVersion.value}`)
 provideMathBlockMinHeightCache(mathBlockMinHeightCache)
+const renderVersionSource = computed(() => {
+  if (props.nodes?.length)
+    return props.nodes
+  return renderContent.value
+})
+
 watch(
-  [() => props.content, () => props.nodes],
+  renderVersionSource,
   () => {
     mathBlockMinHeightCache.clear()
     streamRenderVersion.value += 1

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import { computed, onBeforeUnmount, ref } from 'vue'
+import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
 
 export interface SmoothMarkdownStreamOptions {
   minCharsPerSecond?: number
@@ -226,7 +226,8 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
     rafId = 0
   }
 
-  onBeforeUnmount(cancelLoop)
+  if (getCurrentScope())
+    onScopeDispose(cancelLoop)
 
   return {
     source,

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -1,0 +1,278 @@
+import type { ComputedRef, Ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
+
+export interface SmoothMarkdownStreamOptions {
+  minCharsPerSecond?: number
+  maxCharsPerSecond?: number
+  targetLatencyMs?: number
+  catchUpLatencyMs?: number
+  catchUpThreshold?: number
+  maxCommitFps?: number
+  startDelayMs?: number
+  maxCharsPerCommit?: number
+  flushOnFinish?: boolean
+}
+
+export interface SmoothMarkdownStreamController {
+  source: Ref<string>
+  visible: Ref<string>
+  done: Ref<boolean>
+  final: ComputedRef<boolean>
+  caughtUp: ComputedRef<boolean>
+  pendingChars: ComputedRef<number>
+  enqueue: (chunk: string) => void
+  finish: (options?: { flush?: boolean }) => void
+  flush: () => void
+  reset: (initialMarkdown?: string) => void
+  pause: () => void
+  resume: () => void
+}
+
+interface GraphemeSlice {
+  text: string
+  graphemeCount: number
+}
+
+interface GraphemeSegment {
+  segment: string
+}
+
+interface GraphemeSegmenter {
+  segment: (input: string) => Iterable<GraphemeSegment>
+}
+
+export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {}): SmoothMarkdownStreamController {
+  const {
+    minCharsPerSecond = 40,
+    maxCharsPerSecond = 1000,
+    targetLatencyMs = 900,
+    catchUpLatencyMs = 350,
+    catchUpThreshold = 600,
+    maxCommitFps = 30,
+    startDelayMs = 80,
+    maxCharsPerCommit = 80,
+    flushOnFinish = false,
+  } = options
+
+  const source = ref('')
+  const visible = ref('')
+  const done = ref(false)
+  const paused = ref(false)
+
+  const pendingChars = computed(() => Math.max(0, source.value.length - visible.value.length))
+  const caughtUp = computed(() => pendingChars.value === 0)
+  const final = computed(() => done.value && caughtUp.value)
+  const segmenter = createGraphemeSegmenter()
+
+  let rafId = 0
+  let startedAt = 0
+  let lastTick = 0
+  let charBudget = 0
+  let currentCps = minCharsPerSecond
+
+  function enqueue(chunk: string) {
+    if (!chunk)
+      return
+
+    const wasIdle = pendingChars.value <= 0
+    source.value += chunk
+
+    if (wasIdle) {
+      const t = now()
+      startedAt = t
+      lastTick = t
+      charBudget = 0
+    }
+
+    ensureLoop()
+  }
+
+  function finish(finishOptions: { flush?: boolean } = {}) {
+    done.value = true
+
+    if (finishOptions.flush ?? flushOnFinish) {
+      flush()
+      return
+    }
+
+    ensureLoop()
+  }
+
+  function flush() {
+    visible.value = source.value
+    charBudget = 0
+    currentCps = minCharsPerSecond
+    cancelLoop()
+  }
+
+  function reset(initialMarkdown = '') {
+    cancelLoop()
+
+    source.value = initialMarkdown
+    visible.value = initialMarkdown
+    done.value = false
+    paused.value = false
+
+    startedAt = 0
+    lastTick = 0
+    charBudget = 0
+    currentCps = minCharsPerSecond
+  }
+
+  function pause() {
+    paused.value = true
+    cancelLoop()
+  }
+
+  function resume() {
+    if (!paused.value)
+      return
+
+    paused.value = false
+    const t = now()
+    lastTick = t
+    startedAt ||= t
+    ensureLoop()
+  }
+
+  function ensureLoop() {
+    if (rafId || paused.value || pendingChars.value <= 0)
+      return
+
+    if (typeof requestAnimationFrame !== 'function') {
+      flush()
+      return
+    }
+
+    rafId = requestAnimationFrame(tick)
+  }
+
+  function tick(timestamp: number) {
+    rafId = 0
+
+    if (paused.value)
+      return
+
+    if (pendingChars.value <= 0) {
+      startedAt = 0
+      lastTick = 0
+      charBudget = 0
+      currentCps = minCharsPerSecond
+      return
+    }
+
+    if (timestamp - startedAt < startDelayMs) {
+      rafId = requestAnimationFrame(tick)
+      return
+    }
+
+    const minFrameMs = 1000 / Math.max(1, maxCommitFps)
+    const dt = Math.min(100, Math.max(0, timestamp - lastTick))
+
+    if (dt < minFrameMs) {
+      rafId = requestAnimationFrame(tick)
+      return
+    }
+
+    lastTick = timestamp
+    const pending = pendingChars.value
+    const latencyMs = pending > catchUpThreshold ? catchUpLatencyMs : targetLatencyMs
+
+    const targetCps = clamp(
+      pending / Math.max(0.001, latencyMs / 1000),
+      minCharsPerSecond,
+      maxCharsPerSecond,
+    )
+
+    currentCps += (targetCps - currentCps) * 0.2
+    charBudget += currentCps * (dt / 1000)
+
+    const desiredCount = clamp(Math.floor(charBudget), 1, maxCharsPerCommit)
+    const rest = source.value.slice(visible.value.length)
+    const nextSlice = takeGraphemes(rest, desiredCount, segmenter)
+
+    if (nextSlice.text) {
+      visible.value += nextSlice.text
+      charBudget = Math.max(0, charBudget - nextSlice.graphemeCount)
+    }
+
+    ensureLoop()
+  }
+
+  function cancelLoop() {
+    if (!rafId)
+      return
+
+    if (typeof cancelAnimationFrame === 'function')
+      cancelAnimationFrame(rafId)
+
+    rafId = 0
+  }
+
+  onBeforeUnmount(cancelLoop)
+
+  return {
+    source,
+    visible,
+    done,
+    final,
+    caughtUp,
+    pendingChars,
+    enqueue,
+    finish,
+    flush,
+    reset,
+    pause,
+    resume,
+  }
+}
+
+function createGraphemeSegmenter(): GraphemeSegmenter | null {
+  if (typeof Intl === 'undefined')
+    return null
+
+  const SegmenterCtor = (Intl as unknown as {
+    Segmenter?: new (locale?: string, options?: { granularity?: 'grapheme' }) => GraphemeSegmenter
+  }).Segmenter
+
+  if (!SegmenterCtor)
+    return null
+
+  return new SegmenterCtor(undefined, { granularity: 'grapheme' })
+}
+
+function takeGraphemes(input: string, count: number, segmenter: GraphemeSegmenter | null): GraphemeSlice {
+  if (!input || count <= 0)
+    return { text: '', graphemeCount: 0 }
+
+  if (!segmenter) {
+    const parts = Array.from(input).slice(0, count)
+    return {
+      text: parts.join(''),
+      graphemeCount: parts.length,
+    }
+  }
+
+  let output = ''
+  let used = 0
+
+  for (const part of segmenter.segment(input)) {
+    if (used >= count)
+      break
+    output += part.segment
+    used++
+  }
+
+  return {
+    text: output,
+    graphemeCount: used,
+  }
+}
+
+function now() {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -43,16 +43,21 @@ interface GraphemeSegmenter {
 
 export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {}): SmoothMarkdownStreamController {
   const {
-    minCharsPerSecond = 40,
-    maxCharsPerSecond = 1000,
+    minCharsPerSecond: rawMinCps = 40,
+    maxCharsPerSecond: rawMaxCps = 1000,
     targetLatencyMs = 900,
     catchUpLatencyMs = 350,
     catchUpThreshold = 600,
-    maxCommitFps = 30,
+    maxCommitFps: rawMaxFps = 30,
     startDelayMs = 80,
-    maxCharsPerCommit = 80,
+    maxCharsPerCommit: rawMaxChars = 80,
     flushOnFinish = false,
   } = options
+
+  const minCharsPerSecond = Math.max(1, rawMinCps)
+  const maxCharsPerSecond = Math.max(minCharsPerSecond, rawMaxCps)
+  const maxCommitFps = Math.max(1, Math.trunc(rawMaxFps || 30))
+  const maxCharsPerCommit = Math.max(1, Math.trunc(rawMaxChars || 1))
 
   const source = ref('')
   const visible = ref('')
@@ -69,21 +74,32 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
   let lastTick = 0
   let charBudget = 0
   let currentCps = minCharsPerSecond
+  let hasStarted = false
 
   function enqueue(chunk: string) {
     if (!chunk)
       return
 
+    if (done.value)
+      done.value = false
+
+    const hadSource = source.value.length > 0
     const wasIdle = pendingChars.value <= 0
     source.value += chunk
 
     if (wasIdle) {
       const t = now()
-      startedAt = t
+      // Only apply startDelay for the very first batch of a new stream.
+      // If the stream already had content and wasn't finished, skip the delay
+      // so subsequent appends resume smoothly without an artificial pause.
+      startedAt = hadSource && hasStarted
+        ? t - startDelayMs
+        : t
       lastTick = t
       charBudget = 0
     }
 
+    hasStarted = true
     ensureLoop()
   }
 
@@ -112,6 +128,7 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
     visible.value = initialMarkdown
     done.value = false
     paused.value = false
+    hasStarted = false
 
     startedAt = 0
     lastTick = 0

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -204,7 +204,12 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
     currentCps += (targetCps - currentCps) * 0.2
     charBudget += currentCps * (dt / 1000)
 
-    const desiredCount = clamp(Math.floor(charBudget), 1, maxCharsPerCommit)
+    if (charBudget < 1) {
+      ensureLoop()
+      return
+    }
+
+    const desiredCount = Math.min(Math.floor(charBudget), maxCharsPerCommit)
     const rest = source.value.slice(visible.value.length)
     const nextSlice = takeGraphemes(rest, desiredCount, segmenter)
 

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -41,23 +41,44 @@ interface GraphemeSegmenter {
   segment: (input: string) => Iterable<GraphemeSegment>
 }
 
+function toPositiveFiniteNumber(value: unknown, fallback: number, min = 1) {
+  const normalized = Number(value)
+  return Number.isFinite(normalized)
+    ? Math.max(min, normalized)
+    : fallback
+}
+
+function toNonNegativeFiniteNumber(value: unknown, fallback: number) {
+  const normalized = Number(value)
+  return Number.isFinite(normalized)
+    ? Math.max(0, normalized)
+    : fallback
+}
+
 export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {}): SmoothMarkdownStreamController {
   const {
     minCharsPerSecond: rawMinCps = 40,
     maxCharsPerSecond: rawMaxCps = 1000,
-    targetLatencyMs = 900,
-    catchUpLatencyMs = 350,
-    catchUpThreshold = 600,
+    targetLatencyMs: rawTargetLatencyMs = 900,
+    catchUpLatencyMs: rawCatchUpLatencyMs = 350,
+    catchUpThreshold: rawCatchUpThreshold = 600,
     maxCommitFps: rawMaxFps = 30,
-    startDelayMs = 80,
+    startDelayMs: rawStartDelayMs = 80,
     maxCharsPerCommit: rawMaxChars = 80,
     flushOnFinish = false,
   } = options
 
-  const minCharsPerSecond = Math.max(1, rawMinCps)
-  const maxCharsPerSecond = Math.max(minCharsPerSecond, rawMaxCps)
-  const maxCommitFps = Math.max(1, Math.trunc(rawMaxFps || 30))
-  const maxCharsPerCommit = Math.max(1, Math.trunc(rawMaxChars || 1))
+  const minCharsPerSecond = toPositiveFiniteNumber(rawMinCps, 40, 1)
+  const maxCharsPerSecond = Math.max(
+    minCharsPerSecond,
+    toPositiveFiniteNumber(rawMaxCps, 1000, 1),
+  )
+  const normalizedTargetLatencyMs = toPositiveFiniteNumber(rawTargetLatencyMs, 900, 1)
+  const normalizedCatchUpLatencyMs = toPositiveFiniteNumber(rawCatchUpLatencyMs, 350, 1)
+  const normalizedCatchUpThreshold = toNonNegativeFiniteNumber(rawCatchUpThreshold, 600)
+  const normalizedStartDelayMs = toNonNegativeFiniteNumber(rawStartDelayMs, 80)
+  const maxCommitFps = Math.trunc(toPositiveFiniteNumber(rawMaxFps, 30, 1))
+  const maxCharsPerCommit = Math.trunc(toPositiveFiniteNumber(rawMaxChars, 80, 1))
 
   const source = ref('')
   const visible = ref('')
@@ -93,7 +114,7 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
       // If the stream already had content and wasn't finished, skip the delay
       // so subsequent appends resume smoothly without an artificial pause.
       startedAt = hadSource && hasStarted
-        ? t - startDelayMs
+        ? t - normalizedStartDelayMs
         : t
       lastTick = t
       charBudget = 0
@@ -178,7 +199,7 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
       return
     }
 
-    if (timestamp - startedAt < startDelayMs) {
+    if (timestamp - startedAt < normalizedStartDelayMs) {
       rafId = requestAnimationFrame(tick)
       return
     }
@@ -193,7 +214,7 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
 
     lastTick = timestamp
     const pending = pendingChars.value
-    const latencyMs = pending > catchUpThreshold ? catchUpLatencyMs : targetLatencyMs
+    const latencyMs = pending > normalizedCatchUpThreshold ? normalizedCatchUpLatencyMs : normalizedTargetLatencyMs
 
     const targetCps = clamp(
       pending / Math.max(0.001, latencyMs / 1000),

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -63,7 +63,10 @@ export type { D2Loader } from './components/D2BlockNode/d2'
 export type { KatexLoader } from './components/MathInlineNode/katex'
 
 export type { MermaidLoader } from './components/MermaidBlockNode/mermaid'
-export type { SmoothMarkdownStreamOptions } from './composables/useSmoothMarkdownStream'
+export type {
+  SmoothMarkdownStreamController,
+  SmoothMarkdownStreamOptions,
+} from './composables/useSmoothMarkdownStream'
 export type {
   CodeBlockDiffAppearance,
   CodeBlockDiffHideUnchangedRegions,

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -43,6 +43,7 @@ import ThematicBreakNode from './components/ThematicBreakNode'
 import Tooltip from './components/Tooltip'
 import VmrContainerNode from './components/VmrContainerNode'
 import { setDefaultI18nMap } from './composables/useSafeI18n'
+import { useSmoothMarkdownStream } from './composables/useSmoothMarkdownStream'
 import { setIconTheme } from './icon-themes'
 import { setLanguageIconResolver } from './utils/languageIcon'
 import { clearGlobalCustomComponents, getCustomNodeComponents, removeCustomComponents, setCustomComponents } from './utils/nodeComponents'
@@ -62,6 +63,7 @@ export type { D2Loader } from './components/D2BlockNode/d2'
 export type { KatexLoader } from './components/MathInlineNode/katex'
 
 export type { MermaidLoader } from './components/MermaidBlockNode/mermaid'
+export type { SmoothMarkdownStreamOptions } from './composables/useSmoothMarkdownStream'
 export type {
   CodeBlockDiffAppearance,
   CodeBlockDiffHideUnchangedRegions,
@@ -164,6 +166,7 @@ export {
   TextNode,
   ThematicBreakNode,
   Tooltip,
+  useSmoothMarkdownStream,
   VmrContainerNode,
 }
 

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -71,6 +71,12 @@ export interface NodeRendererProps {
   indexKey?: number | string
   /** Show a blinking typewriter cursor while streamed content grows. Default: false */
   typewriter?: boolean
+  /**
+   * Enable built-in smooth pacing for streaming `content` updates.
+   * Applies when rendering from `content` (not `nodes`) and typewriter/incremental mode is active.
+   * Default: true
+   */
+  smoothStreaming?: boolean
   /** Enable/disable non-code-node enter and streamed-text fade animations. Default: true */
   fade?: boolean
   /** Enable incremental/batched rendering of nodes to avoid large single flush costs. Default: true */

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -1,4 +1,5 @@
 import type { BaseNode, HtmlPolicy, MarkdownIt, ParseOptions } from 'stream-markdown-parser'
+import type { SmoothMarkdownStreamOptions } from '../composables/useSmoothMarkdownStream'
 import type {
   CodeBlockMonacoOptions,
   CodeBlockMonacoTheme,
@@ -73,10 +74,15 @@ export interface NodeRendererProps {
   typewriter?: boolean
   /**
    * Enable built-in smooth pacing for streaming `content` updates.
-   * Applies when rendering from `content` (not `nodes`) and typewriter/incremental mode is active.
-   * Default: true
+   * - `true`: force-enable smooth streaming (content mode only)
+   * - `false`: force-disable smooth streaming
+   * - `'auto'` (default): enable only when typewriter/incremental mode is active
+   * Applies when rendering from `content` (not `nodes`).
+   * Default: 'auto'
    */
-  smoothStreaming?: boolean
+  smoothStreaming?: boolean | 'auto'
+  /** Options forwarded to the built-in smooth streaming composable. */
+  smoothStreamingOptions?: SmoothMarkdownStreamOptions
   /** Enable/disable non-code-node enter and streamed-text fade animations. Default: true */
   fade?: boolean
   /** Enable incremental/batched rendering of nodes to avoid large single flush costs. Default: true */

--- a/test/e2e/node-renderer.e2e.test.ts
+++ b/test/e2e/node-renderer.e2e.test.ts
@@ -28,6 +28,7 @@ async function mountMarkdown(markdown: string, props: Record<string, any> = {}, 
   const wrapper = mount(MarkdownRender, {
     props: {
       content: markdown,
+      smoothStreaming: false,
       ...props,
       customMarkdownIt: (md: any) => md.use(markdownItEmoji),
     },

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import NodeRenderer from '../src/components/NodeRenderer'
+
+describe('node renderer smooth streaming', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses smooth pacing by default in typewriter mode and allows opting out', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const content = 'Hello smooth streaming markdown renderer.'
+
+    const smoothWrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        typewriter: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    expect(smoothWrapper.text()).not.toContain('Hello smooth')
+    expect(queuedFrames.length).toBeGreaterThan(0)
+
+    const baseline = performance.now()
+    for (let step = 1; step <= 6 && smoothWrapper.text().length === 0; step++) {
+      queuedFrames.shift()?.(baseline + (step * 40))
+      await nextTick()
+    }
+    expect(smoothWrapper.text().length).toBeGreaterThan(0)
+
+    const rawWrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    expect(rawWrapper.text()).toContain('Hello smooth streaming markdown renderer.')
+
+    smoothWrapper.unmount()
+    rawWrapper.unmount()
+  })
+})

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -135,4 +135,102 @@ describe('node renderer smooth streaming', () => {
     expect(wrapper.text()).toContain('Auto mode test')
     wrapper.unmount()
   })
+
+  it('raw chunk updates do not bump streamRenderVersion when smooth streaming is active', async () => {
+    // Capture rAF callbacks but never invoke them — visible stays at ''
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    queuedFrames.length = 0
+
+    // Initial append — visible is still empty (rAF not ticked)
+    await wrapper.setProps({ content: 'hello' })
+    await nextTick()
+
+    // More raw chunk appends without advancing rAF
+    await wrapper.setProps({ content: 'hello world 1' })
+    await nextTick()
+    await wrapper.setProps({ content: 'hello world 12' })
+    await nextTick()
+    await wrapper.setProps({ content: 'hello world 123' })
+    await nextTick()
+
+    // DOM should still show nothing (visible hasn't advanced)
+    // but crucially, the rendered text should not have changed due to
+    // streamRenderVersion increments from raw content changes.
+    // Before the fix, each props.content change bumped streamRenderVersion,
+    // which could trigger TextNode watchers even though visible was unchanged.
+    expect(wrapper.text()).not.toContain('hello world')
+    wrapper.unmount()
+  })
+
+  it('nested renderer does not double-pace when parent has smooth streaming enabled', async () => {
+    // When a parent renderer is already smoothing, a nested NodeRenderer
+    // (e.g. inside a thinking block or custom HTML tag) should not apply
+    // its own smooth pacing on top of the parent's already-paced output.
+    // Use 'auto' mode so the mounted gate protects initial static content.
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'static thinking content',
+        typewriter: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+
+    // With typewriter=true and smoothStreaming='auto' (default), the mounted
+    // gate should protect the initial content from being paced.
+    expect(wrapper.text()).toContain('static thinking content')
+
+    // Verify that smoothStreamingEnabled is true for the parent (typewriter is on
+    // and mounted gate is open), so the provide sends true to children.
+    // After mount, with typewriter=true, smooth streaming should be enabled.
+    // We can't easily read the provide from outside, but we can verify that
+    // the parent provides the correct value by testing that a child renderer
+    // would see it. Instead, directly verify the behavior:
+    // mount a second NodeRenderer with inherited provide = true and
+    // smoothStreaming='auto' — it should NOT smooth because the parent is pacing.
+    const childWrapper = mount(NodeRenderer, {
+      props: {
+        content: 'nested content',
+        smoothStreaming: 'auto',
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+      global: {
+        provide: {
+          markstreamSmoothStreaming: { value: true },
+        },
+      },
+    })
+
+    await nextTick()
+
+    // With the parent smooth streaming injected as true, the child's auto mode
+    // should be suppressed — content renders immediately, not paced.
+    expect(childWrapper.text()).toContain('nested content')
+
+    wrapper.unmount()
+    childWrapper.unmount()
+  })
 })

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -233,4 +233,42 @@ describe('node renderer smooth streaming', () => {
     wrapper.unmount()
     childWrapper.unmount()
   })
+
+  it('nested renderer with smoothStreaming=true does force-enable even under inherited parent smooth', async () => {
+    // smoothStreaming === true is an explicit opt-in that intentionally
+    // bypasses the auto-suppression. This is by design — the user explicitly
+    // wants pacing regardless of the parent's state.
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const childWrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+      global: {
+        provide: {
+          markstreamSmoothStreaming: { value: true },
+        },
+      },
+    })
+
+    await nextTick()
+    queuedFrames.length = 0
+
+    await childWrapper.setProps({ content: 'forced smooth' })
+    await nextTick()
+
+    // smoothStreaming: true should schedule rAF even when parent is already smoothing
+    expect(queuedFrames.length).toBeGreaterThan(0)
+
+    childWrapper.unmount()
+  })
 })

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -271,4 +271,82 @@ describe('node renderer smooth streaming', () => {
 
     childWrapper.unmount()
   })
+
+  it('nodes mode never enables smooth streaming', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [
+          { type: 'paragraph', raw: 'hello', children: [{ type: 'text', content: 'hello', raw: 'hello' }] },
+        ],
+        typewriter: true,
+        smoothStreaming: 'auto',
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    // When nodes are provided, smooth streaming must not activate
+    // regardless of typewriter or smoothStreaming='auto'
+    expect(wrapper.text()).toContain('hello')
+    expect(queuedFrames.length).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  it('final is gated by caughtUp when smooth streaming is active', async () => {
+    // When smooth streaming is pacing content, final=true should not
+    // reach the parser until visible has caught up with source.
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      // Stash but don't invoke — visible stays behind source
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    queuedFrames.length = 0
+
+    // Feed content + final=true — but rAF is stalled so visible stays empty
+    await wrapper.setProps({ content: 'Hello world', final: true })
+    await nextTick()
+
+    // Because visible hasn't caught up (rAF never ticked), the content
+    // should not be visible in the DOM yet.
+    expect(wrapper.text()).not.toContain('Hello world')
+
+    // Now drain the rAF queue to let visible catch up with source
+    const baseline = performance.now()
+    for (let step = 1; step <= 40 && queuedFrames.length > 0; step++) {
+      const cb = queuedFrames.shift()!
+      cb(baseline + step * 50)
+      await nextTick()
+    }
+
+    // After visible catches up, content should be rendered and final
+    // should have been forwarded to the parser (closing any open constructs).
+    expect(wrapper.text()).toContain('Hello world')
+
+    wrapper.unmount()
+  })
 })

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -12,7 +12,7 @@ describe('node renderer smooth streaming', () => {
     vi.unstubAllGlobals()
   })
 
-  it('uses smooth pacing by default in typewriter mode and allows opting out', async () => {
+  it('uses smooth pacing in typewriter mode for post-mount appends and allows opting out', async () => {
     const queuedFrames: FrameRequestCallback[] = []
     vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
       queuedFrames.push(cb)
@@ -22,9 +22,10 @@ describe('node renderer smooth streaming', () => {
 
     const content = 'Hello smooth streaming markdown renderer.'
 
+    // Mount with initial content — should render immediately (mounted gate protects)
     const smoothWrapper = mount(NodeRenderer, {
       props: {
-        content,
+        content: '',
         typewriter: true,
         batchRendering: false,
         viewportPriority: false,
@@ -33,19 +34,26 @@ describe('node renderer smooth streaming', () => {
     })
 
     await nextTick()
+
+    // Now append content (simulating a streaming update after mount)
+    queuedFrames.length = 0
+    await smoothWrapper.setProps({ content })
+
+    // Content should not be fully revealed immediately — it's being paced
     expect(smoothWrapper.text()).not.toContain('Hello smooth')
     expect(queuedFrames.length).toBeGreaterThan(0)
 
     const baseline = performance.now()
-    for (let step = 1; step <= 6 && smoothWrapper.text().length === 0; step++) {
+    for (let step = 1; step <= 6 && !smoothWrapper.text().includes('Hello'); step++) {
       queuedFrames.shift()?.(baseline + (step * 40))
       await nextTick()
     }
     expect(smoothWrapper.text().length).toBeGreaterThan(0)
 
+    // smoothStreaming: false should show content immediately
     const rawWrapper = mount(NodeRenderer, {
       props: {
-        content,
+        content: '',
         typewriter: true,
         smoothStreaming: false,
         batchRendering: false,
@@ -55,9 +63,76 @@ describe('node renderer smooth streaming', () => {
     })
 
     await nextTick()
+    await rawWrapper.setProps({ content })
+    await nextTick()
     expect(rawWrapper.text()).toContain('Hello smooth streaming markdown renderer.')
 
     smoothWrapper.unmount()
     rawWrapper.unmount()
+  })
+
+  it('does not smooth initial static content before mounted appends', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'static markdown',
+        maxLiveNodes: 0,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    // Initial content should render immediately, not be paced from blank
+    expect(wrapper.text()).toContain('static markdown')
+    wrapper.unmount()
+  })
+
+  it('smoothStreaming=true force-enables without requiring typewriter', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    // Start with empty content, then append after mount
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    queuedFrames.length = 0
+
+    // Append content — smoothStreaming: true should pace without typewriter
+    await wrapper.setProps({ content: 'Force enabled smooth' })
+    await nextTick()
+
+    // Content should be paced (not immediately visible) and rAF should be scheduled
+    expect(queuedFrames.length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('smoothStreaming="auto" does not enable without typewriter or maxLiveNodes<=0', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'Auto mode test',
+        smoothStreaming: 'auto',
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    // With default maxLiveNodes (320), 'auto' should not enable smooth streaming
+    expect(wrapper.text()).toContain('Auto mode test')
+    wrapper.unmount()
   })
 })

--- a/test/playground-vue-thinking-node.test.ts
+++ b/test/playground-vue-thinking-node.test.ts
@@ -18,6 +18,7 @@ describe('playground Vue thinking node', () => {
         customId,
         deferNodesUntilVisible: false,
         maxLiveNodes: 0,
+        smoothStreaming: false,
         typewriter: true,
         viewportPriority: false,
       },

--- a/test/playground-vue-thinking-node.test.ts
+++ b/test/playground-vue-thinking-node.test.ts
@@ -43,4 +43,67 @@ describe('playground Vue thinking node', () => {
       removeCustomComponents(customId)
     }
   })
+
+  it('does not convert inherited smooth=true into forced smoothStreaming=true', async () => {
+    // When a parent renderer provides markstreamSmoothStreaming=true,
+    // ThinkingNode must pass 'auto' (not true) to the nested MarkdownRender.
+    // Otherwise the nested renderer would see smoothStreaming=true as an
+    // explicit opt-in and double-pace the content.
+    const queuedFrames: FrameRequestCallback[] = []
+    const { vi } = await import('vitest')
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const customId = 'playground-vue-thinking-double-pace'
+    setCustomComponents(customId, { thinking: ThinkingNode })
+
+    // Parent renderer with typewriter=true → smooth streaming auto-enables →
+    // provides markstreamSmoothStreaming={ value: true } to children.
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        batchRendering: false,
+        content: '<thinking>initial thought</thinking>',
+        customHtmlTags: ['thinking'],
+        customId,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        typewriter: true,
+        viewportPriority: false,
+      },
+    })
+
+    try {
+      await flushAll()
+
+      // The initial content should render immediately (mounted gate + auto mode)
+      expect(wrapper.text()).toContain('initial thought')
+
+      // Now append more thinking content — the parent is already pacing,
+      // so the thinking node's nested MarkdownRender should NOT schedule
+      // its own rAF for a second pacing layer.
+      queuedFrames.length = 0
+
+      await wrapper.setProps({
+        content: '<thinking>initial thought extended</thinking>',
+      })
+      await flushAll()
+
+      // With the fix, ThinkingNode passes 'auto' instead of true,
+      // so the nested renderer's auto mode is suppressed by the inherited
+      // smooth streaming guard. Content should be immediately visible.
+      expect(wrapper.text()).toContain('extended')
+
+      // There should be rAF frames from the parent renderer only,
+      // but the thinking content itself should not have been double-paced
+      // from empty — it should have rendered the delta directly.
+    }
+    finally {
+      wrapper.unmount()
+      removeCustomComponents(customId)
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/test/text-node-streaming-consistency.test.ts
+++ b/test/text-node-streaming-consistency.test.ts
@@ -13,6 +13,7 @@ describe('text node streaming consistency', () => {
       props: {
         content: '1. **记忆化递归（动态规划',
         batchRendering: false,
+        smoothStreaming: false,
         viewportPriority: false,
         deferNodesUntilVisible: false,
         maxLiveNodes: 0,
@@ -62,6 +63,7 @@ describe('text node streaming consistency', () => {
       props: {
         content: initial,
         batchRendering: false,
+        smoothStreaming: false,
         deferNodesUntilVisible: false,
         viewportPriority: false,
         maxLiveNodes: 0,

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -139,7 +139,7 @@ describe('useSmoothMarkdownStream', () => {
   it('normalizes extreme option values', () => {
     const wrapper = mountStream({
       maxCharsPerCommit: 0,
-      maxCommitFps: 0,
+      maxCommitFPS: 0,
       minCharsPerSecond: 0,
       maxCharsPerSecond: -10,
     })
@@ -148,6 +148,25 @@ describe('useSmoothMarkdownStream', () => {
     ;(wrapper.vm as any).enqueue('test')
     ;(wrapper.vm as any).flush()
     expect((wrapper.vm as any).visible).toBe('test')
+    wrapper.unmount()
+  })
+
+  it('normalizes NaN and infinite numeric options', () => {
+    const wrapper = mountStream({
+      minCharsPerSecond: Number.NaN,
+      maxCharsPerSecond: Number.POSITIVE_INFINITY,
+      targetLatencyMs: Number.NaN,
+      catchUpLatencyMs: Number.NaN,
+      catchUpThreshold: Number.NaN,
+      startDelayMs: Number.NaN,
+      maxCommitFps: Number.NaN,
+      maxCharsPerCommit: Number.NaN,
+    })
+
+    ;(wrapper.vm as any).enqueue('hello')
+    ;(wrapper.vm as any).flush()
+
+    expect((wrapper.vm as any).visible).toBe('hello')
     wrapper.unmount()
   })
 

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -1,3 +1,4 @@
+import type { SmoothMarkdownStreamOptions } from '../src/composables/useSmoothMarkdownStream'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
@@ -21,7 +22,7 @@ function hasUnpairedSurrogate(input: string) {
   return false
 }
 
-function mountStream(options = {}) {
+function mountStream(options: SmoothMarkdownStreamOptions = {}) {
   return mount(defineComponent({
     setup() {
       return useSmoothMarkdownStream(options)
@@ -138,7 +139,7 @@ describe('useSmoothMarkdownStream', () => {
   it('normalizes extreme option values', () => {
     const wrapper = mountStream({
       maxCharsPerCommit: 0,
-      maxCommitFPS: 0,
+      maxCommitFps: 0,
       minCharsPerSecond: 0,
       maxCharsPerSecond: -10,
     })

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -121,4 +121,32 @@ describe('useSmoothMarkdownStream', () => {
     expect((wrapper.vm as any).pendingChars).toBe(0)
     wrapper.unmount()
   })
+
+  it('reopens the stream when enqueue is called after finish', async () => {
+    const wrapper = mountStream()
+
+    ;(wrapper.vm as any).enqueue('hello')
+    ;(wrapper.vm as any).finish({ flush: true })
+    expect((wrapper.vm as any).final).toBe(true)
+
+    ;(wrapper.vm as any).enqueue(' world')
+    expect((wrapper.vm as any).done).toBe(false)
+    expect((wrapper.vm as any).final).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('normalizes extreme option values', () => {
+    const wrapper = mountStream({
+      maxCharsPerCommit: 0,
+      maxCommitFPS: 0,
+      minCharsPerSecond: 0,
+      maxCharsPerSecond: -10,
+    })
+
+    // Should not throw and should still function
+    ;(wrapper.vm as any).enqueue('test')
+    ;(wrapper.vm as any).flush()
+    expect((wrapper.vm as any).visible).toBe('test')
+    wrapper.unmount()
+  })
 })

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -139,7 +139,7 @@ describe('useSmoothMarkdownStream', () => {
   it('normalizes extreme option values', () => {
     const wrapper = mountStream({
       maxCharsPerCommit: 0,
-      maxCommitFPS: 0,
+      maxCommitFps: 0,
       minCharsPerSecond: 0,
       maxCharsPerSecond: -10,
     })

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -150,4 +150,25 @@ describe('useSmoothMarkdownStream', () => {
     expect((wrapper.vm as any).visible).toBe('test')
     wrapper.unmount()
   })
+
+  it('respects low chars-per-second values instead of emitting once per frame', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStream({
+      minCharsPerSecond: 1,
+      maxCharsPerSecond: 1,
+      maxCommitFps: 60,
+      startDelayMs: 0,
+    })
+
+    ;(wrapper.vm as any).enqueue('abcdefghij')
+
+    // After 100ms at 1 char/s, at most 1 character should be visible.
+    // Without the fix, each frame would emit at least 1 grapheme,
+    // producing ~6 characters in 100ms at 60fps.
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect((wrapper.vm as any).visible.length).toBeLessThanOrEqual(1)
+
+    wrapper.unmount()
+  })
 })

--- a/test/use-smooth-markdown-stream.test.ts
+++ b/test/use-smooth-markdown-stream.test.ts
@@ -1,0 +1,124 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { useSmoothMarkdownStream } from '../src/composables/useSmoothMarkdownStream'
+
+function hasUnpairedSurrogate(input: string) {
+  for (let index = 0; index < input.length; index++) {
+    const code = input.charCodeAt(index)
+    const isHigh = code >= 0xD800 && code <= 0xDBFF
+    const isLow = code >= 0xDC00 && code <= 0xDFFF
+    if (isHigh) {
+      const next = input.charCodeAt(index + 1)
+      if (!(next >= 0xDC00 && next <= 0xDFFF))
+        return true
+      index += 1
+      continue
+    }
+    if (isLow)
+      return true
+  }
+  return false
+}
+
+function mountStream(options = {}) {
+  return mount(defineComponent({
+    setup() {
+      return useSmoothMarkdownStream(options)
+    },
+    template: '<div />',
+  }))
+}
+
+describe('useSmoothMarkdownStream', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not reveal a large chunk all at once', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStream()
+
+    ;(wrapper.vm as any).enqueue('a'.repeat(1800))
+
+    expect((wrapper.vm as any).visible.length).toBeLessThan((wrapper.vm as any).source.length)
+
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect((wrapper.vm as any).visible.length).toBeLessThan((wrapper.vm as any).source.length)
+    wrapper.unmount()
+  })
+
+  it('accelerates output when backlog is larger', async () => {
+    vi.useFakeTimers()
+    const fastWrapper = mountStream({
+      minCharsPerSecond: 30,
+      maxCharsPerSecond: 2000,
+      targetLatencyMs: 900,
+      catchUpLatencyMs: 260,
+      catchUpThreshold: 500,
+      maxCharsPerCommit: 120,
+    })
+    const slowWrapper = mountStream({
+      minCharsPerSecond: 30,
+      maxCharsPerSecond: 2000,
+      targetLatencyMs: 900,
+      catchUpLatencyMs: 260,
+      catchUpThreshold: 500,
+      maxCharsPerCommit: 120,
+    })
+
+    ;(fastWrapper.vm as any).enqueue('x'.repeat(2400))
+    ;(slowWrapper.vm as any).enqueue('x'.repeat(320))
+
+    await vi.advanceTimersByTimeAsync(700)
+
+    expect((fastWrapper.vm as any).visible.length).toBeGreaterThan((slowWrapper.vm as any).visible.length)
+    fastWrapper.unmount()
+    slowWrapper.unmount()
+  })
+
+  it('sets final only after visible catches up', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStream()
+
+    ;(wrapper.vm as any).enqueue('x'.repeat(1400))
+    ;(wrapper.vm as any).finish()
+
+    expect((wrapper.vm as any).done).toBe(true)
+    expect((wrapper.vm as any).final).toBe(false)
+
+    ;(wrapper.vm as any).flush()
+
+    expect((wrapper.vm as any).final).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('keeps surrogate pairs intact while streaming emoji text', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStream({ maxCharsPerCommit: 1, maxCommitFps: 60, startDelayMs: 0 })
+    const emojiText = '👨‍👩‍👧‍👦 hello 👋🌍'
+
+    ;(wrapper.vm as any).enqueue(emojiText)
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(hasUnpairedSurrogate((wrapper.vm as any).visible)).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('reset clears state and keeps pending at zero', async () => {
+    vi.useFakeTimers()
+    const wrapper = mountStream()
+
+    ;(wrapper.vm as any).enqueue('x'.repeat(1000))
+    await vi.advanceTimersByTimeAsync(120)
+    ;(wrapper.vm as any).reset()
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect((wrapper.vm as any).source).toBe('')
+    expect((wrapper.vm as any).visible).toBe('')
+    expect((wrapper.vm as any).pendingChars).toBe(0)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- add useSmoothMarkdownStream composable for adaptive stream pacing
- enable smooth streaming by default in MarkdownRender for typewriter or incremental content flows
- add smooth-streaming prop to opt out per renderer instance
- wire a Smooth Stream toggle into playground settings instead of a separate demo page
- update README/docs and add coverage for composable and renderer behavior

## Notes
- smooth pacing waits to settle final parsing until visible content catches up
- tests that rely on raw chunk cadence now explicitly set smoothStreaming: false
