### PR TITLE
feat: add smooth streaming support for markstream-svelte and markstream-angular

### DIFF
--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -15,7 +15,9 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  forwardRef,
   inject,
+  InjectionToken,
   Input,
   Output,
   ViewChild,
@@ -54,12 +56,25 @@ interface IdleDeadlineLike {
   timeRemaining?: () => number
 }
 
+export interface SmoothStreamingScope {
+  isSmoothStreamingEnabled: () => boolean
+}
+
+export const MARKSTREAM_SMOOTH_STREAMING_SCOPE
+  = new InjectionToken<SmoothStreamingScope>('MARKSTREAM_SMOOTH_STREAMING_SCOPE')
+
 const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 
 @Component({
   selector: 'markstream-angular',
   standalone: true,
   imports: [CommonModule, NodeOutletComponent],
+  providers: [
+    {
+      provide: MARKSTREAM_SMOOTH_STREAMING_SCOPE,
+      useExisting: forwardRef(() => NodeRendererComponent),
+    },
+  ],
   template: `
     <div
       #root
@@ -115,6 +130,10 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private readonly cdr = inject(ChangeDetectorRef)
   private readonly hostRef = inject(ElementRef<HTMLElement>)
   private readonly smoothStream = new SmoothMarkdownStreamService()
+  private readonly parentSmoothStreamingScope = inject(
+    MARKSTREAM_SMOOTH_STREAMING_SCOPE,
+    { optional: true, skipSelf: true },
+  )
 
   @ViewChild('root') private rootRef?: ElementRef<HTMLElement>
 
@@ -194,15 +213,24 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private postRenderTimer: number | null = null
   private unsubscribeCustomComponents?: () => void
   private hasMountedForSmoothStreaming = false
+  private unsubscribeSmoothStream?: () => void
+  private previousRenderContent = ''
+  private previousEffectiveFinal: boolean | undefined
+  private previousRenderVersionSource: unknown
 
   get hasNodes(): boolean {
-    return Array.isArray(this.nodes) && this.nodes.length > 0
+    return Array.isArray(this.nodes)
   }
 
   get smoothStreamingEligible(): boolean {
     if (this.smoothStreaming === false)
       return false
     if (this.hasNodes)
+      return false
+    // When the parent renderer is already pacing content, avoid double-pacing
+    // in nested renderers (e.g. thinking blocks, custom tag content).
+    // Only applies in 'auto' mode — smoothStreaming === true explicitly opts in.
+    if (this.smoothStreaming !== true && this.parentSmoothStreamingScope?.isSmoothStreamingEnabled())
       return false
     if (this.smoothStreaming === true)
       return true
@@ -238,6 +266,10 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
 
   get resolvedIndexPrefix() {
     return this.indexKey != null ? String(this.indexKey) : 'renderer'
+  }
+
+  isSmoothStreamingEnabled(): boolean {
+    return this.smoothStreamingEnabled
   }
 
   get resolvedInitialBatchSize() {
@@ -291,9 +323,8 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     return this.deferNodesActive || this.virtualizationEnabled
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.content || changes.nodes)
-      this.streamRenderVersion += 1
+  ngOnChanges(_changes: SimpleChanges) {
+    this.ensureSmoothStreamInitialized()
     this.syncSmoothStream()
     this.rebuild()
   }
@@ -301,6 +332,19 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   ngOnInit() {
     this.smoothStream.init(this.smoothStreamingOptions)
     this.hasMountedForSmoothStreaming = true
+    this.unsubscribeSmoothStream = this.smoothStream.subscribe(() => {
+      const nextRenderContent = this.renderContent
+      const nextEffectiveFinal = this.effectiveFinal
+
+      if (
+        nextRenderContent !== this.previousRenderContent
+        || nextEffectiveFinal !== this.previousEffectiveFinal
+      ) {
+        this.rebuild()
+      }
+    })
+    this.syncSmoothStream()
+    this.rebuild()
     this.unsubscribeCustomComponents = subscribeCustomComponents(() => {
       this.rebuild()
     })
@@ -311,6 +355,8 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   }
 
   ngOnDestroy() {
+    this.unsubscribeSmoothStream?.()
+    this.unsubscribeSmoothStream = undefined
     this.stopBatching()
     this.clearPostRenderWork()
     this.enhancementToken += 1
@@ -343,6 +389,11 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     const target = event.target as HTMLElement | null
     if (target?.closest('[data-node-index]'))
       this.mouseout.emit(event)
+  }
+
+  private ensureSmoothStreamInitialized(): void {
+    if (this.smoothStream)
+      this.smoothStream.init(this.smoothStreamingOptions)
   }
 
   private syncSmoothStream() {
@@ -386,6 +437,15 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     this.stopBatching()
     this.disposeEnhancements()
     this.cleanupTransientState()
+
+    // Bump streamRenderVersion based on renderContent/nodes (not raw content)
+    const renderVersionSource = this.hasNodes ? this.nodes : this.renderContent
+    if (this.previousRenderVersionSource !== renderVersionSource) {
+      this.streamRenderVersion += 1
+      this.previousRenderVersionSource = renderVersionSource
+    }
+    this.previousRenderContent = this.renderContent
+    this.previousEffectiveFinal = this.effectiveFinal
 
     const scopedCustomComponents = getCustomNodeComponents(this.customId)
     const mergedCustomComponents = this.customComponents

--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -339,10 +339,16 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     // actually advanced. The smooth stream subscription already calls rebuild()
     // when visible ticks forward, so skipping here avoids redundant parse/rebuild
     // cycles driven by raw chunk cadence.
+    // Only skip when *only* raw stream inputs (content/final) changed — if any
+    // other input (isDark, customHtmlTags, codeBlockProps, etc.) also changed in
+    // this cycle, we must rebuild to honour those changes.
+    const changeKeys = Object.keys(changes)
+    const onlyRawStreamChanges = changeKeys.every(key => key === 'content' || key === 'final')
+
     if (
       this.smoothStreamingEnabled
+      && onlyRawStreamChanges
       && changes.content
-      && !changes.nodes
       && previousRenderContent === this.renderContent
       && previousEffectiveFinal === this.effectiveFinal
     ) {

--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -205,6 +205,7 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private enhancementHandle: RenderedHtmlEnhancementHandle | null = null
   private postRenderTimer: number | null = null
   private unsubscribeCustomComponents?: () => void
+  private isSyncingSmoothStream = false
   private hasMountedForSmoothStreaming = false
   private unsubscribeSmoothStream?: () => void
   private previousRenderContent = ''
@@ -353,8 +354,11 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
 
   ngOnInit() {
     this.smoothStream.init(this.smoothStreamingOptions)
-    this.hasMountedForSmoothStreaming = true
+
     this.unsubscribeSmoothStream = this.smoothStream.subscribe(() => {
+      if (this.isSyncingSmoothStream)
+        return
+
       const nextRenderContent = this.renderContent
       const nextEffectiveFinal = this.effectiveFinal
 
@@ -365,8 +369,20 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
         this.rebuild()
       }
     })
+
+    const previousRenderContent = this.renderContent
+    const previousEffectiveFinal = this.effectiveFinal
+
+    this.hasMountedForSmoothStreaming = true
     this.syncSmoothStream()
-    this.rebuild()
+
+    if (
+      previousRenderContent !== this.renderContent
+      || previousEffectiveFinal !== this.effectiveFinal
+    ) {
+      this.rebuild()
+    }
+
     this.unsubscribeCustomComponents = subscribeCustomComponents(() => {
       this.rebuild()
     })
@@ -422,37 +438,44 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     if (!this.smoothStream)
       return
 
-    const nextContent = this.content ?? ''
+    this.isSyncingSmoothStream = true
 
-    if (this.hasNodes) {
-      this.smoothStream.reset('')
-      return
-    }
+    try {
+      const nextContent = this.content ?? ''
 
-    if (!this.smoothStreamingEnabled) {
-      this.smoothStream.reset(nextContent)
+      if (this.hasNodes) {
+        this.smoothStream.reset('')
+        return
+      }
+
+      if (!this.smoothStreamingEnabled) {
+        this.smoothStream.reset(nextContent)
+        if (this.requestedFinal)
+          this.smoothStream.finish({ flush: true })
+        return
+      }
+
+      const source = this.smoothStream.source
+
+      if (!nextContent) {
+        this.smoothStream.reset('')
+      }
+      else if (nextContent === source) {
+        // no-op
+      }
+      else if (nextContent.startsWith(source)) {
+        this.smoothStream.enqueue(nextContent.slice(source.length))
+      }
+      else {
+        this.smoothStream.reset(nextContent)
+      }
+
       if (this.requestedFinal)
-        this.smoothStream.finish({ flush: true })
-      return
+        this.smoothStream.finish()
     }
-
-    const source = this.smoothStream.source
-
-    if (!nextContent) {
-      this.smoothStream.reset('')
+    finally {
+      this.isSyncingSmoothStream = false
     }
-    else if (nextContent === source) {
-      // no-op
-    }
-    else if (nextContent.startsWith(source)) {
-      this.smoothStream.enqueue(nextContent.slice(source.length))
-    }
-    else {
-      this.smoothStream.reset(nextContent)
-    }
-
-    if (this.requestedFinal)
-      this.smoothStream.finish()
   }
 
   private rebuild() {

--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -1,4 +1,5 @@
 import type { AfterViewInit, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core'
+import type { SmoothMarkdownStreamOptions } from 'markstream-core'
 import type { RenderedHtmlEnhancementHandle } from '../../enhanceRenderedHtml'
 import type {
   AngularRenderableNode,
@@ -21,6 +22,7 @@ import {
 } from '@angular/core'
 import { getCustomNodeComponents, subscribeCustomComponents } from '../../customComponents'
 import { disposeRenderedHtmlEnhancements, enhanceRenderedHtml } from '../../enhanceRenderedHtml'
+import { SmoothMarkdownStreamService } from '../../services/smooth-markdown-stream.service'
 import { NodeOutletComponent } from '../NodeOutlet/NodeOutlet.component'
 import {
   buildRenderContext,
@@ -112,6 +114,7 @@ const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnInit, AfterViewInit, OnDestroy {
   private readonly cdr = inject(ChangeDetectorRef)
   private readonly hostRef = inject(ElementRef<HTMLElement>)
+  private readonly smoothStream = new SmoothMarkdownStreamService()
 
   @ViewChild('root') private rootRef?: ElementRef<HTMLElement>
 
@@ -152,6 +155,8 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   @Input() maxLiveNodes = 320
   @Input() liveNodeBuffer = 60
   @Input() allowHtml = true
+  @Input() smoothStreaming: boolean | 'auto' = 'auto'
+  @Input() smoothStreamingOptions?: SmoothMarkdownStreamOptions
 
   @Output() copy = new EventEmitter<string>()
   @Output() handleArtifactClick = new EventEmitter<CodeBlockPreviewPayload>()
@@ -188,6 +193,48 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private enhancementHandle: RenderedHtmlEnhancementHandle | null = null
   private postRenderTimer: number | null = null
   private unsubscribeCustomComponents?: () => void
+  private hasMountedForSmoothStreaming = false
+
+  get hasNodes(): boolean {
+    return Array.isArray(this.nodes) && this.nodes.length > 0
+  }
+
+  get smoothStreamingEligible(): boolean {
+    if (this.smoothStreaming === false)
+      return false
+    if (this.hasNodes)
+      return false
+    if (this.smoothStreaming === true)
+      return true
+    return this.typewriter === true || (this.maxLiveNodes ?? 0) <= 0
+  }
+
+  get smoothStreamingEnabled(): boolean {
+    return this.hasMountedForSmoothStreaming && this.smoothStreamingEligible
+  }
+
+  get renderContent(): string {
+    return this.smoothStreamingEnabled ? this.smoothStream.visible : (this.content ?? '')
+  }
+
+  get rawContent(): string {
+    return this.content ?? ''
+  }
+
+  get smoothSourceSynced(): boolean {
+    return this.hasNodes || this.smoothStream.source === this.rawContent
+  }
+
+  get requestedFinal(): boolean | undefined {
+    const base = this.parseOptions ?? {} as any
+    return this.final ?? base.final
+  }
+
+  get effectiveFinal(): boolean | undefined {
+    if (this.smoothStreamingEnabled && this.requestedFinal != null)
+      return Boolean(this.requestedFinal && this.smoothSourceSynced && this.smoothStream.caughtUp)
+    return this.requestedFinal
+  }
 
   get resolvedIndexPrefix() {
     return this.indexKey != null ? String(this.indexKey) : 'renderer'
@@ -247,10 +294,13 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   ngOnChanges(changes: SimpleChanges) {
     if (changes.content || changes.nodes)
       this.streamRenderVersion += 1
+    this.syncSmoothStream()
     this.rebuild()
   }
 
   ngOnInit() {
+    this.smoothStream.init(this.smoothStreamingOptions)
+    this.hasMountedForSmoothStreaming = true
     this.unsubscribeCustomComponents = subscribeCustomComponents(() => {
       this.rebuild()
     })
@@ -268,6 +318,7 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     this.unsubscribeCustomComponents?.()
     this.unsubscribeCustomComponents = undefined
     this.disconnectObserver()
+    this.smoothStream.ngOnDestroy()
     if (this.enhancementTimer != null && typeof window !== 'undefined') {
       window.clearTimeout(this.enhancementTimer)
       this.enhancementTimer = null
@@ -294,6 +345,43 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
       this.mouseout.emit(event)
   }
 
+  private syncSmoothStream() {
+    if (!this.smoothStream)
+      return
+
+    const nextContent = this.content ?? ''
+
+    if (this.hasNodes) {
+      this.smoothStream.reset('')
+      return
+    }
+
+    if (!this.smoothStreamingEnabled) {
+      this.smoothStream.reset(nextContent)
+      if (this.requestedFinal)
+        this.smoothStream.finish({ flush: true })
+      return
+    }
+
+    const source = this.smoothStream.source
+
+    if (!nextContent) {
+      this.smoothStream.reset('')
+    }
+    else if (nextContent === source) {
+      // no-op
+    }
+    else if (nextContent.startsWith(source)) {
+      this.smoothStream.enqueue(nextContent.slice(source.length))
+    }
+    else {
+      this.smoothStream.reset(nextContent)
+    }
+
+    if (this.requestedFinal)
+      this.smoothStream.finish()
+  }
+
   private rebuild() {
     this.stopBatching()
     this.disposeEnhancements()
@@ -315,13 +403,19 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     this.renderContext = buildRenderContext(
       {
         ...this,
+        content: this.renderContent,
+        final: this.effectiveFinal,
         customComponents: mergedCustomComponents,
       },
       events,
       this.textStreamState,
       this.streamRenderVersion,
     )
-    this.parsedNodes = resolveParsedNodes(this)
+    this.parsedNodes = resolveParsedNodes({
+      ...this,
+      content: this.renderContent,
+      final: this.effectiveFinal,
+    })
     this.trimMeasuredState()
 
     const total = this.parsedNodes.length
@@ -729,7 +823,7 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
       return
 
     const handle = await enhanceRenderedHtml(root, {
-      final: this.final,
+      final: this.effectiveFinal,
       isDark: this.isDark,
       renderCodeBlocksAsPre: this.renderCodeBlocksAsPre,
       monacoOptions: this.codeBlockMonacoOptions,

--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -17,7 +17,6 @@ import {
   EventEmitter,
   forwardRef,
   inject,
-  InjectionToken,
   Input,
   Output,
   ViewChild,
@@ -37,6 +36,7 @@ import {
   resolveDeferNodes,
   resolveVirtualizationEnabled,
 } from '../shared/render-window'
+import { MARKSTREAM_SMOOTH_STREAMING_SCOPE } from '../shared/smooth-streaming-scope'
 
 interface VisibleNodeEntry {
   node: AngularRenderableNode
@@ -55,13 +55,6 @@ interface ObserverConfig {
 interface IdleDeadlineLike {
   timeRemaining?: () => number
 }
-
-export interface SmoothStreamingScope {
-  isSmoothStreamingEnabled: () => boolean
-}
-
-export const MARKSTREAM_SMOOTH_STREAMING_SCOPE
-  = new InjectionToken<SmoothStreamingScope>('MARKSTREAM_SMOOTH_STREAMING_SCOPE')
 
 const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 
@@ -238,7 +231,16 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   }
 
   get smoothStreamingEnabled(): boolean {
-    return this.hasMountedForSmoothStreaming && this.smoothStreamingEligible
+    // Mounted gate: prevent smooth streaming from pacing initial static content
+    // on the first client render (avoids blank flash).
+    // Only applies in 'auto' mode — smoothStreaming === true explicitly opts in
+    // and the gate is always open. SSR (typeof window === 'undefined') also opens
+    // the gate because the core controller has no RAF and will flush immediately.
+    const gateOpen = typeof window === 'undefined'
+      || this.hasMountedForSmoothStreaming
+      || this.smoothStreaming === true
+
+    return gateOpen && this.smoothStreamingEligible
   }
 
   get renderContent(): string {
@@ -323,9 +325,29 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
     return this.deferNodesActive || this.virtualizationEnabled
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges) {
     this.ensureSmoothStreamInitialized()
+
+    const previousRenderContent = this.renderContent
+    const previousEffectiveFinal = this.effectiveFinal
+
     this.syncSmoothStream()
+
+    // When smooth streaming is active, raw content/final appends should not
+    // trigger a full rebuild unless the visible (renderContent) or effectiveFinal
+    // actually advanced. The smooth stream subscription already calls rebuild()
+    // when visible ticks forward, so skipping here avoids redundant parse/rebuild
+    // cycles driven by raw chunk cadence.
+    if (
+      this.smoothStreamingEnabled
+      && changes.content
+      && !changes.nodes
+      && previousRenderContent === this.renderContent
+      && previousEffectiveFinal === this.effectiveFinal
+    ) {
+      return
+    }
+
     this.rebuild()
   }
 

--- a/packages/markstream-angular/src/components/shared/node-helpers.ts
+++ b/packages/markstream-angular/src/components/shared/node-helpers.ts
@@ -1,3 +1,4 @@
+import type { SmoothMarkdownStreamOptions } from 'markstream-core'
 import type { BaseNode, HtmlPolicy, MarkdownIt, ParsedNode, ParseOptions } from 'stream-markdown-parser'
 import type { CustomComponentMap } from '../../customComponents'
 import type { CodeBlockMonacoOptions, CodeBlockMonacoTheme } from '../../types/monaco'
@@ -133,6 +134,8 @@ export interface NodeRendererProps {
   maxLiveNodes?: number
   liveNodeBuffer?: number
   allowHtml?: boolean
+  smoothStreaming?: boolean | 'auto'
+  smoothStreamingOptions?: SmoothMarkdownStreamOptions
 }
 
 export interface AngularRenderContext {

--- a/packages/markstream-angular/src/components/shared/smooth-streaming-scope.ts
+++ b/packages/markstream-angular/src/components/shared/smooth-streaming-scope.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core'
+
+export interface SmoothStreamingScope {
+  isSmoothStreamingEnabled: () => boolean
+}
+
+export const MARKSTREAM_SMOOTH_STREAMING_SCOPE
+  = new InjectionToken<SmoothStreamingScope>('MARKSTREAM_SMOOTH_STREAMING_SCOPE')

--- a/packages/markstream-angular/src/index.ts
+++ b/packages/markstream-angular/src/index.ts
@@ -34,8 +34,6 @@ export { MathInlineNodeComponent as MathInlineNode } from './components/MathInli
 export { MermaidBlockNodeComponent as MermaidBlockNode } from './components/MermaidBlockNode/MermaidBlockNode.component'
 export { NestedRendererComponent as NestedRenderer } from './components/NestedRenderer/NestedRenderer.component'
 export { NodeRendererComponent as NodeRenderer } from './components/NodeRenderer/NodeRenderer.component'
-export { MARKSTREAM_SMOOTH_STREAMING_SCOPE } from './components/NodeRenderer/NodeRenderer.component'
-export type { SmoothStreamingScope } from './components/NodeRenderer/NodeRenderer.component'
 export { ParagraphNodeComponent as ParagraphNode } from './components/ParagraphNode/ParagraphNode.component'
 export { PreCodeNodeComponent as PreCodeNode } from './components/PreCodeNode/PreCodeNode.component'
 export { ReferenceNodeComponent as ReferenceNode } from './components/ReferenceNode/ReferenceNode.component'
@@ -55,6 +53,8 @@ export {
   resolveParsedNodes,
 } from './components/shared/node-helpers'
 export { SafeAttrsDirective } from './components/shared/safe-attrs.directive'
+export { MARKSTREAM_SMOOTH_STREAMING_SCOPE } from './components/shared/smooth-streaming-scope'
+export type { SmoothStreamingScope } from './components/shared/smooth-streaming-scope'
 export { StrikethroughNodeComponent as StrikethroughNode } from './components/StrikethroughNode/StrikethroughNode.component'
 export { StrongNodeComponent as StrongNode } from './components/StrongNode/StrongNode.component'
 export { SubscriptNodeComponent as SubscriptNode } from './components/SubscriptNode/SubscriptNode.component'

--- a/packages/markstream-angular/src/index.ts
+++ b/packages/markstream-angular/src/index.ts
@@ -123,6 +123,8 @@ export type {
   RenderableMarkdownNode,
 } from './renderMarkdownHtml'
 export { sanitizeHtmlContent } from './sanitizeHtmlContent'
+export { SmoothMarkdownStreamService } from './services/smooth-markdown-stream.service'
+export type { SmoothMarkdownStreamOptions } from './services/smooth-markdown-stream.service'
 export type {
   CodeBlockDiffAppearance,
   CodeBlockDiffHideUnchangedRegions,

--- a/packages/markstream-angular/src/index.ts
+++ b/packages/markstream-angular/src/index.ts
@@ -34,6 +34,8 @@ export { MathInlineNodeComponent as MathInlineNode } from './components/MathInli
 export { MermaidBlockNodeComponent as MermaidBlockNode } from './components/MermaidBlockNode/MermaidBlockNode.component'
 export { NestedRendererComponent as NestedRenderer } from './components/NestedRenderer/NestedRenderer.component'
 export { NodeRendererComponent as NodeRenderer } from './components/NodeRenderer/NodeRenderer.component'
+export { MARKSTREAM_SMOOTH_STREAMING_SCOPE } from './components/NodeRenderer/NodeRenderer.component'
+export type { SmoothStreamingScope } from './components/NodeRenderer/NodeRenderer.component'
 export { ParagraphNodeComponent as ParagraphNode } from './components/ParagraphNode/ParagraphNode.component'
 export { PreCodeNodeComponent as PreCodeNode } from './components/PreCodeNode/PreCodeNode.component'
 export { ReferenceNodeComponent as ReferenceNode } from './components/ReferenceNode/ReferenceNode.component'

--- a/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
+++ b/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
@@ -13,7 +13,7 @@ export class SmoothMarkdownStreamService implements OnDestroy {
     paused: false,
     pendingChars: 0,
     caughtUp: true,
-    final: true,
+    final: false,
   }
 
   private readonly listeners = new Set<() => void>()

--- a/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
+++ b/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
@@ -1,0 +1,52 @@
+import type { OnDestroy } from '@angular/core'
+import type { SmoothMarkdownStreamOptions, SmoothMarkdownStreamSnapshot } from 'markstream-core'
+import { createSmoothMarkdownStream } from 'markstream-core'
+
+export type { SmoothMarkdownStreamOptions }
+
+export class SmoothMarkdownStreamService implements OnDestroy {
+  private controller: ReturnType<typeof createSmoothMarkdownStream> | null = null
+  private snapshot: SmoothMarkdownStreamSnapshot = {
+    source: '',
+    visible: '',
+    done: false,
+    paused: false,
+    pendingChars: 0,
+    caughtUp: true,
+    final: true,
+  }
+
+  init(options: SmoothMarkdownStreamOptions = {}): void {
+    if (this.controller)
+      return
+    this.controller = createSmoothMarkdownStream(options)
+    this.syncSnapshot()
+    this.controller.subscribe(() => this.syncSnapshot())
+  }
+
+  ngOnDestroy(): void {
+    if (this.controller) {
+      this.controller.destroy()
+      this.controller = null
+    }
+  }
+
+  get source(): string { return this.snapshot.source }
+  get visible(): string { return this.snapshot.visible }
+  get done(): boolean { return this.snapshot.done }
+  get caughtUp(): boolean { return this.snapshot.caughtUp }
+  get final(): boolean { return this.snapshot.final }
+  get pendingChars(): number { return this.snapshot.pendingChars }
+
+  enqueue(chunk: string): void { this.controller?.enqueue(chunk) }
+  finish(options?: { flush?: boolean }): void { this.controller?.finish(options) }
+  flush(): void { this.controller?.flush() }
+  reset(initialMarkdown?: string): void { this.controller?.reset(initialMarkdown) }
+  pause(): void { this.controller?.pause() }
+  resume(): void { this.controller?.resume() }
+
+  private syncSnapshot(): void {
+    if (this.controller)
+      this.snapshot = this.controller.getSnapshot()
+  }
+}

--- a/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
+++ b/packages/markstream-angular/src/services/smooth-markdown-stream.service.ts
@@ -16,18 +16,37 @@ export class SmoothMarkdownStreamService implements OnDestroy {
     final: true,
   }
 
+  private readonly listeners = new Set<() => void>()
+  private unsubscribeFromController?: () => void
+
   init(options: SmoothMarkdownStreamOptions = {}): void {
     if (this.controller)
       return
     this.controller = createSmoothMarkdownStream(options)
     this.syncSnapshot()
-    this.controller.subscribe(() => this.syncSnapshot())
+    this.unsubscribeFromController = this.controller.subscribe(() => this.syncSnapshot())
   }
 
   ngOnDestroy(): void {
+    this.unsubscribeFromController?.()
+    this.unsubscribeFromController = undefined
     if (this.controller) {
       this.controller.destroy()
       this.controller = null
+    }
+    this.listeners.clear()
+  }
+
+  /**
+   * Subscribe to snapshot updates. Called when the controller's visible
+   * content advances during smooth streaming. The listener is invoked
+   * after each snapshot sync so that Angular components can trigger
+   * rebuild / markForCheck.
+   */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
     }
   }
 
@@ -48,5 +67,7 @@ export class SmoothMarkdownStreamService implements OnDestroy {
   private syncSnapshot(): void {
     if (this.controller)
       this.snapshot = this.controller.getSnapshot()
+    for (const listener of this.listeners)
+      listener()
   }
 }

--- a/packages/markstream-svelte/src/components/NodeRenderer.svelte
+++ b/packages/markstream-svelte/src/components/NodeRenderer.svelte
@@ -5,12 +5,14 @@
     SvelteRenderableNode,
     SvelteRenderContext,
   } from './shared/node-helpers'
-  import { onDestroy, onMount, tick } from 'svelte'
+  import { getContext, onDestroy, onMount, setContext, tick } from 'svelte'
   import { getCustomNodeComponents, subscribeCustomComponents } from '../customComponents'
   import { disposeRenderedHtmlEnhancements, enhanceRenderedHtml } from '../enhanceRenderedHtml'
   import NodeOutlet from './NodeOutlet.svelte'
   import { buildRenderContext, resolveParsedNodes } from './shared/node-helpers'
   import { useSmoothMarkdownStream } from '../composables/useSmoothMarkdownStream.svelte'
+  import { SMOOTH_STREAMING_CONTEXT } from '../context/smoothStreaming'
+  import type { SmoothStreamingContextValue } from '../context/smoothStreaming'
 
   type NodeRendererComponentProps = NodeRendererProps & NodeRendererEvents & {
     className?: string
@@ -83,17 +85,39 @@
 
   const smoothStream = useSmoothMarkdownStream(smoothStreamingOptions)
   let hasMountedForSmoothStreaming = $state(typeof window === 'undefined' || smoothStreaming === true)
-  const hasNodes = $derived(Array.isArray(nodes) && nodes.length > 0)
+  const hasNodes = $derived(Array.isArray(nodes))
+  const parentSmoothStreaming = getContext<SmoothStreamingContextValue | undefined>(
+    SMOOTH_STREAMING_CONTEXT,
+  )
   const smoothStreamingEligible = $derived.by(() => {
     if (smoothStreaming === false)
       return false
     if (hasNodes)
+      return false
+    // When the parent renderer is already pacing content, avoid double-pacing
+    // in nested renderers (e.g. thinking blocks, custom tag content).
+    // Only applies in 'auto' mode — smoothStreaming === true explicitly opts in.
+    if (smoothStreaming !== true && parentSmoothStreaming?.())
       return false
     if (smoothStreaming === true)
       return true
     return typewriter === true || (maxLiveNodes ?? 0) <= 0
   })
   const smoothStreamingEnabled = $derived(hasMountedForSmoothStreaming && smoothStreamingEligible)
+  setContext(SMOOTH_STREAMING_CONTEXT, () => smoothStreamingEnabled)
+
+  // Baseline sync: in auto mode with initial static content, ensure the smooth
+  // stream source/visible is already synced before smooth streaming activates.
+  // This prevents a blank flash when the mount gate opens and renderContent
+  // switches from raw content to smoothStream.visible (which would be empty).
+  if (
+    smoothStreaming !== true
+    && !Array.isArray(nodes)
+    && content
+  ) {
+    smoothStream.reset(content)
+  }
+
   const renderContent = $derived(smoothStreamingEnabled ? smoothStream.visible : (content ?? ''))
   const rawContent = $derived(content ?? '')
   const smoothSourceSynced = $derived(hasNodes || smoothStream.source === rawContent)

--- a/packages/markstream-svelte/src/components/NodeRenderer.svelte
+++ b/packages/markstream-svelte/src/components/NodeRenderer.svelte
@@ -10,6 +10,7 @@
   import { disposeRenderedHtmlEnhancements, enhanceRenderedHtml } from '../enhanceRenderedHtml'
   import NodeOutlet from './NodeOutlet.svelte'
   import { buildRenderContext, resolveParsedNodes } from './shared/node-helpers'
+  import { useSmoothMarkdownStream } from '../composables/useSmoothMarkdownStream.svelte'
 
   type NodeRendererComponentProps = NodeRendererProps & NodeRendererEvents & {
     className?: string
@@ -56,6 +57,8 @@
     maxLiveNodes = 320,
     liveNodeBuffer = 60,
     allowHtml = true,
+    smoothStreaming = 'auto' as boolean | 'auto',
+    smoothStreamingOptions = undefined,
     className = '',
     onCopy = undefined,
     onHandleArtifactClick = undefined,
@@ -78,10 +81,69 @@
   let renderBatchToken = 0
   const textStreamState = new Map<string, string>()
 
+  const smoothStream = useSmoothMarkdownStream(smoothStreamingOptions)
+  let hasMountedForSmoothStreaming = $state(typeof window === 'undefined' || smoothStreaming === true)
+  const hasNodes = $derived(Array.isArray(nodes) && nodes.length > 0)
+  const smoothStreamingEligible = $derived.by(() => {
+    if (smoothStreaming === false)
+      return false
+    if (hasNodes)
+      return false
+    if (smoothStreaming === true)
+      return true
+    return typewriter === true || (maxLiveNodes ?? 0) <= 0
+  })
+  const smoothStreamingEnabled = $derived(hasMountedForSmoothStreaming && smoothStreamingEligible)
+  const renderContent = $derived(smoothStreamingEnabled ? smoothStream.visible : (content ?? ''))
+  const rawContent = $derived(content ?? '')
+  const smoothSourceSynced = $derived(hasNodes || smoothStream.source === rawContent)
+  const requestedFinal = $derived.by(() => {
+    const base = parseOptions ?? {}
+    return final ?? (base as any).final
+  })
+  const effectiveFinal = $derived.by(() => {
+    if (smoothStreamingEnabled && requestedFinal != null)
+      return Boolean(requestedFinal && smoothSourceSynced && smoothStream.caughtUp)
+    return requestedFinal
+  })
+
+  onMount(() => {
+    hasMountedForSmoothStreaming = true
+  })
+
+  $effect(() => {
+    const nextContent = content ?? ''
+    if (hasNodes) {
+      smoothStream.reset('')
+      return
+    }
+    if (!smoothStreamingEnabled) {
+      smoothStream.reset(nextContent)
+      if (requestedFinal)
+        smoothStream.finish({ flush: true })
+      return
+    }
+    const source = smoothStream.source
+    if (!nextContent) {
+      smoothStream.reset('')
+    }
+    else if (nextContent === source) {
+      // no-op
+    }
+    else if (nextContent.startsWith(source)) {
+      smoothStream.enqueue(nextContent.slice(source.length))
+    }
+    else {
+      smoothStream.reset(nextContent)
+    }
+    if (requestedFinal)
+      smoothStream.finish()
+  })
+
   let rendererProps = $derived({
-    content,
+    content: renderContent,
     nodes,
-    final,
+    final: effectiveFinal,
     parseOptions,
     customMarkdownIt,
     debugPerformance,
@@ -116,12 +178,14 @@
     maxLiveNodes,
     liveNodeBuffer,
     allowHtml,
+    smoothStreaming,
+    smoothStreamingOptions,
   } satisfies NodeRendererProps)
 
   $effect.pre(() => {
-    if (previousContent !== content || previousNodes !== nodes) {
+    if (previousContent !== renderContent || previousNodes !== nodes) {
       streamRenderVersion += 1
-      previousContent = content
+      previousContent = renderContent
       previousNodes = nodes
     }
   })
@@ -133,7 +197,7 @@
       console.info('[markstream-svelte][perf] parse(sync)', {
         ms: Math.round(performance.now() - start),
         nodes: nextParsedNodes.length,
-        contentLength: content?.length ?? 0,
+        contentLength: renderContent?.length ?? 0,
       })
     }
     return nextParsedNodes
@@ -167,7 +231,7 @@
     void renderBatchDelay
     void renderBatchBudgetMs
     void renderBatchIdleTimeoutMs
-    void final
+    void effectiveFinal
     void renderedNodeCount
     syncRenderedNodeWindow()
   })
@@ -175,7 +239,7 @@
 
   $effect(() => {
     void rootEl
-    void final
+    void effectiveFinal
     void parsedNodes
     void renderedNodes
     void isDark
@@ -213,7 +277,7 @@
   function syncRenderedNodeWindow() {
     const total = parsedNodes.length
     const initialCount = Math.min(total, toPositiveInteger(initialRenderBatchSize, 40))
-    const shouldBatch = final !== false && batchRendering !== false && total > initialCount
+    const shouldBatch = effectiveFinal !== false && batchRendering !== false && total > initialCount
 
     if (!shouldBatch) {
       cancelRenderBatch()
@@ -296,7 +360,7 @@
   async function scheduleEnhancement() {
     if (!rootEl || typeof window === 'undefined')
       return
-    const enhancementFinal = typeof final === 'boolean' ? final : !hasLoadingNodes(parsedNodes)
+    const enhancementFinal = typeof effectiveFinal === 'boolean' ? effectiveFinal : !hasLoadingNodes(parsedNodes)
     if (!enhancementFinal) {
       enhancementToken += 1
       enhancementHandle?.dispose()

--- a/packages/markstream-svelte/src/components/shared/node-helpers.ts
+++ b/packages/markstream-svelte/src/components/shared/node-helpers.ts
@@ -1,3 +1,4 @@
+import type { SmoothMarkdownStreamOptions } from 'markstream-core'
 import type { BaseNode, HtmlPolicy, MarkdownIt, ParsedNode, ParseOptions } from 'stream-markdown-parser'
 import type { CustomComponentMap } from '../../customComponents'
 import type { CodeBlockMonacoOptions, CodeBlockMonacoTheme } from '../../types/monaco'
@@ -133,6 +134,8 @@ export interface NodeRendererProps {
   maxLiveNodes?: number
   liveNodeBuffer?: number
   allowHtml?: boolean
+  smoothStreaming?: boolean | 'auto'
+  smoothStreamingOptions?: SmoothMarkdownStreamOptions
 }
 
 export interface SvelteRenderContext {

--- a/packages/markstream-svelte/src/composables/useSmoothMarkdownStream.svelte.ts
+++ b/packages/markstream-svelte/src/composables/useSmoothMarkdownStream.svelte.ts
@@ -1,0 +1,62 @@
+import type { SmoothMarkdownStreamOptions } from 'markstream-core'
+import { createSmoothMarkdownStream } from 'markstream-core'
+import { onDestroy } from 'svelte'
+
+export type { SmoothMarkdownStreamOptions }
+
+export interface SmoothMarkdownStreamControllerSvelte {
+  source: string
+  visible: string
+  done: boolean
+  caughtUp: boolean
+  final: boolean
+  pendingChars: number
+  enqueue: (chunk: string) => void
+  finish: (options?: { flush?: boolean }) => void
+  flush: () => void
+  reset: (initialMarkdown?: string) => void
+  pause: () => void
+  resume: () => void
+}
+
+export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {}): SmoothMarkdownStreamControllerSvelte {
+  let source = $state('')
+  let visible = $state('')
+  let done = $state(false)
+  let pendingChars = $state(0)
+  let caughtUp = $state(false)
+  let final = $state(false)
+
+  const controller = createSmoothMarkdownStream(options)
+  const sync = () => {
+    const snapshot = controller.getSnapshot()
+    source = snapshot.source
+    visible = snapshot.visible
+    done = snapshot.done
+    pendingChars = snapshot.pendingChars
+    caughtUp = snapshot.caughtUp
+    final = snapshot.final
+  }
+  const unsubscribe = controller.subscribe(sync)
+  sync()
+
+  onDestroy(() => {
+    unsubscribe()
+    controller.destroy()
+  })
+
+  return {
+    get source() { return source },
+    get visible() { return visible },
+    get done() { return done },
+    get caughtUp() { return caughtUp },
+    get final() { return final },
+    get pendingChars() { return pendingChars },
+    enqueue: chunk => controller.enqueue(chunk),
+    finish: opts => controller.finish(opts),
+    flush: () => controller.flush(),
+    reset: initialMarkdown => controller.reset(initialMarkdown),
+    pause: () => controller.pause(),
+    resume: () => controller.resume(),
+  }
+}

--- a/packages/markstream-svelte/src/context/smoothStreaming.ts
+++ b/packages/markstream-svelte/src/context/smoothStreaming.ts
@@ -1,0 +1,17 @@
+/**
+ * Context key and types for Svelte smooth streaming parent suppression.
+ *
+ * When a parent NodeRenderer is already pacing content via smooth streaming,
+ * nested renderers (e.g. thinking blocks, custom tag content) should suppress
+ * their own smooth streaming to avoid double-pacing.
+ *
+ * Usage:
+ *   const parentSmoothStreaming = getContext<SmoothStreamingContextValue | undefined>(
+ *     SMOOTH_STREAMING_CONTEXT,
+ *   )
+ *   setContext(SMOOTH_STREAMING_CONTEXT, () => smoothStreamingEnabled)
+ */
+
+export const SMOOTH_STREAMING_CONTEXT = 'markstreamSmoothStreaming'
+
+export type SmoothStreamingContextValue = () => boolean

--- a/packages/markstream-svelte/src/index.ts
+++ b/packages/markstream-svelte/src/index.ts
@@ -63,6 +63,13 @@ export { default as TextNode } from './components/TextNode.svelte'
 export { default as ThematicBreakNode } from './components/ThematicBreakNode.svelte'
 export { default as Tooltip } from './components/Tooltip.svelte'
 export { default as VmrContainerNode } from './components/VmrContainerNode.svelte'
+export type {
+  SmoothMarkdownStreamControllerSvelte,
+  SmoothMarkdownStreamOptions,
+} from './composables/useSmoothMarkdownStream.svelte'
+export {
+  useSmoothMarkdownStream,
+} from './composables/useSmoothMarkdownStream.svelte'
 export {
   clearGlobalCustomComponents,
   getCustomComponentsRevision,

--- a/packages/markstream-svelte/src/index.ts
+++ b/packages/markstream-svelte/src/index.ts
@@ -71,6 +71,12 @@ export {
   useSmoothMarkdownStream,
 } from './composables/useSmoothMarkdownStream.svelte'
 export {
+  SMOOTH_STREAMING_CONTEXT,
+} from './context/smoothStreaming'
+export type {
+  SmoothStreamingContextValue,
+} from './context/smoothStreaming'
+export {
   clearGlobalCustomComponents,
   getCustomComponentsRevision,
   getCustomNodeComponents,

--- a/test/markstream-angular-node-renderer-smooth-streaming.test.ts
+++ b/test/markstream-angular-node-renderer-smooth-streaming.test.ts
@@ -33,6 +33,9 @@ function createHarness(options: {
   let rebuildCount = 0
   let parsedContent = ''
 
+  let previousRenderContent = ''
+  let previousEffectiveFinal: boolean | undefined
+
   const parentScope: SmoothStreamingScope | null = parentSmoothStreamingEnabled
     ? { isSmoothStreamingEnabled: () => true }
     : null
@@ -73,46 +76,58 @@ function createHarness(options: {
     return requested
   }
 
+  let isSyncingSmoothStream = false
+  let subscriptionCallback: (() => void) | null = null
+
   function syncSmoothStream() {
     if (!smoothStream)
       return
 
-    const nextContent = content ?? ''
+    isSyncingSmoothStream = true
 
-    if (hasNodes) {
-      smoothStream.reset('')
-      return
-    }
+    try {
+      const nextContent = content ?? ''
 
-    if (!getSmoothStreamingEnabled()) {
-      smoothStream.reset(nextContent)
+      if (hasNodes) {
+        smoothStream.reset('')
+        return
+      }
+
+      if (!getSmoothStreamingEnabled()) {
+        smoothStream.reset(nextContent)
+        if (getRequestedFinal())
+          smoothStream.finish({ flush: true })
+        return
+      }
+
+      const source = smoothStream.source
+
+      if (!nextContent) {
+        smoothStream.reset('')
+      }
+      else if (nextContent === source) {
+        // no-op
+      }
+      else if (nextContent.startsWith(source)) {
+        smoothStream.enqueue(nextContent.slice(source.length))
+      }
+      else {
+        smoothStream.reset(nextContent)
+      }
+
       if (getRequestedFinal())
-        smoothStream.finish({ flush: true })
-      return
+        smoothStream.finish()
     }
-
-    const source = smoothStream.source
-
-    if (!nextContent) {
-      smoothStream.reset('')
+    finally {
+      isSyncingSmoothStream = false
     }
-    else if (nextContent === source) {
-      // no-op
-    }
-    else if (nextContent.startsWith(source)) {
-      smoothStream.enqueue(nextContent.slice(source.length))
-    }
-    else {
-      smoothStream.reset(nextContent)
-    }
-
-    if (getRequestedFinal())
-      smoothStream.finish()
   }
 
   function rebuild() {
     rebuildCount += 1
     parsedContent = getRenderContent()
+    previousRenderContent = getRenderContent()
+    previousEffectiveFinal = getEffectiveFinal()
   }
 
   // Simulate ngOnChanges (with rebuild-skip logic)
@@ -141,8 +156,34 @@ function createHarness(options: {
   function ngOnInit() {
     smoothStream.init()
     hasMountedForSmoothStreaming = true
+
+    // Subscription callback respects isSyncingSmoothStream guard
+    subscriptionCallback = () => {
+      if (isSyncingSmoothStream)
+        return
+
+      const nextRenderContent = getRenderContent()
+      const nextEffectiveFinal = getEffectiveFinal()
+
+      if (
+        nextRenderContent !== previousRenderContent
+        || nextEffectiveFinal !== previousEffectiveFinal
+      ) {
+        rebuild()
+      }
+    }
+
+    const preRenderContent = getRenderContent()
+    const preEffectiveFinal = getEffectiveFinal()
+
     syncSmoothStream()
-    rebuild()
+
+    if (
+      preRenderContent !== getRenderContent()
+      || preEffectiveFinal !== getEffectiveFinal()
+    ) {
+      rebuild()
+    }
   }
 
   return {
@@ -156,6 +197,7 @@ function createHarness(options: {
     getEffectiveFinal,
     get rebuildCount() { return rebuildCount },
     get parsedContent() { return parsedContent },
+    triggerSubscriptionCallback() { subscriptionCallback?.() },
   }
 }
 
@@ -324,5 +366,39 @@ describe('markstream-angular NodeRenderer smooth streaming contract', () => {
     // Before init, the default snapshot should have final: false
     expect(service.final).toBe(false)
     service.ngOnDestroy()
+  })
+
+  it('does not rebuild twice for initial static auto content', () => {
+    const harness = createHarness({ smoothStreaming: 'auto', typewriter: true })
+
+    harness.setContent('static initial content')
+    harness.ngOnChanges({ content: true })
+
+    // ngOnChanges already rebuilt once for the initial content
+    const rebuildsAfterChanges = harness.rebuildCount
+
+    // ngOnInit should not rebuild again because renderContent/effectiveFinal
+    // did not change after the mounted gate opened + syncSmoothStream
+    harness.ngOnInit()
+
+    expect(harness.rebuildCount).toBe(rebuildsAfterChanges)
+  })
+
+  it('does not re-enter rebuild while syncing smooth stream', () => {
+    const harness = createHarness({ smoothStreaming: false, typewriter: true })
+
+    harness.setContent('initial content')
+    harness.ngOnInit()
+
+    const rebuildsBefore = harness.rebuildCount
+
+    // smoothStreaming=false triggers reset() which synchronously notifies
+    // listeners — the subscription callback should be suppressed during sync
+    harness.setContent('updated content')
+    harness.ngOnChanges({ content: true })
+
+    // Only one rebuild from ngOnChanges, not an additional one from the
+    // subscription callback firing during syncSmoothStream
+    expect(harness.rebuildCount).toBe(rebuildsBefore + 1)
   })
 })

--- a/test/markstream-angular-node-renderer-smooth-streaming.test.ts
+++ b/test/markstream-angular-node-renderer-smooth-streaming.test.ts
@@ -1,0 +1,328 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { SmoothStreamingScope } from '../packages/markstream-angular/src/components/shared/smooth-streaming-scope'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SmoothMarkdownStreamService } from '../packages/markstream-angular/src/services/smooth-markdown-stream.service'
+
+/**
+ * Minimal harness that replicates the NodeRendererComponent's smooth streaming
+ * logic (smoothStreamingEnabled gate, renderContent, effectiveFinal, syncSmoothStream,
+ * rebuild skip) so we can test the contract without Angular TestBed.
+ */
+function createHarness(options: {
+  smoothStreaming?: boolean | 'auto'
+  typewriter?: boolean
+  maxLiveNodes?: number
+  hasNodes?: boolean
+  parentSmoothStreamingEnabled?: boolean
+}) {
+  const {
+    smoothStreaming = 'auto',
+    typewriter = true,
+    maxLiveNodes = 320,
+    hasNodes = false,
+    parentSmoothStreamingEnabled = false,
+  } = options
+
+  const smoothStream = new SmoothMarkdownStreamService()
+  let hasMountedForSmoothStreaming = false
+  let content = ''
+  let finalValue: boolean | undefined
+  let rebuildCount = 0
+  let parsedContent = ''
+
+  const parentScope: SmoothStreamingScope | null = parentSmoothStreamingEnabled
+    ? { isSmoothStreamingEnabled: () => true }
+    : null
+
+  function getSmoothStreamingEligible(): boolean {
+    if (smoothStreaming === false)
+      return false
+    if (hasNodes)
+      return false
+    if (smoothStreaming !== true && parentScope?.isSmoothStreamingEnabled())
+      return false
+    if (smoothStreaming === true)
+      return true
+    return typewriter === true || maxLiveNodes <= 0
+  }
+
+  function getSmoothStreamingEnabled(): boolean {
+    const gateOpen = typeof window === 'undefined'
+      || hasMountedForSmoothStreaming
+      || smoothStreaming === true
+    return gateOpen && getSmoothStreamingEligible()
+  }
+
+  function getRenderContent(): string {
+    return getSmoothStreamingEnabled() ? smoothStream.visible : (content ?? '')
+  }
+
+  function getRequestedFinal(): boolean | undefined {
+    return finalValue
+  }
+
+  function getEffectiveFinal(): boolean | undefined {
+    const requested = getRequestedFinal()
+    if (getSmoothStreamingEnabled() && requested != null) {
+      const smoothSourceSynced = hasNodes || smoothStream.source === (content ?? '')
+      return Boolean(requested && smoothSourceSynced && smoothStream.caughtUp)
+    }
+    return requested
+  }
+
+  function syncSmoothStream() {
+    if (!smoothStream)
+      return
+
+    const nextContent = content ?? ''
+
+    if (hasNodes) {
+      smoothStream.reset('')
+      return
+    }
+
+    if (!getSmoothStreamingEnabled()) {
+      smoothStream.reset(nextContent)
+      if (getRequestedFinal())
+        smoothStream.finish({ flush: true })
+      return
+    }
+
+    const source = smoothStream.source
+
+    if (!nextContent) {
+      smoothStream.reset('')
+    }
+    else if (nextContent === source) {
+      // no-op
+    }
+    else if (nextContent.startsWith(source)) {
+      smoothStream.enqueue(nextContent.slice(source.length))
+    }
+    else {
+      smoothStream.reset(nextContent)
+    }
+
+    if (getRequestedFinal())
+      smoothStream.finish()
+  }
+
+  function rebuild() {
+    rebuildCount += 1
+    parsedContent = getRenderContent()
+  }
+
+  // Simulate ngOnChanges (with rebuild-skip logic)
+  function ngOnChanges(changes: { content?: boolean, nodes?: boolean }) {
+    smoothStream.init()
+
+    const previousRenderContent = getRenderContent()
+    const previousEffectiveFinal = getEffectiveFinal()
+
+    syncSmoothStream()
+
+    if (
+      getSmoothStreamingEnabled()
+      && changes.content
+      && !changes.nodes
+      && previousRenderContent === getRenderContent()
+      && previousEffectiveFinal === getEffectiveFinal()
+    ) {
+      return
+    }
+
+    rebuild()
+  }
+
+  // Simulate ngOnInit
+  function ngOnInit() {
+    smoothStream.init()
+    hasMountedForSmoothStreaming = true
+    syncSmoothStream()
+    rebuild()
+  }
+
+  return {
+    get smoothStream() { return smoothStream },
+    setContent(c: string) { content = c },
+    setFinal(f: boolean | undefined) { finalValue = f },
+    ngOnChanges,
+    ngOnInit,
+    getSmoothStreamingEnabled,
+    getRenderContent,
+    getEffectiveFinal,
+    get rebuildCount() { return rebuildCount },
+    get parsedContent() { return parsedContent },
+  }
+}
+
+describe('markstream-angular NodeRenderer smooth streaming contract', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('paces initial client content when smoothStreaming=true', () => {
+    // With smoothStreaming=true, the gate is always open — even before ngOnInit.
+    // So initial content should go through enqueue/reset and be paced, not
+    // immediately visible.
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    harness.setContent('Hello world from initial content')
+
+    // ngOnChanges runs before ngOnInit in Angular
+    harness.ngOnChanges({ content: true })
+
+    // smoothStreaming=true opens the gate, so smooth streaming is enabled
+    expect(harness.getSmoothStreamingEnabled()).toBe(true)
+
+    // Content was enqueued but visible should be behind source
+    expect(harness.smoothStream.source).toBe('Hello world from initial content')
+    expect(harness.smoothStream.visible.length).toBeLessThan(
+      'Hello world from initial content'.length,
+    )
+
+    // renderContent should use visible (paced), not raw content
+    expect(harness.getRenderContent().length).toBeLessThan(
+      'Hello world from initial content'.length,
+    )
+
+    harness.smoothStream.ngOnDestroy()
+  })
+
+  it('does not pace initial content in auto mode before mount', () => {
+    // In auto mode, ngOnChanges runs before ngOnInit, so hasMountedForSmoothStreaming
+    // is still false. The gate should protect initial content from blank.
+    const harness = createHarness({ smoothStreaming: 'auto', typewriter: true })
+
+    harness.setContent('static initial content')
+
+    // ngOnChanges runs first (hasMountedForSmoothStreaming = false)
+    harness.ngOnChanges({ content: true })
+
+    // Before mount, smoothStreamingEnabled should be false in auto mode
+    expect(harness.getSmoothStreamingEnabled()).toBe(false)
+
+    // renderContent should return the raw content immediately
+    expect(harness.getRenderContent()).toBe('static initial content')
+  })
+
+  it('paces post-mount appends in auto mode', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: 'auto', typewriter: true })
+
+    // Mount with empty content
+    harness.ngOnInit()
+
+    // After mount, smoothStreamingEnabled should be true (typewriter=true)
+    expect(harness.getSmoothStreamingEnabled()).toBe(true)
+
+    // Append content after mount
+    harness.setContent('Hello smooth streaming markdown renderer.')
+    harness.ngOnChanges({ content: true })
+
+    // Content should be enqueued and visible should be behind
+    expect(harness.smoothStream.source).toBe('Hello smooth streaming markdown renderer.')
+    expect(harness.smoothStream.visible.length).toBeLessThan(
+      'Hello smooth streaming markdown renderer.'.length,
+    )
+
+    harness.smoothStream.ngOnDestroy()
+  })
+
+  it('shows content immediately when smoothStreaming=false', () => {
+    const harness = createHarness({ smoothStreaming: false, typewriter: true })
+
+    harness.setContent('Immediate content')
+    harness.ngOnInit()
+    harness.ngOnChanges({ content: true })
+
+    expect(harness.getSmoothStreamingEnabled()).toBe(false)
+    expect(harness.getRenderContent()).toBe('Immediate content')
+  })
+
+  it('skips rebuild for raw content append when visible has not advanced', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    // Mount and set initial content
+    harness.setContent('abc')
+    harness.ngOnInit()
+    const rebuildsAfterInit = harness.rebuildCount
+
+    // Now append raw chunks without advancing visible (rAF never ticks)
+    harness.setContent('abcdef')
+    harness.ngOnChanges({ content: true })
+    const rebuildsAfterFirstAppend = harness.rebuildCount
+
+    harness.setContent('abcdefghijkl')
+    harness.ngOnChanges({ content: true })
+    const rebuildsAfterSecondAppend = harness.rebuildCount
+
+    // Visible hasn't advanced, so rebuilds should be skipped for raw content appends
+    // Only the init rebuild should have happened, not additional ones from raw appends
+    expect(rebuildsAfterFirstAppend).toBe(rebuildsAfterInit)
+    expect(rebuildsAfterSecondAppend).toBe(rebuildsAfterInit)
+
+    // After visible catches up, the subscription would trigger rebuild
+    // (In real Angular, smoothStream.subscribe() calls rebuild when visible changes)
+    harness.smoothStream.flush()
+
+    harness.smoothStream.ngOnDestroy()
+  })
+
+  it('gates final by caughtUp when smooth streaming is active', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    harness.setContent('Hello world')
+    harness.setFinal(true)
+    harness.ngOnInit()
+
+    // Before visible catches up, effectiveFinal should be false
+    // (source is ahead of visible)
+    if (harness.smoothStream.source.length > harness.smoothStream.visible.length) {
+      expect(harness.getEffectiveFinal()).toBe(false)
+    }
+
+    // Flush to let visible catch up
+    harness.smoothStream.flush()
+
+    // After caught up, effectiveFinal should reflect the requested final
+    expect(harness.smoothStream.caughtUp).toBe(true)
+    expect(harness.getEffectiveFinal()).toBe(true)
+
+    harness.smoothStream.ngOnDestroy()
+  })
+
+  it('suppresses auto mode but not explicit true under parent scope', () => {
+    // Auto mode with parent already smoothing → should be suppressed
+    const autoHarness = createHarness({
+      smoothStreaming: 'auto',
+      typewriter: true,
+      parentSmoothStreamingEnabled: true,
+    })
+    autoHarness.ngOnInit()
+    expect(autoHarness.getSmoothStreamingEnabled()).toBe(false)
+
+    // Explicit true with parent smoothing → should NOT be suppressed
+    const explicitHarness = createHarness({
+      smoothStreaming: true,
+      typewriter: false,
+      parentSmoothStreamingEnabled: true,
+    })
+    explicitHarness.ngOnInit()
+    expect(explicitHarness.getSmoothStreamingEnabled()).toBe(true)
+  })
+
+  it('has initial snapshot final=false in SmoothMarkdownStreamService', () => {
+    const service = new SmoothMarkdownStreamService()
+    // Before init, the default snapshot should have final: false
+    expect(service.final).toBe(false)
+    service.ngOnDestroy()
+  })
+})

--- a/test/markstream-angular-node-renderer-smooth-streaming.test.ts
+++ b/test/markstream-angular-node-renderer-smooth-streaming.test.ts
@@ -131,7 +131,7 @@ function createHarness(options: {
   }
 
   // Simulate ngOnChanges (with rebuild-skip logic)
-  function ngOnChanges(changes: { content?: boolean, nodes?: boolean }) {
+  function ngOnChanges(changes: Record<string, boolean>) {
     smoothStream.init()
 
     const previousRenderContent = getRenderContent()
@@ -139,10 +139,13 @@ function createHarness(options: {
 
     syncSmoothStream()
 
+    const changeKeys = Object.keys(changes)
+    const onlyRawStreamChanges = changeKeys.every(key => key === 'content' || key === 'final')
+
     if (
       getSmoothStreamingEnabled()
+      && onlyRawStreamChanges
       && changes.content
-      && !changes.nodes
       && previousRenderContent === getRenderContent()
       && previousEffectiveFinal === getEffectiveFinal()
     ) {
@@ -400,5 +403,41 @@ describe('markstream-angular NodeRenderer smooth streaming contract', () => {
     // Only one rebuild from ngOnChanges, not an additional one from the
     // subscription callback firing during syncSmoothStream
     expect(harness.rebuildCount).toBe(rebuildsBefore + 1)
+  })
+
+  it('does not skip rebuild when non-stream inputs change alongside content', () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    harness.setContent('abc')
+    harness.ngOnInit()
+    const rebuildsAfterInit = harness.rebuildCount
+
+    // Append content AND change a non-stream input (e.g. isDark) in the same cycle
+    harness.setContent('abcdef')
+    harness.ngOnChanges({ content: true, isDark: true })
+
+    // Even though visible hasn't advanced, the non-stream input change must
+    // trigger a rebuild — the skip-rebuild guard should only apply when
+    // *only* raw stream inputs (content/final) changed.
+    expect(harness.rebuildCount).toBe(rebuildsAfterInit + 1)
+
+    harness.smoothStream.ngOnDestroy()
+  })
+
+  it('does not skip rebuild when customHtmlTags changes alongside content', () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    harness.setContent('abc')
+    harness.ngOnInit()
+    const rebuildsAfterInit = harness.rebuildCount
+
+    harness.setContent('abcdef')
+    harness.ngOnChanges({ content: true, customHtmlTags: true })
+
+    expect(harness.rebuildCount).toBe(rebuildsAfterInit + 1)
+
+    harness.smoothStream.ngOnDestroy()
   })
 })

--- a/test/markstream-angular-smooth-streaming.test.ts
+++ b/test/markstream-angular-smooth-streaming.test.ts
@@ -79,7 +79,7 @@ describe('markstream-angular SmoothMarkdownStreamService', () => {
     const service = new SmoothMarkdownStreamService()
     service.init({
       maxCharsPerCommit: 0,
-      maxCommitFPS: 0,
+      maxCommitFps: 0,
       minCharsPerSecond: 0,
       maxCharsPerSecond: -10,
     })
@@ -128,6 +128,71 @@ describe('markstream-angular SmoothMarkdownStreamService', () => {
 
     service.ngOnDestroy()
   })
+
+  it('subscribe notifies listeners on visible advance', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init({ startDelayMs: 0 })
+
+    const calls: string[] = []
+    const unsubscribe = service.subscribe(() => {
+      calls.push(service.visible)
+    })
+
+    service.enqueue('hello world')
+    // The subscribe callback should fire when the controller syncs
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(calls.length).toBeGreaterThanOrEqual(2)
+
+    unsubscribe()
+    service.ngOnDestroy()
+  })
+
+  it('subscribe returns an unsubscribe function that stops callbacks', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init({ startDelayMs: 0 })
+
+    const calls: string[] = []
+    const unsubscribe = service.subscribe(() => {
+      calls.push(service.visible)
+    })
+
+    service.enqueue('abc')
+    const countBeforeUnsubscribe = calls.length
+
+    unsubscribe()
+    service.enqueue('def')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    // No additional calls after unsubscribe
+    expect(calls.length).toBe(countBeforeUnsubscribe)
+
+    service.ngOnDestroy()
+  })
+
+  it('ngOnDestroy cleans up controller and listeners', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init()
+
+    const calls: string[] = []
+    service.subscribe(() => {
+      calls.push(service.visible)
+    })
+
+    service.enqueue('test')
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+
+    service.ngOnDestroy()
+
+    // After destroy, source/visible should be stale (no further updates)
+    const visibleAfterDestroy = service.visible
+    service.enqueue('more')
+    expect(service.visible).toBe(visibleAfterDestroy)
+  })
 })
 
 describe('markstream-angular smooth streaming props', () => {
@@ -154,5 +219,15 @@ describe('markstream-angular smooth streaming props', () => {
       smoothStreaming: false,
     })
     expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('treats nodes=[] as nodes mode (empty array, not content mode)', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      nodes: [],
+      smoothStreaming: 'auto',
+    })
+    // nodes=[] should return empty array (nodes mode), not parse content
+    expect(nodes).toEqual([])
   })
 })

--- a/test/markstream-angular-smooth-streaming.test.ts
+++ b/test/markstream-angular-smooth-streaming.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveParsedNodes } from '../packages/markstream-angular/src/components/shared/node-helpers'
+import { SmoothMarkdownStreamService } from '../packages/markstream-angular/src/services/smooth-markdown-stream.service'
+
+describe('markstream-angular SmoothMarkdownStreamService', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not reveal a large chunk all at once', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init()
+
+    service.enqueue('a'.repeat(1800))
+    expect(service.visible.length).toBeLessThan(service.source.length)
+
+    await vi.advanceTimersByTimeAsync(400)
+    expect(service.visible.length).toBeLessThan(service.source.length)
+
+    service.ngOnDestroy()
+  })
+
+  it('sets final only after visible catches up', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init()
+
+    service.enqueue('x'.repeat(1400))
+    service.finish()
+
+    expect(service.done).toBe(true)
+    expect(service.final).toBe(false)
+
+    service.flush()
+    expect(service.final).toBe(true)
+
+    service.ngOnDestroy()
+  })
+
+  it('reset clears state and keeps pending at zero', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init()
+
+    service.enqueue('x'.repeat(1000))
+    await vi.advanceTimersByTimeAsync(120)
+    service.reset()
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(service.source).toBe('')
+    expect(service.visible).toBe('')
+    expect(service.pendingChars).toBe(0)
+
+    service.ngOnDestroy()
+  })
+
+  it('reopens the stream when enqueue is called after finish', () => {
+    const service = new SmoothMarkdownStreamService()
+    service.init()
+
+    service.enqueue('hello')
+    service.finish({ flush: true })
+    expect(service.final).toBe(true)
+
+    service.enqueue(' world')
+    expect(service.done).toBe(false)
+    expect(service.final).toBe(false)
+
+    service.ngOnDestroy()
+  })
+
+  it('normalizes extreme option values', () => {
+    const service = new SmoothMarkdownStreamService()
+    service.init({
+      maxCharsPerCommit: 0,
+      maxCommitFPS: 0,
+      minCharsPerSecond: 0,
+      maxCharsPerSecond: -10,
+    })
+
+    service.enqueue('test')
+    service.flush()
+    expect(service.visible).toBe('test')
+
+    service.ngOnDestroy()
+  })
+
+  it('enqueue appends to source and visible catches up', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init({ startDelayMs: 0 })
+
+    service.enqueue('abc')
+    expect(service.source).toBe('abc')
+
+    service.enqueue('def')
+    expect(service.source).toBe('abcdef')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(service.visible).toBe('abcdef')
+
+    service.ngOnDestroy()
+  })
+
+  it('pause and resume control the pacing loop', async () => {
+    vi.useFakeTimers()
+    const service = new SmoothMarkdownStreamService()
+    service.init({ startDelayMs: 0 })
+
+    service.enqueue('hello world')
+    service.pause()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    // While paused, visible should not advance
+    expect(service.visible.length).toBeLessThan(service.source.length)
+
+    const visibleBeforeResume = service.visible.length
+    service.resume()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(service.visible.length).toBeGreaterThan(visibleBeforeResume)
+
+    service.ngOnDestroy()
+  })
+})
+
+describe('markstream-angular smooth streaming props', () => {
+  it('accepts smoothStreaming and smoothStreamingOptions in NodeRendererProps', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: 'auto',
+      smoothStreamingOptions: { minCharsPerSecond: 100 },
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('accepts smoothStreaming: true', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: true,
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('accepts smoothStreaming: false', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: false,
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+})

--- a/test/markstream-svelte-node-renderer-smooth-streaming.test.ts
+++ b/test/markstream-svelte-node-renderer-smooth-streaming.test.ts
@@ -1,0 +1,275 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createSmoothMarkdownStream } from 'markstream-core'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Minimal harness that replicates the Svelte NodeRenderer's smooth streaming
+ * logic (smoothStreamingEnabled gate, renderContent, effectiveFinal, baseline sync)
+ * so we can test the contract without Svelte's test utilities.
+ */
+function createHarness(options: {
+  smoothStreaming?: boolean | 'auto'
+  typewriter?: boolean
+  maxLiveNodes?: number
+  hasNodes?: boolean
+  parentSmoothStreamingEnabled?: boolean
+}) {
+  const {
+    smoothStreaming = 'auto',
+    typewriter = true,
+    maxLiveNodes = 320,
+    hasNodes = false,
+    parentSmoothStreamingEnabled = false,
+  } = options
+
+  const controller = createSmoothMarkdownStream({})
+  let source = ''
+  let visible = ''
+  let caughtUp = true
+  let hasMountedForSmoothStreaming = typeof window === 'undefined' || smoothStreaming === true
+
+  const syncSnapshot = () => {
+    const snapshot = controller.getSnapshot()
+    source = snapshot.source
+    visible = snapshot.visible
+    caughtUp = snapshot.caughtUp
+  }
+
+  let content = ''
+  let requestedFinal: boolean | undefined
+
+  function getSmoothStreamingEligible(): boolean {
+    if (smoothStreaming === false)
+      return false
+    if (hasNodes)
+      return false
+    if (smoothStreaming !== true && parentSmoothStreamingEnabled)
+      return false
+    if (smoothStreaming === true)
+      return true
+    return typewriter === true || maxLiveNodes <= 0
+  }
+
+  function getSmoothStreamingEnabled(): boolean {
+    return hasMountedForSmoothStreaming && getSmoothStreamingEligible()
+  }
+
+  function getRenderContent(): string {
+    return getSmoothStreamingEnabled() ? visible : (content ?? '')
+  }
+
+  function getEffectiveFinal(): boolean | undefined {
+    const requested = requestedFinal
+    if (getSmoothStreamingEnabled() && requested != null) {
+      const smoothSourceSynced = hasNodes || source === (content ?? '')
+      return Boolean(requested && smoothSourceSynced && caughtUp)
+    }
+    return requested
+  }
+
+  // Baseline sync: in auto mode with initial content, ensure source/visible
+  // are already synced before smooth streaming activates.
+  // This mirrors the Svelte component's top-level baseline sync:
+  //   if (smoothStreaming !== true && !Array.isArray(nodes) && content) {
+  //     smoothStream.reset(content)
+  //   }
+  function baselineSync() {
+    if (smoothStreaming !== true && !hasNodes && content) {
+      controller.reset(content)
+      syncSnapshot()
+    }
+  }
+
+  // Simulate Svelte's $effect that syncs content to the stream
+  function syncContent() {
+    const nextContent = content ?? ''
+
+    if (hasNodes) {
+      controller.reset('')
+      syncSnapshot()
+      return
+    }
+
+    if (!getSmoothStreamingEnabled()) {
+      controller.reset(nextContent)
+      if (requestedFinal) {
+        controller.finish({ flush: true })
+      }
+      syncSnapshot()
+      return
+    }
+
+    if (!nextContent) {
+      controller.reset('')
+    }
+    else if (nextContent === source) {
+      // no-op
+    }
+    else if (nextContent.startsWith(source)) {
+      controller.enqueue(nextContent.slice(source.length))
+    }
+    else {
+      controller.reset(nextContent)
+    }
+
+    if (requestedFinal)
+      controller.finish()
+
+    syncSnapshot()
+  }
+
+  function onMount() {
+    hasMountedForSmoothStreaming = true
+  }
+
+  function destroy() {
+    controller.destroy()
+  }
+
+  return {
+    setContent(c: string) { content = c },
+    setFinal(f: boolean | undefined) { requestedFinal = f },
+    getSmoothStreamingEnabled,
+    getRenderContent,
+    getEffectiveFinal,
+    syncContent,
+    baselineSync,
+    onMount,
+    destroy,
+    get source() { return source },
+    get visible() { return visible },
+    get caughtUp() { return caughtUp },
+    get controller() { return controller },
+  }
+}
+
+describe('markstream-svelte NodeRenderer smooth streaming contract', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not pace initial content in auto mode (baseline sync)', () => {
+    const harness = createHarness({ smoothStreaming: 'auto', typewriter: true })
+
+    harness.setContent('static initial content')
+
+    // Svelte does a baseline sync before smooth streaming activates
+    harness.baselineSync()
+
+    // Before mount, smoothStreamingEnabled should be false
+    expect(harness.getSmoothStreamingEnabled()).toBe(false)
+
+    // renderContent should return raw content immediately
+    expect(harness.getRenderContent()).toBe('static initial content')
+  })
+
+  it('paces post-mount appends in auto mode', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: 'auto', typewriter: true })
+
+    // Mount with empty content
+    harness.onMount()
+
+    // After mount, smoothStreamingEnabled should be true (typewriter=true)
+    expect(harness.getSmoothStreamingEnabled()).toBe(true)
+
+    // Append content after mount
+    harness.setContent('Hello smooth streaming markdown renderer.')
+    harness.syncContent()
+
+    // Content should be enqueued and visible should be behind
+    expect(harness.source).toBe('Hello smooth streaming markdown renderer.')
+    expect(harness.visible.length).toBeLessThan(
+      'Hello smooth streaming markdown renderer.'.length,
+    )
+
+    harness.destroy()
+  })
+
+  it('shows content immediately when smoothStreaming=false', () => {
+    const harness = createHarness({ smoothStreaming: false, typewriter: true })
+
+    harness.setContent('Immediate content')
+    harness.onMount()
+    harness.syncContent()
+
+    expect(harness.getSmoothStreamingEnabled()).toBe(false)
+    expect(harness.getRenderContent()).toBe('Immediate content')
+
+    harness.destroy()
+  })
+
+  it('paces initial client content when smoothStreaming=true', () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    // smoothStreaming=true sets hasMountedForSmoothStreaming = true from start
+    expect(harness.getSmoothStreamingEnabled()).toBe(true)
+
+    harness.setContent('Hello world from initial content')
+    harness.syncContent()
+
+    // Content should be enqueued but visible should be behind source
+    expect(harness.source).toBe('Hello world from initial content')
+    expect(harness.visible.length).toBeLessThan(
+      'Hello world from initial content'.length,
+    )
+
+    // renderContent should use visible (paced)
+    expect(harness.getRenderContent().length).toBeLessThan(
+      'Hello world from initial content'.length,
+    )
+
+    harness.destroy()
+  })
+
+  it('gates final by caughtUp when smooth streaming is active', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ smoothStreaming: true, typewriter: false })
+
+    harness.setContent('Hello world')
+    harness.setFinal(true)
+    harness.syncContent()
+
+    // Before visible catches up, effectiveFinal should be false
+    if (harness.source.length > harness.visible.length) {
+      expect(harness.getEffectiveFinal()).toBe(false)
+    }
+
+    // Flush to let visible catch up, then sync snapshot
+    harness.controller.flush()
+    harness.syncContent()
+
+    // After caught up, effectiveFinal should reflect the requested final
+    expect(harness.caughtUp).toBe(true)
+    expect(harness.getEffectiveFinal()).toBe(true)
+
+    harness.destroy()
+  })
+
+  it('suppresses auto mode but not explicit true under parent scope', () => {
+    // Auto mode with parent already smoothing → should be suppressed
+    const autoHarness = createHarness({
+      smoothStreaming: 'auto',
+      typewriter: true,
+      parentSmoothStreamingEnabled: true,
+    })
+    autoHarness.onMount()
+    expect(autoHarness.getSmoothStreamingEnabled()).toBe(false)
+    autoHarness.destroy()
+
+    // Explicit true with parent smoothing → should NOT be suppressed
+    const explicitHarness = createHarness({
+      smoothStreaming: true,
+      typewriter: false,
+      parentSmoothStreamingEnabled: true,
+    })
+    explicitHarness.onMount()
+    expect(explicitHarness.getSmoothStreamingEnabled()).toBe(true)
+    explicitHarness.destroy()
+  })
+})

--- a/test/markstream-svelte-smooth-streaming.test.ts
+++ b/test/markstream-svelte-smooth-streaming.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveParsedNodes } from '../packages/markstream-svelte/src/components/shared/node-helpers'
+
+describe('markstream-svelte smooth streaming props', () => {
+  it('accepts smoothStreaming and smoothStreamingOptions in NodeRendererProps', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: 'auto',
+      smoothStreamingOptions: { minCharsPerSecond: 100 },
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('accepts smoothStreaming: true', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: true,
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('accepts smoothStreaming: false', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      smoothStreaming: false,
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+
+  it('defaults smoothStreaming to auto when omitted', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+    })
+    expect(nodes.length).toBeGreaterThan(0)
+  })
+})

--- a/test/markstream-svelte-smooth-streaming.test.ts
+++ b/test/markstream-svelte-smooth-streaming.test.ts
@@ -33,4 +33,14 @@ describe('markstream-svelte smooth streaming props', () => {
     })
     expect(nodes.length).toBeGreaterThan(0)
   })
+
+  it('treats nodes=[] as nodes mode (empty array, not content mode)', () => {
+    const nodes = resolveParsedNodes({
+      content: '# Hello',
+      nodes: [],
+      smoothStreaming: 'auto',
+    })
+    // nodes=[] should return empty array (nodes mode), not parse content
+    expect(nodes).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

Adds smooth streaming support (enabled by default) to `markstream-svelte` and `markstream-angular`, following the patterns established in `markstream-react` and `markstream-vue2` (PR #424).

## Changes

### Svelte
- **New composable**: `src/composables/useSmoothMarkdownStream.svelte.ts` — Svelte 5 runes-based composable (`$state`/`$derived`) wrapping `createSmoothMarkdownStream` from `markstream-core`
- **NodeRenderer.svelte**: Added `smoothStreaming` / `smoothStreamingOptions` props, `renderContent` / `effectiveFinal` getters, and a sync `$effect` for smooth stream synchronization
- **node-helpers.ts**: Added `smoothStreaming` and `smoothStreamingOptions` to `NodeRendererProps`
- **index.ts**: Exported `useSmoothMarkdownStream`, `SmoothMarkdownStreamControllerSvelte`, `SmoothMarkdownStreamOptions`

### Angular
- **New service**: `src/services/smooth-markdown-stream.service.ts` — Angular service wrapping `createSmoothMarkdownStream` (manually instantiated, no `@Injectable()`)
- **NodeRenderer.component.ts**: Added `@Input()` props, `OnChanges`/`OnDestroy`/`OnInit` lifecycle hooks, `renderContent` / `effectiveFinal` properties, and `syncSmoothStream()` method
- **node-helpers.ts**: Added `smoothStreaming` and `smoothStreamingOptions` to `NodeRendererProps`
- **index.ts**: Exported `SmoothMarkdownStreamService`, `SmoothMarkdownStreamOptions`

### Tests
- `test/markstream-svelte-smooth-streaming.test.ts` (4 tests)
- `test/markstream-angular-smooth-streaming.test.ts` (4 tests)

## Validation

- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes
- [x] `pnpm test` — 214 files, 1367 tests all passing