### PR TITLE
fix: hide typewriter cursor when effectiveFinal is true

### DIFF
--- a/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
+++ b/packages/markstream-angular/src/components/NodeRenderer/NodeRenderer.component.ts
@@ -1020,7 +1020,9 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private getTypewriterContentLength(): number {
     if (this.nodes?.length)
       return (this.nodes as unknown[]).reduce((total: number, node: unknown) => total + this.getNodeTextLength(node), 0)
-    return this.renderContent.length
+    // Use raw content length, not renderContent (which may be the paced-out
+    // visible portion when smooth streaming is active).
+    return (this.content ?? '').length
   }
 
   private clearTypewriterCursorTimeout() {
@@ -1088,6 +1090,14 @@ export class NodeRendererComponent implements NodeRendererProps, OnChanges, OnIn
   private updateTypewriterCursorState() {
     if (typeof window === 'undefined' || this.hasNodes)
       return
+
+    // When the stream is final (and effective — smooth streaming has caught up),
+    // hide the cursor immediately.
+    if (this.effectiveFinal) {
+      this.showTypewriterCursor = false
+      this.clearTypewriterCursorTimeout()
+      return
+    }
 
     const nextLength = this.getTypewriterContentLength()
     const cursorAllowed = this.shouldShowTypewriterCursorForCurrentNodes()

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -886,8 +886,12 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
   const getTypewriterContentLength = useCallback((): number => {
     if (props.nodes?.length)
       return (props.nodes as unknown[]).reduce<number>((total, node) => total + getNodeTextLength(node), 0)
-    return renderContent.length
-  }, [props.nodes, renderContent, getNodeTextLength])
+    // Use raw content length, not renderContent (which may be the paced-out
+    // visible portion when smooth streaming is active).  The cursor should
+    // appear as long as the source content is growing, even if the visible
+    // stream hasn't caught up yet.
+    return (props.content ?? '').length
+  }, [props.nodes, props.content, getNodeTextLength])
 
   const clearTypewriterCursorTimeout = useCallback(() => {
     if (!typewriterCursorTimeoutRef.current)
@@ -1073,6 +1077,14 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
     if (typeof window === 'undefined' || hasNodes)
       return
 
+    // When the stream is final (and effective — smooth streaming has caught up),
+    // hide the cursor immediately.
+    if (effectiveFinal) {
+      setShowTypewriterCursor(false)
+      clearTypewriterCursorTimeout()
+      return
+    }
+
     const nextLength = getTypewriterContentLength()
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()
     if (props.typewriter === false || !cursorAllowed || nextLength <= lastTypewriterContentLengthRef.current) {
@@ -1099,6 +1111,8 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
     renderContent,
     props.nodes,
     props.typewriter,
+    props.content,
+    effectiveFinal,
     rawParsedNodes.length,
     hasNodes,
     getTypewriterContentLength,

--- a/packages/markstream-svelte/src/components/NodeRenderer.svelte
+++ b/packages/markstream-svelte/src/components/NodeRenderer.svelte
@@ -464,7 +464,9 @@
   function getTypewriterContentLength() {
     if (nodes?.length)
       return nodes.reduce((total: number, node: unknown) => total + getNodeTextLength(node), 0)
-    return renderContent.length
+    // Use raw content length, not renderContent (which may be the paced-out
+    // visible portion when smooth streaming is active).
+    return (content ?? '').length
   }
 
   function clearTypewriterCursorTimeout() {
@@ -534,8 +536,17 @@
     void nodes
     void typewriter
     void parsedNodes.length
+    void effectiveFinal
     if (typeof window === 'undefined' || hasNodes)
       return
+
+    // When the stream is final (and effective — smooth streaming has caught up),
+    // hide the cursor immediately.
+    if (effectiveFinal) {
+      showTypewriterCursor = false
+      clearTypewriterCursorTimeout()
+      return
+    }
 
     const nextLength = getTypewriterContentLength()
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -2347,7 +2347,6 @@ watch(
   },
   { flush: 'post' },
 )
-
 </script>
 
 <template>

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -2233,7 +2233,11 @@ function getNodeTextLength(node: unknown): number {
 function getTypewriterContentLength() {
   if (props.nodes?.length)
     return props.nodes.reduce((total: number, node: unknown) => total + getNodeTextLength(node), 0)
-  return renderContent.value.length
+  // Use raw content length, not renderContent (which may be the paced-out
+  // visible portion when smooth streaming is active).  The cursor should
+  // appear as long as the source content is growing, even if the visible
+  // stream hasn't caught up yet.
+  return rawContent.value.length
 }
 
 function clearTypewriterCursorTimeout() {
@@ -2299,10 +2303,18 @@ function updateTypewriterCursorPosition() {
 }
 
 watch(
-  [renderContent, () => props.nodes, () => props.typewriter],
+  [renderContent, rawContent, () => props.nodes, () => props.typewriter, effectiveFinal],
   async () => {
     if (typeof window === 'undefined' || hasExplicitNodes.value)
       return
+
+    // When the stream is final (and effective — smooth streaming has caught up),
+    // hide the cursor immediately.
+    if (effectiveFinal.value) {
+      showTypewriterCursor.value = false
+      clearTypewriterCursorTimeout()
+      return
+    }
 
     const nextLength = getTypewriterContentLength()
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -203,6 +203,13 @@ const requestedFinal = computed<boolean | undefined>(() => {
   return props.final ?? base.final
 })
 
+const effectiveFinal = computed<boolean | undefined>(() => {
+  const finalRequested = requestedFinal.value
+  if (smoothStreamingEnabled.value && finalRequested != null)
+    return finalRequested ? smoothStream.caughtUp.value : false
+  return finalRequested
+})
+
 watch(
   [() => props.content, () => props.nodes, smoothStreamingEnabled, requestedFinal],
   ([content, nodes, enabled, finalRequested]) => {
@@ -326,9 +333,7 @@ const mdInstance = computed(() => {
 
 const mergedParseOptions = computed(() => {
   const base = (props.parseOptions ?? {}) as RendererParseOptions
-  let resolvedFinal = requestedFinal.value
-  if (smoothStreamingEnabled.value && resolvedFinal != null)
-    resolvedFinal = resolvedFinal ? smoothStream.caughtUp.value : false
+  const resolvedFinal = effectiveFinal.value
   const merged = effectiveCustomHtmlTags.value
   const hasFinal = resolvedFinal != null
   const hasCustom = merged.length > 0
@@ -2452,7 +2457,11 @@ function getNodeTextLength(node: unknown): number {
 function getTypewriterContentLength() {
   if (props.nodes?.length)
     return props.nodes.reduce((total, node) => total + getNodeTextLength(node), 0)
-  return renderContent.value.length
+  // Use raw content length, not renderContent (which may be the paced-out
+  // visible portion when smooth streaming is active).  The cursor should
+  // appear as long as the source content is growing, even if the visible
+  // stream hasn't caught up yet.
+  return (props.content ?? '').length
 }
 
 function clearTypewriterCursorTimeout() {
@@ -2523,10 +2532,18 @@ function updateTypewriterCursorPosition() {
 }
 
 watch(
-  [renderContent, () => props.nodes, () => props.typewriter],
+  [renderContent, () => props.content, () => props.nodes, () => props.typewriter, effectiveFinal],
   async () => {
     if (!isClient || renderAsFragment.value || !ownsTypewriterCursor.value)
       return
+
+    // When the stream is final (and effective — smooth streaming has caught up),
+    // hide the cursor immediately.
+    if (effectiveFinal.value) {
+      showTypewriterCursor.value = false
+      clearTypewriterCursorTimeout()
+      return
+    }
 
     const nextLength = getTypewriterContentLength()
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()


### PR DESCRIPTION
## Problem

Two test failures after the typewriter cursor refactor (`b0a461fe`) that replaced the derived `showTypewriterCursor` with a position-based + 3s-timeout approach:

1. **React** `final=true hides typewriter cursor immediately` — cursor stayed visible for 3s even after `final=true`
2. **Vue2** `smoothStreaming=true + final=true before caughtUp keeps cursor visible` — cursor was hidden even though `effectiveFinal` was `false` (smooth stream hadn't caught up yet)

## Root cause

The typewriter cursor logic had two issues:

1. **No `effectiveFinal` check**: The cursor watch/effect didn't consider `final` / `effectiveFinal`, so it couldn't hide the cursor when the stream finished, nor keep it visible when smooth streaming was still catching up.
2. **`getTypewriterContentLength()` used `renderContent`**: When smooth streaming is active, `renderContent` is the paced-out `visible` portion (which starts empty), so the content-length check saw no growth and never showed the cursor.

## Changes

### Add `effectiveFinal` check to cursor logic (all 5 renderers)
- When `effectiveFinal === true`: hide cursor immediately, clear timeout
- When `effectiveFinal === false` (e.g. smooth streaming hasn't caught up): cursor stays visible

### Fix `getTypewriterContentLength()` to use raw content
- Changed from `renderContent.value.length` → `props.content.length` / `rawContent.value.length`
- Ensures cursor appears when source content grows, even if the visible stream hasn't caught up yet

### Extract `effectiveFinal` as standalone computed (Vue)
- Was previously inlined in `mergedParseOptions`; now a separate computed so the cursor watcher can react to it

## Test results

- 220 test files, 1420 tests — all passing ✅
- `pnpm typecheck` — passing ✅