### PR TITLE
refactor: split node renderer scheduler platform helpers

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -55,6 +55,7 @@ import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
 import { useBatchRenderingState } from './composables/useBatchRenderingState'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
+import { useSchedulerPlatform } from './composables/useSchedulerPlatform'
 import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
 import { useViewportRoot } from './composables/useViewportRoot'
 import FallbackComponent from './FallbackComponent.vue'
@@ -253,17 +254,14 @@ const registerNodeVisibility = provideViewportPriority(
   target => resolveViewportRoot(target ?? containerRef.value ?? null),
   viewportPriorityEnabled,
 )
-const requestFrame = isClient && typeof window.requestAnimationFrame === 'function'
-  ? window.requestAnimationFrame.bind(window)
-  : null
-const cancelFrame = isClient && typeof window.cancelAnimationFrame === 'function'
-  ? window.cancelAnimationFrame.bind(window)
-  : null
-const processEnv = typeof globalThis !== 'undefined' && 'process' in globalThis
-  ? (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env
-  : undefined
-const isTestEnv = processEnv?.NODE_ENV === 'test'
-const hasIdleCallback = isClient && typeof window.requestIdleCallback === 'function'
+const {
+  requestFrame,
+  cancelFrame,
+  hasIdleCallback,
+  isTestEnv,
+} = useSchedulerPlatform({
+  isClient,
+})
 const {
   resolvedBatchSize,
   resolvedInitialBatch,

--- a/src/components/NodeRenderer/composables/useSchedulerPlatform.ts
+++ b/src/components/NodeRenderer/composables/useSchedulerPlatform.ts
@@ -1,0 +1,48 @@
+export interface SchedulerPlatformOptions {
+  isClient: boolean
+}
+
+export interface SchedulerPlatform {
+  requestFrame: typeof window.requestAnimationFrame | null
+  cancelFrame: typeof window.cancelAnimationFrame | null
+  hasIdleCallback: boolean
+  isTestEnv: boolean
+}
+
+function getNodeEnv() {
+  if (typeof globalThis === 'undefined' || !('process' in globalThis))
+    return undefined
+
+  const nodeProcess = Object.getOwnPropertyDescriptor(globalThis, 'process')?.value as {
+    env?: {
+      NODE_ENV?: string
+    }
+  } | undefined
+
+  return nodeProcess?.env
+}
+
+export function useSchedulerPlatform(
+  options: SchedulerPlatformOptions,
+): SchedulerPlatform {
+  const requestFrame = options.isClient && typeof window.requestAnimationFrame === 'function'
+    ? window.requestAnimationFrame.bind(window)
+    : null
+
+  const cancelFrame = options.isClient && typeof window.cancelAnimationFrame === 'function'
+    ? window.cancelAnimationFrame.bind(window)
+    : null
+
+  const hasIdleCallback = options.isClient
+    && typeof window.requestIdleCallback === 'function'
+
+  const processEnv = getNodeEnv()
+  const isTestEnv = processEnv?.NODE_ENV === 'test'
+
+  return {
+    requestFrame,
+    cancelFrame,
+    hasIdleCallback,
+    isTestEnv,
+  }
+}


### PR DESCRIPTION
## Summary
- extract NodeRenderer scheduler platform capability detection into useSchedulerPlatform
- keep focus sync, virtualization, scroll restore, and batch scheduler logic in NodeRenderer.vue
- keep public API/package exports unchanged

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr (exited 0; existing filter skipped all tests)
- pnpm exec vitest run test/ssr-import.test.ts
- pnpm test:api