### PR TITLE
fix: keep currency dollars out of inline math

### DIFF
--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -440,6 +440,17 @@ function isLikelyCurrencyRangeDollar(content: string, nextChar?: string) {
   return /\d/.test(String(nextChar ?? ''))
 }
 
+function isLikelyCurrencyAmountStart(content: string) {
+  const stripped = String(content ?? '').trimStart()
+  const amount = stripped.match(/^\d+(?:,\d{3})*(?:\.\d+)?/)
+  if (!amount)
+    return false
+  const rest = stripped.slice(amount[0].length)
+  if (/^\s*(?:[+\-*/^_=<>]|\\[a-z]+)/i.test(rest))
+    return false
+  return rest === '' || /^[)\s,.!?;:]/.test(rest)
+}
+
 function isLikelyPlaceholderDollar(content: string) {
   const stripped = String(content ?? '').trim()
   if (!stripped)
@@ -753,7 +764,8 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
           }
           if (endIdx === -1) {
             // Do not treat segments containing inline code as math
-            if (allowLoading && !strict && isMathLike(content) && !content.includes('`')) {
+            const isCurrencyAmount = open === '$' && isLikelyCurrencyAmountStart(content)
+            if (allowLoading && !strict && !isCurrencyAmount && isMathLike(content) && !content.includes('`')) {
               searchPos = index + open.length
               foundAny = true
               if (!silent) {

--- a/packages/markdown-parser/test/currency-dollar-text-regression.test.ts
+++ b/packages/markdown-parser/test/currency-dollar-text-regression.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { collect } from '../../../test/utils/midstate-utils'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+describe('currency dollar text regression', () => {
+  it.each([
+    ' ($450,000) or communication preference\u2014governed by organizational schemas that define types (text, number, date, etc.),',
+    ' ($450) or communication preference\u2014governed by organizational schemas that define types (text, number, date, etc.),',
+    'The limit is $450,000 or communication preference governed by schemas that define types (text, number).',
+    'The limit is $450 or communication preference governed by schemas that define types (text, number).',
+    'Costs rose to $1,200.50, then stabilized through usage patterns (email, sms).',
+  ])('keeps currency text as text while streaming: %s', (markdown) => {
+    const md = getMarkdown('currency-dollar-text')
+    const nodes = parseMarkdownToStructure(markdown, md)
+    const serialized = JSON.stringify(nodes)
+
+    expect(collect(nodes as any, 'math_inline')).toHaveLength(0)
+    expect(serialized).toContain(markdown.includes('$450') ? '$450' : '$1,200.50')
+  })
+
+  it('still treats numeric math followed by an operator as loading math', () => {
+    const md = getMarkdown('currency-dollar-leading-math')
+    const nodes = parseMarkdownToStructure('$1,000 + x', md)
+    const math = collect(nodes as any, 'math_inline')
+
+    expect(math).toHaveLength(1)
+    expect(math[0]).toMatchObject({
+      content: '1,000 + x',
+      loading: true,
+      markup: '$',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Keep streaming parser from treating currency-style unclosed single-dollar text as loading inline math.
- Add regression coverage for parenthesized and prose currency cases, plus a numeric math counterexample.

## Tests
- pnpm exec eslint packages/markdown-parser/src/plugins/math.ts packages/markdown-parser/test/currency-dollar-text-regression.test.ts
- pnpm run -C packages/markdown-parser test:run
- pnpm test --run --testTimeout=10000

Close #452
close: https://github.com/Simon-He95/markstream-vue/issues/452