### PR TITLE
test: make ssr check run explicit ssr tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "test:ui": "vitest --ui",
     "test:update": "vitest -u",
     "typecheck": "vue-tsc --noEmit",
-    "check:ssr": "vitest --run -t \"SSR import safety\"",
+    "check:ssr": "vitest --run test/ssr-import.test.ts test/ssr-render-to-string.test.ts",
     "prepublishOnly": "npm run build && pnpm run check:core-published",
     "play": "pnpm run -C playground dev",
     "play:angular": "pnpm run -C playground-angular dev",

--- a/test/ssr-import.test.ts
+++ b/test/ssr-import.test.ts
@@ -1,21 +1,28 @@
+/**
+ * @vitest-environment node
+ */
 import { describe, expect, it } from 'vitest'
 
-// SSR import smoke test: importing the library entry should not throw in Node
-describe('sSR import safety', () => {
+// SSR import smoke test: importing the library entry should not throw in Node.
+describe('ssr import safety', () => {
   it('can import library entry without throwing', async () => {
     let mod: any = null
     let threw = false
+
     try {
-      // import the compiled entry points are under src during dev; import the source exports
       mod = await import('../src/exports')
     }
     catch (e) {
       threw = true
       console.error('Import threw:', e)
     }
+
     expect(threw).toBe(false)
-    // Basic sanity: exports should contain known symbols
     expect(mod).toBeTruthy()
-    expect(typeof mod.default === 'object' || typeof mod.VueRendererMarkdown !== 'undefined' || Object.keys(mod).length > 0).toBe(true)
+    expect(
+      typeof mod.default === 'object'
+      || typeof mod.VueRendererMarkdown !== 'undefined'
+      || Object.keys(mod).length > 0,
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
Summary:
- change check:ssr to run the two SSR test files explicitly
- mark ssr-import smoke test as node environment
- keep smoke assertion behavior while using repo-compliant lowercase test title

Validation:
- pnpm check:ssr
- pnpm test -- --run test/ssr-import.test.ts test/ssr-render-to-string.test.ts (passed; ran full suite with this argv shape)
- pnpm test --run test/ssr-import.test.ts test/ssr-render-to-string.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test:api