### PR TITLE
fix: skip stream token clone without transforms

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -301,7 +301,7 @@ function shouldResetTopLevelStreamCacheForFinalAutoParse(md: MarkdownIt, options
     && typeof stream.reset === 'function'
 }
 
-function shouldCloneTopLevelStreamTokenObjectFields(options: ParseOptions) {
+function shouldCloneTopLevelStreamTokens(options: ParseOptions) {
   return typeof options.preTransformTokens === 'function'
     || typeof options.postTransformTokens === 'function'
 }
@@ -319,13 +319,15 @@ function parseTopLevelTokens(
     return md.parse(source, env)
 
   const tokens = md.stream!.parse!(source, getStableStreamEnv(md, env))
-  const cloneObjectFields = shouldCloneTopLevelStreamTokenObjectFields(options)
+  if (!shouldCloneTopLevelStreamTokens(options))
+    return tokens
+
   const timing = getParseTiming(options)
   if (!timing)
-    return cloneMarkdownTokens(tokens, cloneObjectFields)
+    return cloneMarkdownTokens(tokens, true)
 
   const startedAt = getParserNow()
-  const cloned = cloneMarkdownTokens(tokens, cloneObjectFields)
+  const cloned = cloneMarkdownTokens(tokens, true)
   addTiming(timing, 'tokenCloneMs', getParserNow() - startedAt)
   return cloned
 }

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -12,7 +12,7 @@ import { parseHardBreak } from './node-parsers/hardbreak-parser'
 import { parseHtmlBlock } from './node-parsers/html-block-parser'
 import { parseList } from './node-parsers/list-parser'
 import { parseParagraph } from './node-parsers/paragraph-parser'
-import { copyTokenShallow } from './token-copy'
+import { cloneTokenWithMutableChildren } from './token-copy'
 
 type ParsedNodeWithFields = ParsedNode & {
   children?: ParsedNode[]
@@ -228,7 +228,7 @@ function safeCloneTokenField<T>(value: T, seen = new WeakMap<object, unknown>())
 
 function cloneMarkdownToken(token: Token, cloneObjectFields = true): Token {
   if (!cloneObjectFields)
-    return copyTokenShallow(token as unknown as MarkdownToken) as unknown as Token
+    return cloneTokenWithMutableChildren(token as unknown as MarkdownToken) as unknown as Token
 
   const cloned = Object.create(Object.getPrototypeOf(token)) as Token
   const seen = new WeakMap<object, unknown>()

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -12,6 +12,7 @@ import { parseHardBreak } from './node-parsers/hardbreak-parser'
 import { parseHtmlBlock } from './node-parsers/html-block-parser'
 import { parseList } from './node-parsers/list-parser'
 import { parseParagraph } from './node-parsers/paragraph-parser'
+import { copyTokenShallow } from './token-copy'
 
 type ParsedNodeWithFields = ParsedNode & {
   children?: ParsedNode[]
@@ -226,16 +227,8 @@ function safeCloneTokenField<T>(value: T, seen = new WeakMap<object, unknown>())
 }
 
 function cloneMarkdownToken(token: Token, cloneObjectFields = true): Token {
-  if (!cloneObjectFields) {
-    const cloned = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as Token
-    if (Array.isArray(token.attrs))
-      cloned.attrs = token.attrs.map(attr => [...attr] as [string, string])
-    if (Array.isArray(token.map))
-      cloned.map = [...token.map] as [number, number]
-    if (Array.isArray(token.children))
-      cloned.children = token.children.map(child => cloneMarkdownToken(child, cloneObjectFields))
-    return cloned
-  }
+  if (!cloneObjectFields)
+    return copyTokenShallow(token as unknown as MarkdownToken) as unknown as Token
 
   const cloned = Object.create(Object.getPrototypeOf(token)) as Token
   const seen = new WeakMap<object, unknown>()

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -373,6 +373,13 @@ export function parseInlineTokens(
   let i = 0
   // Default to strict matching for strong unless caller explicitly sets false
   const requireClosingStrong = options?.requireClosingStrong
+  const originalTokens = tokens
+
+  function ensureWorkingTokens() {
+    if (tokens === originalTokens)
+      tokens = tokens.slice()
+    return tokens
+  }
 
   // Helpers to manage text node merging and pushing parsed nodes
   function resetCurrentTextNode() {
@@ -1730,18 +1737,19 @@ export function parseInlineTokens(
         const last = tokens[i + 4]
         let index = 4
         let loading = true
-        let trailingAfterClose = ''
-        let trailingToken: MarkdownToken | null = null
         if (last?.type === 'text') {
           const lastContent = String(last.content ?? '')
           if (lastContent.startsWith(')')) {
             loading = false
-            trailingAfterClose = lastContent.slice(1)
-            index++
+            const trailingAfterClose = lastContent.slice(1)
             if (trailingAfterClose) {
-              trailingToken = copyTokenShallow(last)
+              const trailingToken = copyTokenShallow(last)
               trailingToken.content = trailingAfterClose
               trailingToken.raw = trailingAfterClose
+              ensureWorkingTokens()[i + 4] = trailingToken
+            }
+            else {
+              index++
             }
           }
           else if (lastContent === '.') {
@@ -1764,8 +1772,6 @@ export function parseInlineTokens(
             loading,
           } as ParsedNode)
         }
-        if (trailingToken)
-          pushInlineTextContent(trailingAfterClose, trailingToken)
         i += index
         return true
       }

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,6 +1,6 @@
 import type { InternalParseOptions, MarkdownToken, ParsedNode, ParseOptions, TextNode } from '../../types'
 import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFilenameLikeLinkify } from '../linkifyHeuristics'
-import { copyTokenShallow } from '../token-copy'
+import { cloneTokenWithMutableChildren } from '../token-copy'
 import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
@@ -857,7 +857,7 @@ export function parseInlineTokens(
   function pushToken(token: MarkdownToken) {
     // push a raw token into result as a ParsedNode (best effort cast)
     resetCurrentTextNode()
-    const node = copyTokenShallow(token) as unknown as ParsedNode
+    const node = cloneTokenWithMutableChildren(token) as unknown as ParsedNode
     result.push(node)
   }
 
@@ -1743,7 +1743,7 @@ export function parseInlineTokens(
             loading = false
             const trailingAfterClose = lastContent.slice(1)
             if (trailingAfterClose) {
-              const trailingToken = copyTokenShallow(last)
+              const trailingToken = cloneTokenWithMutableChildren(last)
               trailingToken.content = trailingAfterClose
               trailingToken.raw = trailingAfterClose
               ensureWorkingTokens()[i + 4] = trailingToken

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1,5 +1,6 @@
 import type { InternalParseOptions, MarkdownToken, ParsedNode, ParseOptions, TextNode } from '../../types'
 import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFilenameLikeLinkify } from '../linkifyHeuristics'
+import { copyTokenShallow } from '../token-copy'
 import { parseCheckboxInputToken, parseCheckboxToken } from './checkbox-parser'
 import { parseEmojiToken } from './emoji-parser'
 import { parseEmphasisToken } from './emphasis-parser'
@@ -849,7 +850,7 @@ export function parseInlineTokens(
   function pushToken(token: MarkdownToken) {
     // push a raw token into result as a ParsedNode (best effort cast)
     resetCurrentTextNode()
-    const node = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as ParsedNode
+    const node = copyTokenShallow(token) as unknown as ParsedNode
     result.push(node)
   }
 
@@ -1738,7 +1739,7 @@ export function parseInlineTokens(
             trailingAfterClose = lastContent.slice(1)
             index++
             if (trailingAfterClose) {
-              trailingToken = Object.assign(Object.create(Object.getPrototypeOf(last)), last) as MarkdownToken
+              trailingToken = copyTokenShallow(last)
               trailingToken.content = trailingAfterClose
               trailingToken.raw = trailingAfterClose
             }

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -849,7 +849,8 @@ export function parseInlineTokens(
   function pushToken(token: MarkdownToken) {
     // push a raw token into result as a ParsedNode (best effort cast)
     resetCurrentTextNode()
-    result.push(token as ParsedNode)
+    const node = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as ParsedNode
+    result.push(node)
   }
 
   // backward-compatible alias used by existing call sites that pass parsed nodes

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1729,21 +1729,22 @@ export function parseInlineTokens(
         const last = tokens[i + 4]
         let index = 4
         let loading = true
+        let trailingAfterClose = ''
+        let trailingToken: MarkdownToken | null = null
         if (last?.type === 'text') {
           const lastContent = String(last.content ?? '')
           if (lastContent.startsWith(')')) {
             loading = false
-            const trailing = lastContent.slice(1)
-            if (trailing) {
-              last.content = trailing
-              last.raw = trailing
-            }
-            else {
-              index++
+            trailingAfterClose = lastContent.slice(1)
+            index++
+            if (trailingAfterClose) {
+              trailingToken = Object.assign(Object.create(Object.getPrototypeOf(last)), last) as MarkdownToken
+              trailingToken.content = trailingAfterClose
+              trailingToken.raw = trailingAfterClose
             }
           }
           else if (lastContent === '.') {
-            i++
+            index++
           }
         }
 
@@ -1762,6 +1763,8 @@ export function parseInlineTokens(
             loading,
           } as ParsedNode)
         }
+        if (trailingToken)
+          pushInlineTextContent(trailingAfterClose, trailingToken)
         i += index
         return true
       }

--- a/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
@@ -70,6 +70,7 @@ export function parseLinkToken(
     loading = false
   }
 
+  let childTokens = linkTokens
   const lastLinkToken = linkTokens[linkTokens.length - 1]
   if (
     (options as InternalParseOptions | undefined)?.__insideStrong
@@ -79,12 +80,15 @@ export function parseLinkToken(
   ) {
     const originalContent = String(lastLinkToken.content ?? '')
     const originalRaw = String(lastLinkToken.raw ?? originalContent)
-    lastLinkToken.content = originalContent.slice(0, -2)
-    lastLinkToken.raw = originalRaw.replace(/\*\*$/, '')
+    const adjustedLastLinkToken = Object.assign(Object.create(Object.getPrototypeOf(lastLinkToken)), lastLinkToken) as MarkdownToken
+    adjustedLastLinkToken.content = originalContent.slice(0, -2)
+    adjustedLastLinkToken.raw = originalRaw.replace(/\*\*$/, '')
+    childTokens = linkTokens.slice()
+    childTokens[childTokens.length - 1] = adjustedLastLinkToken
   }
 
   // Parse the collected tokens as inline content
-  const children = parseInlineTokens(linkTokens, undefined, undefined, options)
+  const children = parseInlineTokens(childTokens, undefined, undefined, options)
   const linkText = children
     .map((node) => {
       const nodeAny = node as unknown as { content?: string, raw?: string }

--- a/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
@@ -1,6 +1,6 @@
 import type { InternalParseOptions, LinkNode, MarkdownToken, ParseOptions } from '../../types'
 import { parseInlineTokens } from '../index'
-import { copyTokenShallow } from '../token-copy'
+import { cloneTokenWithMutableChildren } from '../token-copy'
 
 type AttrTuple = [string, string]
 
@@ -81,7 +81,7 @@ export function parseLinkToken(
   ) {
     const originalContent = String(lastLinkToken.content ?? '')
     const originalRaw = String(lastLinkToken.raw ?? originalContent)
-    const adjustedLastLinkToken = copyTokenShallow(lastLinkToken)
+    const adjustedLastLinkToken = cloneTokenWithMutableChildren(lastLinkToken)
     adjustedLastLinkToken.content = originalContent.slice(0, -2)
     adjustedLastLinkToken.raw = originalRaw.replace(/\*\*$/, '')
     childTokens = linkTokens.slice()

--- a/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/link-parser.ts
@@ -1,5 +1,6 @@
 import type { InternalParseOptions, LinkNode, MarkdownToken, ParseOptions } from '../../types'
 import { parseInlineTokens } from '../index'
+import { copyTokenShallow } from '../token-copy'
 
 type AttrTuple = [string, string]
 
@@ -80,7 +81,7 @@ export function parseLinkToken(
   ) {
     const originalContent = String(lastLinkToken.content ?? '')
     const originalRaw = String(lastLinkToken.raw ?? originalContent)
-    const adjustedLastLinkToken = Object.assign(Object.create(Object.getPrototypeOf(lastLinkToken)), lastLinkToken) as MarkdownToken
+    const adjustedLastLinkToken = copyTokenShallow(lastLinkToken)
     adjustedLastLinkToken.content = originalContent.slice(0, -2)
     adjustedLastLinkToken.raw = originalRaw.replace(/\*\*$/, '')
     childTokens = linkTokens.slice()

--- a/packages/markdown-parser/src/parser/node-parsers/code-block-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/code-block-parser.ts
@@ -11,10 +11,10 @@ export function parseCodeBlock(token: MarkdownToken): CodeBlockNode {
 
   const contentStr = String(token.content ?? '')
   const match = contentStr.match(/ type="application\/vnd\.ant\.([^"]+)"/)
+  let code = contentStr
   if (match?.[1]) {
     // 需要把 <antArtifact> 标签去掉
-    // mutate token.content safely by assigning the cleaned string
-    token.content = contentStr
+    code = contentStr
       .replace(/<antArtifact[^>]*>/g, '')
       .replace(/<\/antArtifact>/g, '')
   }
@@ -22,8 +22,8 @@ export function parseCodeBlock(token: MarkdownToken): CodeBlockNode {
   return {
     type: 'code_block',
     language: match ? match[1] : String(token.info ?? ''),
-    code: String(token.content ?? ''),
-    raw: String(token.content ?? ''),
+    code,
+    raw: code,
     loading: !hasMap,
   }
 }

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -11,6 +11,16 @@ import { parseCommonBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { containerTokenHandlers } from './container-token-handlers'
 
+function copyInlineToken(token: MarkdownToken) {
+  const copy = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as MarkdownToken
+  if (Array.isArray(token.children)) {
+    copy.children = token.children.map((child) => {
+      return Object.assign(Object.create(Object.getPrototypeOf(child)), child) as MarkdownToken
+    })
+  }
+  return copy
+}
+
 function trimInlineTokenTail(token: MarkdownToken) {
   const rawContent = String(token.content ?? '')
   const trimmed = rawContent.replace(/[ \t\r\n]+$/g, '')
@@ -120,16 +130,17 @@ export function parseList(
       while (k < tokens.length && tokens[k].type !== 'list_item_close') {
         // Handle different block types inside list items
         if (tokens[k].type === 'paragraph_open') {
-          const contentToken = tokens[k + 1]
+          const contentToken = copyInlineToken(tokens[k + 1])
           const preToken = tokens[k - 1]
           stripLeakedOrderedListMarkerSuffix(contentToken)
           trimInlineTokenTail(contentToken)
+          const paragraphRaw = String(contentToken.content ?? '')
           itemChildren.push({
             type: 'paragraph',
-            children: parseInlineTokens(contentToken.children || [], String(contentToken.content ?? ''), preToken, linkifyContext.options()),
-            raw: String(contentToken.content ?? ''),
+            children: parseInlineTokens(contentToken.children || [], paragraphRaw, preToken, linkifyContext.options()),
+            raw: paragraphRaw,
           })
-          linkifyContext.remember(String(contentToken.content ?? ''))
+          linkifyContext.remember(paragraphRaw)
           k += 3 // Skip paragraph_open, inline, paragraph_close
         }
         else if (tokens[k].type === 'blockquote_open') {

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -96,6 +96,11 @@ function stripLeakedOrderedListMarkerSuffix(token: MarkdownToken) {
   }
 }
 
+function needsListParagraphTokenPatch(token: MarkdownToken) {
+  const rawContent = String(token.content ?? '')
+  return /[ \t\r\n]+$/.test(rawContent) || /\r?\n\s*\d+[.)]?\s*$/.test(rawContent)
+}
+
 export function parseList(
   tokens: MarkdownToken[],
   index: number,
@@ -121,10 +126,15 @@ export function parseList(
       while (k < tokens.length && tokens[k].type !== 'list_item_close') {
         // Handle different block types inside list items
         if (tokens[k].type === 'paragraph_open') {
-          const contentToken = copyTokenShallow(tokens[k + 1])
+          const originalContentToken = tokens[k + 1]
+          const contentToken = needsListParagraphTokenPatch(originalContentToken)
+            ? copyTokenShallow(originalContentToken)
+            : originalContentToken
           const preToken = tokens[k - 1]
-          stripLeakedOrderedListMarkerSuffix(contentToken)
-          trimInlineTokenTail(contentToken)
+          if (contentToken !== originalContentToken) {
+            stripLeakedOrderedListMarkerSuffix(contentToken)
+            trimInlineTokenTail(contentToken)
+          }
           const paragraphRaw = String(contentToken.content ?? '')
           itemChildren.push({
             type: 'paragraph',

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
 import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
-import { copyTokenShallow } from '../token-copy'
+import { cloneTokenWithMutableChildren } from '../token-copy'
 import { parseCommonBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { containerTokenHandlers } from './container-token-handlers'
@@ -128,7 +128,7 @@ export function parseList(
         if (tokens[k].type === 'paragraph_open') {
           const originalContentToken = tokens[k + 1]
           const contentToken = needsListParagraphTokenPatch(originalContentToken)
-            ? copyTokenShallow(originalContentToken)
+            ? cloneTokenWithMutableChildren(originalContentToken)
             : originalContentToken
           const preToken = tokens[k - 1]
           if (contentToken !== originalContentToken) {

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -7,19 +7,10 @@ import type {
 } from '../../types'
 import { parseInlineTokens } from '../inline-parsers'
 import { createLinkifyDemotionContextTracker } from '../linkifyHeuristics'
+import { copyTokenShallow } from '../token-copy'
 import { parseCommonBlockToken } from './block-token-parser'
 import { parseBlockquote } from './blockquote-parser'
 import { containerTokenHandlers } from './container-token-handlers'
-
-function copyInlineToken(token: MarkdownToken) {
-  const copy = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as MarkdownToken
-  if (Array.isArray(token.children)) {
-    copy.children = token.children.map((child) => {
-      return Object.assign(Object.create(Object.getPrototypeOf(child)), child) as MarkdownToken
-    })
-  }
-  return copy
-}
 
 function trimInlineTokenTail(token: MarkdownToken) {
   const rawContent = String(token.content ?? '')
@@ -130,7 +121,7 @@ export function parseList(
       while (k < tokens.length && tokens[k].type !== 'list_item_close') {
         // Handle different block types inside list items
         if (tokens[k].type === 'paragraph_open') {
-          const contentToken = copyInlineToken(tokens[k + 1])
+          const contentToken = copyTokenShallow(tokens[k + 1])
           const preToken = tokens[k - 1]
           stripLeakedOrderedListMarkerSuffix(contentToken)
           trimInlineTokenTail(contentToken)

--- a/packages/markdown-parser/src/parser/token-copy.ts
+++ b/packages/markdown-parser/src/parser/token-copy.ts
@@ -1,6 +1,6 @@
 import type { MarkdownToken } from '../types'
 
-export function copyTokenShallow<T extends MarkdownToken>(token: T): T {
+export function cloneTokenWithMutableChildren<T extends MarkdownToken>(token: T): T {
   const copy = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as MarkdownToken
 
   if (Array.isArray(token.attrs))
@@ -10,7 +10,7 @@ export function copyTokenShallow<T extends MarkdownToken>(token: T): T {
     copy.map = [...token.map]
 
   if (Array.isArray(token.children))
-    copy.children = token.children.map(child => copyTokenShallow(child))
+    copy.children = token.children.map(child => cloneTokenWithMutableChildren(child))
 
   return copy as T
 }

--- a/packages/markdown-parser/src/parser/token-copy.ts
+++ b/packages/markdown-parser/src/parser/token-copy.ts
@@ -1,0 +1,16 @@
+import type { MarkdownToken } from '../types'
+
+export function copyTokenShallow<T extends MarkdownToken>(token: T): T {
+  const copy = Object.assign(Object.create(Object.getPrototypeOf(token)), token) as MarkdownToken
+
+  if (Array.isArray(token.attrs))
+    copy.attrs = token.attrs.map(attr => [...attr] as [string, string])
+
+  if (Array.isArray(token.map))
+    copy.map = [...token.map]
+
+  if (Array.isArray(token.children))
+    copy.children = token.children.map(child => copyTokenShallow(child))
+
+  return copy as T
+}

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -12,6 +12,25 @@ function getStreamStats(md: ReturnType<typeof getMarkdown>) {
   return (md as any).stream.stats()
 }
 
+function deepFreeze(value: unknown, seen = new WeakSet<object>()) {
+  if (!value || typeof value !== 'object')
+    return value
+
+  const object = value as object
+  if (seen.has(object))
+    return value
+
+  seen.add(object)
+
+  for (const key of Reflect.ownKeys(object)) {
+    const descriptor = Object.getOwnPropertyDescriptor(object, key)
+    if (descriptor && 'value' in descriptor)
+      deepFreeze(descriptor.value, seen)
+  }
+
+  return Object.freeze(object)
+}
+
 describe('parseMarkdownToStructure stream parser integration', () => {
   it('uses markdown-it-ts stream.parse for top-level append-heavy parses', () => {
     const md = getMarkdown('stream-parser-top-level')
@@ -307,6 +326,39 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     const serialized = JSON.stringify(second[0]?.children)
     expect(serialized).toContain('after')
     expect(serialized).not.toContain(') after')
+  })
+
+  it('does not mutate cached stream tokens during no-transform cache-hit processing', () => {
+    const md = getMarkdown('stream-parser-cache-freeze-no-mutation')
+    const source = [
+      '1. [site](https://example.com) after',
+      '2. **bold [link](https://example.com)**',
+      '',
+      '```html',
+      '<antArtifact type="application/vnd.ant.react">x</antArtifact>',
+      '```',
+      '',
+      '<details><summary>Hi</summary>Body</details>',
+    ].join('\n')
+
+    ;(md as any).stream.resetStats()
+
+    const first = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+    })
+
+    deepFreeze((md as any).stream.peek())
+
+    expect(() => {
+      const second = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+      })
+      expect(second).toEqual(first)
+    }).not.toThrow()
+
+    expect(getStreamStats(md).cacheHits).toBeGreaterThan(0)
   })
 
   it('does not clone stream tokens without transform hooks', () => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -274,7 +274,7 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(second[0]?.children).toHaveLength(1)
   })
 
-  it('does not deep-clone stream tokens without transform hooks', () => {
+  it('does not clone stream tokens without transform hooks', () => {
     const md = getMarkdown('stream-parser-skip-token-clone')
     ;(md as any).core.ruler.push('test_large_token_meta', (state: any) => {
       const inline = state.tokens?.find((token: any) => token.type === 'inline')
@@ -297,11 +297,14 @@ describe('parseMarkdownToStructure stream parser integration', () => {
       }
     })
 
+    const timing: { tokenCloneMs?: number } = {}
     const nodes = parseMarkdownToStructure(buildLargeAppendFriendlyDoc(40), md, {
       streamParse: true,
-    }) as any[]
+      __timing: timing,
+    } as any) as any[]
 
     expect(nodes).toHaveLength(40)
+    expect(timing.tokenCloneMs ?? 0).toBe(0)
   })
 
   it('deep-clones cached stream token object fields before transform hooks', () => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -423,6 +423,51 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(getStreamStats(md).cacheHits).toBeGreaterThan(0)
   })
 
+  it('does not mutate cached list paragraph tokens when stripping leaked ordered-list markers', () => {
+    const md = getMarkdown('stream-parser-list-jitter-no-mutation')
+    ;(md as any).core.ruler.push('test_leaked_ordered_list_marker', (state: any) => {
+      const inline = state.tokens?.find((token: any, index: number) => {
+        return token.type === 'inline' && state.tokens?.[index - 1]?.type === 'paragraph_open'
+      })
+      if (!inline)
+        return
+
+      inline.content = 'alpha\n\n2.'
+      inline.children = [
+        { type: 'text', content: 'alpha', raw: 'alpha' },
+        { type: 'softbreak', content: '', raw: '\n' },
+        { type: 'softbreak', content: '', raw: '\n' },
+        { type: 'text', content: '2.', raw: '2.' },
+      ]
+    })
+    ;(md as any).stream.resetStats()
+
+    const source = '1. alpha'
+    const first = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    const cachedInline = (md as any).stream.peek().find((token: any) => token.type === 'inline')
+
+    expect(first[0]?.items?.[0]?.children?.[0]?.raw).toBe('alpha')
+    expect(cachedInline?.content).toBe('alpha\n\n2.')
+    expect(cachedInline?.children?.at(-1)?.content).toBe('2.')
+
+    deepFreeze((md as any).stream.peek())
+
+    expect(() => {
+      const second = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+      })
+      expect(second).toEqual(first)
+    }).not.toThrow()
+
+    expect(getStreamStats(md).cacheHits).toBeGreaterThan(0)
+    expect(cachedInline?.content).toBe('alpha\n\n2.')
+    expect(cachedInline?.children?.at(-1)?.content).toBe('2.')
+  })
+
   it('does not clone stream tokens without transform hooks', () => {
     const md = getMarkdown('stream-parser-skip-token-clone')
     ;(md as any).core.ruler.push('test_large_token_meta', (state: any) => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -274,6 +274,41 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(second[0]?.children).toHaveLength(1)
   })
 
+  it('does not mutate cached stream tokens in markdown-link linkify fallback', () => {
+    const md = getMarkdown('stream-parser-linkify-tail-no-mutation')
+    ;(md as any).core.ruler.after('fix_link_tokens', 'test_linkify_markdown_tail_tokens', (state: any) => {
+      const inline = state.tokens?.find((token: any) => token.type === 'inline')
+      if (!inline)
+        return
+
+      inline.content = '[site](https://example.com) after'
+      inline.children = [
+        { type: 'text', content: '[site](', raw: '[site](' },
+        { type: 'link_open', tag: 'a', nesting: 1, markup: 'linkify', attrs: [['href', 'https://example.com']] },
+        { type: 'text', content: 'https://example.com', raw: 'https://example.com' },
+        { type: 'link_close', tag: 'a', nesting: -1, markup: 'linkify' },
+        { type: 'text', content: ') after', raw: ') after' },
+      ]
+    })
+
+    const source = 'placeholder'
+    const first = parseMarkdownToStructure(source, md, { final: false, streamParse: true }) as any[]
+    const cachedInline = (md as any).stream.peek().find((token: any) => token.type === 'inline')
+    const cachedTrailing = cachedInline?.children?.[4]
+
+    expect(cachedTrailing?.content).toBe(') after')
+    expect(cachedTrailing?.raw).toBe(') after')
+
+    const second = parseMarkdownToStructure(source, md, { final: false, streamParse: true }) as any[]
+
+    expect(getStreamStats(md).cacheHits).toBeGreaterThan(0)
+    expect(second).toEqual(first)
+
+    const serialized = JSON.stringify(second[0]?.children)
+    expect(serialized).toContain('after')
+    expect(serialized).not.toContain(') after')
+  })
+
   it('does not clone stream tokens without transform hooks', () => {
     const md = getMarkdown('stream-parser-skip-token-clone')
     ;(md as any).core.ruler.push('test_large_token_meta', (state: any) => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -328,6 +328,68 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(serialized).not.toContain(') after')
   })
 
+  it('preserves following markdown-link linkify fallback when close text starts another link', () => {
+    const md = getMarkdown('stream-parser-linkify-chain-no-mutation')
+    ;(md as any).core.ruler.after('fix_link_tokens', 'test_chained_markdown_linkify_tokens', (state: any) => {
+      const inline = state.tokens?.find((token: any) => token.type === 'inline')
+      if (!inline)
+        return
+
+      inline.content = '[a](https://a.com) [b](https://b.com)'
+      inline.children = [
+        { type: 'text', content: '[a](', raw: '[a](' },
+        { type: 'link_open', tag: 'a', nesting: 1, markup: 'linkify', attrs: [['href', 'https://a.com']] },
+        { type: 'text', content: 'https://a.com', raw: 'https://a.com' },
+        { type: 'link_close', tag: 'a', nesting: -1, markup: 'linkify' },
+        { type: 'text', content: ') [b](', raw: ') [b](' },
+        { type: 'link_open', tag: 'a', nesting: 1, markup: 'linkify', attrs: [['href', 'https://b.com']] },
+        { type: 'text', content: 'https://b.com', raw: 'https://b.com' },
+        { type: 'link_close', tag: 'a', nesting: -1, markup: 'linkify' },
+        { type: 'text', content: ')', raw: ')' },
+      ]
+    })
+
+    const nodes = parseMarkdownToStructure('placeholder', md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    const serialized = JSON.stringify(nodes)
+
+    expect(serialized.match(/"type":"link"/g) ?? []).toHaveLength(2)
+    expect(serialized).toContain('"href":"https://a.com"')
+    expect(serialized).toContain('"href":"https://b.com"')
+    expect(serialized).not.toContain('"href":""')
+  })
+
+  it('does not mutate frozen stream tokens during first-pass processing', () => {
+    const md = getMarkdown('stream-parser-first-pass-freeze-no-mutation')
+    ;(md as any).core.ruler.push('test_freeze_stream_tokens_after_plugins', (state: any) => {
+      const inline = state.tokens?.find((token: any) => token.type === 'inline')
+      if (!inline)
+        return
+
+      inline.content = '[site](https://example.com) after'
+      inline.children = [
+        { type: 'text', content: '[site](', raw: '[site](' },
+        { type: 'link_open', tag: 'a', nesting: 1, markup: 'linkify', attrs: [['href', 'https://example.com']] },
+        { type: 'text', content: 'https://example.com', raw: 'https://example.com' },
+        { type: 'link_close', tag: 'a', nesting: -1, markup: 'linkify' },
+        { type: 'text', content: ') after', raw: ') after' },
+      ]
+      deepFreeze(state.tokens)
+    })
+
+    let nodes: any[] = []
+    expect(() => {
+      nodes = parseMarkdownToStructure('placeholder', md, { final: false, streamParse: true }) as any[]
+    }).not.toThrow()
+
+    const serialized = JSON.stringify(nodes[0]?.children)
+    expect(serialized).toContain('"href":"https://example.com"')
+    expect(serialized).toContain('after')
+    expect(serialized).not.toContain(') after')
+  })
+
   it('does not mutate cached stream tokens during no-transform cache-hit processing', () => {
     const md = getMarkdown('stream-parser-cache-freeze-no-mutation')
     const source = [


### PR DESCRIPTION
## Summary
- skip cached stream token cloning when no token transform hooks are registered
- keep parser token handling read-only by copying only the local tokens that need content adjustments
- assert token clone timing stays at zero for the no-transform stream path

## Tests
- pnpm --filter stream-markdown-parser test:run stream-parser-integration.test.ts
- pnpm --filter stream-markdown-parser test:run ordered-list-streaming-jitter.test.ts strong-link.test.ts strong-link-followed-by-inline-content.test.ts issue-380-html-wrapper-markdown.test.ts
- pnpm --filter stream-markdown-parser test:run
- pnpm --filter stream-markdown-parser typecheck
- pnpm --filter stream-markdown-parser build
- pnpm --filter stream-markdown-parser lint
- pnpm exec vitest --run test/use-markdown-parsing-performance.test.ts