### PR TITLE
fix: preserve custom tag JSON quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Pick one mode per surface: virtualization for best scrollback and steady memory 
 - `parse-options`: reuse parser hooks (e.g., `preTransformTokens`, `requireClosingStrong`) on the component.
 - `final`: marks end-of-stream; disables mid-state loading parsing and forces unfinished constructs to settle.
 - `custom-html-tags`: extend streaming HTML allowlist for custom tags and emit them as custom nodes for `setCustomComponents` (e.g., `['thinking']`).
+  Declared custom nodes keep `content`/`raw` close to the original tag payload, while `children` remains the Markdown-rendered form for rich text.
 - `setCustomComponents(customId?, mapping)`: register inline Vue components for custom tags/markers (scoped by `custom-id` when provided).
 
 Example: map Markdown placeholders to Vue components (scoped)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -363,6 +363,7 @@ function addChunk(chunk: string) {
 - `parse-options`：在组件上复用解析钩子（如 `preTransformTokens`、`requireClosingStrong`）。
 - `final`：标记“最终态/流结束”，关闭中间态 loading 解析并强制收敛未闭合结构。
 - `custom-html-tags`：扩展流式 HTML 白名单并将这些标签输出为自定义节点，便于 `setCustomComponents` 直接映射（如 `['thinking']`）。
+  声明过的自定义节点会尽量让 `content`/`raw` 保留原始标签 payload，`children` 则仍作为富文本场景下的 Markdown 渲染结果。
 - `setCustomComponents(customId?, mapping)`：为自定义标签/标记注册内嵌 Vue 组件（传 `custom-id` 可限定作用域）。
 
 示例：将 Markdown 占位符映射到 Vue 组件（作用域）

--- a/docs/guide/custom-components.md
+++ b/docs/guide/custom-components.md
@@ -127,6 +127,8 @@ For a trusted custom tag, the emitted node typically includes:
 
 For declared custom tags, use `content`/`raw` for source payloads such as JSON, YAML, or tool-call data. Use `children` or a nested renderer when the tag body should render as Markdown; those child nodes still follow the normal inline parsing pipeline.
 
+Because custom tags still use HTML-like delimiters, a literal closing tag such as `</custom-data>` inside a machine payload closes the custom node. Escape `<` in that payload, for example as `\u003c`, when the delimiter text must be preserved as data.
+
 The exact `attrs` shape can vary, so treat it as raw attribute data that your component normalizes for its own needs.
 
 Renderer node reuse compares common custom object fields such as `attrs`, `data`, `props`, and `payload` structurally. If a parser hook attaches other object fields to custom nodes, replace those objects when their contents change.

--- a/docs/guide/custom-components.md
+++ b/docs/guide/custom-components.md
@@ -120,9 +120,12 @@ For a trusted custom tag, the emitted node typically includes:
 - `type`: the tag name, for example `thinking`
 - `tag`: the original tag name
 - `content`: the inner Markdown or text content
+- `raw`: the original tag fragment when available
 - `attrs`: extracted tag attributes when available
 - `loading`: whether the tag is still in a streaming mid-state
 - `autoClosed`: whether the parser temporarily auto-closed the tag during streaming
+
+For declared custom tags, use `content`/`raw` for source payloads such as JSON, YAML, or tool-call data. Use `children` or a nested renderer when the tag body should render as Markdown; those child nodes still follow the normal inline parsing pipeline.
 
 The exact `attrs` shape can vary, so treat it as raw attribute data that your component normalizes for its own needs.
 

--- a/docs/guide/parser-api.md
+++ b/docs/guide/parser-api.md
@@ -182,14 +182,14 @@ Behavior:
 - **When the real closing tag arrives**, `autoClosed` disappears and `loading` becomes `false`.
 
 Extending the allowlist:
-To apply the same mid‑state suppression for custom tags (for example `<thinking>`), pass `customHtmlTags` when creating the markdown instance:
+To apply mid‑state suppression and source payload preservation for custom tags (for example `<thinking>`), pass `customHtmlTags` either when creating the markdown instance or in `ParseOptions`:
 
 ```ts
 const md = getMarkdown('chat', { customHtmlTags: ['thinking'] })
 ```
 
 Emitting custom nodes:
-If you want those tags to become custom node types (so `setCustomComponents` can map them directly), also pass `customHtmlTags` in `ParseOptions` or use the `custom-html-tags` prop on `MarkdownRender` (which wires this automatically):
+If you want those tags to become custom node types (so `setCustomComponents` can map them directly), pass `customHtmlTags` in `ParseOptions` or use the `custom-html-tags` prop on `MarkdownRender` (which wires this automatically):
 
 ```ts
 import { getMarkdown, parseMarkdownToStructure } from 'stream-markdown-parser'

--- a/docs/guide/parser-api.md
+++ b/docs/guide/parser-api.md
@@ -99,6 +99,8 @@ Non-standard HTML-like tags (for example `<question>`) render as raw HTML elemen
 
 If you want a custom tag to be emitted as a custom node (so it can be mapped via `setCustomComponents` with parsed attrs/content), add it to `customHtmlTags`.
 
+For declared custom tags, `content` and `raw` preserve the original payload as closely as possible, while `children` remains the normal Markdown-parsed representation for rich text.
+
 ### ParseOptions: `requireClosingStrong`
 
 `requireClosingStrong` (boolean | optional) controls how the parser treats unmatched `**` strong delimiters inside inline content. Default: `false` (streaming-friendly).

--- a/docs/zh/guide/custom-components.md
+++ b/docs/zh/guide/custom-components.md
@@ -120,9 +120,12 @@ const props = defineProps<{
 - `type`：标签名本身，例如 `thinking`
 - `tag`：原始标签名
 - `content`：标签内部的 Markdown / 文本内容
+- `raw`：可用时为原始标签片段
 - `attrs`：提取出来的标签属性
 - `loading`：当前是否仍处在流式中间态
 - `autoClosed`：流式阶段是否发生过临时自动补闭合
+
+对于声明过的自定义标签，如果标签内部是 JSON、YAML 或工具调用数据，优先使用 `content`/`raw` 作为源码 payload。若希望标签内部继续按 Markdown 渲染，则使用 `children` 或内层渲染器；这些子节点仍会走常规 inline 解析流程。
 
 `attrs` 的具体形状可能会因来源而不同，所以更好的做法是把它当成“原始属性容器”，在你的组件里按需归一化。
 

--- a/docs/zh/guide/custom-components.md
+++ b/docs/zh/guide/custom-components.md
@@ -127,6 +127,8 @@ const props = defineProps<{
 
 对于声明过的自定义标签，如果标签内部是 JSON、YAML 或工具调用数据，优先使用 `content`/`raw` 作为源码 payload。若希望标签内部继续按 Markdown 渲染，则使用 `children` 或内层渲染器；这些子节点仍会走常规 inline 解析流程。
 
+因为自定义标签仍然使用 HTML-like 分隔符，机器 payload 里如果出现字面量闭合标签（例如 `</custom-data>`），它会结束当前自定义节点。需要把这段分隔符文本当作数据保留时，请在 payload 中转义 `<`，例如写成 `\u003c`。
+
 `attrs` 的具体形状可能会因来源而不同，所以更好的做法是把它当成“原始属性容器”，在你的组件里按需归一化。
 
 渲染器复用节点时，会对 `attrs`、`data`、`props`、`payload` 这类常见自定义对象字段做结构比较。如果 parser hook 给自定义节点挂了其他对象字段，内容变化时请替换对象本身。

--- a/docs/zh/guide/parser-api.md
+++ b/docs/zh/guide/parser-api.md
@@ -174,14 +174,14 @@ dasdsad
 - **当真实闭合标签到达后**，`autoClosed` 消失，`loading=false`。
 
 扩展白名单：
-如果需要让自定义标签（例如 `<thinking>`）也享受相同的中间态吞并与自动补闭合策略，可在创建实例时传入 `customHtmlTags`：
+如果需要让自定义标签（例如 `<thinking>`）也享受相同的中间态吞并、自动补闭合和源码 payload 保留策略，可在创建实例时或 `ParseOptions` 中传入 `customHtmlTags`：
 
 ```ts
 const md = getMarkdown('chat', { customHtmlTags: ['thinking'] })
 ```
 
 输出自定义节点：
-如果希望这些标签直接产出自定义节点类型（便于 `setCustomComponents` 直接按 `type` 映射），可在 `ParseOptions` 中同时传入 `customHtmlTags`，或在 `MarkdownRender` 上使用 `custom-html-tags`（组件会自动透传）：
+如果希望这些标签直接产出自定义节点类型（便于 `setCustomComponents` 直接按 `type` 映射），可在 `ParseOptions` 中传入 `customHtmlTags`，或在 `MarkdownRender` 上使用 `custom-html-tags`（组件会自动透传）：
 
 ```ts
 import { getMarkdown, parseMarkdownToStructure } from 'stream-markdown-parser'

--- a/docs/zh/guide/parser-api.md
+++ b/docs/zh/guide/parser-api.md
@@ -91,6 +91,8 @@ setDefaultMathOptions({
 
 如果你希望某个自定义标签参与解析并产出自定义节点（以便 `setCustomComponents` 映射，并携带 attrs/content），请将其加入 `customHtmlTags`。
 
+对于声明过的自定义标签，`content` 和 `raw` 会尽量保留原始 payload，`children` 则仍是适合富文本展示的常规 Markdown 解析结果。
+
 ### ParseOptions: `requireClosingStrong`
 
 `requireClosingStrong`（boolean，可选）控制解析器在解析 inline 内容时如何处理未闭合的 `**` 加粗分隔符。默认值：`false`（更贴合流式场景）。

--- a/packages/markdown-parser/README.md
+++ b/packages/markdown-parser/README.md
@@ -319,6 +319,8 @@ const nodes = parseMarkdownToStructure(
 
 By default, non-standard HTML-like tags (for example `<question>`) are rendered as raw HTML elements once they are complete. Incomplete or malformed fragments stay as **literal text** so they do not swallow surrounding content during streaming or final renders. If you want them emitted as custom nodes (`type: 'question'` with parsed attrs/content), opt in via `customHtmlTags`.
 
+For declared custom tags, `content` and `raw` are kept close to the source payload (including quote- or whitespace-sensitive data such as JSON), while `children` still comes from normal inline Markdown parsing.
+
 ### Utility Functions
 
 #### `isMathLike(content)`

--- a/packages/markdown-parser/README.zh-CN.md
+++ b/packages/markdown-parser/README.zh-CN.md
@@ -317,6 +317,8 @@ const nodes = parseMarkdownToStructure(
 
 默认情况下，非标准的 HTML 类标签（例如 `<question>`）在完整闭合时会按原生 HTML 渲染（作为自定义元素输出）。未闭合或格式不完整的片段会保持为**纯文本**，避免在流式或最终渲染时吞掉周围内容。若希望它们作为自定义节点输出（`type: 'question'`，携带 attrs/content），需要在 `customHtmlTags` 中显式声明。
 
+对于声明过的自定义标签，`content` 和 `raw` 会尽量贴近源码 payload（包括 JSON 这类对引号或空白敏感的数据），而 `children` 仍来自常规 inline Markdown 解析。
+
 ### 工具函数
 
 #### `isMathLike(content)`

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -1763,40 +1763,6 @@ function ensureBlankLineAfterCustomHtmlCloseBeforeBlockMarkerSameLine(markdown: 
   return out
 }
 
-function ensureLineBreakAfterCustomHtmlCloseBeforeTrailingTextSameLine(markdown: string, tags: string[]) {
-  if (!markdown || !tags.length)
-    return markdown
-
-  const tagAlternation = tags
-    .map(tag => escapeTagForRegExp(String(tag ?? '').toLowerCase()))
-    .filter(Boolean)
-    .join('|')
-  if (!tagAlternation)
-    return markdown
-
-  const closeLineRe = new RegExp(String.raw`^([\t ]*<\s*\/\s*(?:${tagAlternation})\s*>)([\t ]+\S.*)$`, 'i')
-  let out = ''
-  let idx = 0
-
-  while (idx < markdown.length) {
-    const nl = markdown.indexOf('\n', idx)
-    const hasNl = nl !== -1
-    const isCrlf = hasNl && nl > idx && markdown[nl - 1] === '\r'
-    const lineEnd = hasNl ? (isCrlf ? nl - 1 : nl) : markdown.length
-    const line = markdown.slice(idx, lineEnd)
-    const newline = hasNl ? (isCrlf ? '\r\n' : '\n') : ''
-    const match = line.match(closeLineRe)
-
-    out += match
-      ? `${match[1]}\n${String(match[2] ?? '').replace(/^[\t ]+/, '')}`
-      : line
-    out += newline
-    idx = hasNl ? nl + 1 : markdown.length
-  }
-
-  return out
-}
-
 function ensureBlankLineBeforeCustomHtmlBlocks(markdown: string, tags: string[]) {
   if (!markdown || !tags.length)
     return markdown
@@ -2284,7 +2250,6 @@ export function parseMarkdownToStructure(
       // newline after the custom block close. Split it into separate lines so the
       // "##" can be parsed as a heading (and to avoid being swallowed by HTML block parsing).
       safeMarkdown = ensureBlankLineAfterCustomHtmlCloseBeforeBlockMarkerSameLine(safeMarkdown, tags)
-      safeMarkdown = ensureLineBreakAfterCustomHtmlCloseBeforeTrailingTextSameLine(safeMarkdown, tags)
 
       // Fast path: no closing tag marker at all.
       if (!safeMarkdown.includes('</')) {

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -312,6 +312,9 @@ function parseTopLevelTokens(
   env: Record<string, unknown>,
   options: ParseOptions,
 ) {
+  if (options.customHtmlTags?.length)
+    env.__markstreamCustomHtmlTags = options.customHtmlTags
+
   if (!shouldUseTopLevelStreamParse(md, options))
     return md.parse(source, env)
 
@@ -1760,6 +1763,40 @@ function ensureBlankLineAfterCustomHtmlCloseBeforeBlockMarkerSameLine(markdown: 
   return out
 }
 
+function ensureLineBreakAfterCustomHtmlCloseBeforeTrailingTextSameLine(markdown: string, tags: string[]) {
+  if (!markdown || !tags.length)
+    return markdown
+
+  const tagAlternation = tags
+    .map(tag => escapeTagForRegExp(String(tag ?? '').toLowerCase()))
+    .filter(Boolean)
+    .join('|')
+  if (!tagAlternation)
+    return markdown
+
+  const closeLineRe = new RegExp(String.raw`^([\t ]*<\s*\/\s*(?:${tagAlternation})\s*>)([\t ]+\S.*)$`, 'i')
+  let out = ''
+  let idx = 0
+
+  while (idx < markdown.length) {
+    const nl = markdown.indexOf('\n', idx)
+    const hasNl = nl !== -1
+    const isCrlf = hasNl && nl > idx && markdown[nl - 1] === '\r'
+    const lineEnd = hasNl ? (isCrlf ? nl - 1 : nl) : markdown.length
+    const line = markdown.slice(idx, lineEnd)
+    const newline = hasNl ? (isCrlf ? '\r\n' : '\n') : ''
+    const match = line.match(closeLineRe)
+
+    out += match
+      ? `${match[1]}\n${String(match[2] ?? '').replace(/^[\t ]+/, '')}`
+      : line
+    out += newline
+    idx = hasNl ? nl + 1 : markdown.length
+  }
+
+  return out
+}
+
 function ensureBlankLineBeforeCustomHtmlBlocks(markdown: string, tags: string[]) {
   if (!markdown || !tags.length)
     return markdown
@@ -2247,6 +2284,7 @@ export function parseMarkdownToStructure(
       // newline after the custom block close. Split it into separate lines so the
       // "##" can be parsed as a heading (and to avoid being swallowed by HTML block parsing).
       safeMarkdown = ensureBlankLineAfterCustomHtmlCloseBeforeBlockMarkerSameLine(safeMarkdown, tags)
+      safeMarkdown = ensureLineBreakAfterCustomHtmlCloseBeforeTrailingTextSameLine(safeMarkdown, tags)
 
       // Fast path: no closing tag marker at all.
       if (!safeMarkdown.includes('</')) {

--- a/packages/markdown-parser/src/parser/inline-parsers/html-inline-code-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/html-inline-code-parser.ts
@@ -68,6 +68,15 @@ function tokenToRaw(token: MarkdownToken) {
   return String(raw ?? '')
 }
 
+function getCustomHtmlSourceMeta(token: MarkdownToken) {
+  const meta = (token as MarkdownToken & { meta?: Record<string, unknown> | null }).meta
+  const raw = meta?.markstreamCustomHtmlRaw
+  const inner = meta?.markstreamCustomHtmlInner
+  return typeof raw === 'string' && typeof inner === 'string'
+    ? { raw, inner }
+    : null
+}
+
 type AttrTuple = [string, string]
 
 function getAttrValue(attrs: AttrTuple[], name: string): string | undefined {
@@ -355,9 +364,10 @@ export function parseHtmlInlineCodeToken(
     attrs.push([attrName, attrValue])
   }
   if (customTagSet?.has(tag)) {
-    const _content = fragment.innerTokens.length
-      ? stringifyTokens(fragment.innerTokens)
-      : ''
+    const sourceMeta = getCustomHtmlSourceMeta(token)
+    const _content = sourceMeta
+      ? sourceMeta.inner
+      : (fragment.innerTokens.length ? stringifyTokens(fragment.innerTokens) : '')
 
     const customChildren = fragment.innerTokens.length
       ? parseInlineTokens(fragment.innerTokens, raw, pPreToken, options)
@@ -369,7 +379,7 @@ export function parseHtmlInlineCodeToken(
         attrs,
         content: _content,
         children: customChildren,
-        raw: content,
+        raw: sourceMeta?.raw ?? content,
         loading: token.loading || loading,
         autoClosed,
       } as ParsedNode,

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -146,6 +146,90 @@ function tokenToRaw(token: MarkdownToken) {
   return String(shape.raw ?? shape.content ?? shape.markup ?? '')
 }
 
+function getMutableMeta(token: MarkdownToken) {
+  const target = token as MarkdownToken & { meta?: Record<string, unknown> | null }
+  if (!target.meta)
+    target.meta = {}
+  return target.meta as Record<string, unknown>
+}
+
+function setCustomHtmlSourceMeta(token: MarkdownToken, raw: string, inner: string) {
+  const meta = getMutableMeta(token)
+  meta.markstreamCustomHtmlRaw = raw
+  meta.markstreamCustomHtmlInner = inner
+}
+
+function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<string>) {
+  if (!customTagSet.size)
+    return
+
+  const stack: Array<{ tag: string, token: MarkdownToken, raw: string, inner: string }> = []
+
+  const appendToOpenFrames = (raw: string) => {
+    if (!raw || !stack.length)
+      return
+    for (const frame of stack) {
+      frame.raw += raw
+      frame.inner += raw
+    }
+  }
+
+  const handleToken = (child: MarkdownToken) => {
+    const raw = tokenToRaw(child)
+    const tag = child.type === 'html_inline'
+      ? getHtmlInlineTagName(raw)
+      : ''
+    const isCustomTag = tag && customTagSet.has(tag)
+
+    if (!isCustomTag) {
+      appendToOpenFrames(raw)
+      return
+    }
+
+    const closing = isHtmlInlineClosingTag(raw)
+    const selfClosing = !closing && isSelfClosingHtmlInline(raw, tag)
+
+    if (closing) {
+      if (!stack.length || stack[stack.length - 1].tag !== tag) {
+        appendToOpenFrames(raw)
+        return
+      }
+
+      for (let i = 0; i < stack.length; i++) {
+        stack[i].raw += raw
+        if (i < stack.length - 1)
+          stack[i].inner += raw
+      }
+
+      const frame = stack.pop()!
+      setCustomHtmlSourceMeta(frame.token, frame.raw, frame.inner)
+      return
+    }
+
+    appendToOpenFrames(raw)
+    if (selfClosing) {
+      setCustomHtmlSourceMeta(child, raw, '')
+      return
+    }
+
+    stack.push({ tag, token: child, raw, inner: '' })
+  }
+
+  for (const token of tokens) {
+    if (token.type === 'inline' && Array.isArray(token.children)) {
+      for (const child of token.children)
+        handleToken(child)
+      continue
+    }
+
+    if (stack.length && typeof token.content === 'string')
+      appendToOpenFrames(token.content)
+  }
+
+  for (const frame of stack)
+    setCustomHtmlSourceMeta(frame.token, frame.raw, frame.inner)
+}
+
 function isNonElementHtmlBlock(content: string) {
   return /^\s*<\s*[!?]/.test(content)
 }
@@ -476,6 +560,8 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
         console.error('[applyFixHtmlInlineTokens] failed to fix streaming html inline', e)
       }
     }
+
+    attachCustomHtmlSourceMeta(toks, customTagSet)
   })
 
   // Fix certain single-token inline HTML cases by expanding into [openTag, text, closeTag]

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -564,29 +564,52 @@ export interface FixHtmlInlineOptions {
   customHtmlTags?: readonly string[]
 }
 
+const BASE_AUTO_CLOSE_INLINE_TAGS = [
+  'a',
+  'span',
+  'strong',
+  'em',
+  'b',
+  'i',
+  'u',
+]
+
 export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineOptions = {}) {
-  const commonHtmlTags = buildCommonHtmlTagSet(options.customHtmlTags)
-  // Tags that should stay inline when we auto-append a closing tag at core stage.
-  const autoCloseInlineTagSet = new Set<string>([
-    'a',
-    'span',
-    'strong',
-    'em',
-    'b',
-    'i',
-    'u',
-  ])
-  const customTagSet = new Set<string>()
+  const configuredCustomTagSet = new Set<string>()
   if (options.customHtmlTags?.length) {
     for (const t of options.customHtmlTags) {
       const name = normalizeCustomHtmlTagName(t)
       if (!name)
         continue
-      customTagSet.add(name)
-      autoCloseInlineTagSet.add(name)
+      configuredCustomTagSet.add(name)
     }
   }
-  const shouldMergeHtmlBlockTag = (tag: string) => customTagSet.has(tag) || !commonHtmlTags.has(tag) || BLOCK_LEVEL_HTML_TAGS.has(tag)
+  const getRuleContext = (state: unknown) => {
+    const s = state as unknown as { env?: { __markstreamCustomHtmlTags?: readonly unknown[] } }
+    const customTagSet = new Set(configuredCustomTagSet)
+    const envTags = Array.isArray(s.env?.__markstreamCustomHtmlTags)
+      ? s.env.__markstreamCustomHtmlTags
+      : []
+    for (const t of envTags) {
+      const name = normalizeCustomHtmlTagName(String(t ?? ''))
+      if (name)
+        customTagSet.add(name)
+    }
+
+    const commonHtmlTags = buildCommonHtmlTagSet(Array.from(customTagSet))
+    const autoCloseInlineTagSet = new Set<string>(BASE_AUTO_CLOSE_INLINE_TAGS)
+    for (const tag of customTagSet)
+      autoCloseInlineTagSet.add(tag)
+
+    const shouldMergeHtmlBlockTag = (tag: string) => customTagSet.has(tag) || !commonHtmlTags.has(tag) || BLOCK_LEVEL_HTML_TAGS.has(tag)
+
+    return {
+      autoCloseInlineTagSet,
+      commonHtmlTags,
+      customTagSet,
+      shouldMergeHtmlBlockTag,
+    }
+  }
   const getHtmlBlockCarrierContent = (token: MarkdownToken & { content?: string, children?: MarkdownToken[] }) => {
     if (token.type === 'html_block')
       return String(token.content ?? '')
@@ -611,6 +634,7 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
   md.core.ruler.after('inline', 'fix_html_inline_streaming', (state: unknown) => {
     const s = state as unknown as { tokens?: MarkdownToken[] }
     const toks = s.tokens ?? []
+    const { commonHtmlTags, customTagSet } = getRuleContext(state)
     for (const t of toks) {
       const tok = t as MarkdownToken & { children?: MarkdownToken[], content?: string, raw?: string }
       if (tok.type !== 'inline' || !Array.isArray(tok.children))
@@ -656,6 +680,11 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
   md.core.ruler.push('fix_html_inline_tokens', (state: unknown) => {
     const s = state as unknown as { tokens?: MarkdownToken[] }
     const toks = s.tokens ?? []
+    const {
+      autoCloseInlineTagSet,
+      customTagSet,
+      shouldMergeHtmlBlockTag,
+    } = getRuleContext(state)
 
     // 有一些很特殊的场景，比如 html_block 开始 <thinking>，但是后面跟着很多段落,如果没匹配到</thinking>，中间的都应该合并为html_block的 content
     const tagStack: [string, number][] = []
@@ -829,8 +858,14 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
           const openTok = toks[top.index] as MarkdownToken & { content?: string, children?: MarkdownToken[] }
 
           // Close via an html_block token like "</thinking>"
-          if (tok.type === 'html_block' && getCloseRe(top.tag).test(content)) {
-            openTok.content = `${String(openTok.content ?? '')}\n${content}`
+          const htmlBlockCloseMatch = tok.type === 'html_block'
+            ? getCloseRe(top.tag).exec(content)
+            : null
+          if (htmlBlockCloseMatch) {
+            const closeEnd = htmlBlockCloseMatch.index + htmlBlockCloseMatch[0].length
+            const closeContent = content.slice(0, closeEnd)
+            const afterContent = content.slice(closeEnd)
+            openTok.content = `${String(openTok.content ?? '')}\n${closeContent}`
             if (Array.isArray(openTok.children)) {
               openTok.children.push({
                 type: 'html_inline',
@@ -838,9 +873,23 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
                 raw: `</${top.tag}>`,
               } as MarkdownToken)
             }
-            toks.splice(i, 1)
-            i--
             stack.pop()
+
+            const afterTrimmed = afterContent.replace(/^\s+/, '')
+            if (afterTrimmed) {
+              const replacement = afterTrimmed.startsWith('<')
+                ? [{ type: 'html_block', content: afterTrimmed } as MarkdownToken]
+                : [
+                    { type: 'paragraph_open', tag: 'p', nesting: 1 } as MarkdownToken,
+                    { type: 'inline', tag: '', nesting: 0, content: afterTrimmed, children: [{ type: 'text', content: afterTrimmed, raw: afterTrimmed }] } as MarkdownToken,
+                    { type: 'paragraph_close', tag: 'p', nesting: -1 } as MarkdownToken,
+                  ]
+              toks.splice(i, 1, ...replacement)
+            }
+            else {
+              toks.splice(i, 1)
+              i--
+            }
             continue
           }
 

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -194,6 +194,25 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     appendToOpenFrames(gap.includes('\n') ? '\n' : gap)
   }
 
+  const closeTopFrameWithRaw = (raw: string) => {
+    for (let i = 0; i < stack.length; i++) {
+      stack[i].raw += raw
+      if (i < stack.length - 1)
+        stack[i].inner += raw
+    }
+
+    const frame = stack.pop()!
+    setCustomHtmlSourceMeta(frame.token, frame.raw, frame.inner)
+  }
+
+  const isCloseOnlyTopFrame = (raw: string) => {
+    const tag = stack[stack.length - 1]?.tag
+    if (!tag)
+      return false
+    const closeOnlyRe = new RegExp(String.raw`^\s*<\s*\/\s*${escapeTagForRegExp(tag)}\s*>\s*$`, 'i')
+    return closeOnlyRe.test(raw)
+  }
+
   const handleToken = (child: MarkdownToken, raw: string, knownTag?: string) => {
     const tag = knownTag ?? (child.type === 'html_inline'
       ? getHtmlInlineTagName(raw)
@@ -214,14 +233,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
         return
       }
 
-      for (let i = 0; i < stack.length; i++) {
-        stack[i].raw += raw
-        if (i < stack.length - 1)
-          stack[i].inner += raw
-      }
-
-      const frame = stack.pop()!
-      setCustomHtmlSourceMeta(frame.token, frame.raw, frame.inner)
+      closeTopFrameWithRaw(raw)
       return
     }
 
@@ -269,7 +281,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
         handleToken(child, raw, tag)
       }
 
-      if (sourceReliable && source && cursor < source.length)
+      if (sourceReliable && source && cursor < source.length && !stack.length)
         appendSourceGap(source.slice(cursor))
 
       needsTopLevelSeparator = stack.length > 0
@@ -277,6 +289,15 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     }
 
     if (stack.length && typeof token.content === 'string') {
+      const raw = tokenToRaw(token)
+      if (token.type === 'html_block' && isCloseOnlyTopFrame(raw)) {
+        closeTopFrameWithRaw(`${needsTopLevelSeparator ? '\n' : ''}${raw}`)
+        needsTopLevelSeparator = stack.length > 0
+        continue
+      }
+      if (!token.content)
+        continue
+
       appendTopLevelSeparator()
       appendToOpenFrames(token.content)
       needsTopLevelSeparator = true

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -629,6 +629,68 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
     token.raw = content
     token.children = []
   }
+  const stripLeadingLineSeparators = (content: string) => content.replace(/^(?:\r?\n)+/, '')
+  const isIndentedCodeTrailingContent = (content: string) => /^(?: {4}|\t)/.test(content)
+  const normalizeIndentedCodeTrailingContent = (content: string) => content.replace(/^(?: {4}|\t)/gm, '')
+  const createTrailingContentTokens = (
+    content: string,
+    textMode: 'inline' | 'paragraph' | 'text',
+  ): MarkdownToken[] => {
+    const source = stripLeadingLineSeparators(content)
+    if (!/\S/.test(source))
+      return []
+
+    if (isIndentedCodeTrailingContent(source)) {
+      return [{
+        type: 'code_block',
+        content: normalizeIndentedCodeTrailingContent(source),
+        raw: source,
+      } as MarkdownToken]
+    }
+
+    const text = source.replace(/^[\t ]+/, '')
+    if (!text)
+      return []
+
+    if (text.startsWith('<'))
+      return [{ type: 'html_block', content: text } as MarkdownToken]
+
+    const inlineToken = { type: 'inline', tag: '', nesting: 0, content: text, children: [{ type: 'text', content: text, raw: text }] } as MarkdownToken
+
+    if (textMode === 'paragraph') {
+      return [
+        { type: 'paragraph_open', tag: 'p', nesting: 1 } as MarkdownToken,
+        inlineToken,
+        { type: 'paragraph_close', tag: 'p', nesting: -1 } as MarkdownToken,
+      ]
+    }
+
+    if (textMode === 'text')
+      return [{ type: 'text', content: text, raw: text } as MarkdownToken]
+
+    return [inlineToken]
+  }
+  const getTrailingContentTextMode = (
+    tokens: MarkdownToken[],
+    index: number,
+    fallback: 'inline' | 'paragraph' | 'text',
+  ) => {
+    return tokens[index - 1]?.type === 'paragraph_open' && tokens[index + 1]?.type === 'paragraph_close'
+      ? 'inline'
+      : fallback
+  }
+  const appendTrailingInlineContent = (
+    token: MarkdownToken & { content?: string, children?: MarkdownToken[] },
+    content: string,
+  ) => {
+    const source = stripLeadingLineSeparators(content)
+    if (!/\S/.test(source) || token.type !== 'inline' || !Array.isArray(token.children))
+      return false
+
+    token.content = `${String(token.content ?? '')}${source}`
+    token.children.push({ type: 'text', content: source, raw: source } as MarkdownToken)
+    return true
+  }
   // Streaming mid-state: suppress partial inline HTML in text tokens until the
   // tag is fully closed with `>`, then allow it to be tokenized as html_inline.
   md.core.ruler.after('inline', 'fix_html_inline_streaming', (state: unknown) => {
@@ -707,7 +769,7 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
           const chunk = String((t as MarkdownToken).content ?? (t as MarkdownToken).raw ?? '')
 
           if (chunk) {
-            const openToken = toks[openIndex] as MarkdownToken & { content?: string, loading?: boolean }
+            const openToken = toks[openIndex] as MarkdownToken & { content?: string, loading?: boolean, children?: MarkdownToken[] }
             const mergedContent = `${String(openToken.content || '')}\n${chunk}`
             const openEnd = findTagCloseIndexOutsideQuotes(mergedContent)
             const closeRange = openEnd === -1
@@ -720,16 +782,16 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
               openToken.content = before
               openToken.loading = false
 
-              const afterTrimmed = after.replace(/^\s+/, '')
               // Remove current token after merging.
               toks.splice(i, 1)
               // Close the stack before reinserting trailing content.
               tagStack.pop()
-              if (afterTrimmed) {
-                toks.splice(i, 0, afterTrimmed.startsWith('<')
-                  ? ({ type: 'html_block', content: afterTrimmed } as MarkdownToken)
-                  : ({ type: 'inline', content: afterTrimmed, children: [{ type: 'text', content: afterTrimmed, raw: afterTrimmed }] } as MarkdownToken))
-              }
+              const appendedTrailing = appendTrailingInlineContent(openToken, after)
+              const replacement = appendedTrailing
+                ? []
+                : createTrailingContentTokens(after, getTrailingContentTextMode(toks, i, 'paragraph'))
+              if (replacement.length)
+                toks.splice(i, 0, ...replacement)
               i--
               continue
             }
@@ -875,15 +937,11 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
             }
             stack.pop()
 
-            const afterTrimmed = afterContent.replace(/^\s+/, '')
-            if (afterTrimmed) {
-              const replacement = afterTrimmed.startsWith('<')
-                ? [{ type: 'html_block', content: afterTrimmed } as MarkdownToken]
-                : [
-                    { type: 'paragraph_open', tag: 'p', nesting: 1 } as MarkdownToken,
-                    { type: 'inline', tag: '', nesting: 0, content: afterTrimmed, children: [{ type: 'text', content: afterTrimmed, raw: afterTrimmed }] } as MarkdownToken,
-                    { type: 'paragraph_close', tag: 'p', nesting: -1 } as MarkdownToken,
-                  ]
+            const appendedTrailing = appendTrailingInlineContent(openTok, afterContent)
+            const replacement = appendedTrailing
+              ? []
+              : createTrailingContentTokens(afterContent, getTrailingContentTextMode(toks, i, 'paragraph'))
+            if (replacement.length) {
               toks.splice(i, 1, ...replacement)
             }
             else {
@@ -921,12 +979,16 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
               const afterText = afterChildren.map((c: MarkdownToken) => String(c.content ?? c.raw ?? '')).join('')
               if (afterText.trim()) {
                 const trimmed = afterText.replace(/^\s+/, '')
-                if (trimmed.startsWith('<')) {
+                if (appendTrailingInlineContent(openTok, afterText)) {
+                  toks.splice(i, 1)
+                  i--
+                }
+                else if (trimmed.startsWith('<')) {
                   toks.splice(i, 1, { type: 'html_block', content: trimmed } as MarkdownToken)
                 }
                 else {
-                  toks.splice(i, 1, { type: 'paragraph_open', tag: 'p', nesting: 1 } as MarkdownToken, { type: 'inline', tag: '', nesting: 0, content: afterText, children: [{ type: 'text', content: afterText, raw: afterText }] } as MarkdownToken, { type: 'paragraph_close', tag: 'p', nesting: -1 } as MarkdownToken)
-                  // current index now points at paragraph_open; move on
+                  const replacement = createTrailingContentTokens(afterText, getTrailingContentTextMode(toks, i, 'paragraph'))
+                  toks.splice(i, 1, ...replacement)
                 }
               }
               else {
@@ -1045,12 +1107,9 @@ export function applyFixHtmlInlineTokens(md: MarkdownIt, options: FixHtmlInlineO
 
             // Insert trailing content as a new token if present
             const afterContent = raw.slice(endTagIndex + closeLen) || ''
-            const afterTrimmed = afterContent.replace(/^\s+/, '')
-            if (afterTrimmed) {
-              toks.splice(i + 1, 0, afterTrimmed.startsWith('<')
-                ? ({ type: 'html_block', content: afterTrimmed } as MarkdownToken)
-                : ({ type: 'text', content: afterTrimmed, raw: afterTrimmed } as MarkdownToken))
-            }
+            const replacement = createTrailingContentTokens(afterContent, 'text')
+            if (replacement.length)
+              toks.splice(i + 1, 0, ...replacement)
           }
           else {
             // No closing tag yet (streaming mid-state)

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -190,7 +190,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
   }
 
   const appendSourceGap = (gap: string) => {
-    appendToOpenFrames(gap.includes('\n') ? '\n' : gap)
+    appendToOpenFrames(gap)
   }
 
   const closeTopFrameWithRaw = (raw: string) => {
@@ -204,12 +204,16 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     setCustomHtmlSourceMeta(frame.token, frame.raw, frame.inner)
   }
 
-  const isCloseOnlyTopFrame = (raw: string) => {
+  const getTopFrameClosePrefix = (raw: string) => {
     const tag = stack[stack.length - 1]?.tag
     if (!tag)
-      return false
-    const closeOnlyRe = new RegExp(String.raw`^\s*<\s*\/\s*${escapeTagForRegExp(tag)}\s*>\s*$`, 'i')
-    return closeOnlyRe.test(raw)
+      return null
+    const closePrefixRe = new RegExp(String.raw`^\s*<\s*\/\s*${escapeTagForRegExp(tag)}\s*>`, 'i')
+    return raw.match(closePrefixRe)?.[0] ?? null
+  }
+
+  const startsWithTopFrameClose = (source: string) => {
+    return !!getTopFrameClosePrefix(source)
   }
 
   const handleToken = (child: MarkdownToken, raw: string, knownTag?: string) => {
@@ -247,9 +251,12 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
 
   for (const token of tokens) {
     if (token.type === 'inline' && Array.isArray(token.children)) {
-      appendTopLevelSeparator()
-
       const source = String(token.content ?? '')
+      if (startsWithTopFrameClose(source))
+        needsTopLevelSeparator = false
+      else
+        appendTopLevelSeparator()
+
       if (!stack.length && !mayOpenCustomTag(source)) {
         needsTopLevelSeparator = false
         continue
@@ -273,6 +280,8 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
             cursor = index + childRaw.length
           }
           else {
+            if (stack.length && !isCustomTag)
+              continue
             sourceReliable = false
           }
         }
@@ -280,7 +289,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
         handleToken(child, raw, tag)
       }
 
-      if (sourceReliable && source && cursor < source.length && !stack.length)
+      if (sourceReliable && source && cursor < source.length && stack.length)
         appendSourceGap(source.slice(cursor))
 
       needsTopLevelSeparator = stack.length > 0
@@ -289,8 +298,9 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
 
     if (stack.length && typeof token.content === 'string') {
       const raw = tokenToRaw(token)
-      if (token.type === 'html_block' && isCloseOnlyTopFrame(raw)) {
-        closeTopFrameWithRaw(`${needsTopLevelSeparator ? '\n' : ''}${raw}`)
+      const closePrefix = token.type === 'html_block' ? getTopFrameClosePrefix(raw) : null
+      if (closePrefix) {
+        closeTopFrameWithRaw(`${needsTopLevelSeparator ? '\n' : ''}${closePrefix}`)
         needsTopLevelSeparator = stack.length > 0
         continue
       }

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -163,8 +163,16 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
   if (!customTagSet.size)
     return
 
+  const customTagOpenNeedles = Array.from(customTagSet, tag => `<${tag}`)
   const stack: Array<{ tag: string, token: MarkdownToken, raw: string, inner: string }> = []
   let needsTopLevelSeparator = false
+
+  const mayOpenCustomTag = (source: string) => {
+    if (!source)
+      return false
+    const lower = source.toLowerCase()
+    return customTagOpenNeedles.some(needle => lower.includes(needle))
+  }
 
   const appendToOpenFrames = (raw: string) => {
     if (!raw || !stack.length)
@@ -186,10 +194,10 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     appendToOpenFrames(gap.includes('\n') ? '\n' : gap)
   }
 
-  const handleToken = (child: MarkdownToken, raw: string) => {
-    const tag = child.type === 'html_inline'
+  const handleToken = (child: MarkdownToken, raw: string, knownTag?: string) => {
+    const tag = knownTag ?? (child.type === 'html_inline'
       ? getHtmlInlineTagName(raw)
-      : ''
+      : '')
     const isCustomTag = tag && customTagSet.has(tag)
 
     if (!isCustomTag) {
@@ -231,13 +239,22 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
       appendTopLevelSeparator()
 
       const source = String(token.content ?? '')
+      if (!stack.length && !mayOpenCustomTag(source)) {
+        needsTopLevelSeparator = false
+        continue
+      }
+
       let cursor = 0
       let sourceReliable = true
       for (const child of token.children) {
         const childRaw = tokenToRaw(child)
+        const tag = child.type === 'html_inline'
+          ? getHtmlInlineTagName(childRaw)
+          : ''
+        const isCustomTag = tag && customTagSet.has(tag)
         let raw = childRaw
 
-        if (sourceReliable && source && childRaw) {
+        if (sourceReliable && source && childRaw && (stack.length || isCustomTag)) {
           const index = source.indexOf(childRaw, cursor)
           if (index !== -1) {
             appendSourceGap(source.slice(cursor, index))
@@ -249,7 +266,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
           }
         }
 
-        handleToken(child, raw)
+        handleToken(child, raw, tag)
       }
 
       if (sourceReliable && source && cursor < source.length)

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -164,6 +164,7 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     return
 
   const stack: Array<{ tag: string, token: MarkdownToken, raw: string, inner: string }> = []
+  let needsTopLevelSeparator = false
 
   const appendToOpenFrames = (raw: string) => {
     if (!raw || !stack.length)
@@ -174,8 +175,18 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
     }
   }
 
-  const handleToken = (child: MarkdownToken) => {
-    const raw = tokenToRaw(child)
+  const appendTopLevelSeparator = () => {
+    if (!stack.length || !needsTopLevelSeparator)
+      return
+    appendToOpenFrames('\n')
+    needsTopLevelSeparator = false
+  }
+
+  const appendSourceGap = (gap: string) => {
+    appendToOpenFrames(gap.includes('\n') ? '\n' : gap)
+  }
+
+  const handleToken = (child: MarkdownToken, raw: string) => {
     const tag = child.type === 'html_inline'
       ? getHtmlInlineTagName(raw)
       : ''
@@ -217,13 +228,42 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
 
   for (const token of tokens) {
     if (token.type === 'inline' && Array.isArray(token.children)) {
-      for (const child of token.children)
-        handleToken(child)
+      appendTopLevelSeparator()
+
+      const source = String(token.content ?? '')
+      let cursor = 0
+      let sourceReliable = true
+      for (const child of token.children) {
+        const childRaw = tokenToRaw(child)
+        let raw = childRaw
+
+        if (sourceReliable && source && childRaw) {
+          const index = source.indexOf(childRaw, cursor)
+          if (index !== -1) {
+            appendSourceGap(source.slice(cursor, index))
+            raw = source.slice(index, index + childRaw.length)
+            cursor = index + childRaw.length
+          }
+          else {
+            sourceReliable = false
+          }
+        }
+
+        handleToken(child, raw)
+      }
+
+      if (sourceReliable && source && cursor < source.length)
+        appendSourceGap(source.slice(cursor))
+
+      needsTopLevelSeparator = stack.length > 0
       continue
     }
 
-    if (stack.length && typeof token.content === 'string')
+    if (stack.length && typeof token.content === 'string') {
+      appendTopLevelSeparator()
       appendToOpenFrames(token.content)
+      needsTopLevelSeparator = true
+    }
   }
 
   for (const frame of stack)

--- a/packages/markdown-parser/src/plugins/fixHtmlInline.ts
+++ b/packages/markdown-parser/src/plugins/fixHtmlInline.ts
@@ -163,15 +163,14 @@ function attachCustomHtmlSourceMeta(tokens: MarkdownToken[], customTagSet: Set<s
   if (!customTagSet.size)
     return
 
-  const customTagOpenNeedles = Array.from(customTagSet, tag => `<${tag}`)
+  const customTagOpenRes = Array.from(customTagSet, tag => new RegExp(String.raw`<\s*${escapeTagForRegExp(tag)}(?=[\s>/])`, 'i'))
   const stack: Array<{ tag: string, token: MarkdownToken, raw: string, inner: string }> = []
   let needsTopLevelSeparator = false
 
   const mayOpenCustomTag = (source: string) => {
     if (!source)
       return false
-    const lower = source.toLowerCase()
-    return customTagOpenNeedles.some(needle => lower.includes(needle))
+    return customTagOpenRes.some(re => re.test(source))
   }
 
   const appendToOpenFrames = (raw: string) => {

--- a/packages/markdown-parser/src/types.d.ts
+++ b/packages/markdown-parser/src/types.d.ts
@@ -323,8 +323,8 @@ export interface ParseOptions {
     /**
      * Custom HTML-like tag names that should be emitted as custom nodes
      * instead of `html_inline` when encountered (e.g. ['thinking']).
-     * Used by inline parsing; pair with `getMarkdown({ customHtmlTags })`
-     * to enable mid-state suppression for the same tags during streaming.
+     * Used by inline parsing and passed to markdown-it core rules for
+     * mid-state suppression during streaming.
      */
     customHtmlTags?: readonly string[];
     /**

--- a/packages/markdown-parser/src/types.ts
+++ b/packages/markdown-parser/src/types.ts
@@ -422,8 +422,8 @@ export interface ParseOptions {
   /**
    * Custom HTML-like tag names that should be emitted as custom nodes
    * instead of `html_inline` when encountered (e.g. ['thinking']).
-   * Used by inline parsing; pair with `getMarkdown({ customHtmlTags })`
-   * to enable mid-state suppression for the same tags during streaming.
+   * Used by inline parsing and passed to markdown-it core rules for
+   * mid-state suppression during streaming.
    */
   customHtmlTags?: readonly string[]
   /**

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -74,14 +74,37 @@ describe('custom HTML JSON content', () => {
   it('preserves line separators and straight quotes inside nested custom tags', () => {
     const tags = ['thinking']
     const md = getMarkdown('custom-html-json-quotes-nested-lines', { customHtmlTags: tags })
-    const markdown = '- prefix <thinking>line 1\n\n  line 2 "ok"</thinking>'
+    const content = 'line 1\nline 2 "ok"'
+    const markdown = `- prefix <thinking>${content}</thinking>`
 
     const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
     const thinking = findNodeByType(nodes, 'thinking')
 
-    expect(thinking?.content).toMatch(/^line 1\n+line 2 "ok"$/)
+    expect(thinking?.content).toBe(content)
     expect(String(thinking?.content ?? '')).not.toContain('“')
     expect(String(thinking?.content ?? '')).not.toContain('”')
+  })
+
+  it('preserves pretty JSON payload whitespace inside custom tags', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-pretty-json', { customHtmlTags: tags })
+    const payload = [
+      '{',
+      '  "type": "fileinfo",',
+      '',
+      '  "meta": {',
+      '    "title": "技能市场产品需求文档.md"',
+      '  }',
+      '}',
+    ].join('\n')
+    const markdown = `<custom-data>\n${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
   it('keeps typographer enabled for normal markdown text', () => {

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+const customDataChunks = [
+  '<custom-data>{"',
+  'type":"fileinfo',
+  '","filename":"技能',
+  '市场产品',
+  '需求文档.md',
+  '","url":"/',
+  'center',
+  '/cke',
+  'Api',
+  '/api/tools',
+  '/file/download?',
+  'fileId=',
+  '67e',
+  '3e',
+  '46',
+  'd-f',
+  '962',
+  '-459',
+  'd',
+  '-a03',
+  'd',
+  '-366',
+  'a0',
+  'af5',
+  'eb69',
+  '"}</custom-data',
+  '>',
+]
+
+function findCustomDataNode(nodes: any[]): any | undefined {
+  for (const node of nodes) {
+    if (node?.type === 'custom-data')
+      return node
+    if (Array.isArray(node?.children)) {
+      const found = findCustomDataNode(node.children)
+      if (found)
+        return found
+    }
+  }
+}
+
+describe('custom HTML JSON content', () => {
+  it('preserves straight JSON quotes inside a streamed custom tag', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-streaming', { customHtmlTags: tags })
+    let content = ''
+
+    for (const chunk of customDataChunks) {
+      content += chunk
+      const nodes = parseMarkdownToStructure(content, md, { customHtmlTags: tags, final: false }) as any[]
+      const customData = findCustomDataNode(nodes)
+      if (!customData?.content)
+        continue
+
+      expect(String(customData.content)).not.toContain('“')
+      expect(String(customData.content)).not.toContain('”')
+    }
+
+    const nodes = parseMarkdownToStructure(content, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findCustomDataNode(nodes)
+    expect(customData?.content).toBe('{"type":"fileinfo","filename":"技能市场产品需求文档.md","url":"/center/ckeApi/api/tools/file/download?fileId=67e3e46d-f962-459d-a03d-366a0af5eb69"}')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+})

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -121,6 +121,22 @@ describe('custom HTML JSON content', () => {
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
+  it('preserves source payload when customHtmlTags are provided at parse time', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-parse-time-tags')
+    const payload = '{"quote":"ok"}'
+    const markdown = `<custom-data>${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(String(customData?.content ?? '')).not.toContain('“')
+    expect(String(customData?.content ?? '')).not.toContain('”')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
   it('preserves trailing source while a streamed custom tag is still open', () => {
     const tags = ['custom-data']
     const md = getMarkdown('custom-html-json-quotes-open-trailing-source', { customHtmlTags: tags })
@@ -189,6 +205,7 @@ describe('custom HTML JSON content', () => {
 
     expect(customData?.content).toBe('{"a":"b"}')
     expect(String(customData?.content ?? '')).not.toContain('trailing')
+    expect(JSON.stringify(nodes)).toContain('trailing')
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -107,6 +107,23 @@ describe('custom HTML JSON content', () => {
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
+  it('does not include a top-level html_block closing tag in custom JSON content', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-html-block-close', { customHtmlTags: tags })
+    const markdown = [
+      '- prefix <custom-data>{"a":"b"}',
+      '',
+      '</custom-data>',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe('{"a":"b"}')
+    expect(String(customData?.raw ?? '')).toContain('</custom-data>')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
   it('keeps typographer enabled for normal markdown text', () => {
     const md = getMarkdown('custom-html-json-quotes-normal-text')
     const nodes = parseMarkdownToStructure('He said "ok".', md, { final: true }) as any[]

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -107,6 +107,31 @@ describe('custom HTML JSON content', () => {
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
+  it('keeps source payload separate from markdown-rendered children', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-markdown-children', { customHtmlTags: tags })
+    const payload = '{"title":"**Report**","note":"don\'t change \\"quotes\\" or x_y"}'
+    const markdown = `<custom-data>${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+    expect(customData?.children?.some((child: any) => child.type === 'strong')).toBe(true)
+  })
+
+  it('does not confuse custom tag names with longer tag prefixes', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-prefix-tags', { customHtmlTags: tags })
+    const markdown = '<custom-data2>{"a":"b"}</custom-data2>'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+  })
+
   it('does not include a top-level html_block closing tag in custom JSON content', () => {
     const tags = ['custom-data']
     const md = getMarkdown('custom-html-json-quotes-html-block-close', { customHtmlTags: tags })

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -209,6 +209,95 @@ describe('custom HTML JSON content', () => {
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
+  it('does not rewrite custom close-looking text inside fenced code', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-fenced-close-text', { customHtmlTags: tags })
+    const markdown = [
+      '```html',
+      '</custom-data> trailing',
+      '```',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+    expect(JSON.stringify(nodes)).toContain('</custom-data> trailing')
+  })
+
+  it('does not rewrite custom close-looking text inside indented code', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-indented-close-text', { customHtmlTags: tags })
+    const markdown = '    </custom-data> trailing'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const codeBlock = findNodeByType(nodes, 'code_block')
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+    expect(String(codeBlock?.code ?? codeBlock?.content ?? '')).toContain('</custom-data> trailing')
+  })
+
+  it('does not rewrite an isolated custom closing tag with trailing text', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-isolated-close-text', { customHtmlTags: tags })
+    const markdown = '</custom-data> trailing'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+    expect(JSON.stringify(nodes)).toContain('</custom-data> trailing')
+  })
+
+  it('preserves indentation after a custom closing tag with trailing code', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-close-trailing-code', { customHtmlTags: tags })
+    const markdown = [
+      '<custom-data>{"a":"b"}',
+      '</custom-data>    const value = 1',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+    const codeBlock = findNodeByType(nodes, 'code_block')
+
+    expect(customData?.content).toBe('{"a":"b"}')
+    expect(String(codeBlock?.code ?? codeBlock?.content ?? '')).toContain('const value = 1')
+  })
+
+  it('handles blockquote custom close tags with trailing text', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-blockquote-close-trailing', { customHtmlTags: tags })
+    const markdown = [
+      '> <custom-data>{"a":"b"}',
+      '> </custom-data> trailing',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(String(customData?.content ?? '').trimEnd()).toBe('{"a":"b"}')
+    expect(String(customData?.content ?? '')).not.toContain('trailing')
+    expect(JSON.stringify(nodes)).toContain('trailing')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
+  it('handles custom close tags with no separating whitespace before trailing text', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-close-no-space-trailing', { customHtmlTags: tags })
+    const markdown = [
+      '- prefix <custom-data>{"a":"b"}',
+      '',
+      '</custom-data>trailing',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe('{"a":"b"}')
+    expect(String(customData?.content ?? '')).not.toContain('trailing')
+    expect(JSON.stringify(nodes)).toContain('trailing')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
   it('keeps typographer enabled for normal markdown text', () => {
     const md = getMarkdown('custom-html-json-quotes-normal-text')
     const nodes = parseMarkdownToStructure('He said "ok".', md, { final: true }) as any[]

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -31,12 +31,17 @@ const customDataChunks = [
   '>',
 ]
 
-function findCustomDataNode(nodes: any[]): any | undefined {
+function findNodeByType(nodes: any[], type: string): any | undefined {
   for (const node of nodes) {
-    if (node?.type === 'custom-data')
+    if (node?.type === type)
       return node
     if (Array.isArray(node?.children)) {
-      const found = findCustomDataNode(node.children)
+      const found = findNodeByType(node.children, type)
+      if (found)
+        return found
+    }
+    if (Array.isArray(node?.items)) {
+      const found = findNodeByType(node.items, type)
       if (found)
         return found
     }
@@ -52,7 +57,7 @@ describe('custom HTML JSON content', () => {
     for (const chunk of customDataChunks) {
       content += chunk
       const nodes = parseMarkdownToStructure(content, md, { customHtmlTags: tags, final: false }) as any[]
-      const customData = findCustomDataNode(nodes)
+      const customData = findNodeByType(nodes, 'custom-data')
       if (!customData?.content)
         continue
 
@@ -61,8 +66,21 @@ describe('custom HTML JSON content', () => {
     }
 
     const nodes = parseMarkdownToStructure(content, md, { customHtmlTags: tags, final: true }) as any[]
-    const customData = findCustomDataNode(nodes)
+    const customData = findNodeByType(nodes, 'custom-data')
     expect(customData?.content).toBe('{"type":"fileinfo","filename":"技能市场产品需求文档.md","url":"/center/ckeApi/api/tools/file/download?fileId=67e3e46d-f962-459d-a03d-366a0af5eb69"}')
     expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
+  it('preserves line separators and straight quotes inside nested custom tags', () => {
+    const tags = ['thinking']
+    const md = getMarkdown('custom-html-json-quotes-nested-lines', { customHtmlTags: tags })
+    const markdown = '- prefix <thinking>line 1\n\n  line 2 "ok"</thinking>'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const thinking = findNodeByType(nodes, 'thinking')
+
+    expect(thinking?.content).toMatch(/^line 1\n+line 2 "ok"$/)
+    expect(String(thinking?.content ?? '')).not.toContain('“')
+    expect(String(thinking?.content ?? '')).not.toContain('”')
   })
 })

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -83,4 +83,12 @@ describe('custom HTML JSON content', () => {
     expect(String(thinking?.content ?? '')).not.toContain('“')
     expect(String(thinking?.content ?? '')).not.toContain('”')
   })
+
+  it('keeps typographer enabled for normal markdown text', () => {
+    const md = getMarkdown('custom-html-json-quotes-normal-text')
+    const nodes = parseMarkdownToStructure('He said "ok".', md, { final: true }) as any[]
+    const text = nodes[0]?.children?.[0]?.content
+
+    expect(text).toBe('He said “ok”.')
+  })
 })

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -107,6 +107,32 @@ describe('custom HTML JSON content', () => {
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
+  it('preserves HTML entities in source payload content', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-entities', { customHtmlTags: tags })
+    const payload = '{"text":"a&amp;b","quote":"&quot;","numeric":"&#34;"}'
+    const markdown = `<custom-data>${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
+  it('preserves trailing source while a streamed custom tag is still open', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-open-trailing-source', { customHtmlTags: tags })
+    const payload = '{"text":"a&amp;b"}   '
+    const markdown = `<custom-data>${payload}`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: false }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+  })
+
   it('keeps source payload separate from markdown-rendered children', () => {
     const tags = ['custom-data']
     const md = getMarkdown('custom-html-json-quotes-markdown-children', { customHtmlTags: tags })
@@ -146,6 +172,23 @@ describe('custom HTML JSON content', () => {
 
     expect(customData?.content).toBe('{"a":"b"}')
     expect(String(customData?.raw ?? '')).toContain('</custom-data>')
+    expect(() => JSON.parse(customData.content)).not.toThrow()
+  })
+
+  it('does not include top-level html_block closing tag trailing content in custom JSON content', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-html-block-close-trailing', { customHtmlTags: tags })
+    const markdown = [
+      '- prefix <custom-data>{"a":"b"}',
+      '',
+      '</custom-data> trailing',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe('{"a":"b"}')
+    expect(String(customData?.content ?? '')).not.toContain('trailing')
     expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 

--- a/packages/markdown-parser/test/custom-html-json-quotes.test.ts
+++ b/packages/markdown-parser/test/custom-html-json-quotes.test.ts
@@ -149,6 +149,21 @@ describe('custom HTML JSON content', () => {
     expect(customData?.content).toBe(payload)
   })
 
+  it('keeps raw in a streamed custom tag source state instead of auto-closing it', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-open-raw-contract', { customHtmlTags: tags })
+    const payload = '{"a":"b"}'
+    const markdown = `<custom-data>\n${payload}`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: false }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(customData?.raw).not.toContain('</custom-data>')
+    expect(customData?.loading).toBe(true)
+  })
+
   it('keeps source payload separate from markdown-rendered children', () => {
     const tags = ['custom-data']
     const md = getMarkdown('custom-html-json-quotes-markdown-children', { customHtmlTags: tags })
@@ -172,6 +187,49 @@ describe('custom HTML JSON content', () => {
     const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
 
     expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+  })
+
+  it('treats a literal custom closing tag inside JSON as the HTML delimiter', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-literal-close-delimiter', { customHtmlTags: tags })
+    const markdown = '<custom-data>{"text":"literal </custom-data> in json"}</custom-data>'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe('{"text":"literal ')
+    expect(String(customData?.raw ?? '')).toBe('<custom-data>{"text":"literal </custom-data>')
+    expect(JSON.stringify(nodes)).toContain(' in json')
+    expect(() => JSON.parse(customData.content)).toThrow()
+  })
+
+  it('preserves escaped custom close markers inside JSON payloads', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-escaped-close-marker', { customHtmlTags: tags })
+    const payload = '{"text":"literal \\u003c/custom-data> in json"}'
+    const markdown = `<custom-data>${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(JSON.parse(customData.content).text).toBe('literal </custom-data> in json')
+  })
+
+  it('preserves custom tag attrs with greater-than characters while keeping JSON payload source', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-attr-gt', { customHtmlTags: tags })
+    const payload = '{"a":"b"}'
+    const markdown = `<custom-data data-x="a>b">${payload}</custom-data>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const customData = findNodeByType(nodes, 'custom-data')
+
+    expect(customData?.attrs).toContainEqual(['data-x', 'a>b'])
+    expect(customData?.content).toBe(payload)
+    expect(customData?.raw).toBe(markdown)
+    expect(() => JSON.parse(customData.content)).not.toThrow()
   })
 
   it('does not include a top-level html_block closing tag in custom JSON content', () => {
@@ -224,6 +282,22 @@ describe('custom HTML JSON content', () => {
     expect(JSON.stringify(nodes)).toContain('</custom-data> trailing')
   })
 
+  it('does not emit custom nodes for complete custom tags inside fenced code', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-fenced-full-tag', { customHtmlTags: tags })
+    const markdown = [
+      '```html',
+      '<custom-data>{"a":"b"}</custom-data>',
+      '```',
+    ].join('\n')
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const codeBlock = findNodeByType(nodes, 'code_block')
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+    expect(String(codeBlock?.code ?? codeBlock?.content ?? '')).toContain('<custom-data>{"a":"b"}</custom-data>')
+  })
+
   it('does not rewrite custom close-looking text inside indented code', () => {
     const tags = ['custom-data']
     const md = getMarkdown('custom-html-json-quotes-indented-close-text', { customHtmlTags: tags })
@@ -234,6 +308,18 @@ describe('custom HTML JSON content', () => {
 
     expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
     expect(String(codeBlock?.code ?? codeBlock?.content ?? '')).toContain('</custom-data> trailing')
+  })
+
+  it('does not emit custom nodes for complete custom tags inside indented code', () => {
+    const tags = ['custom-data']
+    const md = getMarkdown('custom-html-json-quotes-indented-full-tag', { customHtmlTags: tags })
+    const markdown = '    <custom-data>{"a":"b"}</custom-data>'
+
+    const nodes = parseMarkdownToStructure(markdown, md, { customHtmlTags: tags, final: true }) as any[]
+    const codeBlock = findNodeByType(nodes, 'code_block')
+
+    expect(findNodeByType(nodes, 'custom-data')).toBeUndefined()
+    expect(String(codeBlock?.code ?? codeBlock?.content ?? '')).toContain('<custom-data>{"a":"b"}</custom-data>')
   })
 
   it('does not rewrite an isolated custom closing tag with trailing text', () => {


### PR DESCRIPTION
## Summary

Fix custom HTML tag content being smart-quoted by markdown-it typographer during streaming, which broke JSON payloads such as `<custom-data>{\"type\":...}</custom-data>`.

The parser now preserves quote-sensitive `content`/`raw` for configured custom tags while keeping parsed `children` on the normal Markdown inline path for renderers. The preservation is scoped to declared custom tags, not unknown HTML tags or global typographer behavior.

close: #466

## Changes

- [x] Capture custom HTML raw/inner text before typographer-mutated inline tokens are emitted.
- [x] Prefer the preserved inner text when creating custom tag node `content`/`raw`.
- [x] Preserve line separators for custom tags that span top-level inline token boundaries.
- [x] Exclude close-only top-level `html_block` tokens from custom node `content` while keeping them in `raw`.
- [x] Skip source-meta scanning when an inline token cannot open a configured custom tag.
- [x] Add regression coverage for the streamed `<custom-data>` JSON payload and `JSON.parse` compatibility.
- [x] Add regression coverage for pretty JSON payload whitespace, blank lines, and `raw` preservation.
- [x] Add regression coverage for custom tags closed by a top-level `html_block` token.
- [x] Add regression coverage proving normal Markdown text still uses typographer smart quotes.
- [x] Document the custom tag contract: use `content`/`raw` for source payloads and `children` for Markdown-rendered rich text.

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot (not UI-visible; parser-only fix)
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test (not applicable; issue includes a StackBlitz repro)

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `NODE_OPTIONS=--no-experimental-webstorage pnpm test` (Node 25 local Web Storage workaround)
- [x] Targeted parser regression: `pnpm --filter stream-markdown-parser test:run custom-html-json-quotes.test.ts`
- [x] Adjacent HTML/custom parser tests: `pnpm exec vitest --run packages/markdown-parser/test/html-inline.test.ts packages/markdown-parser/test/html-inline-plugin.test.ts packages/markdown-parser/test/issue-380-html-wrapper-markdown.test.ts packages/markdown-parser/test/escaped-punctuation-nested.test.ts packages/markdown-parser/test/custom-html-json-quotes.test.ts`
- [x] Parser package tests: `pnpm exec vitest --run packages/markdown-parser/test`
- [x] Build: `pnpm build` (library + CSS)
- [x] Parser build: `pnpm run build:parser`
- [x] Docs build: `pnpm docs:build`
- [x] Local benchmark sanity: `MARKSTREAM_BENCHMARK_SAMPLES=baseline pnpm benchmark:1.0`
