### PR TITLE
refactor: split node renderer parsing and streaming internals

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import type { HtmlPolicy, MarkdownIt, ParsedNode } from 'stream-markdown-parser'
+import type { ParsedNode } from 'stream-markdown-parser'
 import type { VisibilityHandle } from '../../composables/viewportPriority'
 import type { CustomComponents } from '../../types'
 import type { CodeBlockPreviewPayload } from '../../types/component-props'
 import type { NodeRendererProps } from '../../types/node-renderer-props'
-import { getMarkdown, mergeCustomHtmlTags, parseMarkdownToStructure, resolveCustomHtmlTags } from 'stream-markdown-parser'
-import { computed, defineAsyncComponent, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, useAttrs, watch } from 'vue'
+import { computed, defineAsyncComponent, markRaw, nextTick, onBeforeUnmount, provide, reactive, ref, watch } from 'vue'
 import AdmonitionNode from '../../components/AdmonitionNode'
 import BlockquoteNode from '../../components/BlockquoteNode'
 import CheckboxNode from '../../components/CheckboxNode'
@@ -35,7 +34,6 @@ import TableNode from '../../components/TableNode'
 import TextNode from '../../components/TextNode'
 import ThematicBreakNode from '../../components/ThematicBreakNode'
 import VmrContainerNode from '../../components/VmrContainerNode'
-import { useSmoothMarkdownStream } from '../../composables/useSmoothMarkdownStream'
 import { provideViewportPriority } from '../../composables/viewportPriority'
 import {
   buildBlockTextProfile,
@@ -54,6 +52,9 @@ import HtmlInlineNode from '../HtmlInlineNode/HtmlInlineNode.vue'
 import MarkdownCodeBlockNode from '../MarkdownCodeBlockNode'
 import { createMathBlockMinHeightCache, provideMathBlockMinHeightCache } from '../MathBlockNode/minHeightCache'
 import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
+import { useMarkdownParsing } from './composables/useMarkdownParsing'
+import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
+import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
 import FallbackComponent from './FallbackComponent.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
 import { MermaidBlockNodeLoading } from './MermaidBlockNodeLoading'
@@ -64,12 +65,6 @@ interface IdleDeadlineLike {
   timeRemaining?: () => number
 }
 
-type RendererAttrs = Record<string, unknown> & {
-  'showTooltips'?: unknown
-  'show-tooltips'?: unknown
-}
-
-type RendererParseOptions = NonNullable<NodeRendererProps['parseOptions']>
 type RuntimeCodeBlockNode = ParsedNode & {
   type: 'code_block'
   language?: string
@@ -129,30 +124,19 @@ const headingProbeWrapperRefs = reactive<Record<number, HTMLElement | null>>({
 })
 const viewportPriorityAutoDisabled = ref(false)
 const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
-const isClient = typeof window !== 'undefined'
-const renderAsFragment = computed(() => props.renderAsFragment === true)
-const debugPerformanceEnabled = computed(() => props.debugPerformance && isClient && typeof console !== 'undefined')
-const attrs = useAttrs() as RendererAttrs
 const textStreamState = new Map<string, string>()
 const streamRenderVersion = ref(0)
-const smoothStream = useSmoothMarkdownStream(props.smoothStreamingOptions)
 const experimentContainerWidth = ref(0)
 const simpleTextProbeProfile = ref(createEmptySimpleTextProbeProfile())
-const resolvedShowTooltips = computed<boolean | undefined>(() => {
-  if (typeof props.showTooltips === 'boolean')
-    return props.showTooltips
-  const raw = attrs.showTooltips ?? attrs['show-tooltips']
-  if (raw === '' || raw === true || raw === 'true')
-    return true
-  if (raw === false || raw === 'false')
-    return false
-  return undefined
-})
-const inheritedHtmlPolicy = inject<{ value?: HtmlPolicy } | undefined>('markstreamHtmlPolicy', undefined)
-const inheritedTypewriterCursor = inject<{ value?: boolean } | undefined>('markstreamTypewriterCursor', undefined)
-const inheritedSmoothStreaming = inject<{ value?: boolean } | undefined>('markstreamSmoothStreaming', undefined)
-const resolvedHtmlPolicy = computed<HtmlPolicy>(() => props.htmlPolicy ?? inheritedHtmlPolicy?.value ?? 'safe')
-const ownsTypewriterCursor = computed(() => inheritedTypewriterCursor?.value !== true)
+const {
+  isClient,
+  renderAsFragment,
+  debugPerformanceEnabled,
+  resolvedShowTooltips,
+  resolvedHtmlPolicy,
+  inheritedSmoothStreaming,
+  ownsTypewriterCursor,
+} = useResolvedRendererOptions(props)
 provide('markstreamShowTooltips', resolvedShowTooltips)
 provide('markstreamHtmlPolicy', resolvedHtmlPolicy)
 provide('markstreamTypewriter', computed(() => props.typewriter !== false))
@@ -161,91 +145,15 @@ provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
 provide('markstreamStreamVersion', streamRenderVersion)
 
-const smoothStreamingEligible = computed(() => {
-  if (props.smoothStreaming === false)
-    return false
-  if (props.nodes?.length)
-    return false
-  // When the parent renderer is already pacing content, avoid double-pacing
-  // in nested renderers (e.g. thinking blocks, custom tag content).
-  // Only applies in 'auto' mode — smoothStreaming === true explicitly opts in.
-  if (props.smoothStreaming !== true && inheritedSmoothStreaming?.value)
-    return false
-  if (props.smoothStreaming === true)
-    return true
-  // 'auto': only enable when typewriter/incremental mode is active
-  return props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0
+const {
+  smoothStreamingEnabled,
+  renderContent,
+  effectiveFinal,
+} = useSmoothStreamingBridge(props, {
+  isClient,
+  inheritedSmoothStreaming,
 })
-
-// Mounted gate: prevent smooth streaming from pacing initial static content
-// on the first client render (avoids SSR hydration mismatch and blank flash).
-// Only applies in 'auto' mode — when smoothStreaming === true, the user
-// explicitly opted in and the gate is always open.
-const hasMountedForSmoothStreaming = ref(!isClient || props.smoothStreaming === true)
-
-onMounted(() => {
-  hasMountedForSmoothStreaming.value = true
-})
-
-const smoothStreamingEnabled = computed(() => (
-  hasMountedForSmoothStreaming.value
-  && smoothStreamingEligible.value
-))
 provide('markstreamSmoothStreaming', smoothStreamingEnabled)
-const renderContent = computed(() => (
-  smoothStreamingEnabled.value
-    ? smoothStream.visible.value
-    : (props.content ?? '')
-))
-
-const requestedFinal = computed<boolean | undefined>(() => {
-  const base = (props.parseOptions ?? {}) as RendererParseOptions
-  return props.final ?? base.final
-})
-
-const effectiveFinal = computed<boolean | undefined>(() => {
-  const finalRequested = requestedFinal.value
-  if (smoothStreamingEnabled.value && finalRequested != null)
-    return finalRequested ? smoothStream.caughtUp.value : false
-  return finalRequested
-})
-
-watch(
-  [() => props.content, () => props.nodes, smoothStreamingEnabled, requestedFinal],
-  ([content, nodes, enabled, finalRequested]) => {
-    if (nodes?.length) {
-      smoothStream.reset('')
-      return
-    }
-
-    const nextContent = content ?? ''
-
-    if (!enabled) {
-      smoothStream.reset(nextContent)
-      if (finalRequested)
-        smoothStream.finish({ flush: true })
-      return
-    }
-
-    const source = smoothStream.source.value
-    if (!nextContent) {
-      smoothStream.reset('')
-    }
-    else if (nextContent === source) {
-      // no-op
-    }
-    else if (nextContent.startsWith(source)) {
-      smoothStream.enqueue(nextContent.slice(source.length))
-    }
-    else {
-      smoothStream.reset(nextContent)
-    }
-
-    if (finalRequested)
-      smoothStream.finish()
-  },
-  { immediate: true },
-)
 
 function logPerf(label: string, data: Record<string, unknown>) {
   if (!debugPerformanceEnabled.value)
@@ -306,82 +214,20 @@ watch(
   },
   { immediate: true },
 )
-const defaultMd = getMarkdown(instanceMsgId)
-const customTagCache = new Map<string, MarkdownIt>()
 const customComponentsMap = computed<Partial<CustomComponents>>(() => {
   void customComponentsRevision.value
   return getCustomNodeComponents(props.customId)
 })
-const effectiveCustomHtmlTags = computed(() => mergeCustomHtmlTags(props.customHtmlTags, props.parseOptions?.customHtmlTags))
-const mdBase = computed(() => {
-  const { key, tags } = resolveCustomHtmlTags(effectiveCustomHtmlTags.value)
-  if (!key)
-    return defaultMd
-  const cached = customTagCache.get(key)
-  if (cached)
-    return cached
-  const md = getMarkdown(instanceMsgId, { customHtmlTags: tags })
-  customTagCache.set(key, md)
-  return md
-})
-const mdInstance = computed(() => {
-  const base = mdBase.value
-  return props.customMarkdownIt
-    ? props.customMarkdownIt(base)
-    : base
-})
-
-const mergedParseOptions = computed(() => {
-  const base = (props.parseOptions ?? {}) as RendererParseOptions
-  const resolvedFinal = effectiveFinal.value
-  const merged = effectiveCustomHtmlTags.value
-  const hasFinal = resolvedFinal != null
-  const hasCustom = merged.length > 0
-
-  if (!hasFinal && !hasCustom)
-    return base
-
-  return {
-    ...base,
-    ...(hasFinal ? { final: resolvedFinal } : {}),
-    ...(hasCustom ? { customHtmlTags: merged } : {}),
-  } as RendererParseOptions
-})
-
-// Set of effective custom HTML tags (normalised to lowercase).
-// Used in `renderedItems` to coerce pre-parsed html_block/html_inline nodes
-// whose tag matches a registered custom component.
-const effectiveCustomHtmlTagsSet = computed<Set<string>>(() => {
-  const arr = mergedParseOptions.value.customHtmlTags ?? []
-  return new Set(arr.map(t => String(t).trim().toLowerCase()).filter(Boolean))
-})
-
-const parsedNodes = computed<ParsedNode[]>(() => {
-  // 解析 content 字符串为节点数组
-  // If the consumer passed an explicit `nodes` array, return a shallow
-  // copy so the computed value has a new identity whenever the caller
-  // replaces or mutates the array in-place. This ensures the watchers
-  // that rely on `parsedNodes` will run and update rendering even when
-  // the array length doesn't change.
-  if (props.nodes?.length)
-    return markRaw((props.nodes as unknown as ParsedNode[]).slice())
-  const contentToParse = renderContent.value
-  if (contentToParse) {
-    // Prefer an explicitly passed `markdown` prop, then a globally
-    // provided markdown via `setGlobalMarkdown`, otherwise fall back
-    // to the legacy `getMarkdown()` factory.
-    const parseStart = debugPerformanceEnabled.value ? performance.now() : 0
-    const parsed = parseMarkdownToStructure(contentToParse, mdInstance.value, mergedParseOptions.value)
-    if (debugPerformanceEnabled.value) {
-      logPerf('parse(sync)', {
-        ms: Math.round(performance.now() - parseStart),
-        nodes: parsed.length,
-        contentLength: contentToParse.length,
-      })
-    }
-    return markRaw(parsed)
-  }
-  return []
+const {
+  effectiveCustomHtmlTagsSet,
+  mergedParseOptions,
+  parsedNodes,
+} = useMarkdownParsing(props, {
+  instanceMsgId,
+  renderContent,
+  effectiveFinal,
+  debugPerformanceEnabled,
+  logPerf,
 })
 const paragraphProbeNode = ref<ParsedNode | null>(null)
 const listItemProbeNode = ref<ParsedNode | null>(null)

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -1,0 +1,140 @@
+import type {
+  MarkdownIt,
+  ParsedNode,
+} from 'stream-markdown-parser'
+import type { ComputedRef } from 'vue'
+import type { NodeRendererProps } from '../../../types/node-renderer-props'
+import {
+  getMarkdown,
+  mergeCustomHtmlTags,
+  parseMarkdownToStructure,
+  resolveCustomHtmlTags,
+} from 'stream-markdown-parser'
+import { computed, markRaw } from 'vue'
+
+type RendererParseOptions = NonNullable<NodeRendererProps['parseOptions']>
+
+export interface MarkdownParsingOptions {
+  instanceMsgId: string
+  renderContent: ComputedRef<string>
+  effectiveFinal: ComputedRef<boolean | undefined>
+  debugPerformanceEnabled: ComputedRef<boolean>
+  logPerf: (label: string, data: Record<string, unknown>) => void
+}
+
+export interface MarkdownParsingState {
+  effectiveCustomHtmlTags: ComputedRef<readonly string[]>
+  effectiveCustomHtmlTagsSet: ComputedRef<Set<string>>
+  mdBase: ComputedRef<MarkdownIt>
+  mdInstance: ComputedRef<MarkdownIt>
+  mergedParseOptions: ComputedRef<RendererParseOptions>
+  parsedNodes: ComputedRef<ParsedNode[]>
+}
+
+export function useMarkdownParsing(
+  props: Readonly<NodeRendererProps>,
+  options: MarkdownParsingOptions,
+): MarkdownParsingState {
+  const defaultMd = getMarkdown(options.instanceMsgId)
+  const customTagCache = new Map<string, MarkdownIt>()
+
+  const effectiveCustomHtmlTags = computed(() => {
+    return mergeCustomHtmlTags(
+      props.customHtmlTags,
+      props.parseOptions?.customHtmlTags,
+    )
+  })
+
+  const mdBase = computed(() => {
+    const { key, tags } = resolveCustomHtmlTags(effectiveCustomHtmlTags.value)
+
+    if (!key)
+      return defaultMd
+
+    const cached = customTagCache.get(key)
+
+    if (cached)
+      return cached
+
+    const md = getMarkdown(options.instanceMsgId, {
+      customHtmlTags: tags,
+    })
+
+    customTagCache.set(key, md)
+
+    return md
+  })
+
+  const mdInstance = computed(() => {
+    const base = mdBase.value
+
+    return props.customMarkdownIt
+      ? props.customMarkdownIt(base)
+      : base
+  })
+
+  const mergedParseOptions = computed(() => {
+    const base = (props.parseOptions ?? {}) as RendererParseOptions
+    const resolvedFinal = options.effectiveFinal.value
+    const customHtmlTags = effectiveCustomHtmlTags.value
+
+    const hasFinal = resolvedFinal != null
+    const hasCustom = customHtmlTags.length > 0
+
+    if (!hasFinal && !hasCustom)
+      return base
+
+    return {
+      ...base,
+      ...(hasFinal ? { final: resolvedFinal } : {}),
+      ...(hasCustom ? { customHtmlTags } : {}),
+    } as RendererParseOptions
+  })
+
+  const effectiveCustomHtmlTagsSet = computed(() => {
+    return new Set(
+      (mergedParseOptions.value.customHtmlTags ?? [])
+        .map(tag => String(tag).trim().toLowerCase())
+        .filter(Boolean),
+    )
+  })
+
+  const parsedNodes = computed<ParsedNode[]>(() => {
+    if (props.nodes?.length)
+      return markRaw((props.nodes as unknown as ParsedNode[]).slice())
+
+    const contentToParse = options.renderContent.value
+
+    if (!contentToParse)
+      return []
+
+    const parseStart = options.debugPerformanceEnabled.value
+      ? performance.now()
+      : 0
+
+    const parsed = parseMarkdownToStructure(
+      contentToParse,
+      mdInstance.value,
+      mergedParseOptions.value,
+    )
+
+    if (options.debugPerformanceEnabled.value) {
+      options.logPerf('parse(sync)', {
+        ms: Math.round(performance.now() - parseStart),
+        nodes: parsed.length,
+        contentLength: contentToParse.length,
+      })
+    }
+
+    return markRaw(parsed)
+  })
+
+  return {
+    effectiveCustomHtmlTags,
+    effectiveCustomHtmlTagsSet,
+    mdBase,
+    mdInstance,
+    mergedParseOptions,
+    parsedNodes,
+  }
+}

--- a/src/components/NodeRenderer/composables/useResolvedRendererOptions.ts
+++ b/src/components/NodeRenderer/composables/useResolvedRendererOptions.ts
@@ -1,0 +1,86 @@
+import type { HtmlPolicy } from 'stream-markdown-parser'
+import type { ComputedRef } from 'vue'
+import type { NodeRendererProps } from '../../../types/node-renderer-props'
+import { computed, inject, useAttrs } from 'vue'
+
+type RendererAttrs = Record<string, unknown> & {
+  'showTooltips'?: unknown
+  'show-tooltips'?: unknown
+}
+
+export interface ResolvedRendererOptions {
+  isClient: boolean
+  renderAsFragment: ComputedRef<boolean>
+  debugPerformanceEnabled: ComputedRef<boolean>
+  resolvedShowTooltips: ComputedRef<boolean | undefined>
+  resolvedHtmlPolicy: ComputedRef<HtmlPolicy>
+  inheritedSmoothStreaming: { value?: boolean } | undefined
+  inheritedTypewriterCursor: { value?: boolean } | undefined
+  ownsTypewriterCursor: ComputedRef<boolean>
+}
+
+export function useResolvedRendererOptions(
+  props: Readonly<NodeRendererProps>,
+): ResolvedRendererOptions {
+  const isClient = typeof window !== 'undefined'
+  const attrs = useAttrs() as RendererAttrs
+
+  const inheritedHtmlPolicy = inject<{ value?: HtmlPolicy } | undefined>(
+    'markstreamHtmlPolicy',
+    undefined,
+  )
+
+  const inheritedTypewriterCursor = inject<{ value?: boolean } | undefined>(
+    'markstreamTypewriterCursor',
+    undefined,
+  )
+
+  const inheritedSmoothStreaming = inject<{ value?: boolean } | undefined>(
+    'markstreamSmoothStreaming',
+    undefined,
+  )
+
+  const renderAsFragment = computed(() => props.renderAsFragment === true)
+
+  const debugPerformanceEnabled = computed(() => {
+    return Boolean(
+      props.debugPerformance
+      && isClient
+      && typeof console !== 'undefined',
+    )
+  })
+
+  const resolvedShowTooltips = computed<boolean | undefined>(() => {
+    if (typeof props.showTooltips === 'boolean')
+      return props.showTooltips
+
+    const raw = attrs.showTooltips ?? attrs['show-tooltips']
+
+    if (raw === '' || raw === true || raw === 'true')
+      return true
+
+    if (raw === false || raw === 'false')
+      return false
+
+    return undefined
+  })
+
+  const resolvedHtmlPolicy = computed<HtmlPolicy>(() => {
+    return props.htmlPolicy ?? inheritedHtmlPolicy?.value ?? 'safe'
+  })
+
+  const ownsTypewriterCursor = computed(() => {
+    return inheritedTypewriterCursor?.value !== true
+  })
+
+  return {
+    isClient,
+    renderAsFragment,
+    debugPerformanceEnabled,
+    resolvedShowTooltips,
+    resolvedHtmlPolicy,
+    inheritedSmoothStreaming,
+    inheritedTypewriterCursor,
+    ownsTypewriterCursor,
+  }
+}

--- a/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
+++ b/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
@@ -1,0 +1,128 @@
+import type { ComputedRef } from 'vue'
+import type { NodeRendererProps } from '../../../types/node-renderer-props'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useSmoothMarkdownStream } from '../../../composables/useSmoothMarkdownStream'
+
+type RendererParseOptions = NonNullable<NodeRendererProps['parseOptions']>
+
+export interface SmoothStreamingBridgeOptions {
+  isClient: boolean
+  inheritedSmoothStreaming?: { value?: boolean }
+}
+
+export interface SmoothStreamingBridge {
+  smoothStream: ReturnType<typeof useSmoothMarkdownStream>
+  smoothStreamingEligible: ComputedRef<boolean>
+  smoothStreamingEnabled: ComputedRef<boolean>
+  renderContent: ComputedRef<string>
+  requestedFinal: ComputedRef<boolean | undefined>
+  effectiveFinal: ComputedRef<boolean | undefined>
+}
+
+export function useSmoothStreamingBridge(
+  props: Readonly<NodeRendererProps>,
+  options: SmoothStreamingBridgeOptions,
+): SmoothStreamingBridge {
+  const smoothStream = useSmoothMarkdownStream(props.smoothStreamingOptions)
+
+  const smoothStreamingEligible = computed(() => {
+    if (props.smoothStreaming === false)
+      return false
+
+    if (props.nodes?.length)
+      return false
+
+    // Nested renderers should not double-pace content unless explicitly opted in.
+    if (props.smoothStreaming !== true && options.inheritedSmoothStreaming?.value)
+      return false
+
+    if (props.smoothStreaming === true)
+      return true
+
+    // auto mode: enable only for typewriter or incremental mode.
+    return props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0
+  })
+
+  // Prevent pacing initial static content on first client render.
+  // This avoids SSR hydration mismatch and blank flash.
+  const hasMountedForSmoothStreaming = ref(
+    !options.isClient || props.smoothStreaming === true,
+  )
+
+  onMounted(() => {
+    hasMountedForSmoothStreaming.value = true
+  })
+
+  const smoothStreamingEnabled = computed(() => {
+    return hasMountedForSmoothStreaming.value && smoothStreamingEligible.value
+  })
+
+  const renderContent = computed(() => {
+    return smoothStreamingEnabled.value
+      ? smoothStream.visible.value
+      : (props.content ?? '')
+  })
+
+  const requestedFinal = computed<boolean | undefined>(() => {
+    const base = (props.parseOptions ?? {}) as RendererParseOptions
+    return props.final ?? base.final
+  })
+
+  const effectiveFinal = computed<boolean | undefined>(() => {
+    const finalRequested = requestedFinal.value
+
+    if (smoothStreamingEnabled.value && finalRequested != null)
+      return finalRequested ? smoothStream.caughtUp.value : false
+
+    return finalRequested
+  })
+
+  watch(
+    [() => props.content, () => props.nodes, smoothStreamingEnabled, requestedFinal],
+    ([content, nodes, enabled, finalRequested]) => {
+      if (nodes?.length) {
+        smoothStream.reset('')
+        return
+      }
+
+      const nextContent = content ?? ''
+
+      if (!enabled) {
+        smoothStream.reset(nextContent)
+
+        if (finalRequested)
+          smoothStream.finish({ flush: true })
+
+        return
+      }
+
+      const source = smoothStream.source.value
+
+      if (!nextContent) {
+        smoothStream.reset('')
+      }
+      else if (nextContent === source) {
+        // no-op
+      }
+      else if (nextContent.startsWith(source)) {
+        smoothStream.enqueue(nextContent.slice(source.length))
+      }
+      else {
+        smoothStream.reset(nextContent)
+      }
+
+      if (finalRequested)
+        smoothStream.finish()
+    },
+    { immediate: true },
+  )
+
+  return {
+    smoothStream,
+    smoothStreamingEligible,
+    smoothStreamingEnabled,
+    renderContent,
+    requestedFinal,
+    effectiveFinal,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract resolved renderer option handling from NodeRenderer
- Extract smooth streaming bridge state from NodeRenderer
- Extract markdown parsing setup from NodeRenderer

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr
- pnpm test:api