### PR TITLE
fix: measure batch commit cost

### DIFF
--- a/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
@@ -147,11 +147,36 @@ export function useBatchRenderingScheduler(
 
       // Keep a frame boundary before the next batch without charging RAF wait time as commit cost.
       if (requestFrame) {
+        let finished = false
+        let timeout: number | null = null
+
+        const finishOnce = () => {
+          if (finished)
+            return
+          finished = true
+          finish()
+        }
+
         const raf = requestFrame(() => {
           commitMeasurementRafs.delete(raf)
-          finish()
+          if (timeout != null) {
+            window.clearTimeout(timeout)
+            commitMeasurementTimeouts.delete(timeout)
+            timeout = null
+          }
+          finishOnce()
         })
         commitMeasurementRafs.add(raf)
+
+        timeout = window.setTimeout(() => {
+          if (timeout != null)
+            commitMeasurementTimeouts.delete(timeout)
+          timeout = null
+          cancelFrame?.(raf)
+          commitMeasurementRafs.delete(raf)
+          finishOnce()
+        }, Math.max(32, props.renderBatchIdleTimeoutMs ?? 120))
+        commitMeasurementTimeouts.add(timeout)
         return
       }
 

--- a/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
@@ -246,9 +246,17 @@ export function useBatchRenderingScheduler(
     })
   }
 
-  function requestNextBatch() {
+  function requestNextBatch(
+    increment?: number,
+    opts: { immediate?: boolean } = {},
+  ) {
     if (commitMeasurementPending) {
       followupBatchRequested = true
+      return
+    }
+
+    if (increment != null) {
+      scheduleBatch(increment, opts)
       return
     }
 
@@ -344,7 +352,7 @@ export function useBatchRenderingScheduler(
 
       const baseInitial = Math.max(1, resolvedInitialBatch.value || resolvedBatchSize.value || total)
       if (renderedCount.value < targetCount)
-        scheduleBatch(baseInitial, { immediate: !isClient })
+        requestNextBatch(baseInitial, { immediate: !isClient })
       else
         cleanupNodeVisibility(renderedCount.value)
     },

--- a/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
@@ -2,10 +2,6 @@ import type { ComputedRef, Ref } from 'vue'
 import type { NodeRendererProps } from '../../../types/node-renderer-props'
 import { nextTick, watch } from 'vue'
 
-export interface IdleDeadlineLike {
-  timeRemaining?: () => number
-}
-
 export interface BatchRenderingSchedulerOptions {
   props: Readonly<NodeRendererProps>
   isClient: boolean
@@ -128,7 +124,7 @@ export function useBatchRenderingScheduler(
       queueNextBatchNow()
   }
 
-  function measureBatchCommitCost(start: number, syncElapsed: number) {
+  function measureBatchPostFlushCost(start: number, syncElapsed: number) {
     if (!isClient) {
       finishCommitMeasurement(syncElapsed)
       return
@@ -149,6 +145,7 @@ export function useBatchRenderingScheduler(
         finishCommitMeasurement(measuredCost)
       }
 
+      // Keep a frame boundary before the next batch without charging RAF wait time as commit cost.
       if (requestFrame) {
         const raf = requestFrame(() => {
           commitMeasurementRafs.delete(raf)
@@ -174,7 +171,7 @@ export function useBatchRenderingScheduler(
       return
 
     const amount = Math.max(1, increment)
-    const run = (deadline?: IdleDeadlineLike) => {
+    const run = () => {
       const runStart = now()
       let syncElapsed = 0
       batchRaf = null
@@ -183,35 +180,13 @@ export function useBatchRenderingScheduler(
       batchPending = false
       const applied = pendingIncrement != null ? pendingIncrement : amount
       pendingIncrement = null
-      const budgetMs = Math.max(2, props.renderBatchBudgetMs ?? 6)
 
-      const applyAndMeasure = (size: number) => {
-        const start = now()
-        renderedCount.value = Math.min(target, renderedCount.value + Math.max(1, size))
-        cleanupNodeVisibility(renderedCount.value)
-        const elapsed = now() - start
-        syncElapsed = Math.max(syncElapsed, elapsed)
-        return elapsed
-      }
+      const start = now()
+      renderedCount.value = Math.min(target, renderedCount.value + applied)
+      cleanupNodeVisibility(renderedCount.value)
+      syncElapsed = now() - start
 
-      let nextSize = applied
-      while (true) {
-        const elapsed = applyAndMeasure(nextSize)
-        if (renderedCount.value >= target)
-          break
-        if (elapsed > budgetMs)
-          break
-        if (!deadline)
-          break
-        const remaining = typeof deadline.timeRemaining === 'function'
-          ? deadline.timeRemaining()
-          : 0
-        if (remaining <= budgetMs * 0.5)
-          break
-        nextSize = Math.max(1, Math.round(adaptiveBatchSize.value))
-      }
-
-      measureBatchCommitCost(runStart, syncElapsed)
+      measureBatchPostFlushCost(runStart, syncElapsed)
     }
 
     if (!isClient || opts.immediate) {
@@ -227,9 +202,7 @@ export function useBatchRenderingScheduler(
 
     if (!isTestEnv && hasIdleCallback && window.requestIdleCallback) {
       const timeout = Math.max(0, props.renderBatchIdleTimeoutMs ?? 120)
-      batchIdle = window.requestIdleCallback((deadline) => {
-        run(deadline)
-      }, { timeout })
+      batchIdle = window.requestIdleCallback(() => run(), { timeout })
       return
     }
 
@@ -251,6 +224,7 @@ export function useBatchRenderingScheduler(
     opts: { immediate?: boolean } = {},
   ) {
     if (commitMeasurementPending) {
+      // Use the post-feedback adaptive size instead of the stale requested increment.
       followupBatchRequested = true
       return
     }

--- a/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue'
 import type { NodeRendererProps } from '../../../types/node-renderer-props'
-import { watch } from 'vue'
+import { nextTick, watch } from 'vue'
 
 export interface IdleDeadlineLike {
   timeRemaining?: () => number
@@ -79,6 +79,9 @@ export function useBatchRenderingScheduler(
   let batchPending = false
   let pendingIncrement: number | null = null
   let batchIdle: number | null = null
+  let commitMeasurementGeneration = 0
+  const commitMeasurementRafs = new Set<number>()
+  const commitMeasurementTimeouts = new Set<number>()
 
   function cleanupBatchScheduler() {
     if (!isClient)
@@ -95,8 +98,55 @@ export function useBatchRenderingScheduler(
       window.cancelIdleCallback(batchIdle)
       batchIdle = null
     }
+    commitMeasurementGeneration += 1
+    for (const raf of commitMeasurementRafs)
+      cancelFrame?.(raf)
+    commitMeasurementRafs.clear()
+    for (const timeout of commitMeasurementTimeouts)
+      window.clearTimeout(timeout)
+    commitMeasurementTimeouts.clear()
     batchPending = false
     pendingIncrement = null
+  }
+
+  function now() {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now()
+  }
+
+  function measureBatchCommitCost(start: number, syncElapsed: number, afterMeasure: () => void) {
+    if (!isClient) {
+      adjustAdaptiveBatchSize(syncElapsed)
+      afterMeasure()
+      return
+    }
+
+    const generation = commitMeasurementGeneration
+    void nextTick().then(() => {
+      if (generation !== commitMeasurementGeneration)
+        return
+
+      const finish = () => {
+        if (generation !== commitMeasurementGeneration)
+          return
+        adjustAdaptiveBatchSize(Math.max(syncElapsed, now() - start))
+        afterMeasure()
+      }
+
+      if (requestFrame) {
+        const raf = requestFrame(() => {
+          commitMeasurementRafs.delete(raf)
+          finish()
+        })
+        commitMeasurementRafs.add(raf)
+        return
+      }
+
+      const timeout = window.setTimeout(() => {
+        commitMeasurementTimeouts.delete(timeout)
+        finish()
+      }, 0)
+      commitMeasurementTimeouts.add(timeout)
+    })
   }
 
   function scheduleBatch(increment: number, opts: { immediate?: boolean } = {}) {
@@ -108,6 +158,8 @@ export function useBatchRenderingScheduler(
 
     const amount = Math.max(1, increment)
     const run = (deadline?: IdleDeadlineLike) => {
+      const runStart = now()
+      let syncElapsed = 0
       batchRaf = null
       batchTimeout = null
       batchIdle = null
@@ -117,12 +169,11 @@ export function useBatchRenderingScheduler(
       const budgetMs = Math.max(2, props.renderBatchBudgetMs ?? 6)
 
       const applyAndMeasure = (size: number) => {
-        const start = typeof performance !== 'undefined' ? performance.now() : Date.now()
+        const start = now()
         renderedCount.value = Math.min(target, renderedCount.value + Math.max(1, size))
         cleanupNodeVisibility(renderedCount.value)
-        const end = typeof performance !== 'undefined' ? performance.now() : Date.now()
-        const elapsed = end - start
-        adjustAdaptiveBatchSize(elapsed)
+        const elapsed = now() - start
+        syncElapsed = Math.max(syncElapsed, elapsed)
         return elapsed
       }
 
@@ -141,8 +192,10 @@ export function useBatchRenderingScheduler(
         nextSize = Math.max(1, Math.round(adaptiveBatchSize.value))
       }
 
-      if (renderedCount.value < target)
-        queueNextBatch()
+      measureBatchCommitCost(runStart, syncElapsed, () => {
+        if (renderedCount.value < desiredRenderedCount.value)
+          queueNextBatch()
+      })
     }
 
     if (!isClient || opts.immediate) {

--- a/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingScheduler.ts
@@ -80,6 +80,8 @@ export function useBatchRenderingScheduler(
   let pendingIncrement: number | null = null
   let batchIdle: number | null = null
   let commitMeasurementGeneration = 0
+  let commitMeasurementPending = false
+  let followupBatchRequested = false
   const commitMeasurementRafs = new Set<number>()
   const commitMeasurementTimeouts = new Set<number>()
 
@@ -107,29 +109,44 @@ export function useBatchRenderingScheduler(
     commitMeasurementTimeouts.clear()
     batchPending = false
     pendingIncrement = null
+    commitMeasurementPending = false
+    followupBatchRequested = false
   }
 
   function now() {
     return typeof performance !== 'undefined' ? performance.now() : Date.now()
   }
 
-  function measureBatchCommitCost(start: number, syncElapsed: number, afterMeasure: () => void) {
+  function finishCommitMeasurement(measuredCost: number) {
+    adjustAdaptiveBatchSize(measuredCost)
+    commitMeasurementPending = false
+
+    const shouldContinue = followupBatchRequested || renderedCount.value < desiredRenderedCount.value
+    followupBatchRequested = false
+
+    if (shouldContinue)
+      queueNextBatchNow()
+  }
+
+  function measureBatchCommitCost(start: number, syncElapsed: number) {
     if (!isClient) {
-      adjustAdaptiveBatchSize(syncElapsed)
-      afterMeasure()
+      finishCommitMeasurement(syncElapsed)
       return
     }
 
-    const generation = commitMeasurementGeneration
+    commitMeasurementPending = true
+    const generation = ++commitMeasurementGeneration
     void nextTick().then(() => {
       if (generation !== commitMeasurementGeneration)
         return
 
+      const afterFlush = now()
+      const measuredCost = Math.max(syncElapsed, afterFlush - start)
+
       const finish = () => {
         if (generation !== commitMeasurementGeneration)
           return
-        adjustAdaptiveBatchSize(Math.max(syncElapsed, now() - start))
-        afterMeasure()
+        finishCommitMeasurement(measuredCost)
       }
 
       if (requestFrame) {
@@ -179,8 +196,10 @@ export function useBatchRenderingScheduler(
 
       let nextSize = applied
       while (true) {
-        applyAndMeasure(nextSize)
+        const elapsed = applyAndMeasure(nextSize)
         if (renderedCount.value >= target)
+          break
+        if (elapsed > budgetMs)
           break
         if (!deadline)
           break
@@ -192,10 +211,7 @@ export function useBatchRenderingScheduler(
         nextSize = Math.max(1, Math.round(adaptiveBatchSize.value))
       }
 
-      measureBatchCommitCost(runStart, syncElapsed, () => {
-        if (renderedCount.value < desiredRenderedCount.value)
-          queueNextBatch()
-      })
+      measureBatchCommitCost(runStart, syncElapsed)
     }
 
     if (!isClient || opts.immediate) {
@@ -230,7 +246,16 @@ export function useBatchRenderingScheduler(
     })
   }
 
-  function queueNextBatch() {
+  function requestNextBatch() {
+    if (commitMeasurementPending) {
+      followupBatchRequested = true
+      return
+    }
+
+    queueNextBatchNow()
+  }
+
+  function queueNextBatchNow() {
     if (!incrementalRenderingActive.value)
       return
     const dynamicSize = batchingEnabled.value
@@ -334,7 +359,7 @@ export function useBatchRenderingScheduler(
       if (typeof prev === 'number' && target <= prev)
         return
       if (target > renderedCount.value)
-        queueNextBatch()
+        requestNextBatch()
     },
   )
 

--- a/test/node-renderer-batch-scheduler.test.ts
+++ b/test/node-renderer-batch-scheduler.test.ts
@@ -23,6 +23,7 @@ function createHarness(options: {
   initialBatch?: number
   batchSize?: number
   delay?: number
+  desiredCount?: number
   incremental?: boolean
   requestFrame?: typeof window.requestAnimationFrame | null
   cancelFrame?: typeof window.cancelAnimationFrame | null
@@ -37,7 +38,8 @@ function createHarness(options: {
   const parsedNodes = ref(makeNodes(options.total ?? 8))
   const parsedNodesIdentity = computed(() => parsedNodes.value)
   const parsedNodeCount = computed(() => parsedNodes.value.length)
-  const desiredRenderedCount = computed(() => parsedNodeCount.value)
+  const desiredCount = ref<number | null>(options.desiredCount ?? null)
+  const desiredRenderedCount = computed(() => desiredCount.value ?? parsedNodeCount.value)
   const datasetKey = computed(() => props.indexKey)
 
   const batchingEnabled = computed(() => true)
@@ -111,12 +113,14 @@ function createHarness(options: {
   return {
     props,
     parsedNodes,
+    desiredCount,
     incremental,
     renderedCount,
     adaptiveBatchSize,
     cleanupNodeVisibility,
     onDatasetKeyChanged,
     onDatasetChanged,
+    cleanupBatchScheduler: () => scheduler?.cleanupBatchScheduler(),
   }
 }
 
@@ -159,6 +163,40 @@ describe('useBatchRenderingScheduler', () => {
     expect(h.cleanupNodeVisibility).toHaveBeenLastCalledWith(8)
   })
 
+  it('does not adjust adaptive batch size from RAF wait time', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => callback(currentTime), 0)
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = ((handle: number) => {
+      window.clearTimeout(handle)
+    }) as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 16,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+
+    vi.advanceTimersByTime(10)
+    currentTime = 1
+    await nextTick()
+
+    expect(h.renderedCount.value).toBe(16)
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    currentTime = 20
+    vi.advanceTimersByTime(0)
+
+    expect(h.adaptiveBatchSize.value).toBe(8)
+  })
+
   it('adjusts adaptive batch size from post-flush commit cost', async () => {
     let currentTime = 0
     vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
@@ -181,15 +219,92 @@ describe('useBatchRenderingScheduler', () => {
     expect(h.renderedCount.value).toBe(8)
 
     vi.advanceTimersByTime(10)
+    currentTime = 8
     await nextTick()
 
     expect(h.renderedCount.value).toBe(16)
     expect(h.adaptiveBatchSize.value).toBe(8)
 
-    currentTime = 20
     vi.advanceTimersByTime(0)
 
     expect(h.adaptiveBatchSize.value).toBe(5)
+  })
+
+  it('delays desired-count follow-up until commit feedback updates adaptive size', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => callback(currentTime), 0)
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = ((handle: number) => {
+      window.clearTimeout(handle)
+    }) as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 24,
+      desiredCount: 16,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+
+    vi.advanceTimersByTime(10)
+    expect(h.renderedCount.value).toBe(16)
+
+    h.desiredCount.value = 24
+    currentTime = 8
+    await nextTick()
+
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    vi.advanceTimersByTime(0)
+
+    expect(h.adaptiveBatchSize.value).toBe(5)
+
+    vi.runOnlyPendingTimers()
+    vi.advanceTimersByTime(10)
+    await nextTick()
+
+    expect(h.renderedCount.value).toBe(21)
+  })
+
+  it('does not schedule follow-up after cleanup cancels commit measurement', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => callback(currentTime), 0)
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = ((handle: number) => {
+      window.clearTimeout(handle)
+    }) as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 24,
+      desiredCount: 16,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    vi.advanceTimersByTime(10)
+    expect(h.renderedCount.value).toBe(16)
+
+    h.desiredCount.value = 24
+    currentTime = 8
+    await nextTick()
+    h.cleanupBatchScheduler()
+
+    vi.advanceTimersByTime(0)
+    vi.advanceTimersByTime(10)
+
+    expect(h.adaptiveBatchSize.value).toBe(8)
+    expect(h.renderedCount.value).toBe(16)
   })
 
   it('continues scheduling when desired rendered count grows', async () => {

--- a/test/node-renderer-batch-scheduler.test.ts
+++ b/test/node-renderer-batch-scheduler.test.ts
@@ -24,6 +24,8 @@ function createHarness(options: {
   batchSize?: number
   delay?: number
   incremental?: boolean
+  requestFrame?: typeof window.requestAnimationFrame | null
+  cancelFrame?: typeof window.cancelAnimationFrame | null
 } = {}) {
   const props = reactive<SchedulerProps>({
     indexKey: 'message-1',
@@ -91,8 +93,8 @@ function createHarness(options: {
       previousRenderContext,
       previousBatchConfig,
 
-      requestFrame: null,
-      cancelFrame: null,
+      requestFrame: options.requestFrame ?? null,
+      cancelFrame: options.cancelFrame ?? null,
       hasIdleCallback: false,
 
       cleanupNodeVisibility,
@@ -155,6 +157,39 @@ describe('useBatchRenderingScheduler', () => {
     expect(h.renderedCount.value).toBe(8)
 
     expect(h.cleanupNodeVisibility).toHaveBeenLastCalledWith(8)
+  })
+
+  it('adjusts adaptive batch size from post-flush commit cost', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => callback(currentTime), 0)
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = ((handle: number) => {
+      window.clearTimeout(handle)
+    }) as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 16,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+
+    vi.advanceTimersByTime(10)
+    await nextTick()
+
+    expect(h.renderedCount.value).toBe(16)
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    currentTime = 20
+    vi.advanceTimersByTime(0)
+
+    expect(h.adaptiveBatchSize.value).toBe(5)
   })
 
   it('continues scheduling when desired rendered count grows', async () => {

--- a/test/node-renderer-batch-scheduler.test.ts
+++ b/test/node-renderer-batch-scheduler.test.ts
@@ -27,6 +27,7 @@ function createHarness(options: {
   incremental?: boolean
   requestFrame?: typeof window.requestAnimationFrame | null
   cancelFrame?: typeof window.cancelAnimationFrame | null
+  hasIdleCallback?: boolean
 } = {}) {
   const props = reactive<SchedulerProps>({
     indexKey: 'message-1',
@@ -97,7 +98,7 @@ function createHarness(options: {
 
       requestFrame: options.requestFrame ?? null,
       cancelFrame: options.cancelFrame ?? null,
-      hasIdleCallback: false,
+      hasIdleCallback: options.hasIdleCallback ?? false,
 
       cleanupNodeVisibility,
       onDatasetKeyChanged,
@@ -228,6 +229,66 @@ describe('useBatchRenderingScheduler', () => {
     vi.advanceTimersByTime(0)
 
     expect(h.adaptiveBatchSize.value).toBe(5)
+  })
+
+  it('does not apply multiple idle batches before commit feedback', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+
+    const frames: FrameRequestCallback[] = []
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = vi.fn() as unknown as typeof window.cancelAnimationFrame
+
+    const idleCallbacks: IdleRequestCallback[] = []
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback)
+      return idleCallbacks.length
+    }) as unknown as typeof window.requestIdleCallback
+
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback)
+    vi.stubGlobal('cancelIdleCallback', vi.fn())
+
+    const h = createHarness({
+      total: 64,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+      hasIdleCallback: true,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+    expect(idleCallbacks).toHaveLength(1)
+
+    idleCallbacks.shift()?.({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    } as IdleDeadline)
+
+    expect(h.renderedCount.value).toBe(16)
+    expect(idleCallbacks).toHaveLength(0)
+
+    currentTime = 8
+    await nextTick()
+
+    expect(h.adaptiveBatchSize.value).toBe(8)
+    expect(frames).toHaveLength(1)
+
+    frames.shift()?.(currentTime)
+
+    expect(h.adaptiveBatchSize.value).toBe(5)
+    expect(idleCallbacks).toHaveLength(1)
+
+    idleCallbacks.shift()?.({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    } as IdleDeadline)
+
+    expect(h.renderedCount.value).toBe(21)
   })
 
   it('delays desired-count follow-up until commit feedback updates adaptive size', async () => {

--- a/test/node-renderer-batch-scheduler.test.ts
+++ b/test/node-renderer-batch-scheduler.test.ts
@@ -272,6 +272,47 @@ describe('useBatchRenderingScheduler', () => {
     expect(h.renderedCount.value).toBe(21)
   })
 
+  it('delays same-length parsed node identity follow-up until commit feedback updates adaptive size', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+    const requestFrame = ((callback: FrameRequestCallback) => {
+      return window.setTimeout(() => callback(currentTime), 0)
+    }) as typeof window.requestAnimationFrame
+    const cancelFrame = ((handle: number) => {
+      window.clearTimeout(handle)
+    }) as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 24,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+
+    vi.advanceTimersByTime(10)
+    expect(h.renderedCount.value).toBe(16)
+
+    h.parsedNodes.value = makeNodes(24)
+    currentTime = 8
+    await nextTick()
+
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    vi.advanceTimersByTime(0)
+
+    expect(h.adaptiveBatchSize.value).toBe(5)
+
+    vi.runOnlyPendingTimers()
+    vi.advanceTimersByTime(10)
+    await nextTick()
+
+    expect(h.renderedCount.value).toBe(21)
+  })
+
   it('does not schedule follow-up after cleanup cancels commit measurement', async () => {
     let currentTime = 0
     vi.spyOn(performance, 'now').mockImplementation(() => currentTime)

--- a/test/node-renderer-batch-scheduler.test.ts
+++ b/test/node-renderer-batch-scheduler.test.ts
@@ -136,6 +136,7 @@ describe('useBatchRenderingScheduler', () => {
 
     vi.clearAllTimers()
     vi.useRealTimers()
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -229,6 +230,46 @@ describe('useBatchRenderingScheduler', () => {
     vi.advanceTimersByTime(0)
 
     expect(h.adaptiveBatchSize.value).toBe(5)
+  })
+
+  it('uses timeout fallback when RAF boundary does not fire', async () => {
+    let currentTime = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+
+    let frameHandle = 0
+    const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameHandle += 1
+      if (frameHandle === 1)
+        window.setTimeout(() => callback(currentTime), 0)
+      return frameHandle
+    }) as unknown as typeof window.requestAnimationFrame
+    const cancelFrame = vi.fn() as unknown as typeof window.cancelAnimationFrame
+
+    const h = createHarness({
+      total: 16,
+      initialBatch: 8,
+      batchSize: 8,
+      delay: 10,
+      requestFrame,
+      cancelFrame,
+    })
+
+    expect(h.renderedCount.value).toBe(8)
+
+    vi.advanceTimersByTime(10)
+    currentTime = 8
+    await nextTick()
+
+    expect(h.renderedCount.value).toBe(16)
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    vi.advanceTimersByTime(119)
+    expect(h.adaptiveBatchSize.value).toBe(8)
+
+    vi.advanceTimersByTime(1)
+
+    expect(h.adaptiveBatchSize.value).toBe(5)
+    expect(cancelFrame).toHaveBeenCalledWith(2)
   })
 
   it('does not apply multiple idle batches before commit feedback', async () => {

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -395,6 +395,8 @@ describe('typewriter cursor position', () => {
       await flushAll()
 
       expect(wrapper.find('.node-slot[data-node-index="1"] .node-content').exists()).toBe(true)
+      // Batch commit-cost measurement uses one RAF before the cursor measurement RAF.
+      await runNextFrame(queuedFrames, performance.now() + 64)
       await runNextFrame(queuedFrames, performance.now() + 64)
       expect(measuredText).toBe('second')
     }


### PR DESCRIPTION
## Summary
- measure adaptive batch cost after Vue flush
- use a RAF boundary before follow-up batches without charging RAF wait time as commit cost
- use a timeout fallback if the RAF boundary is throttled or never fires
- delay follow-up batches until commit-cost feedback updates adaptive size
- cover post-flush cost regression, RAF fallback, and RAF queue impact on typewriter cursor tests

## Verification
- pnpm exec vitest --run test/node-renderer-batch-scheduler.test.ts
- pnpm lint
- pnpm typecheck