### PR TITLE
fix: log parse stabilize metrics

### DIFF
--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -41,8 +41,13 @@ interface ParsedNodeSignatureTimingMetrics {
 }
 
 interface ParsedNodeStabilizeMetrics {
+  /** Count of reused nodes anywhere in nextNodes, including unchanged suffix nodes after dirtyStartIndex. */
   reusedNodeCount: number
+  /** First index whose node identity/signature changed; -1 means no dirty node. */
   dirtyStartIndex: number
+  /** Count of stable leading nodes in nextNodes. */
+  stablePrefixNodeCount: number
+  /** Count of nodes in the dirty tail across previousNodes and nextNodes. */
   dirtyTailNodeCount: number
 }
 
@@ -118,9 +123,6 @@ const MAX_SIGNATURE_ARRAY_ITEMS = 200
 const MAX_SIGNATURE_STRING_CHARS = 8192
 const objectIdentityIds = new WeakMap<object, number>()
 const nodeSignatureCache = new WeakMap<object, string>()
-let activeSignatureTimingMetrics: ParsedNodeSignatureTimingMetrics | undefined
-let activeSignatureTimingMetricKey: 'stabilizeSignatureMs' | 'primeSignatureMs' | undefined
-let signatureTimingDepth = 0
 let nextObjectIdentityId = 1
 
 function getNow() {
@@ -352,34 +354,6 @@ function getParsedNodeSignature(
   seen = new WeakMap<object, string>(),
   depth = 0,
 ) {
-  const metrics = activeSignatureTimingMetrics
-  const metricKey = activeSignatureTimingMetricKey
-
-  if (!metrics || !metricKey)
-    return getParsedNodeSignatureImpl(node, seen, depth)
-
-  const shouldMeasure = signatureTimingDepth === 0
-  const startedAt = shouldMeasure ? getNow() : 0
-  signatureTimingDepth += 1
-
-  try {
-    return getParsedNodeSignatureImpl(node, seen, depth)
-  }
-  finally {
-    signatureTimingDepth -= 1
-    if (shouldMeasure) {
-      const elapsed = getNow() - startedAt
-      metrics[metricKey] += elapsed
-      metrics.signatureMs = metrics.stabilizeSignatureMs + metrics.primeSignatureMs
-    }
-  }
-}
-
-function getParsedNodeSignatureImpl(
-  node: ParsedNode,
-  seen = new WeakMap<object, string>(),
-  depth = 0,
-) {
   const cached = nodeSignatureCache.get(node as object)
   if (cached)
     return cached
@@ -404,36 +378,79 @@ function isParsedNodeStable(previous: ParsedNode, next: ParsedNode) {
   return getParsedNodeSignature(previous) === getParsedNodeSignature(next)
 }
 
-function withSignatureTiming<T>(
-  metrics: ParsedNodeSignatureTimingMetrics | undefined,
+function trackSignatureTiming<T>(
+  metrics: ParsedNodeSignatureTimingMetrics,
   metricKey: 'stabilizeSignatureMs' | 'primeSignatureMs',
   callback: () => T,
 ) {
-  if (!metrics && !activeSignatureTimingMetrics)
-    return callback()
-
-  const previousMetrics = activeSignatureTimingMetrics
-  const previousMetricKey = activeSignatureTimingMetricKey
-  activeSignatureTimingMetrics = metrics
-  activeSignatureTimingMetricKey = metrics ? metricKey : undefined
+  const startedAt = getNow()
   try {
     return callback()
   }
   finally {
-    activeSignatureTimingMetrics = previousMetrics
-    activeSignatureTimingMetricKey = previousMetricKey
+    metrics[metricKey] += getNow() - startedAt
+    metrics.signatureMs = metrics.stabilizeSignatureMs + metrics.primeSignatureMs
   }
+}
+
+function getParsedNodeSignatureWithTiming(
+  node: ParsedNode,
+  metrics: ParsedNodeSignatureTimingMetrics,
+  metricKey: 'stabilizeSignatureMs' | 'primeSignatureMs',
+) {
+  return trackSignatureTiming(
+    metrics,
+    metricKey,
+    () => getParsedNodeSignature(node),
+  )
+}
+
+function isParsedNodeStableWithMetrics(
+  previous: ParsedNode,
+  next: ParsedNode,
+  metrics: ParsedNodeSignatureTimingMetrics,
+) {
+  return getParsedNodeSignatureWithTiming(previous, metrics, 'stabilizeSignatureMs')
+    === getParsedNodeSignatureWithTiming(next, metrics, 'stabilizeSignatureMs')
 }
 
 function getInitialStabilizeMetrics(nodeCount: number): ParsedNodeStabilizeMetrics {
   return {
     reusedNodeCount: 0,
     dirtyStartIndex: nodeCount > 0 ? 0 : -1,
+    stablePrefixNodeCount: 0,
     dirtyTailNodeCount: nodeCount,
   }
 }
 
-function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode[]): ParsedNodeStabilizeResult {
+function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode[]) {
+  if (!previousNodes.length)
+    return nextNodes
+
+  const stableNodes = new Array<ParsedNode>(nextNodes.length)
+  let identical = nextNodes.length === previousNodes.length
+
+  for (let index = 0; index < nextNodes.length; index++) {
+    const previous = previousNodes[index]
+    const next = nextNodes[index]
+
+    if (previous && isParsedNodeStable(previous, next)) {
+      stableNodes[index] = previous
+    }
+    else {
+      stableNodes[index] = next
+      identical = false
+    }
+  }
+
+  return identical ? previousNodes : stableNodes
+}
+
+function stabilizeParsedNodesWithMetrics(
+  nextNodes: ParsedNode[],
+  previousNodes: ParsedNode[],
+  signatureTiming: ParsedNodeSignatureTimingMetrics,
+): ParsedNodeStabilizeResult {
   if (!previousNodes.length) {
     return {
       nodes: nextNodes,
@@ -450,7 +467,7 @@ function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode
     const previous = previousNodes[index]
     const next = nextNodes[index]
 
-    if (previous && isParsedNodeStable(previous, next)) {
+    if (previous && isParsedNodeStableWithMetrics(previous, next, signatureTiming)) {
       stableNodes[index] = previous
       reusedNodeCount += 1
     }
@@ -465,12 +482,15 @@ function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode
   if (dirtyStartIndex < 0 && nextNodes.length !== previousNodes.length)
     dirtyStartIndex = Math.min(nextNodes.length, previousNodes.length)
 
+  const stablePrefixNodeCount = dirtyStartIndex < 0 ? nextNodes.length : dirtyStartIndex
+
   return {
     nodes: identical ? previousNodes : stableNodes,
     metrics: {
       reusedNodeCount,
       dirtyStartIndex,
-      dirtyTailNodeCount: dirtyStartIndex < 0 ? 0 : Math.max(0, nextNodes.length - dirtyStartIndex),
+      stablePrefixNodeCount,
+      dirtyTailNodeCount: dirtyStartIndex < 0 ? 0 : Math.max(nextNodes.length, previousNodes.length) - dirtyStartIndex,
     },
   }
 }
@@ -478,6 +498,19 @@ function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode
 function primeParsedNodeSignatures(nodes: ParsedNode[]) {
   for (const node of nodes)
     getParsedNodeSignature(node)
+}
+
+function primeParsedNodeSignaturesWithMetrics(
+  nodes: ParsedNode[],
+  signatureTiming: ParsedNodeSignatureTimingMetrics,
+) {
+  for (const node of nodes) {
+    trackSignatureTiming(
+      signatureTiming,
+      'primeSignatureMs',
+      () => getParsedNodeSignature(node),
+    )
+  }
 }
 
 function getStreamStatsDelta(current: StreamStatsLike, previous: StreamStatsLike | null) {
@@ -658,7 +691,8 @@ export function useMarkdownParsing(
       return []
     }
 
-    const parseStart = options.debugPerformanceEnabled.value
+    const collectPerformanceMetrics = options.debugPerformanceEnabled.value
+    const parseStart = collectPerformanceMetrics
       ? getNow()
       : 0
     const md = mdInstance.value
@@ -673,11 +707,11 @@ export function useMarkdownParsing(
       resetStreamParseCache(md)
     }
 
-    const streamStatsBefore = options.debugPerformanceEnabled.value
+    const streamStatsBefore = collectPerformanceMetrics
       ? readStreamStats(md)
       : null
 
-    const parserTiming: ParserTimingMetrics | undefined = options.debugPerformanceEnabled.value
+    const parserTiming: ParserTimingMetrics | undefined = collectPerformanceMetrics
       ? {}
       : undefined
     const parseOptionsForCall = parserTiming
@@ -689,29 +723,31 @@ export function useMarkdownParsing(
       md,
       parseOptionsForCall,
     )
-    const reuseStart = options.debugPerformanceEnabled.value
+    const reuseStart = collectPerformanceMetrics
       ? getNow()
       : 0
-    const signatureTiming: ParsedNodeSignatureTimingMetrics | undefined = options.debugPerformanceEnabled.value
+    const signatureTiming: ParsedNodeSignatureTimingMetrics | undefined = collectPerformanceMetrics
       ? { signatureMs: 0, stabilizeSignatureMs: 0, primeSignatureMs: 0 }
       : undefined
-    let stabilizeMetrics = getInitialStabilizeMetrics(nextParsed.length)
+    let stabilizeMetrics: ParsedNodeStabilizeMetrics | undefined = collectPerformanceMetrics
+      ? getInitialStabilizeMetrics(nextParsed.length)
+      : undefined
     let stabilizeMs = 0
     let parsed: ParsedNode[]
 
     if (canReuseParsedNodes) {
-      const stabilizeStart = options.debugPerformanceEnabled.value
+      const stabilizeStart = collectPerformanceMetrics
         ? getNow()
         : 0
-      const result = withSignatureTiming(
-        signatureTiming,
-        'stabilizeSignatureMs',
-        () => stabilizeParsedNodes(nextParsed, previousParsedNodes),
-      )
-
-      parsed = result.nodes
-      stabilizeMetrics = result.metrics
-      stabilizeMs = options.debugPerformanceEnabled.value
+      if (signatureTiming) {
+        const result = stabilizeParsedNodesWithMetrics(nextParsed, previousParsedNodes, signatureTiming)
+        parsed = result.nodes
+        stabilizeMetrics = result.metrics
+      }
+      else {
+        parsed = stabilizeParsedNodes(nextParsed, previousParsedNodes)
+      }
+      stabilizeMs = collectPerformanceMetrics
         ? getNow() - stabilizeStart
         : 0
     }
@@ -719,12 +755,12 @@ export function useMarkdownParsing(
       parsed = nextParsed
     }
 
-    withSignatureTiming(
-      signatureTiming,
-      'primeSignatureMs',
-      () => primeParsedNodeSignatures(parsed),
-    )
-    const nodeReuseMs = options.debugPerformanceEnabled.value
+    if (signatureTiming)
+      primeParsedNodeSignaturesWithMetrics(parsed, signatureTiming)
+    else
+      primeParsedNodeSignatures(parsed)
+
+    const nodeReuseMs = collectPerformanceMetrics
       ? getNow() - reuseStart
       : 0
     parseCommitCount += 1
@@ -732,7 +768,7 @@ export function useMarkdownParsing(
     previousParseSemanticKey = currentParseSemanticKey
     previousParsedNodes = parsed
 
-    if (options.debugPerformanceEnabled.value) {
+    if (collectPerformanceMetrics) {
       const streamStats = readStreamStats(md)
       const usedStream = typeof streamStats?.total === 'number'
         && streamStats.total > (streamStatsBefore?.total ?? 0)
@@ -749,7 +785,7 @@ export function useMarkdownParsing(
         stabilizeSignatureMs: signatureTiming?.stabilizeSignatureMs ?? 0,
         primeSignatureMs: signatureTiming?.primeSignatureMs ?? 0,
         stabilizeMs,
-        ...stabilizeMetrics,
+        ...(stabilizeMetrics ?? {}),
         ...(parserTiming
           ? Object.fromEntries(PARSE_TIMING_KEYS.map(key => [key, parserTiming[key] ?? 0]))
           : {}),

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -34,6 +34,21 @@ interface ParserTimingMetrics {
   parseMarkdownToStructureTotalMs?: number
 }
 
+interface ParsedNodeSignatureTimingMetrics {
+  signatureMs: number
+}
+
+interface ParsedNodeStabilizeMetrics {
+  reusedNodeCount: number
+  dirtyStartIndex: number
+  dirtyNodeCount: number
+}
+
+interface ParsedNodeStabilizeResult {
+  nodes: ParsedNode[]
+  metrics: ParsedNodeStabilizeMetrics
+}
+
 export interface MarkdownParsingOptions {
   instanceMsgId: string
   renderContent: ComputedRef<string>
@@ -101,6 +116,8 @@ const MAX_SIGNATURE_ARRAY_ITEMS = 200
 const MAX_SIGNATURE_STRING_CHARS = 8192
 const objectIdentityIds = new WeakMap<object, number>()
 const nodeSignatureCache = new WeakMap<object, string>()
+let activeSignatureTimingMetrics: ParsedNodeSignatureTimingMetrics | undefined
+let signatureTimingDepth = 0
 let nextObjectIdentityId = 1
 
 function getNow() {
@@ -332,36 +349,76 @@ function getParsedNodeSignature(
   seen = new WeakMap<object, string>(),
   depth = 0,
 ) {
-  const cached = nodeSignatureCache.get(node as object)
-  if (cached)
-    return cached
+  const metrics = activeSignatureTimingMetrics
+  const shouldMeasure = metrics != null && signatureTimingDepth === 0
+  const startedAt = shouldMeasure ? getNow() : 0
+  signatureTimingDepth += 1
 
-  const object = node as object
-  const existing = seen.get(object)
-  if (existing)
-    return `node-cycle:${existing}`
+  try {
+    const cached = nodeSignatureCache.get(node as object)
+    if (cached)
+      return cached
 
-  if (depth >= MAX_SIGNATURE_DEPTH)
-    return `node:${node.type}:${getIdentityKey(object)}`
+    const object = node as object
+    const existing = seen.get(object)
+    if (existing)
+      return `node-cycle:${existing}`
 
-  const id = getIdentityKey(object)
-  seen.set(object, id)
+    if (depth >= MAX_SIGNATURE_DEPTH)
+      return `node:${node.type}:${getIdentityKey(object)}`
 
-  const signature = buildCheapNodeSignature(node, seen, depth)
-  nodeSignatureCache.set(object, signature)
-  return signature
+    const id = getIdentityKey(object)
+    seen.set(object, id)
+
+    const signature = buildCheapNodeSignature(node, seen, depth)
+    nodeSignatureCache.set(object, signature)
+    return signature
+  }
+  finally {
+    signatureTimingDepth -= 1
+    if (shouldMeasure)
+      metrics.signatureMs += getNow() - startedAt
+  }
 }
 
 function isParsedNodeStable(previous: ParsedNode, next: ParsedNode) {
   return getParsedNodeSignature(previous) === getParsedNodeSignature(next)
 }
 
-function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode[]) {
-  if (!previousNodes.length)
-    return nextNodes
+function withSignatureTiming<T>(metrics: ParsedNodeSignatureTimingMetrics | undefined, callback: () => T) {
+  if (!metrics)
+    return callback()
+
+  const previousMetrics = activeSignatureTimingMetrics
+  activeSignatureTimingMetrics = metrics
+  try {
+    return callback()
+  }
+  finally {
+    activeSignatureTimingMetrics = previousMetrics
+  }
+}
+
+function getInitialStabilizeMetrics(nodeCount: number): ParsedNodeStabilizeMetrics {
+  return {
+    reusedNodeCount: 0,
+    dirtyStartIndex: nodeCount > 0 ? 0 : -1,
+    dirtyNodeCount: nodeCount,
+  }
+}
+
+function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode[]): ParsedNodeStabilizeResult {
+  if (!previousNodes.length) {
+    return {
+      nodes: nextNodes,
+      metrics: getInitialStabilizeMetrics(nextNodes.length),
+    }
+  }
 
   const stableNodes = new Array<ParsedNode>(nextNodes.length)
   let identical = nextNodes.length === previousNodes.length
+  let reusedNodeCount = 0
+  let dirtyStartIndex = -1
 
   for (let index = 0; index < nextNodes.length; index++) {
     const previous = previousNodes[index]
@@ -369,14 +426,27 @@ function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode
 
     if (previous && isParsedNodeStable(previous, next)) {
       stableNodes[index] = previous
+      reusedNodeCount += 1
     }
     else {
       stableNodes[index] = next
+      if (dirtyStartIndex < 0)
+        dirtyStartIndex = index
       identical = false
     }
   }
 
-  return identical ? previousNodes : stableNodes
+  if (dirtyStartIndex < 0 && nextNodes.length !== previousNodes.length)
+    dirtyStartIndex = Math.min(nextNodes.length, previousNodes.length)
+
+  return {
+    nodes: identical ? previousNodes : stableNodes,
+    metrics: {
+      reusedNodeCount,
+      dirtyStartIndex,
+      dirtyNodeCount: dirtyStartIndex < 0 ? 0 : Math.max(0, nextNodes.length - dirtyStartIndex),
+    },
+  }
 }
 
 function primeParsedNodeSignatures(nodes: ParsedNode[]) {
@@ -596,11 +666,36 @@ export function useMarkdownParsing(
     const reuseStart = options.debugPerformanceEnabled.value
       ? getNow()
       : 0
-    const parsed = canReuseParsedNodes
-      ? stabilizeParsedNodes(nextParsed, previousParsedNodes)
-      : nextParsed
+    const signatureTiming: ParsedNodeSignatureTimingMetrics | undefined = options.debugPerformanceEnabled.value
+      ? { signatureMs: 0 }
+      : undefined
+    let stabilizeMetrics = getInitialStabilizeMetrics(nextParsed.length)
+    let stabilizeMs = 0
+    let parsed: ParsedNode[]
 
-    primeParsedNodeSignatures(parsed)
+    if (canReuseParsedNodes) {
+      const stabilizeStart = options.debugPerformanceEnabled.value
+        ? getNow()
+        : 0
+      const result = withSignatureTiming(
+        signatureTiming,
+        () => stabilizeParsedNodes(nextParsed, previousParsedNodes),
+      )
+
+      parsed = result.nodes
+      stabilizeMetrics = result.metrics
+      stabilizeMs = options.debugPerformanceEnabled.value
+        ? getNow() - stabilizeStart
+        : 0
+    }
+    else {
+      parsed = nextParsed
+    }
+
+    withSignatureTiming(
+      signatureTiming,
+      () => primeParsedNodeSignatures(parsed),
+    )
     const nodeReuseMs = options.debugPerformanceEnabled.value
       ? getNow() - reuseStart
       : 0
@@ -622,6 +717,9 @@ export function useMarkdownParsing(
         parseCommitCount,
         parseCoalescedCount,
         nodeReuseMs,
+        signatureMs: signatureTiming?.signatureMs ?? 0,
+        stabilizeMs,
+        ...stabilizeMetrics,
         ...(parserTiming
           ? Object.fromEntries(PARSE_TIMING_KEYS.map(key => [key, parserTiming[key] ?? 0]))
           : {}),

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -36,12 +36,14 @@ interface ParserTimingMetrics {
 
 interface ParsedNodeSignatureTimingMetrics {
   signatureMs: number
+  stabilizeSignatureMs: number
+  primeSignatureMs: number
 }
 
 interface ParsedNodeStabilizeMetrics {
   reusedNodeCount: number
   dirtyStartIndex: number
-  dirtyNodeCount: number
+  dirtyTailNodeCount: number
 }
 
 interface ParsedNodeStabilizeResult {
@@ -117,6 +119,7 @@ const MAX_SIGNATURE_STRING_CHARS = 8192
 const objectIdentityIds = new WeakMap<object, number>()
 const nodeSignatureCache = new WeakMap<object, string>()
 let activeSignatureTimingMetrics: ParsedNodeSignatureTimingMetrics | undefined
+let activeSignatureTimingMetricKey: 'stabilizeSignatureMs' | 'primeSignatureMs' | undefined
 let signatureTimingDepth = 0
 let nextObjectIdentityId = 1
 
@@ -350,52 +353,75 @@ function getParsedNodeSignature(
   depth = 0,
 ) {
   const metrics = activeSignatureTimingMetrics
-  const shouldMeasure = metrics != null && signatureTimingDepth === 0
+  const metricKey = activeSignatureTimingMetricKey
+
+  if (!metrics || !metricKey)
+    return getParsedNodeSignatureImpl(node, seen, depth)
+
+  const shouldMeasure = signatureTimingDepth === 0
   const startedAt = shouldMeasure ? getNow() : 0
   signatureTimingDepth += 1
 
   try {
-    const cached = nodeSignatureCache.get(node as object)
-    if (cached)
-      return cached
-
-    const object = node as object
-    const existing = seen.get(object)
-    if (existing)
-      return `node-cycle:${existing}`
-
-    if (depth >= MAX_SIGNATURE_DEPTH)
-      return `node:${node.type}:${getIdentityKey(object)}`
-
-    const id = getIdentityKey(object)
-    seen.set(object, id)
-
-    const signature = buildCheapNodeSignature(node, seen, depth)
-    nodeSignatureCache.set(object, signature)
-    return signature
+    return getParsedNodeSignatureImpl(node, seen, depth)
   }
   finally {
     signatureTimingDepth -= 1
-    if (shouldMeasure)
-      metrics.signatureMs += getNow() - startedAt
+    if (shouldMeasure) {
+      const elapsed = getNow() - startedAt
+      metrics[metricKey] += elapsed
+      metrics.signatureMs = metrics.stabilizeSignatureMs + metrics.primeSignatureMs
+    }
   }
+}
+
+function getParsedNodeSignatureImpl(
+  node: ParsedNode,
+  seen = new WeakMap<object, string>(),
+  depth = 0,
+) {
+  const cached = nodeSignatureCache.get(node as object)
+  if (cached)
+    return cached
+
+  const object = node as object
+  const existing = seen.get(object)
+  if (existing)
+    return `node-cycle:${existing}`
+
+  if (depth >= MAX_SIGNATURE_DEPTH)
+    return `node:${node.type}:${getIdentityKey(object)}`
+
+  const id = getIdentityKey(object)
+  seen.set(object, id)
+
+  const signature = buildCheapNodeSignature(node, seen, depth)
+  nodeSignatureCache.set(object, signature)
+  return signature
 }
 
 function isParsedNodeStable(previous: ParsedNode, next: ParsedNode) {
   return getParsedNodeSignature(previous) === getParsedNodeSignature(next)
 }
 
-function withSignatureTiming<T>(metrics: ParsedNodeSignatureTimingMetrics | undefined, callback: () => T) {
-  if (!metrics)
+function withSignatureTiming<T>(
+  metrics: ParsedNodeSignatureTimingMetrics | undefined,
+  metricKey: 'stabilizeSignatureMs' | 'primeSignatureMs',
+  callback: () => T,
+) {
+  if (!metrics && !activeSignatureTimingMetrics)
     return callback()
 
   const previousMetrics = activeSignatureTimingMetrics
+  const previousMetricKey = activeSignatureTimingMetricKey
   activeSignatureTimingMetrics = metrics
+  activeSignatureTimingMetricKey = metrics ? metricKey : undefined
   try {
     return callback()
   }
   finally {
     activeSignatureTimingMetrics = previousMetrics
+    activeSignatureTimingMetricKey = previousMetricKey
   }
 }
 
@@ -403,7 +429,7 @@ function getInitialStabilizeMetrics(nodeCount: number): ParsedNodeStabilizeMetri
   return {
     reusedNodeCount: 0,
     dirtyStartIndex: nodeCount > 0 ? 0 : -1,
-    dirtyNodeCount: nodeCount,
+    dirtyTailNodeCount: nodeCount,
   }
 }
 
@@ -444,7 +470,7 @@ function stabilizeParsedNodes(nextNodes: ParsedNode[], previousNodes: ParsedNode
     metrics: {
       reusedNodeCount,
       dirtyStartIndex,
-      dirtyNodeCount: dirtyStartIndex < 0 ? 0 : Math.max(0, nextNodes.length - dirtyStartIndex),
+      dirtyTailNodeCount: dirtyStartIndex < 0 ? 0 : Math.max(0, nextNodes.length - dirtyStartIndex),
     },
   }
 }
@@ -667,7 +693,7 @@ export function useMarkdownParsing(
       ? getNow()
       : 0
     const signatureTiming: ParsedNodeSignatureTimingMetrics | undefined = options.debugPerformanceEnabled.value
-      ? { signatureMs: 0 }
+      ? { signatureMs: 0, stabilizeSignatureMs: 0, primeSignatureMs: 0 }
       : undefined
     let stabilizeMetrics = getInitialStabilizeMetrics(nextParsed.length)
     let stabilizeMs = 0
@@ -679,6 +705,7 @@ export function useMarkdownParsing(
         : 0
       const result = withSignatureTiming(
         signatureTiming,
+        'stabilizeSignatureMs',
         () => stabilizeParsedNodes(nextParsed, previousParsedNodes),
       )
 
@@ -694,6 +721,7 @@ export function useMarkdownParsing(
 
     withSignatureTiming(
       signatureTiming,
+      'primeSignatureMs',
       () => primeParsedNodeSignatures(parsed),
     )
     const nodeReuseMs = options.debugPerformanceEnabled.value
@@ -718,6 +746,8 @@ export function useMarkdownParsing(
         parseCoalescedCount,
         nodeReuseMs,
         signatureMs: signatureTiming?.signatureMs ?? 0,
+        stabilizeSignatureMs: signatureTiming?.stabilizeSignatureMs ?? 0,
+        primeSignatureMs: signatureTiming?.primeSignatureMs ?? 0,
         stabilizeMs,
         ...stabilizeMetrics,
         ...(parserTiming

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -35,15 +35,19 @@ interface ParserTimingMetrics {
 }
 
 interface ParsedNodeSignatureTimingMetrics {
+  /** Instrumented wall time for timed signature calls, including timing overhead. */
   signatureMs: number
   stabilizeSignatureMs: number
   primeSignatureMs: number
+  signatureCallCount: number
+  stabilizeSignatureCallCount: number
+  primeSignatureCallCount: number
 }
 
 interface ParsedNodeStabilizeMetrics {
   /** Count of reused nodes anywhere in nextNodes, including unchanged suffix nodes after dirtyStartIndex. */
   reusedNodeCount: number
-  /** First index whose node identity/signature changed; -1 means no dirty node. */
+  /** First boundary where previousNodes and nextNodes diverge; -1 means no dirty tail. */
   dirtyStartIndex: number
   /** Count of stable leading nodes in nextNodes. */
   stablePrefixNodeCount: number
@@ -384,12 +388,17 @@ function trackSignatureTiming<T>(
   callback: () => T,
 ) {
   const startedAt = getNow()
+  const countKey = metricKey === 'stabilizeSignatureMs'
+    ? 'stabilizeSignatureCallCount'
+    : 'primeSignatureCallCount'
   try {
     return callback()
   }
   finally {
     metrics[metricKey] += getNow() - startedAt
+    metrics[countKey] += 1
     metrics.signatureMs = metrics.stabilizeSignatureMs + metrics.primeSignatureMs
+    metrics.signatureCallCount = metrics.stabilizeSignatureCallCount + metrics.primeSignatureCallCount
   }
 }
 
@@ -727,7 +736,14 @@ export function useMarkdownParsing(
       ? getNow()
       : 0
     const signatureTiming: ParsedNodeSignatureTimingMetrics | undefined = collectPerformanceMetrics
-      ? { signatureMs: 0, stabilizeSignatureMs: 0, primeSignatureMs: 0 }
+      ? {
+          signatureMs: 0,
+          stabilizeSignatureMs: 0,
+          primeSignatureMs: 0,
+          signatureCallCount: 0,
+          stabilizeSignatureCallCount: 0,
+          primeSignatureCallCount: 0,
+        }
       : undefined
     let stabilizeMetrics: ParsedNodeStabilizeMetrics | undefined = collectPerformanceMetrics
       ? getInitialStabilizeMetrics(nextParsed.length)
@@ -784,6 +800,9 @@ export function useMarkdownParsing(
         signatureMs: signatureTiming?.signatureMs ?? 0,
         stabilizeSignatureMs: signatureTiming?.stabilizeSignatureMs ?? 0,
         primeSignatureMs: signatureTiming?.primeSignatureMs ?? 0,
+        signatureCallCount: signatureTiming?.signatureCallCount ?? 0,
+        stabilizeSignatureCallCount: signatureTiming?.stabilizeSignatureCallCount ?? 0,
+        primeSignatureCallCount: signatureTiming?.primeSignatureCallCount ?? 0,
         stabilizeMs,
         ...(stabilizeMetrics ?? {}),
         ...(parserTiming

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -702,6 +702,7 @@ describe('useMarkdownParsing performance behavior', () => {
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 0,
       dirtyStartIndex: 0,
+      stablePrefixNodeCount: 0,
       dirtyTailNodeCount: 1,
       streamDelta: expect.objectContaining({
         total: expect.any(Number),
@@ -740,6 +741,7 @@ describe('useMarkdownParsing performance behavior', () => {
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 3,
       dirtyStartIndex: 3,
+      stablePrefixNodeCount: 3,
       dirtyTailNodeCount: 1,
     })
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
@@ -767,6 +769,7 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data).toMatchObject({
       reusedNodeCount: 2,
       dirtyStartIndex: 2,
+      stablePrefixNodeCount: 2,
       dirtyTailNodeCount: 1,
     })
 
@@ -788,7 +791,36 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data).toMatchObject({
       reusedNodeCount: 1,
       dirtyStartIndex: 0,
+      stablePrefixNodeCount: 0,
       dirtyTailNodeCount: 2,
+    })
+
+    scope.stop()
+  })
+
+  it('reports dirty tail range when append parsing shrinks node count', () => {
+    const content = ref('one\n\ntwo')
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {
+      parseOptions: {
+        postTransformTokens: tokens => tokens.some(token => token.content === 'drop-tail')
+          ? tokens.slice(0, 3)
+          : tokens,
+      },
+    }, ref(true), logPerf)
+
+    expect(state.parsedNodes.value.length).toBe(2)
+    logPerf.mockClear()
+
+    content.value += '\n\ndrop-tail'
+    expect(state.parsedNodes.value.length).toBe(1)
+
+    const data = logPerf.mock.calls.at(-1)?.[1]
+    expect(data).toMatchObject({
+      reusedNodeCount: 1,
+      dirtyStartIndex: 1,
+      stablePrefixNodeCount: 1,
+      dirtyTailNodeCount: 1,
     })
 
     scope.stop()
@@ -823,6 +855,7 @@ describe('useMarkdownParsing performance behavior', () => {
       stabilizeMs: expect.any(Number),
       reusedNodeCount: expect.any(Number),
       dirtyStartIndex: expect.any(Number),
+      stablePrefixNodeCount: expect.any(Number),
       dirtyTailNodeCount: expect.any(Number),
       streamDelta: expect.any(Object),
     })

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -696,13 +696,48 @@ describe('useMarkdownParsing performance behavior', () => {
     const data = logPerf.mock.calls.at(-1)?.[1]
     expect(data).toMatchObject({
       nodeReuseMs: expect.any(Number),
+      signatureMs: expect.any(Number),
+      stabilizeMs: expect.any(Number),
+      reusedNodeCount: 0,
+      dirtyStartIndex: 0,
+      dirtyNodeCount: 1,
       streamDelta: expect.objectContaining({
         total: expect.any(Number),
       }),
       streamStats: expect.any(Object),
     })
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect(typeof data?.streamMode === 'string' || data?.streamMode == null).toBe(true)
+
+    scope.stop()
+  })
+
+  it('logs stabilize dirty range metrics for append reuse', () => {
+    const content = ref(buildParagraphs(3))
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {}, ref(true), logPerf)
+
+    expect(state.parsedNodes.value.length).toBe(3)
+    logPerf.mockClear()
+
+    content.value = `${content.value}\n\nAppended paragraph.`
+    expect(state.parsedNodes.value.length).toBe(4)
+
+    const data = logPerf.mock.calls.at(-1)?.[1]
+    expect(data).toMatchObject({
+      parseCommitCount: 2,
+      nodeReuseMs: expect.any(Number),
+      signatureMs: expect.any(Number),
+      stabilizeMs: expect.any(Number),
+      reusedNodeCount: 3,
+      dirtyStartIndex: 3,
+      dirtyNodeCount: 1,
+    })
+    expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
 
     scope.stop()
   })
@@ -730,10 +765,17 @@ describe('useMarkdownParsing performance behavior', () => {
       parseCommitCount: 2,
       parseCoalescedCount: expect.any(Number),
       nodeReuseMs: expect.any(Number),
+      signatureMs: expect.any(Number),
+      stabilizeMs: expect.any(Number),
+      reusedNodeCount: expect.any(Number),
+      dirtyStartIndex: expect.any(Number),
+      dirtyNodeCount: expect.any(Number),
       streamDelta: expect.any(Object),
     })
     expect(data?.parseCoalescedCount).toBeGreaterThan(0)
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect((streamDelta?.appendHits ?? 0) + (streamDelta?.tailHits ?? 0) + (streamDelta?.cacheHits ?? 0)).toBeGreaterThan(0)
 
     scope.stop()

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -699,6 +699,9 @@ describe('useMarkdownParsing performance behavior', () => {
       signatureMs: expect.any(Number),
       stabilizeSignatureMs: expect.any(Number),
       primeSignatureMs: expect.any(Number),
+      signatureCallCount: expect.any(Number),
+      stabilizeSignatureCallCount: expect.any(Number),
+      primeSignatureCallCount: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 0,
       dirtyStartIndex: 0,
@@ -714,6 +717,9 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data?.stabilizeSignatureMs).toBe(0)
     expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
+    expect(data?.stabilizeSignatureCallCount).toBe(0)
+    expect(data?.primeSignatureCallCount).toBe(1)
+    expect(data?.signatureCallCount).toBe(data?.stabilizeSignatureCallCount + data?.primeSignatureCallCount)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect(typeof data?.streamMode === 'string' || data?.streamMode == null).toBe(true)
 
@@ -738,6 +744,9 @@ describe('useMarkdownParsing performance behavior', () => {
       signatureMs: expect.any(Number),
       stabilizeSignatureMs: expect.any(Number),
       primeSignatureMs: expect.any(Number),
+      signatureCallCount: expect.any(Number),
+      stabilizeSignatureCallCount: expect.any(Number),
+      primeSignatureCallCount: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 3,
       dirtyStartIndex: 3,
@@ -749,6 +758,9 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data?.stabilizeSignatureMs).toBeGreaterThanOrEqual(0)
     expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
+    expect(data?.stabilizeSignatureCallCount).toBeGreaterThan(0)
+    expect(data?.primeSignatureCallCount).toBeGreaterThan(0)
+    expect(data?.signatureCallCount).toBe(data?.stabilizeSignatureCallCount + data?.primeSignatureCallCount)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
 
     scope.stop()
@@ -852,6 +864,9 @@ describe('useMarkdownParsing performance behavior', () => {
       signatureMs: expect.any(Number),
       stabilizeSignatureMs: expect.any(Number),
       primeSignatureMs: expect.any(Number),
+      signatureCallCount: expect.any(Number),
+      stabilizeSignatureCallCount: expect.any(Number),
+      primeSignatureCallCount: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: expect.any(Number),
       dirtyStartIndex: expect.any(Number),
@@ -865,6 +880,9 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data?.stabilizeSignatureMs).toBeGreaterThanOrEqual(0)
     expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
+    expect(data?.stabilizeSignatureCallCount).toBeGreaterThan(0)
+    expect(data?.primeSignatureCallCount).toBeGreaterThan(0)
+    expect(data?.signatureCallCount).toBe(data?.stabilizeSignatureCallCount + data?.primeSignatureCallCount)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect((streamDelta?.appendHits ?? 0) + (streamDelta?.tailHits ?? 0) + (streamDelta?.cacheHits ?? 0)).toBeGreaterThan(0)
 

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -697,10 +697,12 @@ describe('useMarkdownParsing performance behavior', () => {
     expect(data).toMatchObject({
       nodeReuseMs: expect.any(Number),
       signatureMs: expect.any(Number),
+      stabilizeSignatureMs: expect.any(Number),
+      primeSignatureMs: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 0,
       dirtyStartIndex: 0,
-      dirtyNodeCount: 1,
+      dirtyTailNodeCount: 1,
       streamDelta: expect.objectContaining({
         total: expect.any(Number),
       }),
@@ -708,6 +710,9 @@ describe('useMarkdownParsing performance behavior', () => {
     })
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeSignatureMs).toBe(0)
+    expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect(typeof data?.streamMode === 'string' || data?.streamMode == null).toBe(true)
 
@@ -730,14 +735,61 @@ describe('useMarkdownParsing performance behavior', () => {
       parseCommitCount: 2,
       nodeReuseMs: expect.any(Number),
       signatureMs: expect.any(Number),
+      stabilizeSignatureMs: expect.any(Number),
+      primeSignatureMs: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: 3,
       dirtyStartIndex: 3,
-      dirtyNodeCount: 1,
+      dirtyTailNodeCount: 1,
     })
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeSignatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
+
+    scope.stop()
+  })
+
+  it('logs dirty tail range when appending into the last existing paragraph', () => {
+    const content = ref('one\n\ntwo\n\nthree')
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {}, ref(true), logPerf)
+
+    expect(state.parsedNodes.value.length).toBe(3)
+    logPerf.mockClear()
+
+    content.value += ' appended tail'
+    expect(state.parsedNodes.value.length).toBe(3)
+
+    const data = logPerf.mock.calls.at(-1)?.[1]
+    expect(data).toMatchObject({
+      reusedNodeCount: 2,
+      dirtyStartIndex: 2,
+      dirtyTailNodeCount: 1,
+    })
+
+    scope.stop()
+  })
+
+  it('reports dirty tail range including unchanged suffix nodes', () => {
+    const content = ref('| Link |\n| - |\n| [x][ref] |\n\nlater\n\n')
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {}, ref(true), logPerf)
+
+    expect(state.parsedNodes.value.length).toBe(2)
+    logPerf.mockClear()
+
+    content.value += '[ref]: https://example.com\n'
+    expect(state.parsedNodes.value.length).toBe(2)
+
+    const data = logPerf.mock.calls.at(-1)?.[1]
+    expect(data).toMatchObject({
+      reusedNodeCount: 1,
+      dirtyStartIndex: 0,
+      dirtyTailNodeCount: 2,
+    })
 
     scope.stop()
   })
@@ -766,15 +818,20 @@ describe('useMarkdownParsing performance behavior', () => {
       parseCoalescedCount: expect.any(Number),
       nodeReuseMs: expect.any(Number),
       signatureMs: expect.any(Number),
+      stabilizeSignatureMs: expect.any(Number),
+      primeSignatureMs: expect.any(Number),
       stabilizeMs: expect.any(Number),
       reusedNodeCount: expect.any(Number),
       dirtyStartIndex: expect.any(Number),
-      dirtyNodeCount: expect.any(Number),
+      dirtyTailNodeCount: expect.any(Number),
       streamDelta: expect.any(Object),
     })
     expect(data?.parseCoalescedCount).toBeGreaterThan(0)
     expect(data?.nodeReuseMs).toBeGreaterThanOrEqual(0)
     expect(data?.signatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.stabilizeSignatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.primeSignatureMs).toBeGreaterThanOrEqual(0)
+    expect(data?.signatureMs).toBe(data?.stabilizeSignatureMs + data?.primeSignatureMs)
     expect(data?.stabilizeMs).toBeGreaterThanOrEqual(0)
     expect((streamDelta?.appendHits ?? 0) + (streamDelta?.tailHits ?? 0) + (streamDelta?.cacheHits ?? 0)).toBeGreaterThan(0)
 


### PR DESCRIPTION
## Summary
- add debugPerformance metrics for parsed node signature timing and stabilize timing
- log reused node count and dirty range for parse append reuse
- cover initial parse metrics and append reuse metrics in parsing performance tests

## Verification
- pnpm vitest run test/use-markdown-parsing-performance.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check