### PR TITLE
fix: avoid linkifying filename and ticker-like text

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -1,9 +1,11 @@
 import type { MarkdownIt, Token } from '../markdown-it-types'
 import type { HtmlBlockNode, InternalParseOptions, MarkdownToken, ParsedNode, ParseOptions } from '../types'
+import type { LinkifyDemotionContext } from './linkifyHeuristics'
 import { normalizeCustomHtmlTags } from '../customHtmlTags'
 import { NON_STRUCTURING_HTML_TAGS, STANDARD_HTML_TAGS, VOID_HTML_TAGS } from '../htmlTags'
 import { escapeTagForRegExp, findTagCloseIndexOutsideQuotes, parseTagAttrs } from '../htmlTagUtils'
 import { parseInlineTokens } from './inline-parsers'
+import { inferLinkifyDemotionContext } from './linkifyHeuristics'
 import { parseCommonBlockToken } from './node-parsers/block-token-parser'
 import { parseBlockquote } from './node-parsers/blockquote-parser'
 import { containerTokenHandlers } from './node-parsers/container-token-handlers'
@@ -66,6 +68,29 @@ function processTokensWithTiming(tokens: MarkdownToken[], options: ParseOptions 
   const result = processTokens(tokens, options)
   addTiming(timing, 'processTokensMs', getParserNow() - startedAt)
   return result
+}
+
+function hasLinkifyDemotionContext(context?: LinkifyDemotionContext) {
+  return context?.filename === true || context?.marketTicker === true
+}
+
+function withLinkifyDemotionContext(options: ParseOptions | undefined, context?: LinkifyDemotionContext) {
+  if (!hasLinkifyDemotionContext(context))
+    return options
+
+  const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
+  return {
+    ...options,
+    __linkifyDemotionContext: {
+      filename: inheritedContext?.filename || context?.filename,
+      marketTicker: inheritedContext?.marketTicker || context?.marketTicker,
+    },
+  } as InternalParseOptions
+}
+
+function inferNextBlockLinkifyContext(raw?: string) {
+  const context = inferLinkifyDemotionContext(raw)
+  return hasLinkifyDemotionContext(context) ? context : undefined
 }
 
 function getCustomHtmlTagSet(options?: ParseOptions) {
@@ -2382,6 +2407,11 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
     return []
 
   const result: ParsedNode[] = []
+  let pendingLinkifyDemotionContext: LinkifyDemotionContext | undefined
+  const blockOptions = () => withLinkifyDemotionContext(options, pendingLinkifyDemotionContext)
+  const rememberBlockContext = (raw?: string) => {
+    pendingLinkifyDemotionContext = inferNextBlockLinkifyContext(raw)
+  }
   let i = 0
   // Note: table token normalization is applied during markdown-it parsing
   // via the `applyFixTableTokens` plugin (core.ruler.after('block')).
@@ -2389,9 +2419,10 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
   // their respective plugins. That keeps parsing-time fixes centralized
   // and avoids ad-hoc post-processing here.
   while (i < tokens.length) {
-    const handled = parseCommonBlockToken(tokens, i, options, containerTokenHandlers)
+    const handled = parseCommonBlockToken(tokens, i, blockOptions(), containerTokenHandlers)
     if (handled) {
       result.push(handled[0])
+      rememberBlockContext(handled[0].raw)
       i = handled[1]
       continue
     }
@@ -2400,27 +2431,30 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
     switch (token.type) {
       case 'paragraph_open':
       {
-        const paragraphNode = parseParagraph(tokens, i, options) as ParsedNode
+        const paragraphNode = parseParagraph(tokens, i, blockOptions()) as ParsedNode
         const promoted = maybePromoteCustomNodeFromParagraph(paragraphNode, options)
         if (promoted)
           result.push(...promoted)
         else
           result.push(paragraphNode)
+        rememberBlockContext(paragraphNode.raw)
         i += 3 // Skip paragraph_open, inline, paragraph_close
         break
       }
 
       case 'bullet_list_open':
       case 'ordered_list_open': {
-        const [listNode, newIndex] = parseList(tokens, i, options)
+        const [listNode, newIndex] = parseList(tokens, i, blockOptions())
         result.push(listNode)
+        rememberBlockContext(listNode.raw)
         i = newIndex
         break
       }
 
       case 'blockquote_open': {
-        const [blockquoteNode, newIndex] = parseBlockquote(tokens, i, options)
+        const [blockquoteNode, newIndex] = parseBlockquote(tokens, i, blockOptions())
         result.push(blockquoteNode)
+        rememberBlockContext(blockquoteNode.raw)
         i = newIndex
         break
       }
@@ -2433,6 +2467,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
           id,
           raw: String(token.content ?? ''),
         } as ParsedNode)
+        rememberBlockContext(String(token.content ?? ''))
 
         i++
         break
@@ -2440,6 +2475,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
 
       case 'hardbreak':
         result.push(parseHardBreak())
+        pendingLinkifyDemotionContext = undefined
         i++
         break
 
@@ -2455,6 +2491,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
             ? [{ type: 'text', content, raw: content } as ParsedNode]
             : [],
         } as ParsedNode)
+        rememberBlockContext(content)
         i++
         break
       }
@@ -2471,7 +2508,8 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
         //   historical behavior and emit them as top-level blocks (not wrapped in
         //   a paragraph), since they represent block-like HTML structures.
         {
-          const parsed = parseInlineTokens(token.children || [], String(token.content ?? ''), undefined, options)
+          const raw = String(token.content ?? '')
+          const parsed = parseInlineTokens(token.children || [], raw, undefined, blockOptions())
           if (parsed.length === 0) {
             // no-op (matches previous behavior)
           }
@@ -2481,7 +2519,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
           else {
             const paragraphNode = {
               type: 'paragraph',
-              raw: String(token.content ?? ''),
+              raw,
               children: parsed,
             } as ParsedNode
             const promoted = maybePromoteCustomNodeFromParagraph(paragraphNode, options)
@@ -2490,6 +2528,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
             else
               result.push(paragraphNode)
           }
+          rememberBlockContext(raw)
         }
         i += 1
         break

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -1,11 +1,10 @@
 import type { MarkdownIt, Token } from '../markdown-it-types'
 import type { HtmlBlockNode, InternalParseOptions, MarkdownToken, ParsedNode, ParseOptions } from '../types'
-import type { LinkifyDemotionContext } from './linkifyHeuristics'
 import { normalizeCustomHtmlTags } from '../customHtmlTags'
 import { NON_STRUCTURING_HTML_TAGS, STANDARD_HTML_TAGS, VOID_HTML_TAGS } from '../htmlTags'
 import { escapeTagForRegExp, findTagCloseIndexOutsideQuotes, parseTagAttrs } from '../htmlTagUtils'
 import { parseInlineTokens } from './inline-parsers'
-import { inferLinkifyDemotionContext } from './linkifyHeuristics'
+import { createLinkifyDemotionContextTracker } from './linkifyHeuristics'
 import { parseCommonBlockToken } from './node-parsers/block-token-parser'
 import { parseBlockquote } from './node-parsers/blockquote-parser'
 import { containerTokenHandlers } from './node-parsers/container-token-handlers'
@@ -68,29 +67,6 @@ function processTokensWithTiming(tokens: MarkdownToken[], options: ParseOptions 
   const result = processTokens(tokens, options)
   addTiming(timing, 'processTokensMs', getParserNow() - startedAt)
   return result
-}
-
-function hasLinkifyDemotionContext(context?: LinkifyDemotionContext) {
-  return context?.filename === true || context?.marketTicker === true
-}
-
-function withLinkifyDemotionContext(options: ParseOptions | undefined, context?: LinkifyDemotionContext) {
-  if (!hasLinkifyDemotionContext(context))
-    return options
-
-  const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
-  return {
-    ...options,
-    __linkifyDemotionContext: {
-      filename: inheritedContext?.filename || context?.filename,
-      marketTicker: inheritedContext?.marketTicker || context?.marketTicker,
-    },
-  } as InternalParseOptions
-}
-
-function inferNextBlockLinkifyContext(raw?: string) {
-  const context = inferLinkifyDemotionContext(raw)
-  return hasLinkifyDemotionContext(context) ? context : undefined
 }
 
 function getCustomHtmlTagSet(options?: ParseOptions) {
@@ -2407,11 +2383,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
     return []
 
   const result: ParsedNode[] = []
-  let pendingLinkifyDemotionContext: LinkifyDemotionContext | undefined
-  const blockOptions = () => withLinkifyDemotionContext(options, pendingLinkifyDemotionContext)
-  const rememberBlockContext = (raw?: string) => {
-    pendingLinkifyDemotionContext = inferNextBlockLinkifyContext(raw)
-  }
+  const linkifyContext = createLinkifyDemotionContextTracker(options)
   let i = 0
   // Note: table token normalization is applied during markdown-it parsing
   // via the `applyFixTableTokens` plugin (core.ruler.after('block')).
@@ -2419,10 +2391,10 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
   // their respective plugins. That keeps parsing-time fixes centralized
   // and avoids ad-hoc post-processing here.
   while (i < tokens.length) {
-    const handled = parseCommonBlockToken(tokens, i, blockOptions(), containerTokenHandlers)
+    const handled = parseCommonBlockToken(tokens, i, linkifyContext.options(), containerTokenHandlers)
     if (handled) {
       result.push(handled[0])
-      rememberBlockContext(handled[0].raw)
+      linkifyContext.remember(handled[0].raw)
       i = handled[1]
       continue
     }
@@ -2431,30 +2403,30 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
     switch (token.type) {
       case 'paragraph_open':
       {
-        const paragraphNode = parseParagraph(tokens, i, blockOptions()) as ParsedNode
+        const paragraphNode = parseParagraph(tokens, i, linkifyContext.options()) as ParsedNode
         const promoted = maybePromoteCustomNodeFromParagraph(paragraphNode, options)
         if (promoted)
           result.push(...promoted)
         else
           result.push(paragraphNode)
-        rememberBlockContext(paragraphNode.raw)
+        linkifyContext.remember(paragraphNode.raw)
         i += 3 // Skip paragraph_open, inline, paragraph_close
         break
       }
 
       case 'bullet_list_open':
       case 'ordered_list_open': {
-        const [listNode, newIndex] = parseList(tokens, i, blockOptions())
+        const [listNode, newIndex] = parseList(tokens, i, linkifyContext.options())
         result.push(listNode)
-        rememberBlockContext(listNode.raw)
+        linkifyContext.remember(listNode.raw)
         i = newIndex
         break
       }
 
       case 'blockquote_open': {
-        const [blockquoteNode, newIndex] = parseBlockquote(tokens, i, blockOptions())
+        const [blockquoteNode, newIndex] = parseBlockquote(tokens, i, linkifyContext.options())
         result.push(blockquoteNode)
-        rememberBlockContext(blockquoteNode.raw)
+        linkifyContext.remember(blockquoteNode.raw)
         i = newIndex
         break
       }
@@ -2467,7 +2439,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
           id,
           raw: String(token.content ?? ''),
         } as ParsedNode)
-        rememberBlockContext(String(token.content ?? ''))
+        linkifyContext.remember(String(token.content ?? ''))
 
         i++
         break
@@ -2475,7 +2447,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
 
       case 'hardbreak':
         result.push(parseHardBreak())
-        pendingLinkifyDemotionContext = undefined
+        linkifyContext.reset()
         i++
         break
 
@@ -2491,7 +2463,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
             ? [{ type: 'text', content, raw: content } as ParsedNode]
             : [],
         } as ParsedNode)
-        rememberBlockContext(content)
+        linkifyContext.remember(content)
         i++
         break
       }
@@ -2509,7 +2481,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
         //   a paragraph), since they represent block-like HTML structures.
         {
           const raw = String(token.content ?? '')
-          const parsed = parseInlineTokens(token.children || [], raw, undefined, blockOptions())
+          const parsed = parseInlineTokens(token.children || [], raw, undefined, linkifyContext.options())
           if (parsed.length === 0) {
             // no-op (matches previous behavior)
           }
@@ -2528,7 +2500,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
             else
               result.push(paragraphNode)
           }
-          rememberBlockContext(raw)
+          linkifyContext.remember(raw)
         }
         i += 1
         break

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -2403,7 +2403,8 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
     switch (token.type) {
       case 'paragraph_open':
       {
-        const paragraphNode = parseParagraph(tokens, i, linkifyContext.options()) as ParsedNode
+        const paragraphRaw = String(tokens[i + 1]?.content ?? '')
+        const paragraphNode = parseParagraph(tokens, i, linkifyContext.options(paragraphRaw)) as ParsedNode
         const promoted = maybePromoteCustomNodeFromParagraph(paragraphNode, options)
         if (promoted)
           result.push(...promoted)
@@ -2481,7 +2482,7 @@ export function processTokens(tokens: MarkdownToken[], options?: ParseOptions): 
         //   a paragraph), since they represent block-like HTML structures.
         {
           const raw = String(token.content ?? '')
-          const parsed = parseInlineTokens(token.children || [], raw, undefined, linkifyContext.options())
+          const parsed = parseInlineTokens(token.children || [], raw, undefined, linkifyContext.options(raw))
           if (parsed.length === 0) {
             // no-op (matches previous behavior)
           }

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,5 +1,5 @@
 import type { InternalParseOptions, MarkdownToken, ParsedNode, ParseOptions, TextNode } from '../../types'
-import { shouldDemoteFilenameLikeLinkify } from '../linkifyHeuristics'
+import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFilenameLikeLinkify } from '../linkifyHeuristics'
 import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
@@ -34,25 +34,6 @@ const UNICODE_PUNCTUATION_RE = /\p{P}/u
 // detection logic is easy to tweak and test.
 const AUTOLINK_PROTOCOL_RE = /^(?:https?:\/\/|mailto:|ftp:\/\/)/i
 const AUTOLINK_GENERIC_RE = /:\/\//
-
-function hasNonAsciiText(input: string) {
-  return Array.from(input).some(char => char.charCodeAt(0) > 0x7F)
-}
-
-function getHrefAuthority(href: string) {
-  return href.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').split(/[/?#]/, 1)[0] ?? ''
-}
-
-function hasPunycodeAuthorityLabel(authority: string) {
-  return authority.split('.').some(label => label.toLowerCase().startsWith('xn--'))
-}
-
-function isDecodedFromRawPunycode(linkText: string, href: string, raw?: string) {
-  const authority = getHrefAuthority(href)
-  return hasNonAsciiText(linkText)
-    && hasPunycodeAuthorityLabel(authority)
-    && String(raw ?? '').toLowerCase().includes(authority.toLowerCase())
-}
 
 function countUnescapedAsterisks(str: string): number {
   let count = 0
@@ -369,6 +350,19 @@ export function parseInlineTokens(
 ): ParsedNode[] {
   if (!tokens || tokens.length === 0)
     return []
+
+  const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
+  const inferredContext = inferLinkifyDemotionContext(raw)
+  const linkifyDemotionContext = {
+    filename: inheritedContext?.filename || inferredContext.filename,
+    marketTicker: inheritedContext?.marketTicker || inferredContext.marketTicker,
+  }
+  if (linkifyDemotionContext.filename || linkifyDemotionContext.marketTicker) {
+    options = {
+      ...options,
+      __linkifyDemotionContext: linkifyDemotionContext,
+    } as InternalParseOptions
+  }
 
   const internalOptions = options as InternalParseOptions | undefined
   const result: ParsedNode[] = []
@@ -1365,7 +1359,7 @@ export function parseInlineTokens(
     if (
       token.markup === 'linkify'
       && !isDecodedFromRawPunycode(linkText, node.href, raw)
-      && shouldDemoteFilenameLikeLinkify(linkText)
+      && shouldDemoteFilenameLikeLinkify(linkText, internalOptions?.__linkifyDemotionContext)
     ) {
       pushText(linkText, linkText)
       return

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -35,6 +35,25 @@ const UNICODE_PUNCTUATION_RE = /\p{P}/u
 const AUTOLINK_PROTOCOL_RE = /^(?:https?:\/\/|mailto:|ftp:\/\/)/i
 const AUTOLINK_GENERIC_RE = /:\/\//
 
+function hasNonAsciiText(input: string) {
+  return Array.from(input).some(char => char.charCodeAt(0) > 0x7F)
+}
+
+function getHrefAuthority(href: string) {
+  return href.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').split(/[/?#]/, 1)[0] ?? ''
+}
+
+function hasPunycodeAuthorityLabel(authority: string) {
+  return authority.split('.').some(label => label.toLowerCase().startsWith('xn--'))
+}
+
+function isDecodedFromRawPunycode(linkText: string, href: string, raw?: string) {
+  const authority = getHrefAuthority(href)
+  return hasNonAsciiText(linkText)
+    && hasPunycodeAuthorityLabel(authority)
+    && String(raw ?? '').toLowerCase().includes(authority.toLowerCase())
+}
+
 function countUnescapedAsterisks(str: string): number {
   let count = 0
   let i = 0
@@ -1342,11 +1361,13 @@ export function parseInlineTokens(
     const { node, nextIndex } = parseLinkToken(tokens, i, options)
     i = nextIndex
 
+    const linkText = node.text || node.href || ''
     if (
       token.markup === 'linkify'
-      && shouldDemoteFilenameLikeLinkify(node.text || node.href || '')
+      && !isDecodedFromRawPunycode(linkText, node.href, raw)
+      && shouldDemoteFilenameLikeLinkify(linkText)
     ) {
-      pushText(node.text || node.href || '', node.text || node.href || '')
+      pushText(linkText, linkText)
       return
     }
 

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -355,9 +355,10 @@ export function parseInlineTokens(
   const inferredContext = inferLinkifyDemotionContext(raw)
   const linkifyDemotionContext = {
     filename: inheritedContext?.filename || inferredContext.filename,
+    explicitFilename: inheritedContext?.explicitFilename || inferredContext.explicitFilename,
     marketTicker: inheritedContext?.marketTicker || inferredContext.marketTicker,
   }
-  if (linkifyDemotionContext.filename || linkifyDemotionContext.marketTicker) {
+  if (linkifyDemotionContext.filename || linkifyDemotionContext.explicitFilename || linkifyDemotionContext.marketTicker) {
     options = {
       ...options,
       __linkifyDemotionContext: linkifyDemotionContext,

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
@@ -1,7 +1,13 @@
+import type { ParseOptions } from '../types';
 export interface LinkifyDemotionContext {
     filename?: boolean;
     marketTicker?: boolean;
 }
+export declare function createLinkifyDemotionContextTracker(options?: ParseOptions, sticky?: boolean): {
+    options(): ParseOptions | undefined;
+    remember(raw?: string): void;
+    reset(): void;
+};
 export declare function isDecodedFromRawPunycode(linkText: string, href: string, raw?: string): boolean;
 export declare function inferLinkifyDemotionContext(contextText?: string): LinkifyDemotionContext;
 export declare function shouldDemoteFilenameLikeLinkify(linkText: string, context?: LinkifyDemotionContext): boolean;

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
@@ -1,1 +1,7 @@
-export declare function shouldDemoteFilenameLikeLinkify(linkText: string): boolean;
+export interface LinkifyDemotionContext {
+    filename?: boolean;
+    marketTicker?: boolean;
+}
+export declare function isDecodedFromRawPunycode(linkText: string, href: string, raw?: string): boolean;
+export declare function inferLinkifyDemotionContext(contextText?: string): LinkifyDemotionContext;
+export declare function shouldDemoteFilenameLikeLinkify(linkText: string, context?: LinkifyDemotionContext): boolean;

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.d.ts
@@ -1,10 +1,11 @@
 import type { ParseOptions } from '../types';
 export interface LinkifyDemotionContext {
     filename?: boolean;
+    explicitFilename?: boolean;
     marketTicker?: boolean;
 }
 export declare function createLinkifyDemotionContextTracker(options?: ParseOptions, sticky?: boolean): {
-    options(): ParseOptions | undefined;
+    options(raw?: string): ParseOptions | undefined;
     remember(raw?: string): void;
     reset(): void;
 };

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -1,4 +1,4 @@
-const FILENAMEISH_EXTENSION_RE = /\.([a-z0-9]{1,10})$/i
+const FILENAMEISH_EXTENSION_RE = /\.([a-z0-9]{1,15})$/i
 const FILENAMEISH_SEGMENT_RE = /[_()[\]{}<>]/u
 const URL_PREFIX_HINT_RE = /^(?:https?:\/\/|ftp:\/\/|mailto:|www\.)/i
 const URL_QUERY_OR_AUTH_HINT_RE = /[?#@]/u
@@ -8,7 +8,7 @@ const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
 const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{1,8})$/u
 const MARKET_TICKER_CONTEXT_SYMBOL_RE = /^(?=.{1,12}$)[A-Z0-9]+(?:-[A-Z0-9]+)?$/iu
-const FILENAME_CONTEXT_RE = /文件名\s*[:：]?|文件\s*[:：]?|附件\s*[:：]?|档案\s*[:：]?|檔案\s*[:：]?|\bfile\s*name\b\s*[:：]?|\battachments?\b\s*[:：]?|\bfiles?\b\s*[:：]?/iu
+const FILENAME_CONTEXT_RE = /文件名\s*[:：]?|文件\s*[:：]?|附件\s*[:：]?|档案\s*[:：]?|檔案\s*[:：]?|文档\s*[:：]?|文檔\s*[:：]?|资料\s*[:：]?|資料\s*[:：]?|路径\s*[:：]?|路徑\s*[:：]?|\bfile\s*name\b\s*[:：]?|\battachments?\b\s*[:：]?|\bfiles?\b\s*[:：]?|\bdocuments?\b\s*[:：]?|\bdocs?\b\s*[:：]?|\bpaths?\b\s*[:：]?/iu
 const MARKET_TICKER_CONTEXT_RE = /股票代码|股票代碼|证券代码|證券代碼|代码|代碼|交易所|后缀|後綴|市场|市場|\btickers?\b|\bsymbols?\b|\bexchanges?\b/iu
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
@@ -36,9 +36,24 @@ const MARKET_TICKER_SUFFIXES = new Set([
 const MARKET_TICKER_CONTEXT_SUFFIXES = new Set([
   ...MARKET_TICKER_SUFFIXES,
   'ax',
+  'cn',
+  'jp',
   'ks',
+  'mx',
+  'si',
   'to',
   'tw',
+])
+const FILENAME_CONTEXT_ONLY_EXTENSIONS = new Set([
+  'app',
+  'apk',
+  'dmg',
+  'exe',
+  'ipa',
+  'lock',
+  'log',
+  'markdown',
+  'webmanifest',
 ])
 const FILENAMEISH_LINK_EXTENSIONS = new Set([
   '7z',
@@ -211,8 +226,11 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string, context: Linki
   if (isMarketTickerLikeText(linkText, extension, context.marketTicker === true))
     return true
 
-  if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
+  if (!FILENAMEISH_LINK_EXTENSIONS.has(extension)) {
+    if (context.filename && FILENAME_CONTEXT_ONLY_EXTENSIONS.has(extension))
+      return true
     return false
+  }
 
   // Extensions like `.ai` and `.md` can be both real bare-domain TLDs and
   // common filenames. Keep those linkified unless we also see stronger

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -6,8 +6,8 @@ const PATH_SEPARATOR_RE = /[\\/]/u
 const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
-const NON_ASCII_FILENAME_SEGMENT_RE = /[-\d]/u
-const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{4,8})$/u
+const NON_ASCII_FILENAME_SEGMENT_RE = /[-\d\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\uFF10-\uFF19]/u
+const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{1,8})$/u
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
   'md',

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -1,3 +1,5 @@
+import type { InternalParseOptions, ParseOptions } from '../types'
+
 const FILENAMEISH_EXTENSION_RE = /\.([a-z0-9]{1,15})$/i
 const FILENAMEISH_SEGMENT_RE = /[_()[\]{}<>]/u
 const URL_PREFIX_HINT_RE = /^(?:https?:\/\/|ftp:\/\/|mailto:|www\.)/i
@@ -126,6 +128,62 @@ const FILENAMEISH_LINK_EXTENSIONS = new Set([
 export interface LinkifyDemotionContext {
   filename?: boolean
   marketTicker?: boolean
+}
+
+function hasLinkifyDemotionContext(context?: LinkifyDemotionContext) {
+  return context?.filename === true || context?.marketTicker === true
+}
+
+function mergeLinkifyDemotionContext(
+  left?: LinkifyDemotionContext,
+  right?: LinkifyDemotionContext,
+) {
+  const merged = {
+    filename: left?.filename || right?.filename,
+    marketTicker: left?.marketTicker || right?.marketTicker,
+  }
+  return hasLinkifyDemotionContext(merged) ? merged : undefined
+}
+
+function withLinkifyDemotionContext(options: ParseOptions | undefined, context?: LinkifyDemotionContext) {
+  if (!hasLinkifyDemotionContext(context))
+    return options
+
+  const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
+  return {
+    ...options,
+    __linkifyDemotionContext: {
+      filename: inheritedContext?.filename || context?.filename,
+      marketTicker: inheritedContext?.marketTicker || context?.marketTicker,
+    },
+  } as InternalParseOptions
+}
+
+function inferNextBlockLinkifyContext(raw?: string) {
+  const context = inferLinkifyDemotionContext(raw)
+  return hasLinkifyDemotionContext(context) ? context : undefined
+}
+
+export function createLinkifyDemotionContextTracker(
+  options?: ParseOptions,
+  sticky = false,
+) {
+  let context: LinkifyDemotionContext | undefined
+
+  return {
+    options() {
+      return withLinkifyDemotionContext(options, context)
+    },
+    remember(raw?: string) {
+      const nextContext = inferNextBlockLinkifyContext(raw)
+      context = sticky
+        ? mergeLinkifyDemotionContext(context, nextContext)
+        : nextContext
+    },
+    reset() {
+      context = undefined
+    },
+  }
 }
 
 function isValidDomainLabel(label: string) {

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -9,9 +9,10 @@ const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
 const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{1,8})$/u
-const MARKET_TICKER_CONTEXT_SYMBOL_RE = /^(?=.{1,12}$)[A-Z0-9]+(?:-[A-Z0-9]+)?$/iu
+const MARKET_TICKER_CONTEXT_SYMBOL_RE = /^(?=.{1,12}$)[A-Z0-9]+(?:[-.][A-Z0-9]+)*$/iu
+const EXPLICIT_FILENAME_CONTEXT_RE = /文件名\s*[:：]?|附件\s*[:：]?|路径\s*[:：]?|路徑\s*[:：]?|文件列表\s*[:：]?|文档列表\s*[:：]?|文檔列表\s*[:：]?|\bfile\s*names?\b\s*[:：]?|\battachments?\b\s*[:：]?|\bpaths?\b\s*[:：]?|\bfile\s+lists?\b\s*[:：]?|\bdocument\s+lists?\b\s*[:：]?/iu
 const FILENAME_CONTEXT_RE = /文件名\s*[:：]?|文件\s*[:：]?|附件\s*[:：]?|档案\s*[:：]?|檔案\s*[:：]?|文档\s*[:：]?|文檔\s*[:：]?|资料\s*[:：]?|資料\s*[:：]?|路径\s*[:：]?|路徑\s*[:：]?|\bfile\s*name\b\s*[:：]?|\battachments?\b\s*[:：]?|\bfiles?\b\s*[:：]?|\bdocuments?\b\s*[:：]?|\bdocs?\b\s*[:：]?|\bpaths?\b\s*[:：]?/iu
-const MARKET_TICKER_CONTEXT_RE = /股票代码|股票代碼|证券代码|證券代碼|代码|代碼|交易所|后缀|後綴|市场|市場|\btickers?\b|\bsymbols?\b|\bexchanges?\b/iu
+const MARKET_TICKER_CONTEXT_RE = /股票代码|股票代碼|证券代码|證券代碼|(?:代码|代碼|交易所|后缀|後綴|市场|市場)(?=$|[\s:：/|,，、()（）])|\btickers?\b|\bsymbols?\b|\bexchanges?\b/iu
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
   'md',
@@ -37,14 +38,28 @@ const MARKET_TICKER_SUFFIXES = new Set([
 ])
 const MARKET_TICKER_CONTEXT_SUFFIXES = new Set([
   ...MARKET_TICKER_SUFFIXES,
+  'at',
   'ax',
   'cn',
+  'co',
+  'it',
   'jp',
   'ks',
+  'mc',
   'mx',
+  'nz',
+  'pl',
+  'sa',
   'si',
   'to',
   'tw',
+])
+const EXPLICIT_FILENAME_CONTEXT_ONLY_EXTENSIONS = new Set([
+  'com',
+  'dev',
+  'io',
+  'page',
+  'site',
 ])
 const FILENAME_CONTEXT_ONLY_EXTENSIONS = new Set([
   'app',
@@ -127,11 +142,12 @@ const FILENAMEISH_LINK_EXTENSIONS = new Set([
 
 export interface LinkifyDemotionContext {
   filename?: boolean
+  explicitFilename?: boolean
   marketTicker?: boolean
 }
 
 function hasLinkifyDemotionContext(context?: LinkifyDemotionContext) {
-  return context?.filename === true || context?.marketTicker === true
+  return context?.filename === true || context?.explicitFilename === true || context?.marketTicker === true
 }
 
 function mergeLinkifyDemotionContext(
@@ -140,6 +156,7 @@ function mergeLinkifyDemotionContext(
 ) {
   const merged = {
     filename: left?.filename || right?.filename,
+    explicitFilename: left?.explicitFilename || right?.explicitFilename,
     marketTicker: left?.marketTicker || right?.marketTicker,
   }
   return hasLinkifyDemotionContext(merged) ? merged : undefined
@@ -154,6 +171,7 @@ function withLinkifyDemotionContext(options: ParseOptions | undefined, context?:
     ...options,
     __linkifyDemotionContext: {
       filename: inheritedContext?.filename || context?.filename,
+      explicitFilename: inheritedContext?.explicitFilename || context?.explicitFilename,
       marketTicker: inheritedContext?.marketTicker || context?.marketTicker,
     },
   } as InternalParseOptions
@@ -164,6 +182,35 @@ function inferNextBlockLinkifyContext(raw?: string) {
   return hasLinkifyDemotionContext(context) ? context : undefined
 }
 
+function normalizeStandaloneContinuationText(text: string) {
+  return text
+    .replace(/^[\s>*_`[\]（(【《"'“‘]+/u, '')
+    .replace(/[\s<*_`\]）)】》"'.。；;，,、:：!?！？]+$/u, '')
+}
+
+function inferContinuationLinkifyContext(raw?: string, inherited?: LinkifyDemotionContext) {
+  if (!hasLinkifyDemotionContext(inherited))
+    return undefined
+
+  const text = String(raw ?? '').trim()
+  const parts = text
+    .split(/\s+/u)
+    .map(normalizeStandaloneContinuationText)
+    .filter(Boolean)
+  if (parts.length === 0)
+    return undefined
+
+  const continuation: LinkifyDemotionContext = {}
+  if (inherited?.filename && parts.every(part => shouldDemoteFilenameLikeLinkify(part, { filename: true, explicitFilename: inherited.explicitFilename })))
+    continuation.filename = true
+  if (inherited?.explicitFilename && continuation.filename)
+    continuation.explicitFilename = true
+  if (inherited?.marketTicker && parts.every(part => shouldDemoteFilenameLikeLinkify(part, { marketTicker: true })))
+    continuation.marketTicker = true
+
+  return hasLinkifyDemotionContext(continuation) ? continuation : undefined
+}
+
 export function createLinkifyDemotionContextTracker(
   options?: ParseOptions,
   sticky = false,
@@ -171,14 +218,22 @@ export function createLinkifyDemotionContextTracker(
   let context: LinkifyDemotionContext | undefined
 
   return {
-    options() {
-      return withLinkifyDemotionContext(options, context)
+    options(raw?: string) {
+      if (sticky || raw == null)
+        return withLinkifyDemotionContext(options, context)
+      return withLinkifyDemotionContext(
+        options,
+        mergeLinkifyDemotionContext(
+          inferNextBlockLinkifyContext(raw),
+          inferContinuationLinkifyContext(raw, context),
+        ),
+      )
     },
     remember(raw?: string) {
       const nextContext = inferNextBlockLinkifyContext(raw)
       context = sticky
         ? mergeLinkifyDemotionContext(context, nextContext)
-        : nextContext
+        : mergeLinkifyDemotionContext(nextContext, inferContinuationLinkifyContext(raw, context))
     },
     reset() {
       context = undefined
@@ -225,7 +280,9 @@ export function isDecodedFromRawPunycode(linkText: string, href: string, raw?: s
 
 export function inferLinkifyDemotionContext(contextText?: string): LinkifyDemotionContext {
   const text = String(contextText ?? '')
+  const explicitFilename = EXPLICIT_FILENAME_CONTEXT_RE.test(text)
   return {
+    explicitFilename,
     filename: FILENAME_CONTEXT_RE.test(text),
     marketTicker: MARKET_TICKER_CONTEXT_RE.test(text),
   }
@@ -285,6 +342,8 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string, context: Linki
     return true
 
   if (!FILENAMEISH_LINK_EXTENSIONS.has(extension)) {
+    if (context.explicitFilename && EXPLICIT_FILENAME_CONTEXT_ONLY_EXTENSIONS.has(extension))
+      return true
     if (context.filename && FILENAME_CONTEXT_ONLY_EXTENSIONS.has(extension))
       return true
     return false

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -6,8 +6,10 @@ const PATH_SEPARATOR_RE = /[\\/]/u
 const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
-const NON_ASCII_FILENAME_SEGMENT_RE = /[-\d\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\uFF10-\uFF19]/u
 const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{1,8})$/u
+const MARKET_TICKER_CONTEXT_SYMBOL_RE = /^(?=.{1,12}$)[A-Z0-9]+(?:-[A-Z0-9]+)?$/iu
+const FILENAME_CONTEXT_RE = /文件名\s*[:：]?|文件\s*[:：]?|附件\s*[:：]?|档案\s*[:：]?|檔案\s*[:：]?|\bfile\s*name\b\s*[:：]?|\battachments?\b\s*[:：]?|\bfiles?\b\s*[:：]?/iu
+const MARKET_TICKER_CONTEXT_RE = /股票代码|股票代碼|证券代码|證券代碼|代码|代碼|交易所|后缀|後綴|市场|市場|\btickers?\b|\bsymbols?\b|\bexchanges?\b/iu
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
   'md',
@@ -30,6 +32,13 @@ const MARKET_TICKER_SUFFIXES = new Set([
   'sz',
   't',
   'us',
+])
+const MARKET_TICKER_CONTEXT_SUFFIXES = new Set([
+  ...MARKET_TICKER_SUFFIXES,
+  'ax',
+  'ks',
+  'to',
+  'tw',
 ])
 const FILENAMEISH_LINK_EXTENSIONS = new Set([
   '7z',
@@ -99,6 +108,11 @@ const FILENAMEISH_LINK_EXTENSIONS = new Set([
   'zsh',
 ])
 
+export interface LinkifyDemotionContext {
+  filename?: boolean
+  marketTicker?: boolean
+}
+
 function isValidDomainLabel(label: string) {
   return DOMAIN_LABEL_RE.test(label)
     && !label.startsWith('-')
@@ -115,6 +129,33 @@ function isPlausibleBareDomain(text: string) {
     return false
 
   return labels.every(isValidDomainLabel)
+}
+
+function hasNonAsciiText(input: string) {
+  return Array.from(input).some(char => char.charCodeAt(0) > 0x7F)
+}
+
+function getHrefAuthority(href: string) {
+  return href.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').split(/[/?#]/, 1)[0] ?? ''
+}
+
+function hasPunycodeAuthorityLabel(authority: string) {
+  return authority.split('.').some(label => label.toLowerCase().startsWith('xn--'))
+}
+
+export function isDecodedFromRawPunycode(linkText: string, href: string, raw?: string) {
+  const authority = getHrefAuthority(href)
+  return hasNonAsciiText(linkText)
+    && hasPunycodeAuthorityLabel(authority)
+    && String(raw ?? '').toLowerCase().includes(authority.toLowerCase())
+}
+
+export function inferLinkifyDemotionContext(contextText?: string): LinkifyDemotionContext {
+  const text = String(contextText ?? '')
+  return {
+    filename: FILENAME_CONTEXT_RE.test(text),
+    marketTicker: MARKET_TICKER_CONTEXT_RE.test(text),
+  }
 }
 
 function hasDomainAuthorityPrefix(text: string) {
@@ -138,23 +179,27 @@ function hasStrongFilenameSignals(linkText: string) {
     return !hasDomainAuthorityPrefix(linkText)
 
   const extensionless = linkText.replace(FILENAMEISH_EXTENSION_RE, '')
-  const hasNonAscii = Array.from(extensionless).some(char => char.charCodeAt(0) > 0x7F)
-  if (hasNonAscii && NON_ASCII_FILENAME_SEGMENT_RE.test(extensionless))
+  if (hasNonAsciiText(extensionless))
     return true
 
   const filenameLikeSegments = extensionless.split('.').filter(Boolean)
   return filenameLikeSegments.some(isUppercaseFilenameSegment)
 }
 
-function isMarketTickerLikeText(linkText: string, extension: string) {
-  if (!MARKET_TICKER_SUFFIXES.has(extension))
+function isMarketTickerLikeText(linkText: string, extension: string, hasMarketTickerContext: boolean) {
+  const suffixes = hasMarketTickerContext ? MARKET_TICKER_CONTEXT_SUFFIXES : MARKET_TICKER_SUFFIXES
+  if (!suffixes.has(extension))
     return false
 
   const symbol = linkText.slice(0, -(extension.length + 1))
-  return symbol === '' ? linkText.startsWith('.') : MARKET_TICKER_SYMBOL_RE.test(symbol)
+  if (symbol === '')
+    return linkText.startsWith('.')
+
+  const symbolRe = hasMarketTickerContext ? MARKET_TICKER_CONTEXT_SYMBOL_RE : MARKET_TICKER_SYMBOL_RE
+  return symbolRe.test(symbol)
 }
 
-export function shouldDemoteFilenameLikeLinkify(linkText: string) {
+export function shouldDemoteFilenameLikeLinkify(linkText: string, context: LinkifyDemotionContext = {}) {
   if (!linkText || URL_PREFIX_HINT_RE.test(linkText) || URL_QUERY_OR_AUTH_HINT_RE.test(linkText))
     return false
 
@@ -163,7 +208,7 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string) {
     return false
 
   const extension = String(extensionMatch[1] ?? '').toLowerCase()
-  if (isMarketTickerLikeText(linkText, extension))
+  if (isMarketTickerLikeText(linkText, extension, context.marketTicker === true))
     return true
 
   if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
@@ -174,6 +219,9 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string) {
   // filename-only signals such as path separators, underscores, brackets, or
   // all-uppercase filename segments like `README`.
   if (!AMBIGUOUS_BARE_DOMAIN_EXTENSIONS.has(extension))
+    return true
+
+  if (context.filename)
     return true
 
   return hasStrongFilenameSignals(linkText)

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -6,7 +6,8 @@ const PATH_SEPARATOR_RE = /[\\/]/u
 const DOMAINISH_TEXT_RE = /^[\p{L}\p{N}./\\-]+$/u
 const DOMAIN_LABEL_RE = /^[A-Za-z0-9-]{1,63}$/u
 const PUNYCODE_TLD_RE = /^xn--[a-z0-9-]{2,59}$/i
-const NUMBERED_FILENAME_SEGMENT_RE = /(?:^|[._-])\d+|\d+[._-]/u
+const NON_ASCII_FILENAME_SEGMENT_RE = /[-\d]/u
+const MARKET_TICKER_SYMBOL_RE = /^(?:[A-Z]{1,6}|\d{4,8})$/u
 const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'ai',
   'md',
@@ -14,6 +15,21 @@ const AMBIGUOUS_BARE_DOMAIN_EXTENSIONS = new Set([
   'rs',
   'sh',
   'zip',
+])
+const MARKET_TICKER_SUFFIXES = new Set([
+  'as',
+  'bj',
+  'de',
+  'hk',
+  'l',
+  'ln',
+  'ny',
+  'pa',
+  'sh',
+  'ss',
+  'sz',
+  't',
+  'us',
 ])
 const FILENAMEISH_LINK_EXTENSIONS = new Set([
   '7z',
@@ -123,11 +139,19 @@ function hasStrongFilenameSignals(linkText: string) {
 
   const extensionless = linkText.replace(FILENAMEISH_EXTENSION_RE, '')
   const hasNonAscii = Array.from(extensionless).some(char => char.charCodeAt(0) > 0x7F)
-  if (hasNonAscii && NUMBERED_FILENAME_SEGMENT_RE.test(extensionless))
+  if (hasNonAscii && NON_ASCII_FILENAME_SEGMENT_RE.test(extensionless))
     return true
 
   const filenameLikeSegments = extensionless.split('.').filter(Boolean)
   return filenameLikeSegments.some(isUppercaseFilenameSegment)
+}
+
+function isMarketTickerLikeText(linkText: string, extension: string) {
+  if (!MARKET_TICKER_SUFFIXES.has(extension))
+    return false
+
+  const symbol = linkText.slice(0, -(extension.length + 1))
+  return symbol === '' ? linkText.startsWith('.') : MARKET_TICKER_SYMBOL_RE.test(symbol)
 }
 
 export function shouldDemoteFilenameLikeLinkify(linkText: string) {
@@ -139,6 +163,9 @@ export function shouldDemoteFilenameLikeLinkify(linkText: string) {
     return false
 
   const extension = String(extensionMatch[1] ?? '').toLowerCase()
+  if (isMarketTickerLikeText(linkText, extension))
+    return true
+
   if (!FILENAMEISH_LINK_EXTENSIONS.has(extension))
     return false
 

--- a/packages/markdown-parser/src/parser/node-parsers/admonition-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/admonition-parser.ts
@@ -1,5 +1,6 @@
 import type { AdmonitionNode, MarkdownToken, ParsedNode, ParseOptions } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 import { parseBasicBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { parseList } from './list-parser'
@@ -13,17 +14,20 @@ export function parseAdmonition(
   const kind = String(match[1] ?? 'note')
   const title = String(match[2] ?? (kind.charAt(0).toUpperCase() + kind.slice(1)))
   const admonitionChildren: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   while (j < tokens.length && tokens[j].type !== 'container_close') {
     if (tokens[j].type === 'paragraph_open') {
       const contentToken = tokens[j + 1]
       if (contentToken) {
-        admonitionChildren.push({
+        const paragraphNode = {
           type: 'paragraph',
-          children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, options),
+          children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, linkifyContext.options()),
           raw: String(contentToken.content ?? ''),
-        })
+        } as ParsedNode
+        admonitionChildren.push(paragraphNode)
+        linkifyContext.remember(paragraphNode.raw)
       }
       j += 3 // Skip paragraph_open, inline, paragraph_close
     }
@@ -31,19 +35,22 @@ export function parseAdmonition(
       tokens[j].type === 'bullet_list_open'
       || tokens[j].type === 'ordered_list_open'
     ) {
-      const [listNode, newIndex] = parseList(tokens, j, options)
+      const [listNode, newIndex] = parseList(tokens, j, linkifyContext.options())
       admonitionChildren.push(listNode)
+      linkifyContext.remember(listNode.raw)
       j = newIndex
     }
     else if (tokens[j].type === 'blockquote_open') {
-      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, options)
+      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, linkifyContext.options())
       admonitionChildren.push(blockquoteNode)
+      linkifyContext.remember(blockquoteNode.raw)
       j = newIndex
     }
     else {
-      const handled = parseBasicBlockToken(tokens, j, options)
+      const handled = parseBasicBlockToken(tokens, j, linkifyContext.options())
       if (handled) {
         admonitionChildren.push(handled[0])
+        linkifyContext.remember(handled[0].raw)
         j = handled[1]
       }
       else {

--- a/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
@@ -4,6 +4,7 @@ import { normalizeCustomTag } from '../customHtmlTags'
 import { buildAllowedHtmlTagSet } from '../index'
 import { parseInlineTokens } from '../inline-parsers'
 import { parseFenceToken } from '../inline-parsers/fence-parser'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 import { parseBlockquote } from './blockquote-parser'
 import { parseCodeBlock } from './code-block-parser'
 import { parseDefinitionList } from './definition-list-parser'
@@ -90,6 +91,7 @@ function parseVmrContainer(
   }
 
   const children: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   // Parse children until we find the closing token
@@ -99,11 +101,13 @@ function parseVmrContainer(
       const contentToken = tokens[j + 1]
       if (contentToken) {
         const childrenArr = (contentToken.children as MarkdownToken[]) || []
-        children.push({
+        const paragraphNode = {
           type: 'paragraph',
-          children: parseInlineTokens(childrenArr || [], undefined, undefined, options),
+          children: parseInlineTokens(childrenArr || [], undefined, undefined, linkifyContext.options()),
           raw: String(contentToken.content ?? ''),
-        })
+        } as ParsedNode
+        children.push(paragraphNode)
+        linkifyContext.remember(paragraphNode.raw)
       }
       j += 3 // Skip paragraph_open, inline, paragraph_close
     }
@@ -112,21 +116,24 @@ function parseVmrContainer(
       || tokens[j].type === 'ordered_list_open'
     ) {
       // Handle list tokens
-      const [listNode, newIndex] = parseList(tokens, j, options)
+      const [listNode, newIndex] = parseList(tokens, j, linkifyContext.options())
       children.push(listNode)
+      linkifyContext.remember(listNode.raw)
       j = newIndex
     }
     else if (tokens[j].type === 'blockquote_open') {
       // Handle blockquote tokens
-      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, options)
+      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, linkifyContext.options())
       children.push(blockquoteNode)
+      linkifyContext.remember(blockquoteNode.raw)
       j = newIndex
     }
     else {
       // Handle other basic block tokens (heading, code_block, fence, etc.)
-      const handled = parseBasicBlockToken(tokens, j, options)
+      const handled = parseBasicBlockToken(tokens, j, linkifyContext.options())
       if (handled) {
         children.push(handled[0])
+        linkifyContext.remember(handled[0].raw)
         j = handled[1]
       }
       else {

--- a/packages/markdown-parser/src/parser/node-parsers/blockquote-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/blockquote-parser.ts
@@ -1,5 +1,6 @@
 import type { BlockquoteNode, MarkdownToken, ParsedNode, ParseOptions } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 import { parseCommonBlockToken } from './block-token-parser'
 import { containerTokenHandlers } from './container-token-handlers'
 import { parseList } from './list-parser'
@@ -10,6 +11,7 @@ export function parseBlockquote(
   options?: ParseOptions,
 ): [BlockquoteNode, number] {
   const blockquoteChildren: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   // Process blockquote content until closing tag is found
@@ -18,31 +20,36 @@ export function parseBlockquote(
     switch (token.type) {
       case 'paragraph_open': {
         const contentToken = tokens[j + 1]
-        blockquoteChildren.push({
+        const paragraphNode = {
           type: 'paragraph',
-          children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, options),
+          children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, linkifyContext.options()),
           raw: String(contentToken.content ?? ''),
-        })
+        } as ParsedNode
+        blockquoteChildren.push(paragraphNode)
+        linkifyContext.remember(paragraphNode.raw)
         j += 3 // Skip paragraph_open, inline, paragraph_close
         break
       }
       case 'bullet_list_open':
       case 'ordered_list_open': {
-        const [listNode, newIndex] = parseList(tokens, j, options)
+        const [listNode, newIndex] = parseList(tokens, j, linkifyContext.options())
         blockquoteChildren.push(listNode)
+        linkifyContext.remember(listNode.raw)
         j = newIndex
         break
       }
       case 'blockquote_open': {
-        const [nestedBlockquote, newIndex] = parseBlockquote(tokens, j, options)
+        const [nestedBlockquote, newIndex] = parseBlockquote(tokens, j, linkifyContext.options())
         blockquoteChildren.push(nestedBlockquote)
+        linkifyContext.remember(nestedBlockquote.raw)
         j = newIndex
         break
       }
       default:{
-        const handled = parseCommonBlockToken(tokens, j, options, containerTokenHandlers)
+        const handled = parseCommonBlockToken(tokens, j, linkifyContext.options(), containerTokenHandlers)
         if (handled) {
           blockquoteChildren.push(handled[0])
+          linkifyContext.remember(handled[0].raw)
           j = handled[1]
         }
         else {

--- a/packages/markdown-parser/src/parser/node-parsers/container-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/container-parser.ts
@@ -1,5 +1,6 @@
 import type { AdmonitionNode, MarkdownToken, ParsedNode, ParseOptions, TextNode } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 import { parseBasicBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { parseList } from './list-parser'
@@ -67,6 +68,7 @@ export function parseContainer(
     title = kind.charAt(0).toUpperCase() + kind.slice(1)
 
   const children: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   // Accept closing tokens: 'container_close' or 'container_<kind>_close'
@@ -90,11 +92,13 @@ export function parseContainer(
           }
         }
         const _children = i !== -1 ? childrenArr.slice(0, i) : childrenArr
-        children.push({
+        const paragraphNode = {
           type: 'paragraph',
-          children: parseInlineTokens(_children || [], undefined, undefined, options),
+          children: parseInlineTokens(_children || [], undefined, undefined, linkifyContext.options()),
           raw: String(contentToken.content ?? '').replace(/\n:+$/, '').replace(/\n\s*:::\s*$/, ''),
-        })
+        } as ParsedNode
+        children.push(paragraphNode)
+        linkifyContext.remember(paragraphNode.raw)
       }
       j += 3
     }
@@ -102,19 +106,22 @@ export function parseContainer(
       tokens[j].type === 'bullet_list_open'
       || tokens[j].type === 'ordered_list_open'
     ) {
-      const [listNode, newIndex] = parseList(tokens, j, options)
+      const [listNode, newIndex] = parseList(tokens, j, linkifyContext.options())
       children.push(listNode)
+      linkifyContext.remember(listNode.raw)
       j = newIndex
     }
     else if (tokens[j].type === 'blockquote_open') {
-      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, options)
+      const [blockquoteNode, newIndex] = parseBlockquote(tokens, j, linkifyContext.options())
       children.push(blockquoteNode)
+      linkifyContext.remember(blockquoteNode.raw)
       j = newIndex
     }
     else {
-      const handled = parseBasicBlockToken(tokens, j, options)
+      const handled = parseBasicBlockToken(tokens, j, linkifyContext.options())
       if (handled) {
         children.push(handled[0])
+        linkifyContext.remember(handled[0].raw)
         j = handled[1]
       }
       else {

--- a/packages/markdown-parser/src/parser/node-parsers/definition-list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/definition-list-parser.ts
@@ -6,6 +6,7 @@ import type {
   ParseOptions,
 } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 
 export function parseDefinitionList(
   tokens: MarkdownToken[],
@@ -16,12 +17,14 @@ export function parseDefinitionList(
   let j = index + 1
   let termNodes: ParsedNode[] = []
   let definitionNodes: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
 
   while (j < tokens.length && tokens[j].type !== 'dl_close') {
     if (tokens[j].type === 'dt_open') {
       // Process term
       const termToken = tokens[j + 1]
-      termNodes = parseInlineTokens(termToken.children || [], undefined, undefined, options)
+      termNodes = parseInlineTokens(termToken.children || [], undefined, undefined, linkifyContext.options())
+      linkifyContext.remember(termNodes.map(term => term.raw).join(''))
       j += 3 // Skip dt_open, inline, dt_close
     }
     else if (tokens[j].type === 'dd_open') {
@@ -34,9 +37,10 @@ export function parseDefinitionList(
           const contentToken = tokens[k + 1]
           definitionNodes.push({
             type: 'paragraph',
-            children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, options),
+            children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), undefined, linkifyContext.options()),
             raw: String(contentToken.content ?? ''),
           })
+          linkifyContext.remember(String(contentToken.content ?? ''))
           k += 3 // Skip paragraph_open, inline, paragraph_close
         }
         else {

--- a/packages/markdown-parser/src/parser/node-parsers/footnote-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/footnote-parser.ts
@@ -1,5 +1,6 @@
 import type { FootnoteNode, MarkdownToken, ParsedNode, ParseOptions } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 
 export function parseFootnote(
   tokens: MarkdownToken[],
@@ -10,6 +11,7 @@ export function parseFootnote(
   const meta = (token.meta ?? {}) as unknown as { label?: number | string }
   const id = String(meta?.label ?? '0')
   const footnoteChildren: ParsedNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   while (j < tokens.length && tokens[j].type !== 'footnote_close') {
@@ -19,11 +21,13 @@ export function parseFootnote(
       if (tokens[j + 2].type === 'footnote_anchor') {
         children.push(tokens[j + 2])
       }
-      footnoteChildren.push({
+      const paragraphNode = {
         type: 'paragraph',
-        children: parseInlineTokens(children, String(contentToken.content ?? ''), undefined, options),
+        children: parseInlineTokens(children, String(contentToken.content ?? ''), undefined, linkifyContext.options()),
         raw: String(contentToken.content ?? ''),
-      })
+      } as ParsedNode
+      footnoteChildren.push(paragraphNode)
+      linkifyContext.remember(paragraphNode.raw)
 
       j += 3 // Skip paragraph_open, inline, paragraph_close
     }

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -6,6 +6,7 @@ import type {
   ParseOptions,
 } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
 import { parseCommonBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { containerTokenHandlers } from './container-token-handlers'
@@ -101,6 +102,7 @@ export function parseList(
 ): [ListNode, number] {
   const token = tokens[index]
   const listItems: ListItemNode[] = []
+  const linkifyContext = createLinkifyDemotionContextTracker(options, true)
   let j = index + 1
 
   while (
@@ -124,29 +126,33 @@ export function parseList(
           trimInlineTokenTail(contentToken)
           itemChildren.push({
             type: 'paragraph',
-            children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), preToken, options),
+            children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), preToken, linkifyContext.options()),
             raw: String(contentToken.content ?? ''),
           })
+          linkifyContext.remember(String(contentToken.content ?? ''))
           k += 3 // Skip paragraph_open, inline, paragraph_close
         }
         else if (tokens[k].type === 'blockquote_open') {
           // Parse blockquote within list item
-          const [blockquoteNode, newIndex] = parseBlockquote(tokens, k, options)
+          const [blockquoteNode, newIndex] = parseBlockquote(tokens, k, linkifyContext.options())
           itemChildren.push(blockquoteNode)
+          linkifyContext.remember(blockquoteNode.raw)
           k = newIndex
         }
         else if (
           tokens[k].type === 'bullet_list_open'
           || tokens[k].type === 'ordered_list_open'
         ) {
-          const [nestedListNode, newIndex] = parseList(tokens, k, options)
+          const [nestedListNode, newIndex] = parseList(tokens, k, linkifyContext.options())
           itemChildren.push(nestedListNode)
+          linkifyContext.remember(nestedListNode.raw)
           k = newIndex
         }
         else {
-          const handled = parseCommonBlockToken(tokens, k, options, containerTokenHandlers)
+          const handled = parseCommonBlockToken(tokens, k, linkifyContext.options(), containerTokenHandlers)
           if (handled) {
             itemChildren.push(handled[0])
+            linkifyContext.remember(handled[0].raw)
             k = handled[1]
           }
           else {

--- a/packages/markdown-parser/src/parser/node-parsers/table-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/table-parser.ts
@@ -6,6 +6,7 @@ import type {
   TableNode,
   TableRowNode,
 } from '../../types'
+import type { LinkifyDemotionContext } from '../linkifyHeuristics'
 import { parseInlineTokens } from '../inline-parsers'
 import { inferLinkifyDemotionContext } from '../linkifyHeuristics'
 
@@ -29,17 +30,38 @@ function extractAlign(attrs: MarkdownToken['attrs']): 'left' | 'right' | 'center
   return 'left'
 }
 
-function parseOptionsForTableCell(options: ParseOptions | undefined, headerRaw?: string) {
-  const headerContext = inferLinkifyDemotionContext(headerRaw)
-  if (!headerContext.filename && !headerContext.marketTicker)
+function hasTableCellContext(context?: LinkifyDemotionContext) {
+  return context?.filename === true || context?.explicitFilename === true || context?.marketTicker === true
+}
+
+function mergeTableCellContext(
+  left?: LinkifyDemotionContext,
+  right?: LinkifyDemotionContext,
+) {
+  const merged = {
+    filename: left?.filename || right?.filename,
+    explicitFilename: left?.explicitFilename || right?.explicitFilename,
+    marketTicker: left?.marketTicker || right?.marketTicker,
+  }
+  return hasTableCellContext(merged) ? merged : undefined
+}
+
+function parseOptionsForTableCell(
+  options: ParseOptions | undefined,
+  headerRaw?: string,
+  rowContext?: LinkifyDemotionContext,
+) {
+  const cellContext = mergeTableCellContext(inferLinkifyDemotionContext(headerRaw), rowContext)
+  if (!hasTableCellContext(cellContext))
     return options
 
   const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
   return {
     ...options,
     __linkifyDemotionContext: {
-      filename: inheritedContext?.filename || headerContext.filename,
-      marketTicker: inheritedContext?.marketTicker || headerContext.marketTicker,
+      filename: inheritedContext?.filename || cellContext?.filename,
+      explicitFilename: inheritedContext?.explicitFilename || cellContext?.explicitFilename,
+      marketTicker: inheritedContext?.marketTicker || cellContext?.marketTicker,
     },
   } as InternalParseOptions
 }
@@ -71,6 +93,7 @@ export function parseTable(
     else if (tokens[j].type === 'tr_open') {
       const cells: TableCellNode[] = []
       let k = j + 1
+      let rowContext: LinkifyDemotionContext | undefined
 
       while (k < tokens.length && tokens[k].type !== 'tr_close') {
         if (tokens[k].type === 'th_open' || tokens[k].type === 'td_open') {
@@ -79,15 +102,19 @@ export function parseTable(
           const content = String(contentToken.content ?? '')
           const align = extractAlign(tokens[k].attrs)
           const cellIndex = cells.length
-          const headerRaw = !isHeaderCell && !isHeader ? headerRow?.cells[cellIndex]?.raw : undefined
+          const isBodyCell = !isHeaderCell && !isHeader
+          const headerRaw = isBodyCell ? headerRow?.cells[cellIndex]?.raw : undefined
 
           cells.push({
             type: 'table_cell',
             header: isHeaderCell || isHeader,
-            children: parseInlineTokens(contentToken.children || [], content, undefined, parseOptionsForTableCell(options, headerRaw)),
+            children: parseInlineTokens(contentToken.children || [], content, undefined, parseOptionsForTableCell(options, headerRaw, isBodyCell ? rowContext : undefined)),
             raw: content,
             align,
           })
+
+          if (isBodyCell)
+            rowContext = mergeTableCellContext(rowContext, inferLinkifyDemotionContext(content))
 
           k += 3 // Skip th_open/td_open, inline, th_close/td_close
         }

--- a/packages/markdown-parser/src/parser/node-parsers/table-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/table-parser.ts
@@ -1,4 +1,5 @@
 import type {
+  InternalParseOptions,
   MarkdownToken,
   ParseOptions,
   TableCellNode,
@@ -6,6 +7,7 @@ import type {
   TableRowNode,
 } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
+import { inferLinkifyDemotionContext } from '../linkifyHeuristics'
 
 // Extract alignment from attrs (e.g. ['style','text-align:left'])
 function extractAlign(attrs: MarkdownToken['attrs']): 'left' | 'right' | 'center' | undefined {
@@ -26,6 +28,22 @@ function extractAlign(attrs: MarkdownToken['attrs']): 'left' | 'right' | 'center
   }
   return 'left'
 }
+
+function parseOptionsForTableCell(options: ParseOptions | undefined, headerRaw?: string) {
+  const headerContext = inferLinkifyDemotionContext(headerRaw)
+  if (!headerContext.filename && !headerContext.marketTicker)
+    return options
+
+  const inheritedContext = (options as InternalParseOptions | undefined)?.__linkifyDemotionContext
+  return {
+    ...options,
+    __linkifyDemotionContext: {
+      filename: inheritedContext?.filename || headerContext.filename,
+      marketTicker: inheritedContext?.marketTicker || headerContext.marketTicker,
+    },
+  } as InternalParseOptions
+}
+
 export function parseTable(
   tokens: MarkdownToken[],
   index: number,
@@ -60,11 +78,13 @@ export function parseTable(
           const contentToken = tokens[k + 1]
           const content = String(contentToken.content ?? '')
           const align = extractAlign(tokens[k].attrs)
+          const cellIndex = cells.length
+          const headerRaw = !isHeaderCell && !isHeader ? headerRow?.cells[cellIndex]?.raw : undefined
 
           cells.push({
             type: 'table_cell',
             header: isHeaderCell || isHeader,
-            children: parseInlineTokens(contentToken.children || [], content, undefined, options),
+            children: parseInlineTokens(contentToken.children || [], content, undefined, parseOptionsForTableCell(options, headerRaw)),
             raw: content,
             align,
           })

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -1,6 +1,6 @@
 import type { MarkdownIt } from '../markdown-it-types'
 import type { MarkdownToken } from '../types'
-import { shouldDemoteFilenameLikeLinkify } from '../parser/linkifyHeuristics'
+import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFilenameLikeLinkify } from '../parser/linkifyHeuristics'
 
 // We hard-stop FULLWIDTH exclamation mark used as CJK punctuation.
 // ASCII `!` is valid in URLs (path/query/fragment), so do not stop on it.
@@ -139,7 +139,7 @@ export function applyFixLinkTokens(md: MarkdownIt) {
       const t = toks[i]
       if (t && t.type === 'inline' && Array.isArray(t.children)) {
         try {
-          t.children = fixLinkToken(t.children)
+          t.children = fixLinkToken(t.children, typeof t.content === 'string' ? t.content : undefined)
         }
         catch (e) {
           // Swallow errors to avoid breaking parsing; keep original children
@@ -153,7 +153,7 @@ export function applyFixLinkTokens(md: MarkdownIt) {
   })
 }
 
-function fixLinkToken(tokens: MarkdownToken[]): MarkdownToken[] {
+function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
   // Need at least `link_open + text + link_close` for linkify/autolink fixes.
   // Keep this low to allow fixing `<https://...！suffix>` cases where inline children length is 3.
   if (tokens.length < 3)
@@ -163,6 +163,7 @@ function fixLinkToken(tokens: MarkdownToken[]): MarkdownToken[] {
   if (tokens.some(token => token.type === 'code_inline'))
     return tokens
 
+  const linkifyDemotionContext = inferLinkifyDemotionContext(raw)
   for (let i = 0; i <= tokens.length - 1; i++) {
     if (i < 0) {
       i = 0
@@ -182,16 +183,17 @@ function fixLinkToken(tokens: MarkdownToken[]): MarkdownToken[] {
       }
       if (closeIdx !== -1) {
         const linkText = collectLinkifyText(tokens, i, closeIdx)
+        const href = getHrefFromLinkOpen(curToken)
         if (
           curToken.markup === 'linkify'
           && linkText
-          && shouldDemoteFilenameLikeLinkify(linkText)
+          && !isDecodedFromRawPunycode(linkText, href, raw)
+          && shouldDemoteFilenameLikeLinkify(linkText, linkifyDemotionContext)
         ) {
           tokens.splice(i, closeIdx - i + 1, textToken(linkText))
           continue
         }
 
-        const href = getHrefFromLinkOpen(curToken)
         const hrefStop = firstIndexOfAny(href, LINKIFY_HARD_STOP_CHARS)
         // Prefer splitting by the visible text token, but also trim href if it contains stop chars.
         for (let j = i + 1; j < closeIdx; j++) {

--- a/packages/markdown-parser/src/types.ts
+++ b/packages/markdown-parser/src/types.ts
@@ -442,6 +442,10 @@ export interface InternalParseOptions extends ParseOptions {
   __customHtmlBlockCursor?: number
   __disableStreamParse?: boolean
   __insideStrong?: boolean
+  __linkifyDemotionContext?: {
+    filename?: boolean
+    marketTicker?: boolean
+  }
   __markdownIt?: MarkdownIt
   __sourceMarkdown?: string
 }

--- a/packages/markdown-parser/src/types.ts
+++ b/packages/markdown-parser/src/types.ts
@@ -444,6 +444,7 @@ export interface InternalParseOptions extends ParseOptions {
   __insideStrong?: boolean
   __linkifyDemotionContext?: {
     filename?: boolean
+    explicitFilename?: boolean
     marketTicker?: boolean
   }
   __markdownIt?: MarkdownIt

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -37,6 +37,23 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '西游记后传世界观-热血情感版.md')).toBe(true)
   })
 
+  it('keeps cjk ambiguous-extension filenames without ascii separators as text', () => {
+    const input = `文件：
+**个人简历.md**
+**使用说明.md**
+**世界观设定.md**
+**研究报告.ai**
+**报告２０２６.md**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '个人简历.md')).toBe(true)
+    expect(textIncludes(nodes, '使用说明.md')).toBe(true)
+    expect(textIncludes(nodes, '世界观设定.md')).toBe(true)
+    expect(textIncludes(nodes, '研究报告.ai')).toBe(true)
+    expect(textIncludes(nodes, '报告２０２６.md')).toBe(true)
+  })
+
   it('keeps market ticker suffixes as plain text inside markdown tables', () => {
     const input = `### 总结速查表
 
@@ -59,6 +76,19 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '.SZ')).toBe(true)
     expect(textIncludes(nodes, '003018.SZ')).toBe(true)
     expect(textIncludes(nodes, 'ASML.AS')).toBe(true)
+  })
+
+  it('keeps short numeric market tickers as plain text', () => {
+    const input = `| 代码 | 市场 |
+| :--- | :--- |
+| 5.HK | 港股 |
+| 66.HK | 港股 |
+| 388.HK | 港股 |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '5.HK')).toBe(true)
+    expect(textIncludes(nodes, '388.HK')).toBe(true)
   })
 
   it('still preserves normal bare-domain autolinks', () => {

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -108,6 +108,28 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, 'ASML.AS')).toBe(true)
   })
 
+  it('keeps ticker-like text as plain text in whitespace-separated summary blocks', () => {
+    const input = `### 总结速查表
+
+后缀 对应市场/交易所 典型例子
+.SZ 深交所 (中国) 003018.SZ
+.SS / .SH 上交所 (中国) 600519.SS
+.BJ 北交所 (中国) 835185.BJ
+.US 美股 (通用) AAPL.US
+.NY 纽交所 (NYSE) JPM.NY
+.L / .LN 伦交所 (LSE) HSBA.L
+.HK 港交所 (HKEX) 0700.HK
+.T 东证 (日本) 6758.T
+.DE 德交所 (德国) SAP.DE
+.PA 泛欧 (巴黎) TTE.PA
+.AS 泛欧 (阿姆斯特丹) ASML.AS`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '003018.SZ')).toBe(true)
+    expect(textIncludes(nodes, 'ASML.AS')).toBe(true)
+  })
+
   it('keeps alphanumeric and common exchange ticker-like text as plain text', () => {
     const input = `| 代码 | 市场 |
 | :--- | :--- |
@@ -129,6 +151,35 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, 'aapl.us')).toBe(true)
     expect(textIncludes(nodes, 'SHOP.TO')).toBe(true)
     expect(textIncludes(nodes, '005930.KS')).toBe(true)
+  })
+
+  it('keeps alphanumeric and hyphenated tickers in lists under ticker context', () => {
+    const input = `股票代码：
+
+- BRK-B.US
+- VOW3.DE
+- aapl.us
+- 2330.TW
+- 005930.KS`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'BRK-B.US')).toBe(true)
+    expect(textIncludes(nodes, '005930.KS')).toBe(true)
+  })
+
+  it('keeps context-only market ticker suffixes as plain text', () => {
+    const input = `| 代码 | 市场 |
+| :--- | :--- |
+| 7203.JP | 日股 |
+| 600000.CN | A股 |
+| ABC.SI | 新股 |
+| XYZ.MX | 墨股 |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '7203.JP')).toBe(true)
+    expect(textIncludes(nodes, 'XYZ.MX')).toBe(true)
   })
 
   it('keeps short numeric market tickers as plain text', () => {
@@ -212,6 +263,53 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(linkNodes).toHaveLength(1)
     expect(linkNodes[0].href).toBe('http://xn--fsqu00a.ai')
     expect(textIncludes(linkNodes[0], '例子.ai')).toBe(true)
+  })
+
+  it('keeps ascii markdown filenames in lists under filename context', () => {
+    const input = `文件列表：
+
+- readme.md
+- release-notes.md
+- getting-started.md`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+  })
+
+  it('keeps ascii markdown filenames under document context', () => {
+    const input = `文档：
+
+**readme.md**
+**release-notes.md**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+  })
+
+  it('keeps context-only filename extensions as text only under filename context', () => {
+    const appTldMd = getMarkdown('issue-402-app-tld', {
+      apply: [
+        (md: any) => {
+          md.linkify?.tlds?.(['app'], true)
+        },
+      ],
+    })
+    const nodes = parseMarkdownToStructure(`文件：
+
+- Foo.app
+- installer.app`, appTldMd, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'Foo.app')).toBe(true)
+    expect(textIncludes(nodes, 'installer.app')).toBe(true)
+
+    const domainNodes = parseMarkdownToStructure('访问 example.app 获取更多信息。', appTldMd, { final: true })
+    const linkNodes = links(domainNodes)
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://example.app')
   })
 
   it('keeps standalone uppercase filenames as text', () => {

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -54,6 +54,36 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '报告２０２６.md')).toBe(true)
   })
 
+  it('keeps common lowercase ascii markdown filenames as text when used as filenames', () => {
+    const input = `文件：
+**readme.md**
+**release-notes.md**
+**getting-started.md**
+**2026-plan.md**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+    expect(textIncludes(nodes, 'getting-started.md')).toBe(true)
+    expect(textIncludes(nodes, '2026-plan.md')).toBe(true)
+  })
+
+  it('keeps non-cjk unicode filenames with ambiguous extensions as text', () => {
+    const input = `附件：
+**résumé.md**
+**café.md**
+**отчёт.md**
+**ملف.md**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'résumé.md')).toBe(true)
+    expect(textIncludes(nodes, 'café.md')).toBe(true)
+    expect(textIncludes(nodes, 'отчёт.md')).toBe(true)
+    expect(textIncludes(nodes, 'ملف.md')).toBe(true)
+  })
+
   it('keeps market ticker suffixes as plain text inside markdown tables', () => {
     const input = `### 总结速查表
 
@@ -76,6 +106,29 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '.SZ')).toBe(true)
     expect(textIncludes(nodes, '003018.SZ')).toBe(true)
     expect(textIncludes(nodes, 'ASML.AS')).toBe(true)
+  })
+
+  it('keeps alphanumeric and common exchange ticker-like text as plain text', () => {
+    const input = `| 代码 | 市场 |
+| :--- | :--- |
+| VOW3.DE | 德股 |
+| 1COV.DE | 德股 |
+| B4B.DE | 德股 |
+| BRK-B.US | 美股 |
+| aapl.us | 美股 |
+| Asml.as | 荷股 |
+| 2330.TW | 台股 |
+| BHP.AX | 澳股 |
+| SHOP.TO | 加股 |
+| 005930.KS | 韩股 |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'VOW3.DE')).toBe(true)
+    expect(textIncludes(nodes, 'BRK-B.US')).toBe(true)
+    expect(textIncludes(nodes, 'aapl.us')).toBe(true)
+    expect(textIncludes(nodes, 'SHOP.TO')).toBe(true)
+    expect(textIncludes(nodes, '005930.KS')).toBe(true)
   })
 
   it('keeps short numeric market tickers as plain text', () => {
@@ -128,6 +181,37 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(linkNodes).toHaveLength(1)
     expect(linkNodes[0].href).toBe('http://xn--fsqu00a.ai')
     expect(textIncludes(linkNodes[0], 'xn--fsqu00a.ai')).toBe(true)
+  })
+
+  it('preserves decoded visible text from raw punycode before filename demotion', () => {
+    const punycodeMd = getMarkdown('issue-402-punycode-fixlink', {
+      apply: [
+        (md: any) => {
+          md.core.ruler.before('fix_link_tokens', 'decode_punycode_linkify_text_for_test', (state: any) => {
+            for (const token of state.tokens ?? []) {
+              if (token?.type !== 'inline' || !Array.isArray(token.children))
+                continue
+
+              for (let index = 0; index < token.children.length; index++) {
+                const child = token.children[index]
+                const href = child?.attrs?.find((attr: [string, string]) => attr?.[0] === 'href')?.[1]
+                if (child?.type === 'link_open' && child.markup === 'linkify' && href === 'http://xn--fsqu00a.ai') {
+                  const textToken = token.children[index + 1]
+                  if (textToken?.type === 'text')
+                    textToken.content = '例子.ai'
+                }
+              }
+            }
+          })
+        },
+      ],
+    })
+    const nodes = parseMarkdownToStructure('文件：xn--fsqu00a.ai', punycodeMd, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://xn--fsqu00a.ai')
+    expect(textIncludes(linkNodes[0], '例子.ai')).toBe(true)
   })
 
   it('keeps standalone uppercase filenames as text', () => {

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -24,6 +24,43 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '制度02-XX银行呆账核销管理办法.md')).toBe(true)
   })
 
+  it('keeps cjk markdown filenames without numeric segments as text', () => {
+    const input = `文件名：
+
+**《西游记后传世界观-热血情感版.md》**
+
+如果你要，我下一步可以直接继续补其中一个：
+1. **主角团角色设定**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '西游记后传世界观-热血情感版.md')).toBe(true)
+  })
+
+  it('keeps market ticker suffixes as plain text inside markdown tables', () => {
+    const input = `### 总结速查表
+
+| 后缀 | 对应市场/交易所 | 典型例子 |
+| :--- | :--- | :--- |
+| **.SZ** | 深交所 (中国) | 003018.SZ |
+| **.SS / .SH** | 上交所 (中国) | 600519.SS |
+| **.BJ** | 北交所 (中国) | 835185.BJ |
+| **.US** | 美股 (通用) | AAPL.US |
+| **.NY** | 纽交所 (NYSE) | JPM.NY |
+| **.L / .LN** | 伦交所 (LSE) | HSBA.L |
+| **.HK** | 港交所 (HKEX) | 0700.HK |
+| **.T** | 东证 (日本) | 6758.T |
+| **.DE** | 德交所 (德国) | SAP.DE |
+| **.PA** | 泛欧 (巴黎) | TTE.PA |
+| **.AS** | 泛欧 (阿姆斯特丹) | ASML.AS |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, '.SZ')).toBe(true)
+    expect(textIncludes(nodes, '003018.SZ')).toBe(true)
+    expect(textIncludes(nodes, 'ASML.AS')).toBe(true)
+  })
+
   it('still preserves normal bare-domain autolinks', () => {
     const nodes = parseMarkdownToStructure('访问 example.com 获取更多信息。', md, { final: true })
     const linkNodes = links(nodes)

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -204,6 +204,23 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, 'XYZ.MX')).toBe(true)
   })
 
+  it('keeps additional exchange ticker suffixes as plain text under market context', () => {
+    const input = `| 代码 | 市场 |
+| :--- | :--- |
+| MAERSK-B.CO | 丹麦 |
+| FPH.NZ | 新西兰 |
+| ITUB.SA | 巴西 |
+| TEF.MC | 西班牙 |
+| PKO.PL | 波兰 |
+| EBS.AT | 奥地利 |
+| ENEL.IT | 意大利 |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'MAERSK-B.CO')).toBe(true)
+    expect(textIncludes(nodes, 'ENEL.IT')).toBe(true)
+  })
+
   it('keeps short numeric market tickers as plain text', () => {
     const input = `| 代码 | 市场 |
 | :--- | :--- |
@@ -224,6 +241,14 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(linkNodes).toHaveLength(1)
     expect(linkNodes[0].href).toBe('http://example.com')
     expect(textIncludes(linkNodes[0], 'example.com')).toBe(true)
+  })
+
+  it('preserves real bare domains in broad market prose', () => {
+    const nodes = parseMarkdownToStructure('市场说明：请访问 example.us 获取更多信息。', md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://example.us')
   })
 
   it('preserves bare domains whose TLDs overlap with file extensions', () => {
@@ -328,6 +353,22 @@ archive.zip`
     expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
   })
 
+  it('inherits filename context across multiple top-level filename paragraphs', () => {
+    const input = `文件名：
+
+readme.md
+
+release-notes.md
+
+getting-started.md`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+    expect(textIncludes(nodes, 'getting-started.md')).toBe(true)
+  })
+
   it('inherits filename context across sibling list items', () => {
     const input = `- 文件名：
 - readme.md
@@ -375,6 +416,51 @@ archive.zip`
     expect(textIncludes(nodes, '2330.TW')).toBe(true)
   })
 
+  it('inherits ticker context across multiple top-level ticker paragraphs', () => {
+    const input = `股票代码：
+
+BRK-B.US
+
+VOW3.DE
+
+aapl.us`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'BRK-B.US')).toBe(true)
+    expect(textIncludes(nodes, 'VOW3.DE')).toBe(true)
+    expect(textIncludes(nodes, 'aapl.us')).toBe(true)
+  })
+
+  it('keeps dot-class US tickers under ticker context', () => {
+    const input = `股票代码：
+
+BRK.B.US
+
+BRK.A.US
+
+BF.B.US`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'BRK.B.US')).toBe(true)
+    expect(textIncludes(nodes, 'BF.B.US')).toBe(true)
+  })
+
+  it('inherits filename and ticker context from row label cells', () => {
+    const input = `| 字段 | 值 |
+| :--- | :--- |
+| 文件名 | readme.md |
+| 股票代码 | BRK-B.US |
+| 证券代码 | VOW3.DE |`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'BRK-B.US')).toBe(true)
+    expect(textIncludes(nodes, 'VOW3.DE')).toBe(true)
+  })
+
   it('keeps ascii markdown filenames under document context', () => {
     const input = `文档：
 
@@ -407,6 +493,35 @@ archive.zip`
     const linkNodes = links(domainNodes)
     expect(linkNodes).toHaveLength(1)
     expect(linkNodes[0].href).toBe('http://example.app')
+  })
+
+  it('keeps explicit filename-context TLD files as text without demoting generic file domains', () => {
+    const filenameTldMd = getMarkdown('issue-402-filename-tlds', {
+      apply: [
+        (md: any) => {
+          md.linkify?.tlds?.(['com', 'dev', 'io', 'page', 'site'], true)
+        },
+      ],
+    })
+    const nodes = parseMarkdownToStructure(`文件名：
+
+server.dev
+
+notes.io
+
+homepage.site
+
+release.page
+
+command.com`, filenameTldMd, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'server.dev')).toBe(true)
+    expect(textIncludes(nodes, 'command.com')).toBe(true)
+
+    const domainNodes = parseMarkdownToStructure('文件：example.com', filenameTldMd, { final: true })
+    const linkNodes = links(domainNodes)
+    expect(linkNodes).toHaveLength(1)
+    expect(linkNodes[0].href).toBe('http://example.com')
   })
 
   it('keeps standalone uppercase filenames as text', () => {

--- a/test/issue402-filename-linkify-regression.test.ts
+++ b/test/issue402-filename-linkify-regression.test.ts
@@ -168,6 +168,28 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(textIncludes(nodes, '005930.KS')).toBe(true)
   })
 
+  it('documents bare ticker-like text without market context', () => {
+    const input = `- BRK-B.US
+- VOW3.DE
+- 2330.TW
+- 005930.KS`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes.map(link => link.text)).toEqual([
+      'BRK-B.US',
+      'VOW3.DE',
+      '2330.TW',
+    ])
+    expect(linkNodes.map(link => link.href)).toEqual([
+      'http://BRK-B.US',
+      'http://VOW3.DE',
+      'http://2330.TW',
+    ])
+    expect(textIncludes(nodes, '005930.KS')).toBe(true)
+  })
+
   it('keeps context-only market ticker suffixes as plain text', () => {
     const input = `| 代码 | 市场 |
 | :--- | :--- |
@@ -214,6 +236,34 @@ describe('issue #402 filename-like linkify regression', () => {
       'http://example.md',
       'http://OpenAI.ai',
     ])
+  })
+
+  it('documents standalone lowercase ambiguous filename-like text without filename context', () => {
+    const input = `readme.md
+release-notes.md
+report.final.md
+setup.py
+script.sh
+archive.zip`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    const linkNodes = links(nodes)
+
+    expect(linkNodes.map(link => link.text)).toEqual([
+      'readme.md',
+      'release-notes.md',
+      'report.final.md',
+      'setup.py',
+      'script.sh',
+    ])
+    expect(linkNodes.map(link => link.href)).toEqual([
+      'http://readme.md',
+      'http://release-notes.md',
+      'http://report.final.md',
+      'http://setup.py',
+      'http://script.sh',
+    ])
+    expect(textIncludes(nodes, 'archive.zip')).toBe(true)
   })
 
   it('preserves adjacent cjk bare domains when they are intended as links', () => {
@@ -276,6 +326,53 @@ describe('issue #402 filename-like linkify regression', () => {
     expect(links(nodes)).toHaveLength(0)
     expect(textIncludes(nodes, 'readme.md')).toBe(true)
     expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+  })
+
+  it('inherits filename context across sibling list items', () => {
+    const input = `- 文件名：
+- readme.md
+- release-notes.md`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+  })
+
+  it('inherits filename context from a list item into nested list items', () => {
+    const input = `- 文件名：
+  - readme.md
+  - getting-started.md`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'getting-started.md')).toBe(true)
+  })
+
+  it('inherits filename context across blockquote paragraphs', () => {
+    const input = `> 文件名：
+>
+> **readme.md**
+> **release-notes.md**`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'readme.md')).toBe(true)
+    expect(textIncludes(nodes, 'release-notes.md')).toBe(true)
+  })
+
+  it('inherits ticker context across sibling list items', () => {
+    const input = `- 股票代码：
+- BRK-B.US
+- VOW3.DE
+- 2330.TW`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    expect(links(nodes)).toHaveLength(0)
+    expect(textIncludes(nodes, 'BRK-B.US')).toBe(true)
+    expect(textIncludes(nodes, 'VOW3.DE')).toBe(true)
+    expect(textIncludes(nodes, '2330.TW')).toBe(true)
   })
 
   it('keeps ascii markdown filenames under document context', () => {


### PR DESCRIPTION
## Summary
- demote CJK filename-like `.md` linkify matches with filename separators or digits
- demote stock ticker / exchange suffix patterns such as `.SZ`, `003018.SZ`, and `AAPL.US`
- add regression coverage for #463 and #464 samples

## Tests
- pnpm exec vitest run test/issue402-filename-linkify-regression.test.ts test/inline-parsers/autolink.test.ts test/inline-parsers/fix-link-inline.test.ts test/inline-parsers/fix-link-inline-edgecases.test.ts test/inline-parsers/multiple-links-same-line.test.ts packages/markdown-parser/test/link-special-cases.test.ts packages/markdown-parser/test/multiple-links-same-line.test.ts packages/markdown-parser/test/parse-link-with-code.test.ts test/node-renderer-show-tooltips.test.ts
- pnpm lint
- pnpm typecheck
- pnpm exec vitest run --testTimeout=10000

Closes #463
Closes #464