### PR TITLE
fix: keep typewriter cursor aligned during smooth streaming

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1712,6 +1712,7 @@ const typewriterCursorRef = ref<HTMLElement | null>(null)
 const showTypewriterCursor = ref(false)
 let typewriterCursorTimeout: ReturnType<typeof setTimeout> | undefined
 let lastTypewriterContentLength = 0
+let lastTypewriterVisibleLength = 0
 const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image'])
 
 function shouldSkipTypewriterCursorForNode(node: unknown) {
@@ -1756,11 +1757,22 @@ function getTypewriterContentLength() {
   return (props.content ?? '').length
 }
 
+function getTypewriterVisibleLength() {
+  if (props.nodes?.length)
+    return props.nodes.reduce((total, node) => total + getNodeTextLength(node), 0)
+  return renderContent.value.length
+}
+
 function clearTypewriterCursorTimeout() {
   if (!typewriterCursorTimeout)
     return
   clearTimeout(typewriterCursorTimeout)
   typewriterCursorTimeout = undefined
+}
+
+function hideTypewriterCursorElement() {
+  if (typewriterCursorRef.value)
+    typewriterCursorRef.value.style.visibility = 'hidden'
 }
 
 function getLastTextNode(root: HTMLElement) {
@@ -1798,29 +1810,37 @@ function updateTypewriterCursorPosition() {
   const cursor = typewriterCursorRef.value
   const lastText = getLastTextNode(root)
   const rootRect = root.getBoundingClientRect()
+  cursor.style.visibility = 'hidden'
   let left = 0
   let top = 0
   let height = 20
+  let measured = false
 
   if (lastText?.textContent) {
-    const range = document.createRange()
     const end = lastText.textContent.length
+    const range = document.createRange()
     range.setStart(lastText, Math.max(0, end - 1))
     range.setEnd(lastText, end)
     const rects = typeof range.getClientRects === 'function'
       ? range.getClientRects()
       : undefined
     const rect = rects?.[rects.length - 1] ?? lastText.parentElement?.getBoundingClientRect()
+
     if (rect) {
       left = rect.right - rootRect.left + root.scrollLeft
       top = rect.top - rootRect.top + root.scrollTop
       height = rect.height || height
+      measured = true
     }
     range.detach()
   }
 
+  if (!measured)
+    return
+
   cursor.style.transform = `translate(${Math.max(0, left)}px, ${Math.max(0, top)}px)`
   cursor.style.height = `${height}px`
+  cursor.style.visibility = 'visible'
 }
 
 watch(
@@ -1838,16 +1858,22 @@ watch(
     }
 
     const nextLength = getTypewriterContentLength()
+    const nextVisibleLength = getTypewriterVisibleLength()
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()
-    if (props.typewriter === false || !cursorAllowed || nextLength <= lastTypewriterContentLength) {
+    const sourceGrowing = nextLength > lastTypewriterContentLength
+    const visibleGrowing = nextVisibleLength > lastTypewriterVisibleLength
+    if (props.typewriter === false || !cursorAllowed || (!sourceGrowing && !visibleGrowing)) {
       if (props.typewriter === false || !cursorAllowed)
         showTypewriterCursor.value = false
       lastTypewriterContentLength = nextLength
+      lastTypewriterVisibleLength = nextVisibleLength
       return
     }
 
     lastTypewriterContentLength = nextLength
+    lastTypewriterVisibleLength = nextVisibleLength
     showTypewriterCursor.value = true
+    hideTypewriterCursorElement()
     clearTypewriterCursorTimeout()
     await nextTick()
     updateTypewriterCursorPosition()
@@ -2098,6 +2124,7 @@ onBeforeUnmount(() => {
   vertical-align: -0.12em;
   border-right: 2px solid currentColor;
   pointer-events: none;
+  visibility: hidden;
   animation: typewriter-cursor-blink 1s steps(1, end) infinite;
 }
 

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import NodeRenderer from '../src/components/NodeRenderer'
+import { flushAll } from './setup/flush-all'
+
+function rect(partial: Partial<DOMRect>): DOMRect {
+  return {
+    x: partial.x ?? partial.left ?? 0,
+    y: partial.y ?? partial.top ?? 0,
+    width: partial.width ?? 0,
+    height: partial.height ?? 0,
+    top: partial.top ?? 0,
+    right: partial.right ?? 0,
+    bottom: partial.bottom ?? 0,
+    left: partial.left ?? 0,
+    toJSON: () => ({}),
+  }
+}
+
+describe('typewriter cursor position', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('repositions while smooth visible content catches up after the source stops growing', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      const element = this as HTMLElement
+      if (element.classList.contains('markdown-renderer'))
+        return rect({ left: 20, top: 10 })
+      return rect({})
+    })
+
+    const originalCreateRange = document.createRange.bind(document)
+    vi.spyOn(document, 'createRange').mockImplementation(() => {
+      const range = originalCreateRange()
+      let rangeNode: Node | null = null
+      let endOffset = 0
+
+      range.setStart = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.setEnd = vi.fn((_node: Node, offset: number) => {
+        rangeNode = _node
+        endOffset = offset
+      })
+      range.getClientRects = vi.fn(() => {
+        let previousLength = 0
+        let sibling = rangeNode?.parentElement?.previousSibling ?? null
+        while (sibling) {
+          previousLength += sibling.textContent?.length ?? 0
+          sibling = sibling.previousSibling
+        }
+
+        return [
+          rect({ right: (previousLength + endOffset) * 10, top: 60, bottom: 80, height: 20 }),
+        ] as unknown as DOMRectList
+      })
+
+      return range
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: true,
+        smoothStreamingOptions: {
+          startDelayMs: 0,
+          minCharsPerSecond: 1000,
+          maxCharsPerSecond: 1000,
+          maxCommitFps: 60,
+          maxCharsPerCommit: 4,
+        },
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    queuedFrames.length = 0
+
+    await wrapper.setProps({
+      content: 'abcdefghij',
+    })
+    await flushAll()
+
+    const baseline = performance.now()
+    queuedFrames.shift()?.(baseline + 50)
+    await flushAll()
+
+    const cursor = wrapper.get('.typewriter-cursor').element as HTMLElement
+    const firstVisibleLength = wrapper.get('.text-node').text().length
+    expect(firstVisibleLength).toBeGreaterThan(0)
+    expect(cursor.style.transform).toBe(`translate(${Math.max(0, firstVisibleLength * 10 - 20)}px, 50px)`)
+    expect(cursor.style.visibility).toBe('visible')
+
+    queuedFrames.shift()?.(baseline + 100)
+    await flushAll()
+
+    const secondVisibleLength = wrapper.get('.text-node').text().length
+    expect(secondVisibleLength).toBeGreaterThan(firstVisibleLength)
+    expect(cursor.style.transform).toBe(`translate(${Math.max(0, secondVisibleLength * 10 - 20)}px, 50px)`)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- track visible smooth-streaming content growth when deciding whether to reposition the typewriter cursor
- hide the cursor until a fresh measured position is available to avoid initial jump artifacts
- add a regression test for cursor movement while smooth content catches up

## Tests
- pnpm exec vitest run test/typewriter-cursor-position.test.ts test/node-renderer-smooth-streaming.test.ts
- pnpm exec eslint src/components/NodeRenderer/NodeRenderer.vue test/typewriter-cursor-position.test.ts
- pnpm exec vue-tsc --noEmit --pretty false