### PR TITLE
fix: parse image alt math without link jitter

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/image-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/image-parser.ts
@@ -1,5 +1,26 @@
 import type { ImageNode, MarkdownToken } from '../../types'
 
+function stringifyAltToken(token: MarkdownToken): string {
+  if (token.type === 'math_inline') {
+    if (token.raw)
+      return String(token.raw)
+    const markup = token.markup === '$$' ? '$$' : '$'
+    return `${markup}${String(token.content ?? '')}${markup}`
+  }
+
+  if (Array.isArray(token.children) && token.children.length > 0)
+    return token.children.map(child => stringifyAltToken(child)).join('')
+
+  return String(token.content ?? '')
+}
+
+function getAltFromTokenChildren(token: MarkdownToken | null | undefined) {
+  if (!token || !Array.isArray(token.children) || token.children.length === 0)
+    return ''
+
+  return token.children.map(child => stringifyAltToken(child)).join('')
+}
+
 export function parseImageToken(token: MarkdownToken, loading = false): ImageNode {
   // Some call-sites pass an outer/inline token whose children contain the
   // actual image token (with attrs). Prefer token.attrs when present; when
@@ -23,12 +44,12 @@ export function parseImageToken(token: MarkdownToken, loading = false): ImageNod
   }
   const src = String(attrs.find(attr => attr[0] === 'src')?.[1] ?? '')
   const altAttr = attrs.find(attr => attr[0] === 'alt')?.[1]
-  // Prefer a non-empty alt attribute. If attrs were sourced from an inner
-  // child token prefer that child's `content` over the parent's `token.content`
-  // because the parent may contain the raw markdown instead of the plain alt
-  // text.
+  const childAlt = getAltFromTokenChildren(childWithAttrs ?? token)
   let alt = ''
-  if (altAttr != null && String(altAttr).length > 0) {
+  if (childAlt) {
+    alt = childAlt
+  }
+  else if (altAttr != null && String(altAttr).length > 0) {
     alt = String(altAttr)
   }
   else if (childWithAttrs?.content != null && String(childWithAttrs.content).length > 0) {

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1183,6 +1183,9 @@ export function parseInlineTokens(
         else if (recoverOuterImageLinkFromSyntheticLinkToken(token)) {
           i++
         }
+        else if (recoverMarkdownImageFromLoadingImageTail(token)) {
+          i++
+        }
         else if (recoverMarkdownImageFromTrailingBang(token)) {
           i++
         }
@@ -1347,6 +1350,9 @@ export function parseInlineTokens(
   }
 
   function handleLinkOpen(token: MarkdownToken) {
+    if (recoverMarkdownImageFromLoadingImageTailLinkOpen(token))
+      return
+
     if (shouldTreatLinkOpenAsTextInEscapedOuterImageTail()) {
       const { node, nextIndex } = parseLinkToken(tokens, i, options)
       const text = String(node.text || node.href || '')
@@ -1426,6 +1432,18 @@ export function parseInlineTokens(
     pushParsed(node)
   }
 
+  function recoverMarkdownImageFromLoadingImageTailLinkOpen(token: MarkdownToken): boolean {
+    if (token.markup !== 'linkify')
+      return false
+
+    const { node, nextIndex } = parseLinkToken(tokens, i, options)
+    if (!recoverMarkdownImageFromLoadingImageTailLink(node, nextIndex))
+      return false
+
+    i = nextIndex
+    return true
+  }
+
   function handleReference(token: MarkdownToken) {
     resetCurrentTextNode()
     pushNode(parseReferenceToken(token))
@@ -1469,6 +1487,61 @@ export function parseInlineTokens(
       children: [{ type: 'text', content: label, raw: label }],
       raw: String(`[${label}](${href}${linkToken.title ? ` "${linkToken.title}"` : ''})`),
     } as ParsedNode)
+    return true
+  }
+
+  function recoverMarkdownImageFromLoadingImageTail(token: MarkdownToken): boolean {
+    if (token.type !== 'link')
+      return false
+
+    const linkToken = token as MarkdownToken & { href?: string, loading?: boolean, title?: string | null }
+    const href = String(linkToken.href ?? '')
+    if (!href)
+      return false
+
+    return recoverMarkdownImageFromLoadingImageTailLink({
+      href,
+      title: linkToken.title == null || linkToken.title === '' ? null : String(linkToken.title),
+      loading: Boolean(linkToken.loading),
+    }, i + 1)
+  }
+
+  function recoverMarkdownImageFromLoadingImageTailLink(
+    link: { href: string, loading?: boolean, title: string | null },
+    nextIndex: number,
+  ): boolean {
+    const previous = result[result.length - 1] as ParsedNode & {
+      alt?: string
+      loading?: boolean
+      raw?: string
+      src?: string
+    } | undefined
+    if (previous?.type !== 'image' || previous.src || !previous.loading || !String(previous.raw ?? '').endsWith(']('))
+      return false
+
+    const nextToken = tokens[nextIndex]
+    const nextContent = String(nextToken?.content ?? '')
+    if (nextToken?.type !== 'text' || !nextContent.startsWith(')'))
+      return false
+
+    result.pop()
+    currentTextNode = null
+
+    const alt = String(previous.alt ?? '')
+    pushParsed({
+      type: 'image',
+      src: link.href,
+      alt,
+      title: link.title,
+      raw: String(`![${alt}](${link.href}${link.title ? ` "${link.title}"` : ''})`),
+      loading: Boolean(link.loading),
+    } as ParsedNode)
+
+    const trailing = nextContent.slice(1)
+    const adjustedNext = cloneTokenWithMutableChildren(nextToken)
+    adjustedNext.content = trailing
+    adjustedNext.raw = trailing
+    ensureWorkingTokens()[nextIndex] = adjustedNext
     return true
   }
 

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -342,24 +342,27 @@ function findRangeAt(ranges: Array<[number, number]>, index: number): [number, n
   return null
 }
 
-function buildImageRanges(src: string): Array<[number, number]> {
+function buildImageRanges(src: string, allowIncomplete = false): Array<[number, number]> {
   const ranges: Array<[number, number]> = []
   let i = 0
   while (i < src.length - 1) {
     if (src[i] === '!' && src[i + 1] === '[') {
       const start = i
       let j = i + 2
-      while (j < src.length) {
+      let labelDepth = 1
+      while (j < src.length && labelDepth > 0) {
         if (src[j] === '\\' && j + 1 < src.length) {
           j += 2
           continue
         }
-        if (src[j] === ']')
-          break
+        if (src[j] === '[')
+          labelDepth++
+        else if (src[j] === ']')
+          labelDepth--
         j++
       }
-      if (j < src.length && src[j] === ']' && j + 1 < src.length && src[j + 1] === '(') {
-        let k = j + 2
+      if (labelDepth === 0 && j < src.length && src[j] === '(') {
+        let k = j + 1
         let depth = 1
         while (k < src.length && depth > 0) {
           if (src[k] === '\\' && k + 1 < src.length) {
@@ -375,6 +378,11 @@ function buildImageRanges(src: string): Array<[number, number]> {
         if (depth === 0) {
           ranges.push([start, k])
           i = k
+          continue
+        }
+        if (allowIncomplete) {
+          ranges.push([start, src.length])
+          i = src.length
           continue
         }
       }
@@ -513,7 +521,7 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
       // We'll scan the entire inline source and tokenize all occurrences
       const src = s.src
       const codeSpanRanges = buildCodeSpanRanges(src)
-      const imageRanges = buildImageRanges(src)
+      const imageRanges = buildImageRanges(src, allowLoading)
       let foundAny = false
       // Reset searchPos for $$ to allow it to scan the full content
       // even after $ rule has processed some text

--- a/packages/markdown-parser/test/image-alt-math-regression.test.ts
+++ b/packages/markdown-parser/test/image-alt-math-regression.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+describe('image alt parsing regressions', () => {
+  it('parses an image when alt text contains inline math with bracket indexes', () => {
+    const md = getMarkdown('image-alt-math-bracket-index')
+    const input = String.raw`![图 1: 实证概率密度 $X^{(c)}[v,d]$，在示例语料图 $G_{c}$ 中突出显示的节点 v，使用 5000 个独立训练的 GNN 模型实例获得，适用于基于子图匹配的图检索。面板 (b)–(d) 显示了模型初始化后和不同训练阶段的 $X^{(c)}[v,d]$ 的密度。](https://www.baidu.com/img/PCfb_5bf082d29588c07f842ccde3f97243ea.png)`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.type).toBe('paragraph')
+    const children = (nodes[0] as any).children
+    expect(children).toHaveLength(1)
+    expect(children[0]).toMatchObject({
+      type: 'image',
+      src: 'https://www.baidu.com/img/PCfb_5bf082d29588c07f842ccde3f97243ea.png',
+      alt: '图 1: 实证概率密度 $X^{(c)}[v,d]$，在示例语料图 $G_{c}$ 中突出显示的节点 v，使用 5000 个独立训练的 GNN 模型实例获得，适用于基于子图匹配的图检索。面板 (b)–(d) 显示了模型初始化后和不同训练阶段的 $X^{(c)}[v,d]$ 的密度。',
+      title: null,
+      loading: false,
+    })
+  })
+
+  it('still parses inline math after an image with bracketed math in alt text', () => {
+    const md = getMarkdown('image-alt-math-followed-by-math')
+    const input = String.raw`![caption $X[v,d]$](https://example.com/image.png) and $y$`
+
+    const nodes = parseMarkdownToStructure(input, md, { final: true })
+    const children = (nodes[0] as any).children
+
+    expect(children.map((child: any) => child.type)).toEqual(['image', 'text', 'math_inline'])
+    expect(children[0]).toMatchObject({
+      type: 'image',
+      src: 'https://example.com/image.png',
+      alt: 'caption $X[v,d]$',
+      loading: false,
+    })
+    expect(children[2]).toMatchObject({
+      type: 'math_inline',
+      content: 'y',
+      loading: false,
+    })
+  })
+
+  it('keeps image parsing stable while the destination streams in', () => {
+    const md = getMarkdown('image-alt-math-streaming-stability')
+    const chunks: Array<[string, string[]]> = [
+      [String.raw`![caption $X[v,d]$](`, ['image']],
+      [String.raw`![caption $X[v,d]$](https://example.com/image.png`, ['image']],
+      [String.raw`![caption $X[v,d]$](https://example.com/image.png)`, ['image']],
+      [String.raw`![caption $X[v,d]$](https://example.com/image.png) and $y$`, ['image', 'text', 'math_inline']],
+    ]
+
+    for (const [chunk, expectedTypes] of chunks) {
+      const nodes = parseMarkdownToStructure(chunk, md, { final: false })
+      const children = (nodes[0] as any).children
+      expect(children.map((child: any) => child.type)).toEqual(expectedTypes)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- protect markdown image ranges from math parsing when alt text contains bracket indexes like `$X[v,d]$`
- recover complete image nodes when image destinations are temporarily tokenized as linkified URLs
- preserve stable streaming node types while an image destination is still arriving

close: #484

## Verification

- `pnpm exec vitest run packages/markdown-parser/test/image-alt-math-regression.test.ts test/inline-parsers/image-parser.test.ts packages/markdown-parser/test/link-special-cases.test.ts packages/markdown-parser/test/parse-link-with-code.test.ts packages/markdown-parser/test/list-inline-streaming-regression.test.ts packages/markdown-parser/test/stream-parser-integration.test.ts`
- `pnpm exec vitest run packages/markdown-parser/test`
- `pnpm exec vitest run`
- `pnpm typecheck`
- `pnpm lint`