### PR TITLE
fix: preserve capped mermaid diagrams

### DIFF
--- a/packages/markdown-parser/src/mermaidSvgSanitizer.ts
+++ b/packages/markdown-parser/src/mermaidSvgSanitizer.ts
@@ -1,6 +1,8 @@
 import { isUnsafeHtmlUrl } from './htmlTags'
 
 const DISALLOWED_STYLE_PATTERNS = [/javascript:/i, /vbscript:/i, /data:text\/html/i, /expression\s*\(/i, /@import/i]
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const FOREIGN_OBJECT_IGNORED_TAGS = new Set(['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta'])
 const ALLOWED_SVG_TAGS = new Set([
   'svg',
   'style',
@@ -204,7 +206,85 @@ function hardenSvgAnchorAttrs(node: Element) {
   node.setAttribute('rel', Array.from(relTokens).join(' '))
 }
 
+function parseSvgNumber(value: string | null | undefined) {
+  const parsed = Number.parseFloat(String(value ?? ''))
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function collectForeignObjectText(node: Node, parts: string[]) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? ''
+    if (text)
+      parts.push(text)
+    return
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE)
+    return
+
+  const element = node as Element
+  const tag = element.tagName.toLowerCase()
+  if (FOREIGN_OBJECT_IGNORED_TAGS.has(tag))
+    return
+
+  if (tag === 'br') {
+    parts.push('\n')
+    return
+  }
+
+  for (const child of Array.from(element.childNodes))
+    collectForeignObjectText(child, parts)
+}
+
+function replaceForeignObjectLabels(svgEl: SVGElement) {
+  for (const node of Array.from(svgEl.querySelectorAll<Element>('foreignObject'))) {
+    const parts: string[] = []
+    collectForeignObjectText(node, parts)
+    const lines = parts
+      .join('')
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+    if (!lines.length) {
+      node.remove()
+      continue
+    }
+
+    const width = parseSvgNumber(node.getAttribute('width'))
+    const height = parseSvgNumber(node.getAttribute('height'))
+    const x = parseSvgNumber(node.getAttribute('x'))
+    const y = parseSvgNumber(node.getAttribute('y'))
+    const text = svgEl.ownerDocument.createElementNS(SVG_NS, 'text')
+    text.setAttribute('x', String(x + width / 2))
+    text.setAttribute('y', String(y + height / 2))
+    text.setAttribute('text-anchor', 'middle')
+    text.setAttribute('dominant-baseline', 'central')
+
+    const label = node.querySelector('.nodeLabel')
+    if (label?.getAttribute('class'))
+      text.setAttribute('class', label.getAttribute('class')!)
+
+    if (lines.length === 1) {
+      text.textContent = lines[0]!
+    }
+    else {
+      const firstDy = -0.6 * (lines.length - 1)
+      for (const [index, line] of lines.entries()) {
+        const tspan = svgEl.ownerDocument.createElementNS(SVG_NS, 'tspan')
+        tspan.setAttribute('x', String(x + width / 2))
+        tspan.setAttribute('dy', index === 0 ? `${firstDy}em` : '1.2em')
+        tspan.textContent = line
+        text.appendChild(tspan)
+      }
+    }
+
+    node.parentNode?.replaceChild(text, node)
+  }
+}
+
 function scrubSvgElement(svgEl: SVGElement) {
+  replaceForeignObjectLabels(svgEl)
+
   const nodes = [svgEl, ...Array.from(svgEl.querySelectorAll<Element>('*'))]
   for (const node of nodes) {
     const tag = node.tagName.toLowerCase()

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -185,7 +185,10 @@ const baseFixedCode = computed(() => {
 function getCodeWithTheme(theme: 'light' | 'dark', code = baseFixedCode.value) {
   const baseCode = code
   const themeValue = theme === 'dark' ? 'dark' : 'default'
-  const themeConfig = `%%{init: {"theme": "${themeValue}"}}%%\n`
+  const initConfig: Record<string, unknown> = { theme: themeValue }
+  if (mermaidSecurityLevel.value === 'strict')
+    initConfig.flowchart = { htmlLabels: false }
+  const themeConfig = `%%{init: ${JSON.stringify(initConfig)}}%%\n`
   if (baseCode.trim().startsWith('%%{')) {
     return baseCode
   }
@@ -307,6 +310,7 @@ function scheduleRenderRetry(delayMs = 600) {
 }
 
 const containerHeight = ref<string>(resolveInitialContainerHeight())
+const contentHeight = ref<string>(containerHeight.value)
 let resizeObserver: ResizeObserver | null = null
 
 // rendering state management
@@ -471,6 +475,7 @@ function renderErrorToContainer(error: unknown) {
     ? getComputedStyle(mermaidContent.value).getPropertyValue('--ms-size-diagram-min-height').trim()
     : ''
   containerHeight.value = tokenH || '360px'
+  contentHeight.value = containerHeight.value
   hasRenderError.value = true
   // 在错误显示时，停止任何预览轮询，避免错误被覆盖
   stopPreviewPolling()
@@ -524,7 +529,10 @@ function onCopyHover(e: Event) {
 // Apply theme header to arbitrary code snippet
 function applyThemeTo(code: string, theme: 'light' | 'dark') {
   const themeValue = theme === 'dark' ? 'dark' : 'default'
-  const themeConfig = `%%{init: {"theme": "${themeValue}"}}%%\n`
+  const initConfig: Record<string, unknown> = { theme: themeValue }
+  if (mermaidSecurityLevel.value === 'strict')
+    initConfig.flowchart = { htmlLabels: false }
+  const themeConfig = `%%{init: ${JSON.stringify(initConfig)}}%%\n`
   const trimmed = code.trimStart()
   if (trimmed.startsWith('%%{'))
     return code
@@ -731,8 +739,7 @@ function resolveMaxContainerHeight() {
 function updateContainerHeight(newContainerWidth?: number, options?: { force?: boolean }) {
   if (!mermaidContainer.value || !mermaidContent.value)
     return
-  if (!options?.force && shouldFreezeStreamingPreviewHeight())
-    return
+  const freezePreviewHeight = !options?.force && shouldFreezeStreamingPreviewHeight()
 
   const svgElement = mermaidContent.value.querySelector('svg')
   if (!svgElement)
@@ -792,10 +799,15 @@ function updateContainerHeight(newContainerWidth?: number, options?: { force?: b
     // 如果外部传入了宽度，则使用它，否则自己获取
     const containerWidth
       = newContainerWidth ?? mermaidContainer.value.clientWidth
+    const renderedSvgWidth = svgElement.getBoundingClientRect().width
+    const effectiveWidth = renderedSvgWidth > 0 ? renderedSvgWidth : containerWidth
     const maxHeight = resolveMaxContainerHeight()
-    const newHeight = containerWidth * aspectRatio
+    const newHeight = effectiveWidth * aspectRatio
     const resolvedHeight = maxHeight == null ? newHeight : Math.min(newHeight, maxHeight)
-    containerHeight.value = `${Math.max(resolvedHeight, resolveEstimatedPreviewHeight())}px`
+    const previewHeight = Math.max(resolvedHeight, resolveEstimatedPreviewHeight())
+    contentHeight.value = `${Math.max(newHeight, previewHeight)}px`
+    if (!freezePreviewHeight)
+      containerHeight.value = `${previewHeight}px`
   }
 }
 
@@ -1831,8 +1843,10 @@ watch(
 watch(
   [() => props.estimatedPreviewHeightPx, () => baseFixedCode.value],
   () => {
-    if (!hasRenderedOnce.value && !hasPreviewSvg() && !showSource.value)
+    if (!hasRenderedOnce.value && !hasPreviewSvg() && !showSource.value) {
       containerHeight.value = resolveInitialContainerHeight()
+      contentHeight.value = containerHeight.value
+    }
   },
 )
 
@@ -2083,6 +2097,7 @@ const computedButtonStyle = 'mermaid-action-btn p-[var(--ms-action-btn-padding)]
             <div
               ref="mermaidContent"
               class="_mermaid w-full text-center flex items-center justify-center min-h-full"
+              :style="{ height: contentHeight }"
             />
           </div>
         </div>

--- a/test/mermaid-max-height.test.ts
+++ b/test/mermaid-max-height.test.ts
@@ -36,17 +36,19 @@ async function renderWithMaxHeight(maxHeight: string) {
   setupState.updateContainerHeight()
   await nextTick()
 
-  return { wrapper, container }
+  return { wrapper, container, content }
 }
 
 describe('mermaid block max height', () => {
   it('caps preview height unless maxHeight is none', async () => {
     const capped = await renderWithMaxHeight('500px')
     expect(capped.container.style.height).toBe('500px')
+    expect(capped.content.style.height).toBe('2000px')
     capped.wrapper.unmount()
 
     const uncapped = await renderWithMaxHeight('none')
     expect(uncapped.container.style.height).toBe('2000px')
+    expect(uncapped.content.style.height).toBe('2000px')
     uncapped.wrapper.unmount()
   })
 
@@ -84,12 +86,22 @@ describe('mermaid block max height', () => {
     await nextTick()
 
     expect(container.style.height).toBe('360px')
+    expect(content.style.height).toBe('2000px')
 
     await wrapper.setProps({ loading: false })
     setupState.updateContainerHeight(undefined, { force: true })
     await nextTick()
 
     expect(container.style.height).toBe('500px')
+    wrapper.unmount()
+  })
+
+  it('sizes capped preview content to the full SVG height', async () => {
+    const { wrapper } = await renderWithMaxHeight('500px')
+    const content = wrapper.get('div._mermaid').element as HTMLElement
+
+    expect(content.style.height).toBe('2000px')
+
     wrapper.unmount()
   })
 })

--- a/test/mermaid-static-performance.test.ts
+++ b/test/mermaid-static-performance.test.ts
@@ -103,6 +103,7 @@ describe('mermaid static render performance', () => {
     await flushVueUpdates()
 
     expect(fakeMermaid.render).toHaveBeenCalledTimes(1)
+    expect(fakeMermaid.render.mock.calls[0]?.[1]).toContain('"flowchart":{"htmlLabels":false}')
     expect(fakeMermaid.initialize).toHaveBeenCalledWith(expect.objectContaining({
       securityLevel: 'strict',
       flowchart: { htmlLabels: false },

--- a/test/security/mermaid-svg-sanitizer.test.ts
+++ b/test/security/mermaid-svg-sanitizer.test.ts
@@ -71,6 +71,23 @@ describe('mermaid SVG sanitizer', () => {
     expect(svg).toMatch(/<rect/i)
   })
 
+  it('preserves Mermaid foreignObject label text as safe SVG text', () => {
+    const svg = sanitizeMermaidSvg(`
+      <svg viewBox="0 0 100 50">
+        <g class="label" transform="translate(10, 10)">
+          <foreignObject width="80" height="24">
+            <div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">八戒叫阵火云洞</span></div>
+          </foreignObject>
+        </g>
+      </svg>
+    `)
+
+    expect(svg).toBeTruthy()
+    expect(svg).not.toMatch(/foreignObject/i)
+    expect(svg).toMatch(/<text/i)
+    expect(svg).toContain('八戒叫阵火云洞')
+  })
+
   it('removes non-SVG tags from Mermaid output', () => {
     const svg = sanitizeMermaidSvg(`
       <svg viewBox="0 0 10 10">


### PR DESCRIPTION
## Summary
- size capped Mermaid preview content to the full rendered SVG so drag can reveal hidden areas
- preserve Mermaid foreignObject label text as safe SVG text during sanitization
- keep strict Mermaid theme init aligned with htmlLabels=false

Closes #451

## Tests
- pnpm vitest run test/mermaid-max-height.test.ts test/mermaid-static-performance.test.ts test/security/mermaid-svg-sanitizer.test.ts
- pnpm exec eslint packages/markdown-parser/src/mermaidSvgSanitizer.ts src/components/MermaidBlockNode/MermaidBlockNode.vue test/mermaid-max-height.test.ts test/mermaid-static-performance.test.ts test/security/mermaid-svg-sanitizer.test.ts