### PR TITLE
refactor: split node renderer height measurements

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -54,6 +54,7 @@ import { createMathBlockMinHeightCache, provideMathBlockMinHeightCache } from '.
 import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
 import { useBatchRenderingScheduler } from './composables/useBatchRenderingScheduler'
 import { useBatchRenderingState } from './composables/useBatchRenderingState'
+import { useHeightMeasurements } from './composables/useHeightMeasurements'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
 import { useSchedulerPlatform } from './composables/useSchedulerPlatform'
@@ -286,13 +287,28 @@ const sortedNodeSlots = computed(() => {
   void nodeSlotVersion.value
   return Array.from(nodeSlotElements.entries()).sort((a, b) => a[0] - b[0])
 })
-const heightTreeSize = ref(0)
-const heightSumTree = ref<number[]>([])
-const heightKnownTree = ref<number[]>([])
 const scrollRootElement = ref<HTMLElement | null>(null)
 const activeRestoreAnchor = ref<{ nodeIndex: number, offsetWithinNodePx: number } | null>(null)
 let restoreReconcileRaf: number | null = null
 let restoreReconcileTimers: number[] = []
+const {
+  nodeHeights,
+  heightStats,
+  heightTreeSize,
+  heightSumTree,
+  heightKnownTree,
+  averageNodeHeight,
+  resetHeightMeasurements,
+  pruneHeightMeasurements,
+  rebuildHeightTrees,
+  recordNodeHeight,
+  fenwickRangeSum,
+} = useHeightMeasurements({
+  onHeightRecorded: () => {
+    if (activeRestoreAnchor.value)
+      scheduleRestoreReconcile()
+  },
+})
 let detachScrollHandler: (() => void) | null = null
 let pendingFocusSync: { id: number | ReturnType<typeof setTimeout>, viaTimeout: boolean } | null = null
 const deferNodes = computed(() => {
@@ -533,115 +549,6 @@ function updateLiveRange() {
   liveRange.start = desiredStart
   liveRange.end = Math.min(total, desiredStart + windowSize)
 }
-
-const nodeHeights = reactive<Record<number, number>>({})
-const heightStats = reactive({ total: 0, count: 0 })
-
-function resetHeightMeasurements() {
-  for (const key of Object.keys(nodeHeights))
-    delete nodeHeights[Number(key)]
-  heightStats.total = 0
-  heightStats.count = 0
-  heightTreeSize.value = 0
-  heightSumTree.value = []
-  heightKnownTree.value = []
-}
-
-function pruneHeightMeasurements(size: number) {
-  if (size <= 0) {
-    resetHeightMeasurements()
-    return
-  }
-
-  let total = 0
-  let count = 0
-  for (const [rawIndex, rawHeight] of Object.entries(nodeHeights)) {
-    const index = Number(rawIndex)
-    const height = Number(rawHeight)
-    if (!Number.isFinite(index) || index < 0 || index >= size || !Number.isFinite(height) || height <= 0) {
-      delete nodeHeights[index]
-      continue
-    }
-    total += height
-    count++
-  }
-  heightStats.total = total
-  heightStats.count = count
-}
-
-function fenwickUpdate(tree: number[], index: number, delta: number) {
-  for (let i = index + 1; i < tree.length; i += i & -i)
-    tree[i] += delta
-}
-
-function fenwickQuery(tree: number[], index: number) {
-  let sum = 0
-  for (let i = index + 1; i > 0; i -= i & -i)
-    sum += tree[i]
-  return sum
-}
-
-function fenwickRangeSum(tree: number[], start: number, end: number) {
-  if (end <= start)
-    return 0
-  const endSum = fenwickQuery(tree, end - 1)
-  if (start <= 0)
-    return endSum
-  return endSum - fenwickQuery(tree, start - 1)
-}
-
-function rebuildHeightTrees(size: number) {
-  heightTreeSize.value = size
-  const sumTree = new Array(size + 1).fill(0)
-  const countTree = new Array(size + 1).fill(0)
-  for (const [rawIndex, rawHeight] of Object.entries(nodeHeights)) {
-    const index = Number(rawIndex)
-    const height = Number(rawHeight)
-    if (!Number.isFinite(index) || index < 0 || index >= size)
-      continue
-    if (!Number.isFinite(height) || height <= 0)
-      continue
-    fenwickUpdate(sumTree, index, height)
-    fenwickUpdate(countTree, index, 1)
-  }
-  heightSumTree.value = sumTree
-  heightKnownTree.value = countTree
-}
-
-function recordNodeHeight(index: number, height: number) {
-  if (!Number.isFinite(height) || height <= 0)
-    return
-  const previous = nodeHeights[index]
-  nodeHeights[index] = height
-  if (previous) {
-    heightStats.total += height - previous
-  }
-  else {
-    heightStats.total += height
-    heightStats.count++
-  }
-  if (heightTreeSize.value > index) {
-    const sumTree = heightSumTree.value
-    const countTree = heightKnownTree.value
-    if (sumTree.length && countTree.length) {
-      if (previous) {
-        const delta = height - previous
-        if (delta !== 0)
-          fenwickUpdate(sumTree, index, delta)
-      }
-      else {
-        fenwickUpdate(sumTree, index, height)
-        fenwickUpdate(countTree, index, 1)
-      }
-    }
-  }
-  if (activeRestoreAnchor.value)
-    scheduleRestoreReconcile()
-}
-
-const averageNodeHeight = computed(() => {
-  return heightStats.count > 0 ? Math.max(12, heightStats.total / heightStats.count) : 32
-})
 
 function getProbeRoot(wrapper: HTMLElement | null | undefined) {
   return wrapper?.firstElementChild as HTMLElement | null
@@ -1027,8 +934,8 @@ function estimateIndexForOffset(offsetPx: number) {
     const prefix = (endExclusive: number) => {
       if (endExclusive <= 0)
         return 0
-      const sumKnown = fenwickQuery(sumTree, endExclusive - 1)
-      const countKnown = fenwickQuery(countTree, endExclusive - 1)
+      const sumKnown = fenwickRangeSum(sumTree, 0, endExclusive)
+      const countKnown = fenwickRangeSum(countTree, 0, endExclusive)
       return sumKnown + (endExclusive - countKnown) * avg
     }
     let low = 0

--- a/src/components/NodeRenderer/composables/useHeightMeasurements.ts
+++ b/src/components/NodeRenderer/composables/useHeightMeasurements.ts
@@ -1,0 +1,186 @@
+import type { ComputedRef, Ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
+
+export interface HeightMeasurementsOptions {
+  onHeightRecorded?: () => void
+}
+
+export interface HeightMeasurements {
+  nodeHeights: Record<number, number>
+  heightStats: {
+    total: number
+    count: number
+  }
+  heightTreeSize: Ref<number>
+  heightSumTree: Ref<number[]>
+  heightKnownTree: Ref<number[]>
+  averageNodeHeight: ComputedRef<number>
+
+  resetHeightMeasurements: () => void
+  pruneHeightMeasurements: (size: number) => void
+  rebuildHeightTrees: (size: number) => void
+  recordNodeHeight: (index: number, height: number) => void
+
+  fenwickRangeSum: (tree: number[], start: number, end: number) => number
+}
+
+export function useHeightMeasurements(
+  options: HeightMeasurementsOptions = {},
+): HeightMeasurements {
+  const nodeHeights = reactive<Record<number, number>>({})
+  const heightStats = reactive({ total: 0, count: 0 })
+  const heightTreeSize = ref(0)
+  const heightSumTree = ref<number[]>([])
+  const heightKnownTree = ref<number[]>([])
+
+  function resetHeightMeasurements() {
+    for (const key of Object.keys(nodeHeights))
+      delete nodeHeights[Number(key)]
+
+    heightStats.total = 0
+    heightStats.count = 0
+    heightTreeSize.value = 0
+    heightSumTree.value = []
+    heightKnownTree.value = []
+  }
+
+  function pruneHeightMeasurements(size: number) {
+    if (size <= 0) {
+      resetHeightMeasurements()
+      return
+    }
+
+    let total = 0
+    let count = 0
+
+    for (const [rawIndex, rawHeight] of Object.entries(nodeHeights)) {
+      const index = Number(rawIndex)
+      const height = Number(rawHeight)
+
+      if (
+        !Number.isFinite(index)
+        || index < 0
+        || index >= size
+        || !Number.isFinite(height)
+        || height <= 0
+      ) {
+        delete nodeHeights[index]
+        continue
+      }
+
+      total += height
+      count++
+    }
+
+    heightStats.total = total
+    heightStats.count = count
+  }
+
+  function fenwickUpdate(tree: number[], index: number, delta: number) {
+    for (let i = index + 1; i < tree.length; i += i & -i)
+      tree[i] += delta
+  }
+
+  function fenwickQuery(tree: number[], index: number) {
+    let sum = 0
+
+    for (let i = index + 1; i > 0; i -= i & -i)
+      sum += tree[i]
+
+    return sum
+  }
+
+  function fenwickRangeSum(tree: number[], start: number, end: number) {
+    if (end <= start)
+      return 0
+
+    const endSum = fenwickQuery(tree, end - 1)
+
+    if (start <= 0)
+      return endSum
+
+    return endSum - fenwickQuery(tree, start - 1)
+  }
+
+  function rebuildHeightTrees(size: number) {
+    heightTreeSize.value = size
+
+    const sumTree = new Array(size + 1).fill(0)
+    const countTree = new Array(size + 1).fill(0)
+
+    for (const [rawIndex, rawHeight] of Object.entries(nodeHeights)) {
+      const index = Number(rawIndex)
+      const height = Number(rawHeight)
+
+      if (!Number.isFinite(index) || index < 0 || index >= size)
+        continue
+
+      if (!Number.isFinite(height) || height <= 0)
+        continue
+
+      fenwickUpdate(sumTree, index, height)
+      fenwickUpdate(countTree, index, 1)
+    }
+
+    heightSumTree.value = sumTree
+    heightKnownTree.value = countTree
+  }
+
+  function recordNodeHeight(index: number, height: number) {
+    if (!Number.isFinite(height) || height <= 0)
+      return
+
+    const previous = nodeHeights[index]
+    nodeHeights[index] = height
+
+    if (previous) {
+      heightStats.total += height - previous
+    }
+    else {
+      heightStats.total += height
+      heightStats.count++
+    }
+
+    if (heightTreeSize.value > index) {
+      const sumTree = heightSumTree.value
+      const countTree = heightKnownTree.value
+
+      if (sumTree.length && countTree.length) {
+        if (previous) {
+          const delta = height - previous
+
+          if (delta !== 0)
+            fenwickUpdate(sumTree, index, delta)
+        }
+        else {
+          fenwickUpdate(sumTree, index, height)
+          fenwickUpdate(countTree, index, 1)
+        }
+      }
+    }
+
+    options.onHeightRecorded?.()
+  }
+
+  const averageNodeHeight = computed(() => {
+    return heightStats.count > 0
+      ? Math.max(12, heightStats.total / heightStats.count)
+      : 32
+  })
+
+  return {
+    nodeHeights,
+    heightStats,
+    heightTreeSize,
+    heightSumTree,
+    heightKnownTree,
+    averageNodeHeight,
+
+    resetHeightMeasurements,
+    pruneHeightMeasurements,
+    rebuildHeightTrees,
+    recordNodeHeight,
+
+    fenwickRangeSum,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract NodeRenderer height measurement state and Fenwick tree helpers into useHeightMeasurements.
- Keep height estimation, scroll restore, focus sync, live range, and render logic in NodeRenderer.
- Preserve restore reconciliation via the onHeightRecorded callback.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr
- pnpm test:api