### PR TITLE
fix: keep tuple math inside strong captions

### DIFF
--- a/packages/markdown-parser/src/plugins/isMathLike.ts
+++ b/packages/markdown-parser/src/plugins/isMathLike.ts
@@ -39,6 +39,7 @@ const OPS_RE = /(?:^|[^+])\+(?!\+)|[=\-*/^<>]|\\times|\\pm|\\cdot|\\le|\\ge|\\ne
 // still math; so only ignore hyphens between multi-letter words.
 const HYPHENATED_MULTIWORD_RE = /\b[A-Z]{2,}-[A-Z]{2,}\b/i
 const FUNC_CALL_RE = /[A-Z]+\s*\([^)]+\)/i
+const PAREN_VARIABLE_TUPLE_RE = /^\(\s*[a-z](?:\s*,\s*[a-z])+\s*\)$/i
 const WORDS_RE = /\b(?:sin|cos|tan|log|ln|exp|sqrt|frac|sum|lim|int|prod)\b/
 // Heuristic to detect common date/time patterns like 2025/9/30 21:37:24 and
 // avoid classifying them as math merely because they contain '/' or ':'
@@ -94,6 +95,7 @@ export function isMathLike(s: string) {
   const ops = OPS_RE.test(norm) && !HYPHENATED_MULTIWORD_RE.test(norm)
   // function-like patterns: f(x), sin(x)
   const funcCall = FUNC_CALL_RE.test(norm)
+  const variableTuple = PAREN_VARIABLE_TUPLE_RE.test(stripped)
   // common math words
   const words = WORDS_RE.test(norm)
   // 纯单个英文字母也渲染成数学公式（常见变量/元素符号）
@@ -105,5 +107,5 @@ export function isMathLike(s: string) {
   // - 下标/上标通常是数字（可选花括号），避免匹配 get_time 之类的普通下划线单词
   const chemicalLike = /^(?:[A-Z][a-z]?(?:_\{?\d+\}?|\^\{?\d+\}?)?)+$/.test(stripped)
 
-  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || words || pureWord || chemicalLike
+  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || variableTuple || words || pureWord || chemicalLike
 }

--- a/packages/markdown-parser/test/strong-math-inline-regression.test.ts
+++ b/packages/markdown-parser/test/strong-math-inline-regression.test.ts
@@ -44,6 +44,43 @@ describe('parseMarkdownToStructure - strong around multiple inline math spans', 
     expect(textContent).not.toContain('**')
   })
 
+  it('keeps a caption strong when the first math span is a coordinate tuple', () => {
+    const md = getMarkdown('strong-coordinate-tuple-inline-math')
+    const input = '**图 2: \\((d,n)\\) 和 \\((\\log d,\\log n)\\) 的散点图。在 (a) 中，我们绘制 \\(n\\) 与 \\(d\\) 的关系，在 (b) 中，我们绘制 \\(\\log n\\) 与 \\(\\log d\\) 的关系。如 (b) 所示，我们选择 \\(n\\) 和 \\(d\\) 使其在对数后形成均匀间隔的网格。**'
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    const paragraph = nodes[0] as any
+    expect(paragraph.type).toBe('paragraph')
+    expect(paragraph.children).toHaveLength(1)
+
+    const strong = paragraph.children[0]
+    expect(strong.type).toBe('strong')
+
+    const mathContents = strong.children
+      .filter((child: any) => child.type === 'math_inline')
+      .map((child: any) => child.content)
+
+    expect(mathContents).toEqual([
+      '(d,n)',
+      '(\\log d,\\log n)',
+      'n',
+      'd',
+      '\\log n',
+      '\\log d',
+      'n',
+      'd',
+    ])
+
+    const textContent = strong.children
+      .filter((child: any) => child.type === 'text')
+      .map((child: any) => child.content)
+      .join('')
+
+    expect(textContent).toBe('图 2:  和  的散点图。在 (a) 中，我们绘制  与  的关系，在 (b) 中，我们绘制  与  的关系。如 (b) 所示，我们选择  和  使其在对数后形成均匀间隔的网格。')
+    expect(textContent).not.toContain('**')
+    expect(textContent).not.toContain('((d,n))')
+  })
+
   it('keeps strong intact when the first child is inline math', () => {
     const md = getMarkdown('strong-starts-with-inline-math')
     const nodes = parseMarkdownToStructure('**\\(x\\) 开头 math 后面文字 \\(y\\)**', md, { final: true })


### PR DESCRIPTION
## Summary
- treat simple parenthesized variable tuples like `(d,n)` as math-like content
- keep the #418 comment caption rendered as one strong span when it contains inline math
- add regression coverage for the exact comment sample

## Tests
- `pnpm --dir packages/markdown-parser test:run -- test/strong-math-inline-regression.test.ts`
- `pnpm exec vitest run test/fix-strong-tokens-parse.test.ts packages/markdown-parser/test/issue-334-inline-math-formatting.test.ts test/math-inline-escaped-parens-duplicate.test.ts packages/markdown-parser/test/escaped-punctuation-math-adjacent.test.ts`
- `pnpm exec vitest run test/math-isMathLike.test.ts test/debug/isMathLike.test.ts test/math-plugin.test.ts --reporter=dot`
- `pnpm typecheck`

## Notes
- `pnpm test` still fails on two pre-existing typewriter cursor tests unrelated to this parser change: `test/react-typewriter-fade-separation.test.tsx:265` and `test/vue2-typewriter-fade-separation.test.ts:190`.