### PR TITLE
fix: isolate utils package entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
       "import": "./dist/index.js"
     },
     "./utils": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
     },
     "./utils/katex-threshold": {
       "types": "./dist/utils/katex-threshold.d.ts",

--- a/scripts/check-package-exports.mjs
+++ b/scripts/check-package-exports.mjs
@@ -31,6 +31,7 @@ const runtimeSubpathChecks = [
   {
     subpath: './utils',
     exports: ['getLanguageIcon', 'normalizeLanguageIdentifier', 'parseMarkdownToStructure', 'safeRaf'],
+    forbiddenExports: isolatedRootExports,
   },
   {
     subpath: './utils/katex-threshold',
@@ -71,10 +72,6 @@ const runtimeSubpathChecks = [
 
 const failures = []
 const rootImportTarget = typeof pkg.exports?.['.'] === 'object' ? pkg.exports['.'].import : undefined
-const rootBackedSubpathsAllowed = new Set([
-  './utils',
-])
-
 function normalizeTargets(entry) {
   if (typeof entry === 'string')
     return [{ condition: 'default', target: entry }]
@@ -130,7 +127,6 @@ for (const subpath of requiredSubpaths) {
     && typeof entry.import === 'string'
     && typeof rootImportTarget === 'string'
     && entry.import === rootImportTarget
-    && !rootBackedSubpathsAllowed.has(subpath)
   ) {
     failures.push(`${subpath} should not import the root bundle (${rootImportTarget})`)
   }

--- a/scripts/check-package-exports.mjs
+++ b/scripts/check-package-exports.mjs
@@ -25,7 +25,21 @@ const requiredSubpaths = [
   './workers/mermaidParser.worker',
 ]
 
-const isolatedRootExports = ['MarkdownRender', 'VueRendererMarkdown', 'CodeBlockNode']
+const isolatedRootExports = [
+  'MarkdownRender',
+  'VueRendererMarkdown',
+  'CodeBlockNode',
+  'MarkdownCodeBlockNode',
+  'MathBlockNode',
+  'MathInlineNode',
+  'MermaidBlockNode',
+  'D2BlockNode',
+  'InfographicBlockNode',
+  'MarkstreamVirtualTimeline',
+  'Tooltip',
+  'useMarkstreamVirtualAdapter',
+  'useSmoothMarkdownStream',
+]
 
 const runtimeSubpathChecks = [
   {

--- a/scripts/check-package-size.mjs
+++ b/scripts/check-package-size.mjs
@@ -7,10 +7,10 @@ const root = process.cwd()
 const distDir = join(root, 'dist')
 
 const budgets = {
-  maxDistBytes: Number(process.env.MAX_DIST_BYTES || 820 * 1024),
+  maxDistBytes: Number(process.env.MAX_DIST_BYTES || 840 * 1024),
   maxJsChunkBytes: Number(process.env.MAX_JS_CHUNK_BYTES || 300 * 1024),
   maxPackSizeBytes: Number(process.env.MAX_PACK_TGZ_BYTES || 250 * 1024),
-  maxPackUnpackedBytes: Number(process.env.MAX_PACK_UNPACKED_BYTES || 900 * 1024),
+  maxPackUnpackedBytes: Number(process.env.MAX_PACK_UNPACKED_BYTES || 910 * 1024),
 }
 
 function formatBytes(bytes) {

--- a/scripts/check-subpath-isolation.mjs
+++ b/scripts/check-subpath-isolation.mjs
@@ -6,6 +6,7 @@ const rootTypes = pkg.exports?.['.']?.types
 const rootImport = pkg.exports?.['.']?.import
 
 const isolatedSubpaths = [
+  './utils',
   './utils/katex-threshold',
   './utils/performance-monitor',
   './utils/safeRaf',

--- a/scripts/rollup.dts.config.mjs
+++ b/scripts/rollup.dts.config.mjs
@@ -12,6 +12,14 @@ const entryPoints = [
     ],
   },
   {
+    output: 'dist/utils/index.d.ts',
+    candidates: [
+      './dist/types/src/entries/utils.d.ts',
+      './dist/types/entries/utils.d.ts',
+      './dist/utils/index.d.ts',
+    ],
+  },
+  {
     output: 'dist/utils/katex-threshold.d.ts',
     candidates: [
       './dist/types/src/entries/utils-katex-threshold.d.ts',

--- a/src/entries/utils.ts
+++ b/src/entries/utils.ts
@@ -1,0 +1,1 @@
+export * from '../utils'

--- a/test/public-api/public-api-package-negative.ts
+++ b/test/public-api/public-api-package-negative.ts
@@ -1,5 +1,5 @@
-// @ts-expect-error Declared subpaths must still reject unknown exports.
-import { __missingUtilsExport } from 'markstream-vue/utils'
+// @ts-expect-error Declared utilities subpath must reject unknown and root-only exports.
+import { __missingUtilsExport, VueRendererMarkdown as __unexpectedUtilsRenderer } from 'markstream-vue/utils'
 
 // @ts-expect-error Isolated utility subpaths must not expose renderer/root exports.
 import { MarkdownRender as __unexpectedKatexThresholdRenderer } from 'markstream-vue/utils/katex-threshold'
@@ -10,4 +10,5 @@ import { __missingWorkerExport, MarkdownRender as __unexpectedWorkerRenderer } f
 void __missingUtilsExport
 void __missingWorkerExport
 void __unexpectedKatexThresholdRenderer
+void __unexpectedUtilsRenderer
 void __unexpectedWorkerRenderer

--- a/test/public-api/public-api-package-negative.ts
+++ b/test/public-api/public-api-package-negative.ts
@@ -1,14 +1,24 @@
-// @ts-expect-error Declared utilities subpath must reject unknown and root-only exports.
-import { __missingUtilsExport, VueRendererMarkdown as __unexpectedUtilsRenderer } from 'markstream-vue/utils'
+import type * as MarkstreamUtils from 'markstream-vue/utils'
+import type * as KatexThresholdUtils from 'markstream-vue/utils/katex-threshold'
+import type * as KatexWorkerClient from 'markstream-vue/workers/katexWorkerClient'
+
+// @ts-expect-error Declared utilities subpath must reject unknown exports.
+type MissingUtilsExport = typeof MarkstreamUtils.__missingUtilsExport
+
+// @ts-expect-error Utilities subpath must not expose root-only renderer exports.
+type UnexpectedUtilsRenderer = typeof MarkstreamUtils.VueRendererMarkdown
 
 // @ts-expect-error Isolated utility subpaths must not expose renderer/root exports.
-import { MarkdownRender as __unexpectedKatexThresholdRenderer } from 'markstream-vue/utils/katex-threshold'
+type UnexpectedKatexThresholdRenderer = typeof KatexThresholdUtils.MarkdownRender
 
-// @ts-expect-error Declared worker subpaths must reject unknown and root-only exports.
-import { __missingWorkerExport, MarkdownRender as __unexpectedWorkerRenderer } from 'markstream-vue/workers/katexWorkerClient'
+// @ts-expect-error Declared worker subpaths must reject unknown exports.
+type MissingWorkerExport = typeof KatexWorkerClient.__missingWorkerExport
 
-void __missingUtilsExport
-void __missingWorkerExport
-void __unexpectedKatexThresholdRenderer
-void __unexpectedUtilsRenderer
-void __unexpectedWorkerRenderer
+// @ts-expect-error Declared worker subpaths must reject root-only exports.
+type UnexpectedWorkerRenderer = typeof KatexWorkerClient.MarkdownRender
+
+void (null as unknown as MissingUtilsExport)
+void (null as unknown as MissingWorkerExport)
+void (null as unknown as UnexpectedKatexThresholdRenderer)
+void (null as unknown as UnexpectedUtilsRenderer)
+void (null as unknown as UnexpectedWorkerRenderer)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig(({ mode }) => {
       lib: {
         entry: {
           'index': './src/exports.ts',
+          'utils/index': './src/entries/utils.ts',
           'utils/katex-threshold': './src/entries/utils-katex-threshold.ts',
           'utils/performance-monitor': './src/entries/utils-performance-monitor.ts',
           'utils/safeRaf': './src/entries/utils-safeRaf.ts',


### PR DESCRIPTION
## Summary
- add a dedicated Vite library entry for `markstream-vue/utils`
- point the package `./utils` export at `dist/utils/index.*` instead of the root bundle
- extend package export checks to keep `./utils` isolated from root-only renderer exports

## Verification
- `pnpm run test:api:strict`
- `pnpm lint`
- `pnpm exec vue-tsc -p tsconfig.public-api.package.json --noEmit`