### PR TITLE
refactor: split node renderer live range state

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -55,6 +55,7 @@ import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
 import { useBatchRenderingScheduler } from './composables/useBatchRenderingScheduler'
 import { useBatchRenderingState } from './composables/useBatchRenderingState'
 import { useHeightMeasurements } from './composables/useHeightMeasurements'
+import { useLiveRangeState } from './composables/useLiveRangeState'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
 import { useSchedulerPlatform } from './composables/useSchedulerPlatform'
@@ -352,9 +353,17 @@ const deferNodes = computed(() => {
   return viewportPriorityEnabled.value
 })
 const shouldObserveSlots = computed(() => !!registerNodeVisibility && (deferNodes.value || virtualizationEnabled.value))
-const liveNodeBufferResolved = computed(() => Math.max(0, props.liveNodeBuffer ?? 60))
-const focusIndex = ref(0)
-const liveRange = reactive({ start: 0, end: 0 })
+const {
+  liveNodeBufferResolved,
+  focusIndex,
+  liveRange,
+  updateLiveRange,
+} = useLiveRangeState(props, {
+  parsedNodeCount,
+  virtualizationEnabled,
+  maxLiveNodesResolved,
+  clamp,
+})
 const nodeContentElements = new Map<number, HTMLElement | null>()
 const nodeContentDeferredMeasureTimers = new Map<number, number[]>()
 const desiredRenderedCount = computed(() => {
@@ -557,19 +566,6 @@ function syncFocusToScroll(force = false) {
 }
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
-}
-function updateLiveRange() {
-  const total = parsedNodes.value.length
-  if (!virtualizationEnabled.value || total === 0) {
-    liveRange.start = 0
-    liveRange.end = total
-    return
-  }
-  const windowSize = Math.min(maxLiveNodesResolved.value, total)
-  const buffer = liveNodeBufferResolved.value
-  const desiredStart = clamp(focusIndex.value - buffer, 0, Math.max(0, total - windowSize))
-  liveRange.start = desiredStart
-  liveRange.end = Math.min(total, desiredStart + windowSize)
 }
 
 function getProbeRoot(wrapper: HTMLElement | null | undefined) {

--- a/src/components/NodeRenderer/composables/useLiveRangeState.ts
+++ b/src/components/NodeRenderer/composables/useLiveRangeState.ts
@@ -1,0 +1,73 @@
+import type { ComputedRef, Ref } from 'vue'
+import type { NodeRendererProps } from '../../../types/node-renderer-props'
+import { computed, reactive, ref } from 'vue'
+
+export interface LiveRange {
+  start: number
+  end: number
+}
+
+export interface LiveRangeStateOptions {
+  parsedNodeCount: ComputedRef<number>
+  virtualizationEnabled: ComputedRef<boolean>
+  maxLiveNodesResolved: ComputedRef<number>
+  clamp: (value: number, min: number, max: number) => number
+}
+
+export interface LiveRangeState {
+  liveNodeBufferResolved: ComputedRef<number>
+  focusIndex: Ref<number>
+  liveRange: LiveRange
+  updateLiveRange: () => void
+}
+
+export function useLiveRangeState(
+  props: Readonly<NodeRendererProps>,
+  options: LiveRangeStateOptions,
+): LiveRangeState {
+  const {
+    parsedNodeCount,
+    virtualizationEnabled,
+    maxLiveNodesResolved,
+    clamp,
+  } = options
+
+  const liveNodeBufferResolved = computed(() => {
+    return Math.max(0, props.liveNodeBuffer ?? 60)
+  })
+
+  const focusIndex = ref(0)
+
+  const liveRange = reactive<LiveRange>({
+    start: 0,
+    end: 0,
+  })
+
+  function updateLiveRange() {
+    const total = parsedNodeCount.value
+
+    if (!virtualizationEnabled.value || total === 0) {
+      liveRange.start = 0
+      liveRange.end = total
+      return
+    }
+
+    const windowSize = Math.min(maxLiveNodesResolved.value, total)
+    const buffer = liveNodeBufferResolved.value
+    const desiredStart = clamp(
+      focusIndex.value - buffer,
+      0,
+      Math.max(0, total - windowSize),
+    )
+
+    liveRange.start = desiredStart
+    liveRange.end = Math.min(total, desiredStart + windowSize)
+  }
+
+  return {
+    liveNodeBufferResolved,
+    focusIndex,
+    liveRange,
+    updateLiveRange,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract NodeRenderer live range state into useLiveRangeState
- Keep focus sync, scroll listener, renderedItems, height measurement, and batch logic in NodeRenderer.vue
- Preserve public API files unchanged

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr
- pnpm test:api