### PR TITLE
fix(parser): upgrade markdown-it-ts to 1.0

### DIFF
--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -59,7 +59,7 @@
     "markdown-it-sub": "^2.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-checkbox": "^1.0.6",
-    "markdown-it-ts": "^0.0.9"
+    "markdown-it-ts": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -30,12 +30,23 @@ export interface FactoryOptions extends Record<string, unknown> {
 }
 
 export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
+  const markdownItOptions = opts.markdownItOptions ?? {}
+  const experimental = typeof markdownItOptions.experimental === 'object' && markdownItOptions.experimental !== null
+    ? markdownItOptions.experimental as Record<string, unknown>
+    : {}
+  const stream = Object.prototype.hasOwnProperty.call(markdownItOptions, 'stream')
+    ? Boolean(markdownItOptions.stream)
+    : true
+
   const md = new MarkdownIt({
     html: true,
     linkify: true,
     typographer: true,
-    stream: true,
-    ...(opts.markdownItOptions ?? {}),
+    ...markdownItOptions,
+    experimental: {
+      stream,
+      ...experimental,
+    },
   }) as unknown as MarkdownItInstance
 
   if (opts.enableMath ?? true) {

--- a/packages/markdown-parser/tsdown.config.ts
+++ b/packages/markdown-parser/tsdown.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'tsdown'
 // touching those packages directly, eliminating the SSR build flood of DEP0155 logs.
 const markdownItDeps = [
   /^markdown-it(?:-[\w-]+)?$/,
-  'markdown-it-ts',
+  /^markdown-it-ts(?:\/.*)?$/,
   'entities',
   'linkify-it',
   'mdurl',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       markdown-it-ts:
-        specifier: ^0.0.9
-        version: 0.0.9
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -9283,8 +9283,8 @@ packages:
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
-  markdown-it-ts@0.0.9:
-    resolution: {integrity: sha512-krzuXIaUUiXI8SLlyssp1q4FzDlnfP3wrJwb7ulzwa1DLTYnYDtVe9R5NLTi2FZTo59APCD6to5JnFFj5bs0nA==}
+  markdown-it-ts@1.0.0:
+    resolution: {integrity: sha512-hQT/yCYryC3jNs2wJ35R4m1zKcBxNuFaKCGzwpmq2OuMXMNbUK1oTwCxONIjy5lXWWG1UCNbGXe1nbTiWbH/iA==}
     engines: {node: '>=18'}
 
   markdown-it@14.1.1:
@@ -22839,8 +22839,10 @@ snapshots:
 
   markdown-it-task-checkbox@1.0.6: {}
 
-  markdown-it-ts@0.0.9:
+  markdown-it-ts@1.0.0:
     dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
       entities: 4.5.0
       linkify-it: 5.0.0
       mdurl: 2.0.0


### PR DESCRIPTION
## Summary
- upgrade `stream-markdown-parser` to `markdown-it-ts@^1.0.0`
- move the default streaming option to `experimental.stream` while preserving the legacy `markdownItOptions.stream` override
- bundle `markdown-it-ts/*` subpaths in the parser build config

## Verification
- `pnpm install`
- `pnpm install --frozen-lockfile`
- `pnpm run build:parser`
- `pnpm run test --run`
- `pnpm run test:api:strict`
- `pnpm run check:ssr`
- `pnpm exec eslint packages/markdown-parser/src/factory.ts packages/markdown-parser/tsdown.config.ts`
- `git diff --check`