### PR TITLE
fix: reduce typewriter cursor DOM scanning

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5107,7 +5107,7 @@ let typewriterCursorTimeout: ReturnType<typeof setTimeout> | undefined
 let typewriterCursorRaf: number | null = null
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
-const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image'])
+const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image', 'thematic_break'])
 
 function shouldSkipTypewriterCursorForNode(node: unknown) {
   if (!node || typeof node !== 'object')
@@ -5226,7 +5226,6 @@ function updateTypewriterCursorPosition() {
   const root = containerRef.value
   const cursor = typewriterCursorRef.value
   const searchRoot = getTypewriterCursorSearchRoot()
-  const rootRect = root.getBoundingClientRect()
   cursor.style.visibility = 'hidden'
   if (!searchRoot)
     return
@@ -5248,6 +5247,7 @@ function updateTypewriterCursorPosition() {
     const rect = rects?.[rects.length - 1] ?? lastText.parentElement?.getBoundingClientRect()
 
     if (rect) {
+      const rootRect = root.getBoundingClientRect()
       left = rect.right - rootRect.left + root.scrollLeft
       top = rect.top - rootRect.top + root.scrollTop
       height = rect.height || height

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5118,6 +5118,7 @@ const TYPEWRITER_CURSOR_EXCLUDED_SELECTOR = [
   '[data-node-type="math_block"]',
   '[data-node-type="html_block"]',
   '[data-node-type="image"]',
+  '[data-node-type="thematic_break"]',
   'script',
   'style',
 ].join(',')
@@ -5193,21 +5194,6 @@ function hideTypewriterCursorElement() {
     typewriterCursorRef.value.style.visibility = 'hidden'
 }
 
-function getTypewriterCursorSearchRoot() {
-  const items = renderedItems.value
-  for (let index = items.length - 1; index >= 0; index--) {
-    const item = items[index]
-    if (!item || shouldSkipTypewriterCursorForNode(item.node) || !shouldRenderNode(item.index))
-      continue
-
-    const slot = nodeSlotElements.get(item.index)
-    if (slot)
-      return slot
-  }
-
-  return null
-}
-
 function isAcceptedTypewriterCursorTextNode(node: Node): node is Text {
   if (node.nodeType !== Node.TEXT_NODE)
     return false
@@ -5250,18 +5236,37 @@ function getLastTextNode(root: HTMLElement) {
   return null
 }
 
+function getTypewriterCursorTextTarget() {
+  const items = renderedItems.value
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index]
+    if (!item || shouldSkipTypewriterCursorForNode(item.node) || !shouldRenderNode(item.index))
+      continue
+
+    const slot = nodeSlotElements.get(item.index)
+    if (!slot)
+      continue
+
+    const text = getLastTextNode(slot)
+    if (text)
+      return { slot, text }
+  }
+
+  return null
+}
+
 function updateTypewriterCursorPosition() {
   if (!isClient || !showTypewriterCursor.value || !containerRef.value || !typewriterCursorRef.value)
     return
 
   const root = containerRef.value
   const cursor = typewriterCursorRef.value
-  const searchRoot = getTypewriterCursorSearchRoot()
   cursor.style.visibility = 'hidden'
-  if (!searchRoot)
+  const target = getTypewriterCursorTextTarget()
+  if (!target)
     return
 
-  const lastText = getLastTextNode(searchRoot)
+  const lastText = target.text
   let left = 0
   let top = 0
   let height = 20

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5108,17 +5108,20 @@ let typewriterCursorRaf: number | null = null
 let typewriterCursorRafVersion = 0
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
-const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image', 'thematic_break'])
+const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPE_LIST = [
+  'code_block',
+  'admonition',
+  'table',
+  'math_block',
+  'html_block',
+  'image',
+  'thematic_break',
+] as const
+const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES: ReadonlySet<string> = new Set(TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPE_LIST)
 const TYPEWRITER_CURSOR_EXCLUDED_SELECTOR = [
   '.typewriter-cursor',
   '.height-estimation-probes',
-  '[data-node-type="code_block"]',
-  '[data-node-type="admonition"]',
-  '[data-node-type="table"]',
-  '[data-node-type="math_block"]',
-  '[data-node-type="html_block"]',
-  '[data-node-type="image"]',
-  '[data-node-type="thematic_break"]',
+  ...TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPE_LIST.map(type => `[data-node-type="${type}"]`),
   'script',
   'style',
 ].join(',')

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5109,6 +5109,18 @@ let typewriterCursorRafVersion = 0
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
 const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image', 'thematic_break'])
+const TYPEWRITER_CURSOR_EXCLUDED_SELECTOR = [
+  '.typewriter-cursor',
+  '.height-estimation-probes',
+  '[data-node-type="code_block"]',
+  '[data-node-type="admonition"]',
+  '[data-node-type="table"]',
+  '[data-node-type="math_block"]',
+  '[data-node-type="html_block"]',
+  '[data-node-type="image"]',
+  'script',
+  'style',
+].join(',')
 
 function shouldSkipTypewriterCursorForNode(node: unknown) {
   if (!node || typeof node !== 'object')
@@ -5196,31 +5208,46 @@ function getTypewriterCursorSearchRoot() {
   return null
 }
 
+function isAcceptedTypewriterCursorTextNode(node: Node): node is Text {
+  if (node.nodeType !== Node.TEXT_NODE)
+    return false
+
+  const text = node.textContent ?? ''
+  if (!text.trim())
+    return false
+
+  const parent = node.parentElement
+  if (!parent)
+    return false
+
+  return !parent.closest(TYPEWRITER_CURSOR_EXCLUDED_SELECTOR)
+}
+
 function getLastTextNode(root: HTMLElement) {
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-    acceptNode(node) {
-      const text = node.textContent ?? ''
-      if (!text.trim())
-        return NodeFilter.FILTER_REJECT
+  let current: Node | null = root.lastChild
 
-      const parent = node.parentElement
-      if (!parent)
-        return NodeFilter.FILTER_REJECT
-      if (parent.closest('.typewriter-cursor, .height-estimation-probes, [data-node-type="code_block"], [data-node-type="admonition"], [data-node-type="table"], [data-node-type="math_block"], [data-node-type="html_block"], [data-node-type="image"], script, style'))
-        return NodeFilter.FILTER_REJECT
-
-      return NodeFilter.FILTER_ACCEPT
-    },
-  })
-
-  let last: Text | null = null
-  let current = walker.nextNode()
   while (current) {
-    last = current as Text
-    current = walker.nextNode()
+    if (isAcceptedTypewriterCursorTextNode(current))
+      return current
+
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const element = current as Element
+      if (!element.matches(TYPEWRITER_CURSOR_EXCLUDED_SELECTOR) && element.lastChild) {
+        current = element.lastChild
+        continue
+      }
+    }
+
+    while (current && current !== root && !current.previousSibling)
+      current = current.parentNode
+
+    if (!current || current === root)
+      break
+
+    current = current.previousSibling
   }
 
-  return last
+  return null
 }
 
 function updateTypewriterCursorPosition() {
@@ -5340,6 +5367,7 @@ watch(
     await nextTick()
     scheduleTypewriterCursorPositionUpdate()
     typewriterCursorTimeout = setTimeout(() => {
+      typewriterCursorTimeout = undefined
       showTypewriterCursor.value = false
     }, 3000)
   },
@@ -5353,6 +5381,18 @@ watch(
       hideTypewriterCursorElement()
       return
     }
+    await nextTick()
+    scheduleTypewriterCursorPositionUpdate()
+  },
+  { flush: 'post' },
+)
+
+watch(
+  [() => renderedCount.value, () => liveRange.start, () => liveRange.end],
+  async () => {
+    if (!isClient || renderAsFragment.value || !ownsTypewriterCursor.value || !showTypewriterCursor.value)
+      return
+
     await nextTick()
     scheduleTypewriterCursorPositionUpdate()
   },

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5105,6 +5105,7 @@ const typewriterCursorRef = ref<HTMLElement | null>(null)
 const showTypewriterCursor = ref(false)
 let typewriterCursorTimeout: ReturnType<typeof setTimeout> | undefined
 let typewriterCursorRaf: number | null = null
+let typewriterCursorRafVersion = 0
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
 const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image', 'thematic_break'])
@@ -5165,8 +5166,11 @@ function clearTypewriterCursorTimeout() {
 }
 
 function clearTypewriterCursorRaf() {
+  typewriterCursorRafVersion += 1
+
   if (typewriterCursorRaf == null)
     return
+
   cancelFrame?.(typewriterCursorRaf)
   typewriterCursorRaf = null
 }
@@ -5270,8 +5274,11 @@ function scheduleTypewriterCursorPositionUpdate() {
   if (typewriterCursorRaf != null)
     return
 
+  const version = typewriterCursorRafVersion
   const run = () => {
     typewriterCursorRaf = null
+    if (version !== typewriterCursorRafVersion)
+      return
     updateTypewriterCursorPosition()
   }
 
@@ -5327,7 +5334,8 @@ watch(
     lastTypewriterContentLength = nextLength
     lastTypewriterVisibleLength = nextVisibleLength
     showTypewriterCursor.value = true
-    hideTypewriterCursorElement()
+    if (typewriterCursorRef.value)
+      typewriterCursorRef.value.style.visibility = 'hidden'
     clearTypewriterCursorTimeout()
     await nextTick()
     scheduleTypewriterCursorPositionUpdate()

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5104,6 +5104,7 @@ function handleFragmentMouseout(event: MouseEvent) {
 const typewriterCursorRef = ref<HTMLElement | null>(null)
 const showTypewriterCursor = ref(false)
 let typewriterCursorTimeout: ReturnType<typeof setTimeout> | undefined
+let typewriterCursorRaf: number | null = null
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
 const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPES = new Set(['code_block', 'admonition', 'table', 'math_block', 'html_block', 'image'])
@@ -5163,9 +5164,32 @@ function clearTypewriterCursorTimeout() {
   typewriterCursorTimeout = undefined
 }
 
+function clearTypewriterCursorRaf() {
+  if (typewriterCursorRaf == null)
+    return
+  cancelFrame?.(typewriterCursorRaf)
+  typewriterCursorRaf = null
+}
+
 function hideTypewriterCursorElement() {
+  clearTypewriterCursorRaf()
   if (typewriterCursorRef.value)
     typewriterCursorRef.value.style.visibility = 'hidden'
+}
+
+function getTypewriterCursorSearchRoot() {
+  const items = renderedItems.value
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index]
+    if (!item || shouldSkipTypewriterCursorForNode(item.node) || !shouldRenderNode(item.index))
+      continue
+
+    const slot = nodeSlotElements.get(item.index)
+    if (slot)
+      return slot
+  }
+
+  return null
 }
 
 function getLastTextNode(root: HTMLElement) {
@@ -5201,9 +5225,13 @@ function updateTypewriterCursorPosition() {
 
   const root = containerRef.value
   const cursor = typewriterCursorRef.value
-  const lastText = getLastTextNode(root)
+  const searchRoot = getTypewriterCursorSearchRoot()
   const rootRect = root.getBoundingClientRect()
   cursor.style.visibility = 'hidden'
+  if (!searchRoot)
+    return
+
+  const lastText = getLastTextNode(searchRoot)
   let left = 0
   let top = 0
   let height = 20
@@ -5236,6 +5264,25 @@ function updateTypewriterCursorPosition() {
   cursor.style.visibility = 'visible'
 }
 
+function scheduleTypewriterCursorPositionUpdate() {
+  if (!isClient || !showTypewriterCursor.value)
+    return
+  if (typewriterCursorRaf != null)
+    return
+
+  const run = () => {
+    typewriterCursorRaf = null
+    updateTypewriterCursorPosition()
+  }
+
+  if (requestFrame) {
+    typewriterCursorRaf = requestFrame(run)
+    return
+  }
+
+  run()
+}
+
 watch(
   [renderContent, () => props.content, () => props.nodes, () => props.typewriter, effectiveFinal],
   async () => {
@@ -5247,6 +5294,16 @@ watch(
     if (effectiveFinal.value) {
       showTypewriterCursor.value = false
       clearTypewriterCursorTimeout()
+      hideTypewriterCursorElement()
+      return
+    }
+
+    if (props.nodes?.length) {
+      showTypewriterCursor.value = false
+      clearTypewriterCursorTimeout()
+      hideTypewriterCursorElement()
+      lastTypewriterContentLength = getTypewriterContentLength()
+      lastTypewriterVisibleLength = getTypewriterVisibleLength()
       return
     }
 
@@ -5256,8 +5313,10 @@ watch(
     const sourceGrowing = nextLength > lastTypewriterContentLength
     const visibleGrowing = nextVisibleLength > lastTypewriterVisibleLength
     if (props.typewriter === false || !cursorAllowed || (!sourceGrowing && !visibleGrowing)) {
-      if (props.typewriter === false || !cursorAllowed)
+      if (props.typewriter === false || !cursorAllowed) {
         showTypewriterCursor.value = false
+        hideTypewriterCursorElement()
+      }
       lastTypewriterContentLength = nextLength
       lastTypewriterVisibleLength = nextVisibleLength
       return
@@ -5269,7 +5328,7 @@ watch(
     hideTypewriterCursorElement()
     clearTypewriterCursorTimeout()
     await nextTick()
-    updateTypewriterCursorPosition()
+    scheduleTypewriterCursorPositionUpdate()
     typewriterCursorTimeout = setTimeout(() => {
       showTypewriterCursor.value = false
     }, 3000)
@@ -5280,16 +5339,19 @@ watch(
 watch(
   showTypewriterCursor,
   async (visible) => {
-    if (!visible)
+    if (!visible) {
+      hideTypewriterCursorElement()
       return
+    }
     await nextTick()
-    updateTypewriterCursorPosition()
+    scheduleTypewriterCursorPositionUpdate()
   },
   { flush: 'post' },
 )
 
 onBeforeUnmount(() => {
   clearTypewriterCursorTimeout()
+  clearTypewriterCursorRaf()
   mathBlockMinHeightCache.clear()
 })
 </script>

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5249,7 +5249,7 @@ function getTypewriterCursorTextTarget() {
 
     const text = getLastTextNode(slot)
     if (text)
-      return { slot, text }
+      return text
   }
 
   return null
@@ -5262,11 +5262,10 @@ function updateTypewriterCursorPosition() {
   const root = containerRef.value
   const cursor = typewriterCursorRef.value
   cursor.style.visibility = 'hidden'
-  const target = getTypewriterCursorTextTarget()
-  if (!target)
+  const lastText = getTypewriterCursorTextTarget()
+  if (!lastText)
     return
 
-  const lastText = target.text
   let left = 0
   let top = 0
   let height = 20

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5302,8 +5302,10 @@ watch(
       showTypewriterCursor.value = false
       clearTypewriterCursorTimeout()
       hideTypewriterCursorElement()
-      lastTypewriterContentLength = getTypewriterContentLength()
-      lastTypewriterVisibleLength = getTypewriterVisibleLength()
+      // Cursor is disabled in nodes mode; keep the baseline on content so
+      // switching back to content mode can show it again.
+      lastTypewriterContentLength = (props.content ?? '').length
+      lastTypewriterVisibleLength = renderContent.value.length
       return
     }
 

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -317,7 +317,7 @@ export interface NodeRendererProps {
   /** Scope key used by `setCustomComponents()` and `data-custom-id` style overrides. */
   customId?: string
   indexKey?: number | string
-  /** Show a blinking typewriter cursor while streamed content grows. Default: false */
+  /** Show a blinking typewriter cursor while streamed content grows. Applies to `content` mode; ignored when `nodes` are provided. Default: false */
   typewriter?: boolean
   /**
    * Enable built-in smooth pacing for streaming `content` updates.

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -317,7 +317,7 @@ export interface NodeRendererProps {
   /** Scope key used by `setCustomComponents()` and `data-custom-id` style overrides. */
   customId?: string
   indexKey?: number | string
-  /** Show a blinking typewriter cursor while streamed content grows. Applies to `content` mode; ignored when `nodes` are provided. Default: false */
+  /** Show a blinking typewriter cursor while streamed content grows. Applies to `content` mode; ignored when non-empty `nodes` are provided. Default: false */
   typewriter?: boolean
   /**
    * Enable built-in smooth pacing for streaming `content` updates.

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -304,6 +304,7 @@ describe('node renderer smooth streaming', () => {
     // When nodes are provided, smooth streaming must not activate
     // regardless of typewriter or smoothStreaming='auto'
     expect(wrapper.text()).toContain('hello')
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
     expect(queuedFrames.length).toBe(0)
 
     wrapper.unmount()

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -4,7 +4,9 @@
 
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
 import NodeRenderer from '../src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
 import { flushAll } from './setup/flush-all'
 
 function rect(partial: Partial<DOMRect>): DOMRect {
@@ -193,6 +195,76 @@ describe('typewriter cursor position', () => {
     expect(measuredSlot instanceof HTMLElement && measuredSlot.matches('.node-slot[data-node-index="1"]')).toBe(true)
 
     wrapper.unmount()
+  })
+
+  it('falls back to previous rendered text slot when the last non-excluded slot has no text', async () => {
+    const scopeId = 'typewriter-empty-tail'
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const EmptyNode = {
+      name: 'EmptyNode',
+      setup() {
+        return () => h('span', { class: 'empty-node' })
+      },
+    }
+    setCustomComponents(scopeId, { 'empty-node': EmptyNode })
+
+    let rangeNode: Node | null = null
+    let measuredText = ''
+    let measuredSlot: Element | null = null
+    const originalCreateRange = document.createRange.bind(document)
+    vi.spyOn(document, 'createRange').mockImplementation(() => {
+      const range = originalCreateRange()
+      range.setStart = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.setEnd = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.getClientRects = vi.fn(() => {
+        measuredText = rangeNode?.textContent ?? ''
+        measuredSlot = rangeNode?.parentElement?.closest('.node-slot[data-node-index]') ?? null
+        return [
+          rect({ right: 50, top: 20, bottom: 40, height: 20 }),
+        ] as unknown as DOMRectList
+      })
+      return range
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        customId: scopeId,
+        customHtmlTags: ['empty-node'],
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      queuedFrames.length = 0
+
+      await wrapper.setProps({ content: 'hello\n\n<empty-node></empty-node>' })
+      await flushAll()
+      await runNextFrame(queuedFrames, performance.now() + 16)
+
+      expect(measuredText).toBe('hello')
+      expect(measuredSlot instanceof HTMLElement && measuredSlot.matches('.node-slot[data-node-index="0"]')).toBe(true)
+      expect((wrapper.get('.typewriter-cursor').element as HTMLElement).style.visibility).toBe('visible')
+    }
+    finally {
+      wrapper.unmount()
+      removeCustomComponents(scopeId)
+    }
   })
 
   it('repositions when incremental rendering mounts the next slot', async () => {

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -36,11 +36,19 @@ describe('typewriter cursor position', () => {
 
   it('repositions while smooth visible content catches up after the source stops growing', async () => {
     const queuedFrames: FrameRequestCallback[] = []
+    const frameIds = new WeakMap<FrameRequestCallback, number>()
+    let nextFrameId = 1
     vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      const id = nextFrameId++
+      frameIds.set(cb, id)
       queuedFrames.push(cb)
-      return queuedFrames.length
+      return id
     }) as typeof requestAnimationFrame)
-    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', ((id: number) => {
+      const index = queuedFrames.findIndex(cb => frameIds.get(cb) === id)
+      if (index >= 0)
+        queuedFrames.splice(index, 1)
+    }) as typeof cancelAnimationFrame)
     const createTreeWalkerSpy = vi.spyOn(document, 'createTreeWalker')
 
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
@@ -101,7 +109,7 @@ describe('typewriter cursor position', () => {
     queuedFrames.length = 0
 
     await wrapper.setProps({
-      content: 'abcdefghij',
+      content: 'abcdefghijklmnopqrst',
     })
     await flushAll()
 
@@ -117,6 +125,7 @@ describe('typewriter cursor position', () => {
 
     await runNextFrame(queuedFrames, baseline + 100)
     await runNextFrame(queuedFrames, baseline + 116)
+    await runNextFrame(queuedFrames, baseline + 132)
 
     const secondVisibleLength = wrapper.get('.text-node').text().length
     expect(secondVisibleLength).toBeGreaterThan(firstVisibleLength)
@@ -125,6 +134,50 @@ describe('typewriter cursor position', () => {
     expect(createTreeWalkerSpy.mock.calls.every(([root]) => {
       return root instanceof HTMLElement && root.matches('.node-slot[data-node-index]')
     })).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('scans only the last rendered text node slot', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    const createTreeWalkerSpy = vi.spyOn(document, 'createTreeWalker')
+
+    const originalCreateRange = document.createRange.bind(document)
+    vi.spyOn(document, 'createRange').mockImplementation(() => {
+      const range = originalCreateRange()
+      range.getClientRects = vi.fn(() => [
+        rect({ right: 40, top: 20, bottom: 40, height: 20 }),
+      ] as unknown as DOMRectList)
+      return range
+    })
+
+    const huge = 'x'.repeat(20_000)
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    queuedFrames.length = 0
+
+    await wrapper.setProps({ content: `${huge}\n\nlast` })
+    await flushAll()
+    await runNextFrame(queuedFrames, performance.now() + 16)
+
+    const roots = createTreeWalkerSpy.mock.calls.map(([root]) => root as HTMLElement)
+    expect(roots.length).toBeGreaterThan(0)
+    expect(roots.every(root => root.matches('.node-slot[data-node-index="1"]'))).toBe(true)
 
     wrapper.unmount()
   })
@@ -169,6 +222,78 @@ describe('typewriter cursor position', () => {
 
     expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(cursorFrameId)
     expect(queuedFrameIds).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
+  it('does not flash cursor when leaving nodes mode with unchanged content', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [
+          { type: 'paragraph', raw: 'node text', children: [{ type: 'text', content: 'node text', raw: 'node text' }] },
+        ],
+        content: 'already here',
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(queuedFrames).toHaveLength(0)
+
+    await wrapper.setProps({ nodes: undefined })
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(queuedFrames).toHaveLength(0)
+
+    await wrapper.setProps({ content: 'already here!' })
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(true)
+    expect(queuedFrames).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('does not show cursor when content ends with a thematic break', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    await wrapper.setProps({ content: 'hello\n\n---' })
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(queuedFrames).toHaveLength(0)
 
     wrapper.unmount()
   })

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -49,7 +49,7 @@ describe('typewriter cursor position', () => {
       if (index >= 0)
         queuedFrames.splice(index, 1)
     }) as typeof cancelAnimationFrame)
-    const createTreeWalkerSpy = vi.spyOn(document, 'createTreeWalker')
+    const measuredSlots: HTMLElement[] = []
 
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
       const element = this as HTMLElement
@@ -74,6 +74,10 @@ describe('typewriter cursor position', () => {
       range.getClientRects = vi.fn(() => {
         let previousLength = 0
         let sibling = rangeNode?.parentElement?.previousSibling ?? null
+        const slot = rangeNode?.parentElement?.closest('.node-slot[data-node-index]')
+        if (slot instanceof HTMLElement)
+          measuredSlots.push(slot)
+
         while (sibling) {
           previousLength += sibling.textContent?.length ?? 0
           sibling = sibling.previousSibling
@@ -130,10 +134,8 @@ describe('typewriter cursor position', () => {
     const secondVisibleLength = wrapper.get('.text-node').text().length
     expect(secondVisibleLength).toBeGreaterThan(firstVisibleLength)
     expect(cursor.style.transform).toBe(`translate(${Math.max(0, secondVisibleLength * 10 - 20)}px, 50px)`)
-    expect(createTreeWalkerSpy).toHaveBeenCalled()
-    expect(createTreeWalkerSpy.mock.calls.every(([root]) => {
-      return root instanceof HTMLElement && root.matches('.node-slot[data-node-index]')
-    })).toBe(true)
+    expect(measuredSlots.length).toBeGreaterThan(0)
+    expect(measuredSlots.every(slot => slot.matches('.node-slot[data-node-index]'))).toBe(true)
 
     wrapper.unmount()
   })
@@ -145,14 +147,26 @@ describe('typewriter cursor position', () => {
       return queuedFrames.length
     }) as typeof requestAnimationFrame)
     vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
-    const createTreeWalkerSpy = vi.spyOn(document, 'createTreeWalker')
 
+    let rangeNode: Node | null = null
+    let measuredText = ''
+    let measuredSlot: Element | null = null
     const originalCreateRange = document.createRange.bind(document)
     vi.spyOn(document, 'createRange').mockImplementation(() => {
       const range = originalCreateRange()
-      range.getClientRects = vi.fn(() => [
-        rect({ right: 40, top: 20, bottom: 40, height: 20 }),
-      ] as unknown as DOMRectList)
+      range.setStart = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.setEnd = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.getClientRects = vi.fn(() => {
+        measuredText = rangeNode?.textContent ?? ''
+        measuredSlot = rangeNode?.parentElement?.closest('.node-slot[data-node-index]') ?? null
+        return [
+          rect({ right: 40, top: 20, bottom: 40, height: 20 }),
+        ] as unknown as DOMRectList
+      })
       return range
     })
 
@@ -175,11 +189,90 @@ describe('typewriter cursor position', () => {
     await flushAll()
     await runNextFrame(queuedFrames, performance.now() + 16)
 
-    const roots = createTreeWalkerSpy.mock.calls.map(([root]) => root as HTMLElement)
-    expect(roots.length).toBeGreaterThan(0)
-    expect(roots.every(root => root.matches('.node-slot[data-node-index="1"]'))).toBe(true)
+    expect(measuredText).toBe('last')
+    expect(measuredSlot instanceof HTMLElement && measuredSlot.matches('.node-slot[data-node-index="1"]')).toBe(true)
 
     wrapper.unmount()
+  })
+
+  it('repositions when incremental rendering mounts the next slot', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    const queuedFrames: FrameRequestCallback[] = []
+    const frameIds = new WeakMap<FrameRequestCallback, number>()
+    let nextFrameId = 1
+    let wrapper: ReturnType<typeof mount> | null = null
+    let rangeNode: Node | null = null
+    let measuredText = ''
+
+    process.env.NODE_ENV = 'development'
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      const id = nextFrameId++
+      frameIds.set(cb, id)
+      queuedFrames.push(cb)
+      return id
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', ((id: number) => {
+      const index = queuedFrames.findIndex(cb => frameIds.get(cb) === id)
+      if (index >= 0)
+        queuedFrames.splice(index, 1)
+    }) as typeof cancelAnimationFrame)
+
+    const originalCreateRange = document.createRange.bind(document)
+    vi.spyOn(document, 'createRange').mockImplementation(() => {
+      const range = originalCreateRange()
+      range.setStart = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.setEnd = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.getClientRects = vi.fn(() => {
+        measuredText = rangeNode?.textContent ?? ''
+        return [
+          rect({ right: measuredText.length * 10, top: 20, bottom: 40, height: 20 }),
+        ] as unknown as DOMRectList
+      })
+      return range
+    })
+
+    try {
+      wrapper = mount(NodeRenderer, {
+        props: {
+          content: '',
+          typewriter: true,
+          smoothStreaming: false,
+          batchRendering: true,
+          maxLiveNodes: 0,
+          initialRenderBatchSize: 1,
+          renderBatchSize: 1,
+          renderBatchDelay: 20,
+          viewportPriority: false,
+          deferNodesUntilVisible: false,
+        },
+      })
+
+      await flushAll()
+      queuedFrames.length = 0
+
+      await wrapper.setProps({ content: 'first\n\nsecond' })
+      await flushAll()
+
+      expect(wrapper.find('.node-slot[data-node-index="1"] .node-placeholder').exists()).toBe(true)
+      await runNextFrame(queuedFrames, performance.now() + 16)
+      await runNextFrame(queuedFrames, performance.now() + 32)
+      expect(measuredText).toBe('first')
+
+      await new Promise(resolve => setTimeout(resolve, 25))
+      await flushAll()
+
+      expect(wrapper.find('.node-slot[data-node-index="1"] .node-content').exists()).toBe(true)
+      await runNextFrame(queuedFrames, performance.now() + 64)
+      expect(measuredText).toBe('second')
+    }
+    finally {
+      wrapper?.unmount()
+      process.env.NODE_ENV = originalNodeEnv
+    }
   })
 
   it('cancels pending cursor RAF when cursor is hidden before the frame runs', async () => {

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -128,4 +128,48 @@ describe('typewriter cursor position', () => {
 
     wrapper.unmount()
   })
+
+  it('cancels pending cursor RAF when cursor is hidden before the frame runs', async () => {
+    const queuedFrameIds: number[] = []
+    const cancelAnimationFrameSpy = vi.fn((id: number) => {
+      const index = queuedFrameIds.indexOf(id)
+      if (index >= 0)
+        queuedFrameIds.splice(index, 1)
+    })
+    let nextFrameId = 1
+
+    vi.stubGlobal('requestAnimationFrame', (() => {
+      const id = nextFrameId++
+      queuedFrameIds.push(id)
+      return id
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameSpy as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    await wrapper.setProps({ content: 'hello world' })
+    await flushAll()
+
+    expect(queuedFrameIds).toHaveLength(1)
+    const cursorFrameId = queuedFrameIds[0]
+
+    await wrapper.setProps({ final: true })
+    await flushAll()
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(cursorFrameId)
+    expect(queuedFrameIds).toHaveLength(0)
+
+    wrapper.unmount()
+  })
 })

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -172,4 +172,40 @@ describe('typewriter cursor position', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps content baseline while cursor is disabled in nodes mode', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const longText = 'x'.repeat(1000)
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [
+          { type: 'paragraph', raw: longText, children: [{ type: 'text', content: longText, raw: longText }] },
+        ],
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(queuedFrames).toHaveLength(0)
+
+    await wrapper.setProps({ nodes: undefined, content: 'hi' })
+    await flushAll()
+
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(true)
+    expect(queuedFrames).toHaveLength(1)
+
+    wrapper.unmount()
+  })
 })

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -21,6 +21,13 @@ function rect(partial: Partial<DOMRect>): DOMRect {
   }
 }
 
+async function runNextFrame(queuedFrames: FrameRequestCallback[], now: number) {
+  const frame = queuedFrames.shift()
+  expect(frame).toBeDefined()
+  frame?.(now)
+  await flushAll()
+}
+
 describe('typewriter cursor position', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -34,6 +41,7 @@ describe('typewriter cursor position', () => {
       return queuedFrames.length
     }) as typeof requestAnimationFrame)
     vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    const createTreeWalkerSpy = vi.spyOn(document, 'createTreeWalker')
 
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
       const element = this as HTMLElement
@@ -98,8 +106,8 @@ describe('typewriter cursor position', () => {
     await flushAll()
 
     const baseline = performance.now()
-    queuedFrames.shift()?.(baseline + 50)
-    await flushAll()
+    await runNextFrame(queuedFrames, baseline + 50)
+    await runNextFrame(queuedFrames, baseline + 66)
 
     const cursor = wrapper.get('.typewriter-cursor').element as HTMLElement
     const firstVisibleLength = wrapper.get('.text-node').text().length
@@ -107,12 +115,16 @@ describe('typewriter cursor position', () => {
     expect(cursor.style.transform).toBe(`translate(${Math.max(0, firstVisibleLength * 10 - 20)}px, 50px)`)
     expect(cursor.style.visibility).toBe('visible')
 
-    queuedFrames.shift()?.(baseline + 100)
-    await flushAll()
+    await runNextFrame(queuedFrames, baseline + 100)
+    await runNextFrame(queuedFrames, baseline + 116)
 
     const secondVisibleLength = wrapper.get('.text-node').text().length
     expect(secondVisibleLength).toBeGreaterThan(firstVisibleLength)
     expect(cursor.style.transform).toBe(`translate(${Math.max(0, secondVisibleLength * 10 - 20)}px, 50px)`)
+    expect(createTreeWalkerSpy).toHaveBeenCalled()
+    expect(createTreeWalkerSpy.mock.calls.every(([root]) => {
+      return root instanceof HTMLElement && root.matches('.node-slot[data-node-index]')
+    })).toBe(true)
 
     wrapper.unmount()
   })

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -197,6 +197,63 @@ describe('typewriter cursor position', () => {
     wrapper.unmount()
   })
 
+  it('coalesces cursor positioning into one RAF and measures latest content', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    let rangeNode: Node | null = null
+    let measuredText = ''
+    const originalCreateRange = document.createRange.bind(document)
+    vi.spyOn(document, 'createRange').mockImplementation(() => {
+      const range = originalCreateRange()
+      range.setStart = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.setEnd = vi.fn((node: Node) => {
+        rangeNode = node
+      })
+      range.getClientRects = vi.fn(() => {
+        measuredText = rangeNode?.textContent ?? ''
+        return [
+          rect({ right: measuredText.length * 10, top: 20, bottom: 40, height: 20 }),
+        ] as unknown as DOMRectList
+      })
+      return range
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    queuedFrames.length = 0
+
+    await wrapper.setProps({ content: 'hello' })
+    await flushAll()
+    expect(queuedFrames).toHaveLength(1)
+
+    await wrapper.setProps({ content: 'hello world' })
+    await flushAll()
+    expect(queuedFrames).toHaveLength(1)
+
+    await runNextFrame(queuedFrames, performance.now() + 16)
+    expect(wrapper.get('.text-node').text()).toBe('hello world')
+    expect(measuredText).toBe(' world')
+
+    wrapper.unmount()
+  })
+
   it('falls back to previous rendered text slot when the last non-excluded slot has no text', async () => {
     const scopeId = 'typewriter-empty-tail'
     const queuedFrames: FrameRequestCallback[] = []


### PR DESCRIPTION
## Summary
- limit typewriter cursor text-node lookup to the last rendered node slot
- coalesce cursor positioning work through a cancellable RAF
- keep nodes mode from showing the typewriter cursor or scheduling cursor RAF work

## Tests
- pnpm exec vitest --run test/typewriter-cursor-position.test.ts test/node-renderer-smooth-streaming.test.ts test/vue2-typewriter-fade-separation.test.ts
- pnpm exec eslint src/components/NodeRenderer/NodeRenderer.vue test/typewriter-cursor-position.test.ts test/node-renderer-smooth-streaming.test.ts
- pnpm typecheck