### PR TITLE
fix(parser): avoid linkifying numbered cjk filenames

### DIFF
--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -6,6 +6,7 @@ const PATH_SEPARATOR_RE = /[\\/]/u
 const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
+const NUMBERED_FILENAME_SEGMENT_RE = /(?:^|[._-])\d+|\d+[._-]/u
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
   'md',
@@ -121,6 +122,10 @@ function hasStrongFilenameSignals(linkText: string) {
     return !hasDomainAuthorityPrefix(linkText)
 
   const extensionless = linkText.replace(FILENAMEISH_EXTENSION_RE, '')
+  const hasNonAscii = Array.from(extensionless).some(char => char.charCodeAt(0) > 0x7F)
+  if (hasNonAscii && NUMBERED_FILENAME_SEGMENT_RE.test(extensionless))
+    return true
+
   const filenameLikeSegments = extensionless.split('.').filter(Boolean)
   return filenameLikeSegments.some(isUppercaseFilenameSegment)
 }

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -70,6 +70,13 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, 'README.md')).toBe(true)
   })
 
+  it('keeps numbered cjk filenames in headings as text', () => {
+    const nodes = parseMarkdownToStructure('### ① 主角团（01-主角团.md）', md, { final: true })
+
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '01-主角团.md')).toBe(true)
+  })
+
   it('keeps file-like paths as text instead of preserving linkify output', () => {
     const nodes = parseMarkdownToStructure('请查看 docs/README.md 和 src/index.ts。', md, { final: true })
 


### PR DESCRIPTION
Closes #450

## Summary

- Treat numbered non-ASCII filename-like `linkify` output, such as `01-主角团.md`, as plain text.
- Add a regression test for the #450 heading sample while preserving existing bare-domain coverage for `example.md`, `example.ai`, `OpenAI.ai`, and punycode domains.

## Verification

- `pnpm exec vitest --run test/issue402-filename-linkify-regression.test.ts`
- `pnpm exec eslint packages/markdown-parser/src/parser/linkifyHeuristics.ts test/issue402-filename-linkify-regression.test.ts`
- `pnpm run -C packages/markdown-parser build`
- `pnpm typecheck`