### PR TITLE
fix(css): remove invalid :deep() selector from published CSS

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -2222,7 +2222,7 @@ const computedButtonStyle = 'mermaid-action-btn p-[var(--ms-action-btn-padding)]
   align-items: center;
   justify-content: center;
 }
-.icon-slot :deep(svg) {
+.icon-slot svg {
   display: block;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary

Fix invalid Vue-specific `:deep()` syntax leaking into the published CSS bundle.
This prevents strict CSS parsers/minifiers such as Lightning CSS from failing on `markstream-vue/dist/*.css`.

## Changes

- [x] Replaced the non-scoped Mermaid icon slot selector `.icon-slot :deep(svg)` with standard CSS `.icon-slot svg`
- [x] Left scoped `:deep()` usages unchanged because they rely on Vue SFC scoped CSS compilation

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

Not applicable: this is a CSS validity/build compatibility fix with no intended UI change.

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)

Additional verification:

- [x] Verified generated `dist/*.css` no longer contains `.icon-slot :deep(svg)`
- [x] Verified the packed package in a Vite 8 / Lightning CSS consumer build

I verified the fix in a consumer project that previously reproduced the Lightning CSS minify error.
before:
<img width="1464" height="351" alt="屏幕截图 2026-05-11 110419" src="https://github.com/user-attachments/assets/23fd075f-bf76-4fdc-b3cb-ee6428b88d33" />

now:
<img width="810" height="118" alt="image" src="https://github.com/user-attachments/assets/87c202a0-f05e-4da9-be74-4e42144eb03b" />
