### PR TITLE
refactor: split node renderer viewport root helpers

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -55,6 +55,7 @@ import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
 import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
+import { useViewportRoot } from './composables/useViewportRoot'
 import FallbackComponent from './FallbackComponent.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
 import { MermaidBlockNodeLoading } from './MermaidBlockNodeLoading'
@@ -123,7 +124,6 @@ const headingProbeWrapperRefs = reactive<Record<number, HTMLElement | null>>({
   6: null,
 })
 const viewportPriorityAutoDisabled = ref(false)
-const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 const textStreamState = new Map<string, string>()
 const streamRenderVersion = ref(0)
 const experimentContainerWidth = ref(0)
@@ -137,6 +137,15 @@ const {
   inheritedSmoothStreaming,
   ownsTypewriterCursor,
 } = useResolvedRendererOptions(props)
+const {
+  resolveViewportRoot,
+  resolveScrollContainer,
+  isReverseFlexScrollRoot,
+  getNormalizedScrollTop,
+  getOffsetTopWithinRoot,
+} = useViewportRoot(containerRef, {
+  isClient,
+})
 provide('markstreamShowTooltips', resolvedShowTooltips)
 provide('markstreamHtmlPolicy', resolvedHtmlPolicy)
 provide('markstreamTypewriter', computed(() => props.typewriter !== false))
@@ -159,40 +168,6 @@ function logPerf(label: string, data: Record<string, unknown>) {
   if (!debugPerformanceEnabled.value)
     return
   console.info(`[markstream-vue][perf] ${label}`, data)
-}
-
-function hasOverflowScrollStyle(style: CSSStyleDeclaration | null | undefined) {
-  if (!style)
-    return false
-  const overflowY = (style.overflowY || '').toLowerCase()
-  const overflow = (style.overflow || '').toLowerCase()
-  return SCROLL_PARENT_OVERFLOW_RE.test(overflowY) || SCROLL_PARENT_OVERFLOW_RE.test(overflow)
-}
-
-function isActuallyScrollableElement(element: HTMLElement) {
-  const verticalOverflow = Math.ceil(element.scrollHeight) > Math.ceil(element.clientHeight) + 1
-  const horizontalOverflow = Math.ceil(element.scrollWidth) > Math.ceil(element.clientWidth) + 1
-  return verticalOverflow || horizontalOverflow
-}
-
-function resolveViewportRoot(node?: HTMLElement | null) {
-  if (typeof window === 'undefined')
-    return null
-  const base = node ?? containerRef.value
-  if (!base)
-    return null
-  const doc = base.ownerDocument || document
-  const rootScrollable = doc.scrollingElement || doc.documentElement
-  let current: HTMLElement | null = base
-  while (current) {
-    if (current === doc.body || current === rootScrollable)
-      break
-    const style = window.getComputedStyle(current)
-    if (hasOverflowScrollStyle(style) && isActuallyScrollableElement(current))
-      return current
-    current = current.parentElement
-  }
-  return null
 }
 const instanceMsgId = props.customId
   ? `renderer-${props.customId}`
@@ -413,52 +388,6 @@ function ensureExperimentProbeNodes() {
 
 function getHeadingProbeNode(level: number) {
   return headingProbeNodes.value?.[level] ?? null
-}
-
-function resolveScrollContainer(node?: HTMLElement | null) {
-  const resolved = resolveViewportRoot(node ?? containerRef.value ?? null)
-  if (resolved)
-    return resolved
-  const host = node?.ownerDocument ?? containerRef.value?.ownerDocument ?? (typeof document !== 'undefined' ? document : null)
-  return host?.scrollingElement as HTMLElement || host?.documentElement || null
-}
-
-function isReverseFlexScrollRoot(root: HTMLElement) {
-  if (!isClient)
-    return false
-  try {
-    const style = window.getComputedStyle(root)
-    const display = (style.display || '').toLowerCase()
-    if (!display.includes('flex'))
-      return false
-    const dir = (style.flexDirection || '').toLowerCase()
-    return dir.endsWith('reverse')
-  }
-  catch {
-    return false
-  }
-}
-
-function getNormalizedScrollTop(root: HTMLElement, doc: Document, isViewportRoot: boolean) {
-  if (isViewportRoot)
-    return (doc?.documentElement?.scrollTop ?? doc?.body?.scrollTop ?? 0)
-  const raw = root.scrollTop
-  if (!isReverseFlexScrollRoot(root))
-    return raw
-  const distanceFromBottom = raw < 0 ? -raw : raw
-  const max = Math.max(0, (root.scrollHeight ?? 0) - (root.clientHeight ?? 0))
-  return max - distanceFromBottom
-}
-
-function getOffsetTopWithinRoot(node: HTMLElement, root: HTMLElement) {
-  let current: HTMLElement | null = node
-  let total = 0
-  let guard = 0
-  while (current && current !== root && guard++ < 64) {
-    total += current.offsetTop || 0
-    current = current.offsetParent as HTMLElement | null
-  }
-  return total
 }
 
 function cleanupScrollListener() {

--- a/src/components/NodeRenderer/composables/useViewportRoot.ts
+++ b/src/components/NodeRenderer/composables/useViewportRoot.ts
@@ -1,0 +1,149 @@
+import type { Ref } from 'vue'
+
+const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
+
+export interface ViewportRootOptions {
+  isClient: boolean
+}
+
+export interface ViewportRootController {
+  resolveViewportRoot: (node?: HTMLElement | null) => HTMLElement | null
+  resolveScrollContainer: (node?: HTMLElement | null) => HTMLElement | null
+  isReverseFlexScrollRoot: (root: HTMLElement) => boolean
+  getNormalizedScrollTop: (
+    root: HTMLElement,
+    doc: Document,
+    isViewportRoot: boolean,
+  ) => number
+  getOffsetTopWithinRoot: (node: HTMLElement, root: HTMLElement) => number
+}
+
+function hasOverflowScrollStyle(style: CSSStyleDeclaration | null | undefined) {
+  if (!style)
+    return false
+
+  const overflowY = (style.overflowY || '').toLowerCase()
+  const overflow = (style.overflow || '').toLowerCase()
+
+  return SCROLL_PARENT_OVERFLOW_RE.test(overflowY)
+    || SCROLL_PARENT_OVERFLOW_RE.test(overflow)
+}
+
+function isActuallyScrollableElement(element: HTMLElement) {
+  const verticalOverflow = Math.ceil(element.scrollHeight) > Math.ceil(element.clientHeight) + 1
+  const horizontalOverflow = Math.ceil(element.scrollWidth) > Math.ceil(element.clientWidth) + 1
+
+  return verticalOverflow || horizontalOverflow
+}
+
+export function useViewportRoot(
+  containerRef: Ref<HTMLElement | undefined>,
+  options: ViewportRootOptions,
+): ViewportRootController {
+  function resolveViewportRoot(node?: HTMLElement | null) {
+    if (typeof window === 'undefined')
+      return null
+
+    const base = node ?? containerRef.value
+
+    if (!base)
+      return null
+
+    const doc = base.ownerDocument || document
+    const rootScrollable = doc.scrollingElement || doc.documentElement
+
+    let current: HTMLElement | null = base
+
+    while (current) {
+      if (current === doc.body || current === rootScrollable)
+        break
+
+      const style = window.getComputedStyle(current)
+
+      if (hasOverflowScrollStyle(style) && isActuallyScrollableElement(current))
+        return current
+
+      current = current.parentElement
+    }
+
+    return null
+  }
+
+  function resolveScrollContainer(node?: HTMLElement | null) {
+    const resolved = resolveViewportRoot(node ?? containerRef.value ?? null)
+
+    if (resolved)
+      return resolved
+
+    const host = node?.ownerDocument
+      ?? containerRef.value?.ownerDocument
+      ?? (typeof document !== 'undefined' ? document : null)
+
+    return (host?.scrollingElement as HTMLElement | null)
+      || host?.documentElement
+      || null
+  }
+
+  function isReverseFlexScrollRoot(root: HTMLElement) {
+    if (!options.isClient)
+      return false
+
+    try {
+      const style = window.getComputedStyle(root)
+      const display = (style.display || '').toLowerCase()
+
+      if (!display.includes('flex'))
+        return false
+
+      const dir = (style.flexDirection || '').toLowerCase()
+
+      return dir.endsWith('reverse')
+    }
+    catch {
+      return false
+    }
+  }
+
+  function getNormalizedScrollTop(
+    root: HTMLElement,
+    doc: Document,
+    isViewportRoot: boolean,
+  ) {
+    if (isViewportRoot)
+      return doc.documentElement?.scrollTop ?? doc.body?.scrollTop ?? 0
+
+    const raw = root.scrollTop
+
+    if (!isReverseFlexScrollRoot(root))
+      return raw
+
+    const distanceFromBottom = raw < 0 ? -raw : raw
+    const max = Math.max(
+      0,
+      (root.scrollHeight ?? 0) - (root.clientHeight ?? 0),
+    )
+
+    return max - distanceFromBottom
+  }
+
+  function getOffsetTopWithinRoot(node: HTMLElement, root: HTMLElement) {
+    let current: HTMLElement | null = node
+    let total = 0
+    let guard = 0
+
+    while (current && current !== root && guard++ < 64) {
+      total += current.offsetTop || 0
+      current = current.offsetParent as HTMLElement | null
+    }
+
+    return total
+  }
+
+  return {
+    resolveViewportRoot,
+    resolveScrollContainer,
+    isReverseFlexScrollRoot,
+    getNormalizedScrollTop,
+    getOffsetTopWithinRoot,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract NodeRenderer viewport and scroll root helpers into useViewportRoot
- Keep NodeRenderer call sites unchanged and avoid public API/export changes

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr
- pnpm test:api