### PR TITLE
refactor: split node renderer scroll listener

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -60,6 +60,7 @@ import { useLiveRangeState } from './composables/useLiveRangeState'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useResolvedRendererOptions } from './composables/useResolvedRendererOptions'
 import { useSchedulerPlatform } from './composables/useSchedulerPlatform'
+import { useScrollListener } from './composables/useScrollListener'
 import { useScrollRestore } from './composables/useScrollRestore'
 import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
 import { useViewportRoot } from './composables/useViewportRoot'
@@ -333,7 +334,6 @@ const {
       scheduleRestoreReconcile()
   },
 })
-let detachScrollHandler: (() => void) | null = null
 const deferNodes = computed(() => {
   if (renderAsFragment.value)
     return false
@@ -435,28 +435,16 @@ const {
   syncFocusToScroll,
 })
 
-function cleanupScrollListener() {
-  if (detachScrollHandler) {
-    detachScrollHandler()
-    detachScrollHandler = null
-  }
-  scrollRootElement.value = null
-}
-
-function setupScrollListener() {
-  if (!isClient || !virtualizationEnabled.value)
-    return
-  const root = resolveScrollContainer()
-  if (!root || scrollRootElement.value === root)
-    return
-  cleanupScrollListener()
-  const handler = () => scheduleFocusSync()
-  root.addEventListener('scroll', handler, { passive: true })
-  scrollRootElement.value = root
-  detachScrollHandler = () => {
-    root.removeEventListener('scroll', handler)
-  }
-}
+const {
+  cleanupScrollListener,
+  setupScrollListener,
+} = useScrollListener({
+  isClient,
+  virtualizationEnabled,
+  scrollRootElement,
+  resolveScrollContainer,
+  scheduleFocusSync,
+})
 
 function syncFocusToScroll(force = false) {
   if (!virtualizationEnabled.value)

--- a/src/components/NodeRenderer/composables/useScrollListener.ts
+++ b/src/components/NodeRenderer/composables/useScrollListener.ts
@@ -1,0 +1,63 @@
+import type { ComputedRef, Ref } from 'vue'
+
+export interface ScrollListenerOptions {
+  isClient: boolean
+  virtualizationEnabled: ComputedRef<boolean>
+  scrollRootElement: Ref<HTMLElement | null>
+  resolveScrollContainer: (node?: HTMLElement | null) => HTMLElement | null
+  scheduleFocusSync: (options?: { immediate?: boolean }) => void
+}
+
+export interface ScrollListener {
+  cleanupScrollListener: () => void
+  setupScrollListener: () => void
+}
+
+export function useScrollListener(
+  options: ScrollListenerOptions,
+): ScrollListener {
+  const {
+    isClient,
+    virtualizationEnabled,
+    scrollRootElement,
+    resolveScrollContainer,
+    scheduleFocusSync,
+  } = options
+
+  let detachScrollHandler: (() => void) | null = null
+
+  function cleanupScrollListener() {
+    if (detachScrollHandler) {
+      detachScrollHandler()
+      detachScrollHandler = null
+    }
+
+    scrollRootElement.value = null
+  }
+
+  function setupScrollListener() {
+    if (!isClient || !virtualizationEnabled.value)
+      return
+
+    const root = resolveScrollContainer()
+
+    if (!root || scrollRootElement.value === root)
+      return
+
+    cleanupScrollListener()
+
+    const handler = () => scheduleFocusSync()
+
+    root.addEventListener('scroll', handler, { passive: true })
+    scrollRootElement.value = root
+
+    detachScrollHandler = () => {
+      root.removeEventListener('scroll', handler)
+    }
+  }
+
+  return {
+    cleanupScrollListener,
+    setupScrollListener,
+  }
+}


### PR DESCRIPTION
## Summary
- extract NodeRenderer scroll listener state/helpers into useScrollListener
- keep scrollRootElement, syncFocusToScroll, scroll restore, height estimation, and render logic in NodeRenderer.vue

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run
- pnpm check:ssr
- pnpm test:api