### PR TITLE
perf: reduce simple list and table renderer wrappers

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -48,6 +48,7 @@ declare module 'vue' {
     ReferenceNode: typeof import('./src/components/ReferenceNode/ReferenceNode.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    SimpleInlineRenderer: typeof import('./src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue')['default']
     StrikethroughNode: typeof import('./src/components/StrikethroughNode/StrikethroughNode.vue')['default']
     StrongNode: typeof import('./src/components/StrongNode/StrongNode.vue')['default']
     SubscriptNode: typeof import('./src/components/SubscriptNode/SubscriptNode.vue')['default']

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -135,7 +135,15 @@ provide('markstreamFade', computed(() => props.fade))
 .blockquote > .paragraph-node {
   font-size: var(--ms-text-body);
   line-height: var(--ms-leading-body);
-  margin: 0;
+  margin: var(--ms-flow-paragraph-y) 0;
+}
+
+.blockquote > .paragraph-node:first-child {
+  margin-top: 0;
+}
+
+.blockquote > .paragraph-node:last-child {
+  margin-bottom: 0;
 }
 
 /* 防止内部 NodeRenderer 使用 content-visibility: auto 时在大文档滚动中出现“高但空白”的占位 */

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
+import { computed, provide } from 'vue'
+import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
+import SimpleInlineRenderer from '../SimpleInlineRenderer'
+import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 
 // child node shape used across many node components
 interface NodeChild {
   type: string
   raw: string
+  children?: NodeChild[]
   [key: string]: unknown
 }
 
@@ -22,17 +27,90 @@ const props = defineProps<{
   typewriter?: boolean
   fade?: boolean
   customId?: string
+  showTooltips?: boolean
 }>()
 
 // typed emit for better DX and type-safety when forwarding copy events
 defineEmits<{
   copy: [text: string]
 }>()
+
+const customComponents = useCustomNodeComponents(() => props.customId)
+const simpleParagraphChildren = computed(() => {
+  if ((customComponents.value as any).paragraph)
+    return null
+
+  const children = props.node.children
+  if (!Array.isArray(children) || children.length !== 1)
+    return null
+
+  const child = children[0]
+  if (child?.type !== 'paragraph' || !Array.isArray(child.children))
+    return null
+
+  const paragraphChildren = child.children
+  return areSimpleInlineNodes(paragraphChildren) ? paragraphChildren : null
+})
+const simpleInlineChildren = computed(() => {
+  if (simpleParagraphChildren.value)
+    return null
+
+  const children = props.node.children
+  return areSimpleInlineNodes(children) ? children : null
+})
+const canRenderPlainTextInline = computed(() => {
+  return props.fade === false && !(customComponents.value as any).text
+})
+const simpleParagraphPlainText = computed(() => {
+  if (!canRenderPlainTextInline.value)
+    return null
+
+  return getPlainTextContent(simpleParagraphChildren.value)
+})
+const simpleInlinePlainText = computed(() => {
+  if (!canRenderPlainTextInline.value)
+    return null
+
+  return getPlainTextContent(simpleInlineChildren.value)
+})
+
+provide('markstreamShowTooltips', computed(() => props.showTooltips))
+provide('markstreamFade', computed(() => props.fade))
 </script>
 
 <template>
-  <blockquote class="blockquote" dir="auto" :cite="node.cite">
+  <blockquote class="blockquote blockquote-node" dir="auto" :cite="node.cite">
+    <p
+      v-if="simpleParagraphChildren"
+      dir="auto"
+      class="paragraph-node"
+    >
+      <span
+        v-if="simpleParagraphPlainText !== null"
+        class="simple-inline-text whitespace-pre-wrap break-words text-node"
+        :custom-id="props.customId"
+      >{{ simpleParagraphPlainText }}</span>
+      <SimpleInlineRenderer
+        v-else
+        :nodes="simpleParagraphChildren"
+        :custom-id="props.customId"
+        :index-key="`blockquote-${props.indexKey}-paragraph`"
+      />
+    </p>
+    <span
+      v-else-if="simpleInlinePlainText !== null"
+      class="simple-inline-text whitespace-pre-wrap break-words text-node"
+      :custom-id="props.customId"
+    >{{ simpleInlinePlainText }}</span>
+    <SimpleInlineRenderer
+      v-else-if="simpleInlineChildren"
+      :nodes="simpleInlineChildren"
+      :custom-id="props.customId"
+      :index-key="`blockquote-${props.indexKey}`"
+    />
     <NodeRenderer
+      v-else
+      :show-tooltips="props.showTooltips"
       :index-key="`blockquote-${props.indexKey}`"
       :nodes="props.node.children || []"
       :custom-id="props.customId"
@@ -52,6 +130,12 @@ defineEmits<{
   margin-top: var(--ms-flow-blockquote-y);
   margin-bottom: var(--ms-flow-blockquote-y);
   padding-left: var(--ms-flow-blockquote-indent);
+}
+
+.blockquote > .paragraph-node {
+  font-size: var(--ms-text-body);
+  line-height: var(--ms-leading-body);
+  margin: 0;
 }
 
 /* 防止内部 NodeRenderer 使用 content-visibility: auto 时在大文档滚动中出现“高但空白”的占位 */

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -43,16 +43,13 @@ const hasTextOverride = computed(() =>
   Boolean((customComponents.value as any).text),
 )
 const simpleBlockChildren = computed(() => {
-  return resolveSimpleInlineChildren(props.node.children as any, {
-    allowSingleParagraph: !hasParagraphOverride.value,
-    allowEmpty: false,
-  })
+  return resolveSimpleInlineChildren(props.node.children as any, !hasParagraphOverride.value)
 })
-const canRenderPlainTextInline = computed(() => {
+function canRenderPlainTextInline() {
   return props.fade === false && !hasTextOverride.value
-})
+}
 const simpleBlockPlainText = computed(() => {
-  if (!canRenderPlainTextInline.value)
+  if (!canRenderPlainTextInline())
     return null
 
   return getPlainTextContent(simpleBlockChildren.value)
@@ -71,7 +68,7 @@ provide('markstreamFade', computed(() => props.fade))
     >
       <span
         v-if="simpleBlockPlainText !== null"
-        class="simple-inline-text whitespace-pre-wrap break-words text-node"
+        class="text-node"
         :custom-id="props.customId"
       >{{ simpleBlockPlainText }}</span>
       <SimpleInlineRenderer

--- a/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -3,7 +3,7 @@ import { computed, provide } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
-import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
+import { getPlainTextContent, resolveSimpleInlineChildren } from '../SimpleInlineRenderer/simpleInline'
 
 // child node shape used across many node components
 interface NodeChild {
@@ -36,42 +36,26 @@ defineEmits<{
 }>()
 
 const customComponents = useCustomNodeComponents(() => props.customId)
-const simpleParagraphChildren = computed(() => {
-  if ((customComponents.value as any).paragraph)
-    return null
-
-  const children = props.node.children
-  if (!Array.isArray(children) || children.length !== 1)
-    return null
-
-  const child = children[0]
-  if (child?.type !== 'paragraph' || !Array.isArray(child.children))
-    return null
-
-  const paragraphChildren = child.children
-  return areSimpleInlineNodes(paragraphChildren) ? paragraphChildren : null
-})
-const simpleInlineChildren = computed(() => {
-  if (simpleParagraphChildren.value)
-    return null
-
-  const children = props.node.children
-  return areSimpleInlineNodes(children) ? children : null
+const hasParagraphOverride = computed(() =>
+  Boolean((customComponents.value as any).paragraph),
+)
+const hasTextOverride = computed(() =>
+  Boolean((customComponents.value as any).text),
+)
+const simpleBlockChildren = computed(() => {
+  return resolveSimpleInlineChildren(props.node.children as any, {
+    allowSingleParagraph: !hasParagraphOverride.value,
+    allowEmpty: false,
+  })
 })
 const canRenderPlainTextInline = computed(() => {
-  return props.fade === false && !(customComponents.value as any).text
+  return props.fade === false && !hasTextOverride.value
 })
-const simpleParagraphPlainText = computed(() => {
+const simpleBlockPlainText = computed(() => {
   if (!canRenderPlainTextInline.value)
     return null
 
-  return getPlainTextContent(simpleParagraphChildren.value)
-})
-const simpleInlinePlainText = computed(() => {
-  if (!canRenderPlainTextInline.value)
-    return null
-
-  return getPlainTextContent(simpleInlineChildren.value)
+  return getPlainTextContent(simpleBlockChildren.value)
 })
 
 provide('markstreamShowTooltips', computed(() => props.showTooltips))
@@ -81,33 +65,22 @@ provide('markstreamFade', computed(() => props.fade))
 <template>
   <blockquote class="blockquote blockquote-node" dir="auto" :cite="node.cite">
     <p
-      v-if="simpleParagraphChildren"
+      v-if="simpleBlockChildren"
       dir="auto"
       class="paragraph-node"
     >
       <span
-        v-if="simpleParagraphPlainText !== null"
+        v-if="simpleBlockPlainText !== null"
         class="simple-inline-text whitespace-pre-wrap break-words text-node"
         :custom-id="props.customId"
-      >{{ simpleParagraphPlainText }}</span>
+      >{{ simpleBlockPlainText }}</span>
       <SimpleInlineRenderer
         v-else
-        :nodes="simpleParagraphChildren"
+        :nodes="simpleBlockChildren as any"
         :custom-id="props.customId"
         :index-key="`blockquote-${props.indexKey}-paragraph`"
       />
     </p>
-    <span
-      v-else-if="simpleInlinePlainText !== null"
-      class="simple-inline-text whitespace-pre-wrap break-words text-node"
-      :custom-id="props.customId"
-    >{{ simpleInlinePlainText }}</span>
-    <SimpleInlineRenderer
-      v-else-if="simpleInlineChildren"
-      :nodes="simpleInlineChildren"
-      :custom-id="props.customId"
-      :index-key="`blockquote-${props.indexKey}`"
-    />
     <NodeRenderer
       v-else
       :show-tooltips="props.showTooltips"

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -3693,6 +3693,11 @@ onUnmounted(() => {
   transition: opacity 120ms ease-out;
 }
 
+.code-block-container.is-diff :deep(pre.code-pre-fallback.markstream-pre--diff-preview .markstream-pre__diff-pane) {
+  box-sizing: border-box;
+  padding-bottom: 10px;
+}
+
 :deep(pre.code-pre-fallback.is-fading-out) {
   opacity: 0;
   pointer-events: none;

--- a/src/components/HeadingNode/HeadingNode.vue
+++ b/src/components/HeadingNode/HeadingNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import CheckboxNode from '../CheckboxNode'
 import EmojiNode from '../EmojiNode'
@@ -14,6 +14,7 @@ import LinkNode from '../LinkNode'
 import NodeChildRenderer from '../NodeChildRenderer'
 import { MathInlineNodeAsync } from '../NodeRenderer/asyncComponent'
 import ReferenceNode from '../ReferenceNode'
+import { getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 import StrikethroughNode from '../StrikethroughNode'
 import StrongNode from '../StrongNode'
 import SubscriptNode from '../SubscriptNode'
@@ -41,6 +42,14 @@ const props = defineProps<{
 }>()
 
 const overrides = useCustomNodeComponents(() => props.customId)
+const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
+
+const plainTextContent = computed(() => {
+  if (inheritedFade?.value !== false || (overrides.value as any).text)
+    return null
+
+  return getPlainTextContent(props.node.children)
+})
 
 const nodeComponents = computed(() => ({
   text: TextNode,
@@ -73,14 +82,21 @@ const nodeComponents = computed(() => ({
     dir="auto"
     v-bind="node.attrs"
   >
-    <NodeChildRenderer
-      v-for="(child, index) in node.children"
-      :key="`${indexKey || 'heading'}-${index}`"
-      :components="nodeComponents"
+    <span
+      v-if="plainTextContent !== null"
+      class="simple-inline-text whitespace-pre-wrap break-words text-node"
       :custom-id="props.customId"
-      :node="child"
-      :index-key="`${indexKey || 'heading'}-${index}`"
-    />
+    >{{ plainTextContent }}</span>
+    <template v-else>
+      <NodeChildRenderer
+        v-for="(child, index) in node.children"
+        :key="`${indexKey || 'heading'}-${index}`"
+        :components="nodeComponents"
+        :custom-id="props.customId"
+        :node="child"
+        :index-key="`${indexKey || 'heading'}-${index}`"
+      />
+    </template>
   </component>
 </template>
 

--- a/src/components/HeadingNode/HeadingNode.vue
+++ b/src/components/HeadingNode/HeadingNode.vue
@@ -84,13 +84,13 @@ const nodeComponents = computed(() => ({
   >
     <span
       v-if="plainTextContent !== null"
-      class="simple-inline-text whitespace-pre-wrap break-words text-node"
+      class="text-node"
       :custom-id="props.customId"
     >{{ plainTextContent }}</span>
     <template v-else>
       <NodeChildRenderer
         v-for="(child, index) in node.children"
-        :key="`${indexKey || 'heading'}-${index}`"
+        :key="index"
         :components="nodeComponents"
         :custom-id="props.customId"
         :node="child"

--- a/src/components/InlineCodeNode/InlineCodeNode.vue
+++ b/src/components/InlineCodeNode/InlineCodeNode.vue
@@ -29,6 +29,8 @@ const fadeEnabled = computed(() => {
     return inheritedFade.value
   return true
 })
+const codeContent = computed(() => String(props.node.code ?? ''))
+const canRenderStaticCode = computed(() => !fadeEnabled.value)
 const streamStateKey = computed(() => {
   const raw = attrs['index-key'] ?? attrs.indexKey
   if (raw == null || raw === '')
@@ -103,14 +105,17 @@ const streamedDeltaClass = computed(() => (
   <code
     class="inline-code"
   >
-    <span v-if="settledCode">{{ settledCode }}</span>
-    <span
-      v-if="streamedDelta"
-      class="inline-code-stream-delta" :class="[streamedDeltaClass]"
-      @animationend="settleStreamedDelta"
-    >
-      {{ streamedDelta }}
-    </span>
+    <template v-if="canRenderStaticCode">{{ codeContent }}</template>
+    <template v-else>
+      <span v-if="settledCode">{{ settledCode }}</span>
+      <span
+        v-if="streamedDelta"
+        class="inline-code-stream-delta" :class="[streamedDeltaClass]"
+        @animationend="settleStreamedDelta"
+      >
+        {{ streamedDelta }}
+      </span>
+    </template>
   </code>
 </template>
 

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -3,7 +3,7 @@ import { computed, provide } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
-import { areSimpleInlineNodes } from '../SimpleInlineRenderer/simpleInline'
+import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 
 // 节点子元素类型
 interface NodeChild {
@@ -62,6 +62,21 @@ const simpleInlineChildren = computed(() => {
   const children = itemNode.value?.children
   return areSimpleInlineNodes(children) ? children : null
 })
+const canRenderPlainTextInline = computed(() => {
+  return props.fade === false && !(customComponents.value as any).text
+})
+const simpleParagraphPlainText = computed(() => {
+  if (!canRenderPlainTextInline.value)
+    return null
+
+  return getPlainTextContent(simpleParagraphChildren.value)
+})
+const simpleInlinePlainText = computed(() => {
+  if (!canRenderPlainTextInline.value)
+    return null
+
+  return getPlainTextContent(simpleInlineChildren.value)
+})
 
 const EMPTY_LI_VALUE_ATTRS = Object.freeze({}) as Record<string, never>
 
@@ -84,12 +99,23 @@ provide('markstreamFade', computed(() => props.fade))
       dir="auto"
       class="paragraph-node"
     >
+      <span
+        v-if="simpleParagraphPlainText !== null"
+        class="simple-inline-text whitespace-pre-wrap break-words text-node"
+        :custom-id="props.customId"
+      >{{ simpleParagraphPlainText }}</span>
       <SimpleInlineRenderer
+        v-else
         :nodes="simpleParagraphChildren"
         :custom-id="props.customId"
         :index-key="`list-item-${props.indexKey}-paragraph`"
       />
     </p>
+    <span
+      v-else-if="simpleInlinePlainText !== null"
+      class="simple-inline-text whitespace-pre-wrap break-words text-node"
+      :custom-id="props.customId"
+    >{{ simpleInlinePlainText }}</span>
     <SimpleInlineRenderer
       v-else-if="simpleInlineChildren"
       :nodes="simpleInlineChildren"

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -3,7 +3,7 @@ import { computed, provide } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
-import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
+import { getPlainTextContent, resolveSimpleInlineChildren } from '../SimpleInlineRenderer/simpleInline'
 
 // 节点子元素类型
 interface NodeChild {
@@ -40,23 +40,20 @@ defineEmits<{
 
 const itemNode = computed(() => props.node ?? props.item)
 const customComponents = useCustomNodeComponents(() => props.customId)
-const simpleParagraphChildren = computed(() => {
-  if ((customComponents.value as any).paragraph)
-    return null
-
-  const children = itemNode.value?.children
-  if (!Array.isArray(children) || children.length !== 1)
-    return null
-
-  const child = children[0]
-  if (child?.type !== 'paragraph' || !Array.isArray((child as any).children))
-    return null
-
-  const paragraphChildren = (child as any).children
-  return areSimpleInlineNodes(paragraphChildren) ? paragraphChildren : null
+const hasParagraphOverride = computed(() =>
+  Boolean((customComponents.value as any).paragraph),
+)
+const hasTextOverride = computed(() =>
+  Boolean((customComponents.value as any).text),
+)
+const simpleBlockChildren = computed(() => {
+  return resolveSimpleInlineChildren(itemNode.value?.children as any, {
+    allowSingleParagraph: !hasParagraphOverride.value,
+    allowEmpty: false,
+  })
 })
-const simpleParagraphWithNestedLists = computed(() => {
-  if ((customComponents.value as any).paragraph)
+const simpleBlockWithNestedLists = computed(() => {
+  if (hasParagraphOverride.value)
     return null
 
   const children = itemNode.value?.children
@@ -71,41 +68,32 @@ const simpleParagraphWithNestedLists = computed(() => {
   if (!nestedLists.every(child => child?.type === 'list'))
     return null
 
-  const paragraphChildren = (firstChild as any).children
-  return areSimpleInlineNodes(paragraphChildren)
+  const paragraphChildren = resolveSimpleInlineChildren([firstChild] as any, {
+    allowSingleParagraph: true,
+    allowEmpty: false,
+  })
+
+  return paragraphChildren
     ? {
         paragraphChildren,
         nestedLists,
       }
     : null
 })
-const simpleInlineChildren = computed(() => {
-  if (simpleParagraphChildren.value || simpleParagraphWithNestedLists.value)
-    return null
-
-  const children = itemNode.value?.children
-  return areSimpleInlineNodes(children) ? children : null
-})
 const canRenderPlainTextInline = computed(() => {
-  return props.fade === false && !(customComponents.value as any).text
+  return props.fade === false && !hasTextOverride.value
 })
-const simpleParagraphPlainText = computed(() => {
+const simpleBlockPlainText = computed(() => {
   if (!canRenderPlainTextInline.value)
     return null
 
-  return getPlainTextContent(simpleParagraphChildren.value)
+  return getPlainTextContent(simpleBlockChildren.value)
 })
 const simpleNestedParagraphPlainText = computed(() => {
   if (!canRenderPlainTextInline.value)
     return null
 
-  return getPlainTextContent(simpleParagraphWithNestedLists.value?.paragraphChildren)
-})
-const simpleInlinePlainText = computed(() => {
-  if (!canRenderPlainTextInline.value)
-    return null
-
-  return getPlainTextContent(simpleInlineChildren.value)
+  return getPlainTextContent(simpleBlockWithNestedLists.value?.paragraphChildren)
 })
 
 const EMPTY_LI_VALUE_ATTRS = Object.freeze({}) as Record<string, never>
@@ -125,23 +113,23 @@ provide('markstreamFade', computed(() => props.fade))
 <template>
   <li class="list-item" dir="auto" v-bind="liValueAttrs">
     <p
-      v-if="simpleParagraphChildren"
+      v-if="simpleBlockChildren"
       dir="auto"
       class="paragraph-node"
     >
       <span
-        v-if="simpleParagraphPlainText !== null"
+        v-if="simpleBlockPlainText !== null"
         class="simple-inline-text whitespace-pre-wrap break-words text-node"
         :custom-id="props.customId"
-      >{{ simpleParagraphPlainText }}</span>
+      >{{ simpleBlockPlainText }}</span>
       <SimpleInlineRenderer
         v-else
-        :nodes="simpleParagraphChildren"
+        :nodes="simpleBlockChildren as any"
         :custom-id="props.customId"
         :index-key="`list-item-${props.indexKey}-paragraph`"
       />
     </p>
-    <template v-else-if="simpleParagraphWithNestedLists">
+    <template v-else-if="simpleBlockWithNestedLists">
       <p
         dir="auto"
         class="paragraph-node"
@@ -153,13 +141,13 @@ provide('markstreamFade', computed(() => props.fade))
         >{{ simpleNestedParagraphPlainText }}</span>
         <SimpleInlineRenderer
           v-else
-          :nodes="simpleParagraphWithNestedLists.paragraphChildren"
+          :nodes="simpleBlockWithNestedLists.paragraphChildren as any"
           :custom-id="props.customId"
           :index-key="`list-item-${props.indexKey}-paragraph`"
         />
       </p>
       <NodeRenderer
-        v-for="(nestedList, nestedIndex) in simpleParagraphWithNestedLists.nestedLists"
+        v-for="(nestedList, nestedIndex) in simpleBlockWithNestedLists.nestedLists"
         :key="`list-item-${props.indexKey}-nested-${nestedIndex}`"
         :nodes="[nestedList]"
         :custom-id="props.customId"
@@ -173,17 +161,6 @@ provide('markstreamFade', computed(() => props.fade))
         @copy="$emit('copy', $event)"
       />
     </template>
-    <span
-      v-else-if="simpleInlinePlainText !== null"
-      class="simple-inline-text whitespace-pre-wrap break-words text-node"
-      :custom-id="props.customId"
-    >{{ simpleInlinePlainText }}</span>
-    <SimpleInlineRenderer
-      v-else-if="simpleInlineChildren"
-      :nodes="simpleInlineChildren"
-      :custom-id="props.customId"
-      :index-key="`list-item-${props.indexKey}`"
-    />
     <NodeRenderer
       v-else
       :show-tooltips="props.showTooltips"

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -2,7 +2,6 @@
 import { computed, provide } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
-import ParagraphNode from '../ParagraphNode'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
 import { areSimpleInlineNodes } from '../SimpleInlineRenderer/simpleInline'
 
@@ -41,7 +40,7 @@ defineEmits<{
 
 const itemNode = computed(() => props.node ?? props.item)
 const customComponents = useCustomNodeComponents(() => props.customId)
-const simpleParagraphNode = computed(() => {
+const simpleParagraphChildren = computed(() => {
   if ((customComponents.value as any).paragraph)
     return null
 
@@ -53,10 +52,11 @@ const simpleParagraphNode = computed(() => {
   if (child?.type !== 'paragraph' || !Array.isArray((child as any).children))
     return null
 
-  return areSimpleInlineNodes((child as any).children) ? child : null
+  const paragraphChildren = (child as any).children
+  return areSimpleInlineNodes(paragraphChildren) ? paragraphChildren : null
 })
 const simpleInlineChildren = computed(() => {
-  if (simpleParagraphNode.value)
+  if (simpleParagraphChildren.value)
     return null
 
   const children = itemNode.value?.children
@@ -79,12 +79,17 @@ provide('markstreamFade', computed(() => props.fade))
 
 <template>
   <li class="list-item" dir="auto" v-bind="liValueAttrs">
-    <ParagraphNode
-      v-if="simpleParagraphNode"
-      :node="simpleParagraphNode as any"
-      :custom-id="props.customId"
-      :index-key="`list-item-${props.indexKey}-paragraph`"
-    />
+    <p
+      v-if="simpleParagraphChildren"
+      dir="auto"
+      class="paragraph-node"
+    >
+      <SimpleInlineRenderer
+        :nodes="simpleParagraphChildren"
+        :custom-id="props.customId"
+        :index-key="`list-item-${props.indexKey}-paragraph`"
+      />
+    </p>
     <SimpleInlineRenderer
       v-else-if="simpleInlineChildren"
       :nodes="simpleInlineChildren"
@@ -118,6 +123,12 @@ ol > .list-item::marker {
 
 ul > .list-item::marker {
   color: var(--list-marker);
+}
+
+.list-item > .paragraph-node {
+  font-size: var(--ms-text-body);
+  line-height: var(--ms-leading-body);
+  margin: 0;
 }
 
 /* 大列表滚动到视口时，嵌套 NodeRenderer 需要立即绘制内容，避免空白 */

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, provide } from 'vue'
+import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
+import ParagraphNode from '../ParagraphNode'
+import SimpleInlineRenderer from '../SimpleInlineRenderer'
+import { areSimpleInlineNodes } from '../SimpleInlineRenderer/simpleInline'
 
 // 节点子元素类型
 interface NodeChild {
@@ -36,6 +40,28 @@ defineEmits<{
 }>()
 
 const itemNode = computed(() => props.node ?? props.item)
+const customComponents = useCustomNodeComponents(() => props.customId)
+const simpleParagraphNode = computed(() => {
+  if ((customComponents.value as any).paragraph)
+    return null
+
+  const children = itemNode.value?.children
+  if (!Array.isArray(children) || children.length !== 1)
+    return null
+
+  const child = children[0]
+  if (child?.type !== 'paragraph' || !Array.isArray((child as any).children))
+    return null
+
+  return areSimpleInlineNodes((child as any).children) ? child : null
+})
+const simpleInlineChildren = computed(() => {
+  if (simpleParagraphNode.value)
+    return null
+
+  const children = itemNode.value?.children
+  return areSimpleInlineNodes(children) ? children : null
+})
 
 const EMPTY_LI_VALUE_ATTRS = Object.freeze({}) as Record<string, never>
 
@@ -46,11 +72,27 @@ const liValueAttrs = computed(() => {
     ? { value }
     : EMPTY_LI_VALUE_ATTRS
 })
+
+provide('markstreamShowTooltips', computed(() => props.showTooltips))
+provide('markstreamFade', computed(() => props.fade))
 </script>
 
 <template>
   <li class="list-item" dir="auto" v-bind="liValueAttrs">
+    <ParagraphNode
+      v-if="simpleParagraphNode"
+      :node="simpleParagraphNode as any"
+      :custom-id="props.customId"
+      :index-key="`list-item-${props.indexKey}-paragraph`"
+    />
+    <SimpleInlineRenderer
+      v-else-if="simpleInlineChildren"
+      :nodes="simpleInlineChildren"
+      :custom-id="props.customId"
+      :index-key="`list-item-${props.indexKey}`"
+    />
     <NodeRenderer
+      v-else
       :show-tooltips="props.showTooltips"
       :index-key="`list-item-${props.indexKey}`"
       :nodes="itemNode?.children ?? []"

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -47,10 +47,7 @@ const hasTextOverride = computed(() =>
   Boolean((customComponents.value as any).text),
 )
 const simpleBlockChildren = computed(() => {
-  return resolveSimpleInlineChildren(itemNode.value?.children as any, {
-    allowSingleParagraph: !hasParagraphOverride.value,
-    allowEmpty: false,
-  })
+  return resolveSimpleInlineChildren(itemNode.value?.children as any, !hasParagraphOverride.value)
 })
 const simpleBlockWithNestedLists = computed(() => {
   if (hasParagraphOverride.value)
@@ -68,10 +65,7 @@ const simpleBlockWithNestedLists = computed(() => {
   if (!nestedLists.every(child => child?.type === 'list'))
     return null
 
-  const paragraphChildren = resolveSimpleInlineChildren([firstChild] as any, {
-    allowSingleParagraph: true,
-    allowEmpty: false,
-  })
+  const paragraphChildren = resolveSimpleInlineChildren([firstChild] as any)
 
   return paragraphChildren
     ? {
@@ -80,17 +74,17 @@ const simpleBlockWithNestedLists = computed(() => {
       }
     : null
 })
-const canRenderPlainTextInline = computed(() => {
+function canRenderPlainTextInline() {
   return props.fade === false && !hasTextOverride.value
-})
+}
 const simpleBlockPlainText = computed(() => {
-  if (!canRenderPlainTextInline.value)
+  if (!canRenderPlainTextInline())
     return null
 
   return getPlainTextContent(simpleBlockChildren.value)
 })
 const simpleNestedParagraphPlainText = computed(() => {
-  if (!canRenderPlainTextInline.value)
+  if (!canRenderPlainTextInline())
     return null
 
   return getPlainTextContent(simpleBlockWithNestedLists.value?.paragraphChildren)
@@ -119,7 +113,7 @@ provide('markstreamFade', computed(() => props.fade))
     >
       <span
         v-if="simpleBlockPlainText !== null"
-        class="simple-inline-text whitespace-pre-wrap break-words text-node"
+        class="text-node"
         :custom-id="props.customId"
       >{{ simpleBlockPlainText }}</span>
       <SimpleInlineRenderer
@@ -136,7 +130,7 @@ provide('markstreamFade', computed(() => props.fade))
       >
         <span
           v-if="simpleNestedParagraphPlainText !== null"
-          class="simple-inline-text whitespace-pre-wrap break-words text-node"
+          class="text-node"
           :custom-id="props.customId"
         >{{ simpleNestedParagraphPlainText }}</span>
         <SimpleInlineRenderer
@@ -148,7 +142,7 @@ provide('markstreamFade', computed(() => props.fade))
       </p>
       <NodeRenderer
         v-for="(nestedList, nestedIndex) in simpleBlockWithNestedLists.nestedLists"
-        :key="`list-item-${props.indexKey}-nested-${nestedIndex}`"
+        :key="nestedIndex"
         :nodes="[nestedList]"
         :custom-id="props.customId"
         :index-key="`list-item-${props.indexKey}-nested-${nestedIndex}`"

--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -55,8 +55,32 @@ const simpleParagraphChildren = computed(() => {
   const paragraphChildren = (child as any).children
   return areSimpleInlineNodes(paragraphChildren) ? paragraphChildren : null
 })
+const simpleParagraphWithNestedLists = computed(() => {
+  if ((customComponents.value as any).paragraph)
+    return null
+
+  const children = itemNode.value?.children
+  if (!Array.isArray(children) || children.length < 2)
+    return null
+
+  const firstChild = children[0]
+  if (firstChild?.type !== 'paragraph' || !Array.isArray((firstChild as any).children))
+    return null
+
+  const nestedLists = children.slice(1)
+  if (!nestedLists.every(child => child?.type === 'list'))
+    return null
+
+  const paragraphChildren = (firstChild as any).children
+  return areSimpleInlineNodes(paragraphChildren)
+    ? {
+        paragraphChildren,
+        nestedLists,
+      }
+    : null
+})
 const simpleInlineChildren = computed(() => {
-  if (simpleParagraphChildren.value)
+  if (simpleParagraphChildren.value || simpleParagraphWithNestedLists.value)
     return null
 
   const children = itemNode.value?.children
@@ -70,6 +94,12 @@ const simpleParagraphPlainText = computed(() => {
     return null
 
   return getPlainTextContent(simpleParagraphChildren.value)
+})
+const simpleNestedParagraphPlainText = computed(() => {
+  if (!canRenderPlainTextInline.value)
+    return null
+
+  return getPlainTextContent(simpleParagraphWithNestedLists.value?.paragraphChildren)
 })
 const simpleInlinePlainText = computed(() => {
   if (!canRenderPlainTextInline.value)
@@ -111,6 +141,38 @@ provide('markstreamFade', computed(() => props.fade))
         :index-key="`list-item-${props.indexKey}-paragraph`"
       />
     </p>
+    <template v-else-if="simpleParagraphWithNestedLists">
+      <p
+        dir="auto"
+        class="paragraph-node"
+      >
+        <span
+          v-if="simpleNestedParagraphPlainText !== null"
+          class="simple-inline-text whitespace-pre-wrap break-words text-node"
+          :custom-id="props.customId"
+        >{{ simpleNestedParagraphPlainText }}</span>
+        <SimpleInlineRenderer
+          v-else
+          :nodes="simpleParagraphWithNestedLists.paragraphChildren"
+          :custom-id="props.customId"
+          :index-key="`list-item-${props.indexKey}-paragraph`"
+        />
+      </p>
+      <NodeRenderer
+        v-for="(nestedList, nestedIndex) in simpleParagraphWithNestedLists.nestedLists"
+        :key="`list-item-${props.indexKey}-nested-${nestedIndex}`"
+        :nodes="[nestedList]"
+        :custom-id="props.customId"
+        :index-key="`list-item-${props.indexKey}-nested-${nestedIndex}`"
+        :show-tooltips="props.showTooltips"
+        :typewriter="props.typewriter"
+        :fade="props.fade"
+        :batch-rendering="false"
+        :defer-nodes-until-visible="false"
+        :render-as-fragment="true"
+        @copy="$emit('copy', $event)"
+      />
+    </template>
     <span
       v-else-if="simpleInlinePlainText !== null"
       class="simple-inline-text whitespace-pre-wrap break-words text-node"
@@ -161,6 +223,6 @@ ul > .list-item::marker {
 .list-item :deep(.markdown-renderer) {
   content-visibility: visible;
   contain-intrinsic-size: 0px 0px;
-  contain: none;
+  contain: content;
 }
 </style>

--- a/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
+++ b/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
@@ -965,6 +965,11 @@ function clearRestoredItemHeightFloorIfSourceChanged(
   }
 }
 
+function clearRestoredItemHeightFloor(key: string) {
+  restoredItemHeightFloors.delete(key)
+  restoredItemHeightFloorSources.delete(key)
+}
+
 function setItemSize(key: string, size: number, source?: TimelineItemSizeSource) {
   if (!Number.isFinite(size) || size <= 0)
     return
@@ -974,11 +979,10 @@ function setItemSize(key: string, size: number, source?: TimelineItemSizeSource)
 
   clearRestoredItemHeightFloorIfSourceChanged(key, source)
 
-  const restoredFloor = sourceChanged
-    ? 0
-    : getRestoredItemHeightFloor(key, source)
-
-  const next = Math.max(Math.ceil(size), restoredFloor)
+  const restoredFloor = getRestoredItemHeightFloor(key, source)
+  const next = restoredFloor > 0
+    ? restoredFloor
+    : Math.ceil(size)
 
   // Monaco / pre fallback / browser font rounding can differ by exactly 1px.
   // Treat that as measurement noise; otherwise an item above the current
@@ -1110,6 +1114,9 @@ function reconcileRecordSize(
 
     if ((!options.allowMarkdownShrink || restoringThread.value) && cachedSize > 0)
       next = Math.max(next, cachedSize)
+
+    if (options.allowMarkdownShrink && !restoringThread.value)
+      clearRestoredItemHeightFloor(record.key)
 
     if (next > 0)
       setItemSize(record.key, next, getItemSizeSource(record))
@@ -1857,6 +1864,7 @@ function readRestoreViewportSignature() {
     .map((record) => {
       const item = itemByKey.get(record.key)
       const renderer = item?.querySelector<HTMLElement>('.markdown-renderer')
+      const metrics = markdownStates.get(record.key)?.metrics
 
       return [
         record.key,
@@ -1865,6 +1873,13 @@ function readRestoreViewportSignature() {
         item?.scrollHeight ?? 0,
         renderer?.offsetHeight ?? 0,
         renderer?.scrollHeight ?? 0,
+        metrics ? Math.round(Number(metrics.totalHeight || 0)) : '',
+        metrics?.measuredCount ?? '',
+        metrics?.estimatedCount ?? '',
+        metrics?.nodeCount ?? '',
+        metrics?.final === true ? 1 : 0,
+        metrics?.stable === true ? 1 : 0,
+        metrics?.confidence ?? '',
       ].join(':')
     })
     .join('|')
@@ -2168,11 +2183,10 @@ function finishThreadRestore(seq: number) {
   activeThreadRestoreScrollTop = null
   activeThreadRestoreSeq = 0
 
-  // Restored floors are only a restore-time guard against partial mounted DOM.
-  // Once the restored viewport is ready, later stable/final measurements should
-  // be allowed to shrink stale persisted heights.
-  restoredItemHeightFloors.clear()
-  restoredItemHeightFloorSources.clear()
+  for (const record of layout.value.records) {
+    if (!record.markdown)
+      clearRestoredItemHeightFloor(record.key)
+  }
 
   updateScrollMetrics({ remember: false })
   markRestorePaintReady()

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5089,6 +5089,14 @@ const listBindings = computed(() => ({
   ...nonCodeBindings.value,
   ...(typeof resolvedShowTooltips.value === 'boolean' ? { showTooltips: resolvedShowTooltips.value } : {}),
 }))
+const blockquoteBindings = computed(() => ({
+  ...nonCodeBindings.value,
+  ...(typeof resolvedShowTooltips.value === 'boolean' ? { showTooltips: resolvedShowTooltips.value } : {}),
+}))
+const tableBindings = computed(() => ({
+  ...nonCodeBindings.value,
+  ...(typeof resolvedShowTooltips.value === 'boolean' ? { showTooltips: resolvedShowTooltips.value } : {}),
+}))
 
 function getCodeBlockRenderNode(node: ParsedNode) {
   if (node.type !== 'code_block')
@@ -5361,6 +5369,12 @@ function getBindingsFor(node: ParsedNode, language?: string, component?: unknown
 
   if (node.type === 'list')
     return listBindings.value
+
+  if (node.type === 'blockquote')
+    return blockquoteBindings.value
+
+  if (node.type === 'table')
+    return tableBindings.value
 
   return node.type === 'code_block'
     ? codeBlockBindings.value

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -224,7 +224,7 @@ const processedChildren = computed(() => renderedChildren.value.map((child, inde
   <p dir="auto" class="paragraph-node">
     <span
       v-if="plainTextContent !== null"
-      class="simple-inline-text whitespace-pre-wrap break-words text-node"
+      class="text-node"
       :custom-id="props.customId"
     >{{ plainTextContent }}</span>
     <template

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -20,6 +20,7 @@ import InsertNode from '../InsertNode'
 import LinkNode from '../LinkNode'
 import { MathInlineNodeAsync } from '../NodeRenderer/asyncComponent'
 import ReferenceNode from '../ReferenceNode'
+import { getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 import StrikethroughNode from '../StrikethroughNode'
 import StrongNode from '../StrongNode'
 import SubscriptNode from '../SubscriptNode'
@@ -48,6 +49,7 @@ const props = defineProps<{
 
 const overrides = useCustomNodeComponents(() => props.customId)
 const inheritedHtmlPolicy = inject<{ value?: HtmlPolicy } | undefined>('markstreamHtmlPolicy', undefined)
+const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const inheritedParseOptions = inject<{ value?: NodeRendererProps['parseOptions'] } | undefined>('markstreamParseOptions', undefined)
 const inheritedCustomMarkdownIt = inject<{ value?: NodeRendererProps['customMarkdownIt'] } | undefined>('markstreamCustomMarkdownIt', undefined)
 const inheritedNestedRendererProps = inject<{ value?: Partial<NodeRendererProps> } | undefined>('markstreamNestedRendererProps', undefined)
@@ -127,6 +129,17 @@ const renderedChildren = computed(() => {
   }
 
   return children
+})
+
+const canRenderPlainTextParagraph = computed(() => {
+  return inheritedFade?.value === false && !(overrides.value as any).text
+})
+
+const plainTextContent = computed(() => {
+  if (!canRenderPlainTextParagraph.value)
+    return null
+
+  return getPlainTextContent(renderedChildren.value)
 })
 
 function getChildProps(child: NodeChild, index: number) {
@@ -209,8 +222,14 @@ const processedChildren = computed(() => renderedChildren.value.map((child, inde
 
 <template>
   <p dir="auto" class="paragraph-node">
+    <span
+      v-if="plainTextContent !== null"
+      class="simple-inline-text whitespace-pre-wrap break-words text-node"
+      :custom-id="props.customId"
+    >{{ plainTextContent }}</span>
     <template
       v-for="item in processedChildren"
+      v-else
       :key="item.key"
     >
       <template v-if="isMediaOnlyParagraph && isWhitespaceText(item.originalChild)">

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -18,12 +18,7 @@ import StrongNode from '../StrongNode'
 import SubscriptNode from '../SubscriptNode'
 import SuperscriptNode from '../SuperscriptNode'
 import TextNode from '../TextNode'
-
-type TextLikeSimpleInlineNode = SimpleInlineNode & {
-  type: 'text'
-  content?: unknown
-  center?: boolean
-}
+import { getPlainTextContent } from './simpleInline'
 
 const props = defineProps<{
   nodes: SimpleInlineNode[]
@@ -53,30 +48,6 @@ const overrides = useCustomNodeComponents(() => props.customId)
 const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const hasTextOverride = computed(() => Boolean((overrides.value as any).text))
 
-function getTextContent(node: TextLikeSimpleInlineNode) {
-  return String(node.content ?? node.raw ?? '')
-}
-
-const plainTextNodes = computed<TextLikeSimpleInlineNode[] | null>(() => {
-  if (hasTextOverride.value || props.nodes.length === 0)
-    return null
-
-  const nodes: TextLikeSimpleInlineNode[] = []
-
-  for (const node of props.nodes) {
-    if (node?.type !== 'text')
-      return null
-
-    const textNode = node as TextLikeSimpleInlineNode
-    if (textNode.center === true)
-      return null
-
-    nodes.push(textNode)
-  }
-
-  return nodes
-})
-
 const singleDefaultTextNode = computed(() => {
   if (hasTextOverride.value || props.nodes.length !== 1)
     return null
@@ -85,13 +56,13 @@ const singleDefaultTextNode = computed(() => {
   return node?.type === 'text' ? node : null
 })
 
-const canRenderPlainTextNodes = computed(() => {
-  return Boolean(plainTextNodes.value && inheritedFade?.value === false)
-})
-
 const plainTextContent = computed(() => {
-  return plainTextNodes.value?.map(getTextContent).join('') ?? ''
+  if (hasTextOverride.value || inheritedFade?.value !== false)
+    return null
+
+  return getPlainTextContent(props.nodes)
 })
+const canRenderPlainTextNodes = computed(() => plainTextContent.value !== null)
 
 const nodeComponents = computed<Record<string, Component | undefined>>(() => {
   const custom = overrides.value as Record<string, Component | undefined>
@@ -109,7 +80,7 @@ const nodeComponents = computed<Record<string, Component | undefined>>(() => {
     v-if="canRenderPlainTextNodes"
     class="simple-inline-text whitespace-pre-wrap break-words text-node"
     :custom-id="props.customId"
-  >{{ plainTextContent }}</span>
+  >{{ plainTextContent ?? '' }}</span>
   <TextNode
     v-else-if="singleDefaultTextNode"
     :node="singleDefaultTextNode as any"

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 import type { SimpleInlineNode } from './simpleInline'
-import { computed, inject, markRaw } from 'vue'
+import { computed, markRaw } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import CheckboxNode from '../CheckboxNode'
 import EmojiNode from '../EmojiNode'
@@ -18,7 +18,6 @@ import StrongNode from '../StrongNode'
 import SubscriptNode from '../SubscriptNode'
 import SuperscriptNode from '../SuperscriptNode'
 import TextNode from '../TextNode'
-import { getPlainTextContent } from './simpleInline'
 
 const props = defineProps<{
   nodes: SimpleInlineNode[]
@@ -45,24 +44,6 @@ const DEFAULT_SIMPLE_INLINE_COMPONENTS = markRaw<Record<string, Component>>({
 })
 
 const overrides = useCustomNodeComponents(() => props.customId)
-const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
-const hasTextOverride = computed(() => Boolean((overrides.value as any).text))
-
-const singleDefaultTextNode = computed(() => {
-  if (hasTextOverride.value || props.nodes.length !== 1)
-    return null
-
-  const node = props.nodes[0]
-  return node?.type === 'text' ? node : null
-})
-
-const plainTextContent = computed(() => {
-  if (hasTextOverride.value || inheritedFade?.value !== false)
-    return null
-
-  return getPlainTextContent(props.nodes)
-})
-const canRenderPlainTextNodes = computed(() => plainTextContent.value !== null)
 
 const nodeComponents = computed<Record<string, Component | undefined>>(() => {
   const custom = overrides.value as Record<string, Component | undefined>
@@ -76,21 +57,9 @@ const nodeComponents = computed<Record<string, Component | undefined>>(() => {
 </script>
 
 <template>
-  <span
-    v-if="canRenderPlainTextNodes"
-    class="simple-inline-text whitespace-pre-wrap break-words text-node"
-    :custom-id="props.customId"
-  >{{ plainTextContent ?? '' }}</span>
-  <TextNode
-    v-else-if="singleDefaultTextNode"
-    :node="singleDefaultTextNode as any"
-    :index-key="`${indexKey || 'inline'}-0`"
-    :custom-id="props.customId"
-  />
   <NodeChildRenderer
     v-for="(node, index) in nodes"
-    v-else
-    :key="`${indexKey || 'inline'}-${index}`"
+    :key="index"
     :components="nodeComponents"
     :node="node"
     :custom-id="props.customId"

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { SimpleInlineNode } from './simpleInline'
+import { computed } from 'vue'
+import { useCustomNodeComponents } from '../../utils/nodeComponents'
+import CheckboxNode from '../CheckboxNode'
+import EmojiNode from '../EmojiNode'
+import EmphasisNode from '../EmphasisNode'
+import HardBreakNode from '../HardBreakNode'
+import HighlightNode from '../HighlightNode'
+import InlineCodeNode from '../InlineCodeNode'
+import InsertNode from '../InsertNode'
+import LinkNode from '../LinkNode'
+import NodeChildRenderer from '../NodeChildRenderer'
+import ReferenceNode from '../ReferenceNode'
+import StrikethroughNode from '../StrikethroughNode'
+import StrongNode from '../StrongNode'
+import SubscriptNode from '../SubscriptNode'
+import SuperscriptNode from '../SuperscriptNode'
+import TextNode from '../TextNode'
+
+const props = defineProps<{
+  nodes: SimpleInlineNode[]
+  customId?: string
+  indexKey?: number | string
+}>()
+
+const overrides = useCustomNodeComponents(() => props.customId)
+const nodeComponents = computed(() => ({
+  checkbox: CheckboxNode,
+  checkbox_input: CheckboxNode,
+  emoji: EmojiNode,
+  emphasis: EmphasisNode,
+  hardbreak: HardBreakNode,
+  highlight: HighlightNode,
+  inline_code: InlineCodeNode,
+  insert: InsertNode,
+  link: LinkNode,
+  reference: ReferenceNode,
+  strikethrough: StrikethroughNode,
+  strong: StrongNode,
+  subscript: SubscriptNode,
+  superscript: SuperscriptNode,
+  text: TextNode,
+  ...overrides.value,
+}))
+</script>
+
+<template>
+  <NodeChildRenderer
+    v-for="(node, index) in nodes"
+    :key="`${indexKey || 'inline'}-${index}`"
+    :components="nodeComponents"
+    :node="node"
+    :custom-id="props.customId"
+    :index-key="`${indexKey || 'inline'}-${index}`"
+  />
+</template>

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -19,6 +19,12 @@ import SubscriptNode from '../SubscriptNode'
 import SuperscriptNode from '../SuperscriptNode'
 import TextNode from '../TextNode'
 
+type TextLikeSimpleInlineNode = SimpleInlineNode & {
+  type: 'text'
+  content?: unknown
+  center?: boolean
+}
+
 const props = defineProps<{
   nodes: SimpleInlineNode[]
   customId?: string
@@ -46,6 +52,31 @@ const DEFAULT_SIMPLE_INLINE_COMPONENTS = markRaw<Record<string, Component>>({
 const overrides = useCustomNodeComponents(() => props.customId)
 const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const hasTextOverride = computed(() => Boolean((overrides.value as any).text))
+
+function getTextContent(node: TextLikeSimpleInlineNode) {
+  return String(node.content ?? node.raw ?? '')
+}
+
+const plainTextNodes = computed<TextLikeSimpleInlineNode[] | null>(() => {
+  if (hasTextOverride.value || props.nodes.length === 0)
+    return null
+
+  const nodes: TextLikeSimpleInlineNode[] = []
+
+  for (const node of props.nodes) {
+    if (node?.type !== 'text')
+      return null
+
+    const textNode = node as TextLikeSimpleInlineNode
+    if (textNode.center === true)
+      return null
+
+    nodes.push(textNode)
+  }
+
+  return nodes
+})
+
 const singleDefaultTextNode = computed(() => {
   if (hasTextOverride.value || props.nodes.length !== 1)
     return null
@@ -53,17 +84,13 @@ const singleDefaultTextNode = computed(() => {
   const node = props.nodes[0]
   return node?.type === 'text' ? node : null
 })
-const canRenderPlainTextNode = computed(() => {
-  const node = singleDefaultTextNode.value as (SimpleInlineNode & { center?: boolean }) | null
-  return Boolean(
-    node
-    && inheritedFade?.value === false
-    && node.center !== true,
-  )
+
+const canRenderPlainTextNodes = computed(() => {
+  return Boolean(plainTextNodes.value && inheritedFade?.value === false)
 })
-const singlePlainTextContent = computed(() => {
-  const node = singleDefaultTextNode.value as (SimpleInlineNode & { content?: unknown }) | null
-  return String(node?.content ?? node?.raw ?? '')
+
+const plainTextContent = computed(() => {
+  return plainTextNodes.value?.map(getTextContent).join('') ?? ''
 })
 
 const nodeComponents = computed<Record<string, Component | undefined>>(() => {
@@ -79,13 +106,15 @@ const nodeComponents = computed<Record<string, Component | undefined>>(() => {
 
 <template>
   <span
-    v-if="canRenderPlainTextNode"
+    v-if="canRenderPlainTextNodes"
     class="simple-inline-text whitespace-pre-wrap break-words text-node"
-  >{{ singlePlainTextContent }}</span>
+    :custom-id="props.customId"
+  >{{ plainTextContent }}</span>
   <TextNode
     v-else-if="singleDefaultTextNode"
     :node="singleDefaultTextNode as any"
     :index-key="`${indexKey || 'inline'}-0`"
+    :custom-id="props.customId"
   />
   <NodeChildRenderer
     v-for="(node, index) in nodes"

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
 import type { SimpleInlineNode } from './simpleInline'
-import { computed } from 'vue'
+import { computed, markRaw } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import CheckboxNode from '../CheckboxNode'
 import EmojiNode from '../EmojiNode'
@@ -24,8 +25,7 @@ const props = defineProps<{
   indexKey?: number | string
 }>()
 
-const overrides = useCustomNodeComponents(() => props.customId)
-const nodeComponents = computed(() => ({
+const DEFAULT_SIMPLE_INLINE_COMPONENTS = markRaw<Record<string, Component>>({
   checkbox: CheckboxNode,
   checkbox_input: CheckboxNode,
   emoji: EmojiNode,
@@ -41,13 +41,38 @@ const nodeComponents = computed(() => ({
   subscript: SubscriptNode,
   superscript: SuperscriptNode,
   text: TextNode,
-  ...overrides.value,
-}))
+})
+
+const overrides = useCustomNodeComponents(() => props.customId)
+const hasTextOverride = computed(() => Boolean((overrides.value as any).text))
+const singleDefaultTextNode = computed(() => {
+  if (hasTextOverride.value || props.nodes.length !== 1)
+    return null
+
+  const node = props.nodes[0]
+  return node?.type === 'text' ? node : null
+})
+
+const nodeComponents = computed<Record<string, Component | undefined>>(() => {
+  const custom = overrides.value as Record<string, Component | undefined>
+  return Object.keys(custom).length > 0
+    ? {
+        ...DEFAULT_SIMPLE_INLINE_COMPONENTS,
+        ...custom,
+      }
+    : DEFAULT_SIMPLE_INLINE_COMPONENTS
+})
 </script>
 
 <template>
+  <TextNode
+    v-if="singleDefaultTextNode"
+    :node="singleDefaultTextNode as any"
+    :index-key="`${indexKey || 'inline'}-0`"
+  />
   <NodeChildRenderer
     v-for="(node, index) in nodes"
+    v-else
     :key="`${indexKey || 'inline'}-${index}`"
     :components="nodeComponents"
     :node="node"

--- a/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
+++ b/src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 import type { SimpleInlineNode } from './simpleInline'
-import { computed, markRaw } from 'vue'
+import { computed, inject, markRaw } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import CheckboxNode from '../CheckboxNode'
 import EmojiNode from '../EmojiNode'
@@ -44,6 +44,7 @@ const DEFAULT_SIMPLE_INLINE_COMPONENTS = markRaw<Record<string, Component>>({
 })
 
 const overrides = useCustomNodeComponents(() => props.customId)
+const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const hasTextOverride = computed(() => Boolean((overrides.value as any).text))
 const singleDefaultTextNode = computed(() => {
   if (hasTextOverride.value || props.nodes.length !== 1)
@@ -51,6 +52,18 @@ const singleDefaultTextNode = computed(() => {
 
   const node = props.nodes[0]
   return node?.type === 'text' ? node : null
+})
+const canRenderPlainTextNode = computed(() => {
+  const node = singleDefaultTextNode.value as (SimpleInlineNode & { center?: boolean }) | null
+  return Boolean(
+    node
+    && inheritedFade?.value === false
+    && node.center !== true,
+  )
+})
+const singlePlainTextContent = computed(() => {
+  const node = singleDefaultTextNode.value as (SimpleInlineNode & { content?: unknown }) | null
+  return String(node?.content ?? node?.raw ?? '')
 })
 
 const nodeComponents = computed<Record<string, Component | undefined>>(() => {
@@ -65,8 +78,12 @@ const nodeComponents = computed<Record<string, Component | undefined>>(() => {
 </script>
 
 <template>
+  <span
+    v-if="canRenderPlainTextNode"
+    class="simple-inline-text whitespace-pre-wrap break-words text-node"
+  >{{ singlePlainTextContent }}</span>
   <TextNode
-    v-if="singleDefaultTextNode"
+    v-else-if="singleDefaultTextNode"
     :node="singleDefaultTextNode as any"
     :index-key="`${indexKey || 'inline'}-0`"
   />

--- a/src/components/SimpleInlineRenderer/index.ts
+++ b/src/components/SimpleInlineRenderer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SimpleInlineRenderer.vue'

--- a/src/components/SimpleInlineRenderer/simpleInline.ts
+++ b/src/components/SimpleInlineRenderer/simpleInline.ts
@@ -11,75 +11,37 @@ export type SimpleInlineTextNode = SimpleInlineNode & {
   center?: boolean
 }
 
-export interface ResolveSimpleInlineChildrenOptions {
-  allowSingleParagraph?: boolean
-  allowEmpty?: boolean
-}
+const SIMPLE_INLINE_TYPES = '|checkbox|checkbox_input|emoji|emphasis|hardbreak|highlight|inline_code|insert|link|reference|strikethrough|strong|subscript|superscript|text|'
 
-const SIMPLE_INLINE_TYPES = new Set([
-  'checkbox',
-  'checkbox_input',
-  'emoji',
-  'emphasis',
-  'hardbreak',
-  'highlight',
-  'inline_code',
-  'insert',
-  'link',
-  'reference',
-  'strikethrough',
-  'strong',
-  'subscript',
-  'superscript',
-  'text',
-])
-
-const SIMPLE_INLINE_CONTAINER_TYPES = new Set([
-  'emphasis',
-  'highlight',
-  'insert',
-  'link',
-  'strikethrough',
-  'strong',
-  'subscript',
-  'superscript',
-])
+const SIMPLE_INLINE_CONTAINER_TYPES = '|emphasis|highlight|insert|link|strikethrough|strong|subscript|superscript|'
 
 export function isSimpleInlineNode(node: SimpleInlineNode) {
   if (!node || typeof node !== 'object')
     return false
 
-  const type = String(node.type)
-  if (!SIMPLE_INLINE_TYPES.has(type))
+  const type = `|${node.type}|`
+  if (!SIMPLE_INLINE_TYPES.includes(type))
     return false
 
-  if (!SIMPLE_INLINE_CONTAINER_TYPES.has(type))
+  if (!SIMPLE_INLINE_CONTAINER_TYPES.includes(type))
     return true
 
   const children = node.children
   return Array.isArray(children) && children.every(isSimpleInlineNode)
 }
 
-export function areSimpleInlineNodes(nodes: readonly SimpleInlineNode[] | undefined) {
-  return Array.isArray(nodes) && nodes.every(isSimpleInlineNode)
-}
-
 export function resolveSimpleInlineChildren(
   nodes: readonly SimpleInlineNode[] | undefined,
-  options: ResolveSimpleInlineChildrenOptions = {},
+  allowSingleParagraph = true,
+  allowEmpty = false,
 ): readonly SimpleInlineNode[] | null {
-  if (!Array.isArray(nodes))
+  if (!nodes || (!allowEmpty && nodes.length === 0))
     return null
 
-  const allowEmpty = options.allowEmpty === true
-
-  if (nodes.length === 0)
-    return allowEmpty ? nodes : null
-
-  if (areSimpleInlineNodes(nodes))
+  if (nodes.every(isSimpleInlineNode))
     return nodes
 
-  if (options.allowSingleParagraph === false || nodes.length !== 1)
+  if (!allowSingleParagraph || nodes.length !== 1)
     return null
 
   const only = nodes[0]
@@ -87,10 +49,7 @@ export function resolveSimpleInlineChildren(
     return null
 
   const paragraphChildren = only.children
-  if (!allowEmpty && paragraphChildren.length === 0)
-    return null
-
-  return areSimpleInlineNodes(paragraphChildren)
+  return (allowEmpty || paragraphChildren.length > 0) && paragraphChildren.every(isSimpleInlineNode)
     ? paragraphChildren
     : null
 }
@@ -98,20 +57,16 @@ export function resolveSimpleInlineChildren(
 export function getPlainTextContent(
   nodes: readonly SimpleInlineNode[] | undefined,
 ) {
-  if (!Array.isArray(nodes) || nodes.length === 0)
+  if (!nodes?.length)
     return null
 
   let content = ''
 
   for (const node of nodes) {
-    if (node?.type !== 'text')
+    if (node?.type !== 'text' || (node as SimpleInlineTextNode).center === true)
       return null
 
-    const textNode = node as SimpleInlineTextNode
-    if (textNode.center === true)
-      return null
-
-    content += String(textNode.content ?? textNode.raw ?? '')
+    content += String((node as SimpleInlineTextNode).content ?? node.raw ?? '')
   }
 
   return content

--- a/src/components/SimpleInlineRenderer/simpleInline.ts
+++ b/src/components/SimpleInlineRenderer/simpleInline.ts
@@ -1,0 +1,54 @@
+export interface SimpleInlineNode {
+  type: string
+  raw?: string
+  children?: SimpleInlineNode[]
+  [key: string]: unknown
+}
+
+const SIMPLE_INLINE_TYPES = new Set([
+  'checkbox',
+  'checkbox_input',
+  'emoji',
+  'emphasis',
+  'hardbreak',
+  'highlight',
+  'inline_code',
+  'insert',
+  'link',
+  'reference',
+  'strikethrough',
+  'strong',
+  'subscript',
+  'superscript',
+  'text',
+])
+
+const SIMPLE_INLINE_CONTAINER_TYPES = new Set([
+  'emphasis',
+  'highlight',
+  'insert',
+  'link',
+  'strikethrough',
+  'strong',
+  'subscript',
+  'superscript',
+])
+
+export function isSimpleInlineNode(node: SimpleInlineNode) {
+  if (!node || typeof node !== 'object')
+    return false
+
+  const type = String(node.type)
+  if (!SIMPLE_INLINE_TYPES.has(type))
+    return false
+
+  if (!SIMPLE_INLINE_CONTAINER_TYPES.has(type))
+    return true
+
+  const children = node.children
+  return Array.isArray(children) && children.every(isSimpleInlineNode)
+}
+
+export function areSimpleInlineNodes(nodes: readonly SimpleInlineNode[] | undefined) {
+  return Array.isArray(nodes) && nodes.every(isSimpleInlineNode)
+}

--- a/src/components/SimpleInlineRenderer/simpleInline.ts
+++ b/src/components/SimpleInlineRenderer/simpleInline.ts
@@ -11,6 +11,11 @@ export type SimpleInlineTextNode = SimpleInlineNode & {
   center?: boolean
 }
 
+export interface ResolveSimpleInlineChildrenOptions {
+  allowSingleParagraph?: boolean
+  allowEmpty?: boolean
+}
+
 const SIMPLE_INLINE_TYPES = new Set([
   'checkbox',
   'checkbox_input',
@@ -57,6 +62,37 @@ export function isSimpleInlineNode(node: SimpleInlineNode) {
 
 export function areSimpleInlineNodes(nodes: readonly SimpleInlineNode[] | undefined) {
   return Array.isArray(nodes) && nodes.every(isSimpleInlineNode)
+}
+
+export function resolveSimpleInlineChildren(
+  nodes: readonly SimpleInlineNode[] | undefined,
+  options: ResolveSimpleInlineChildrenOptions = {},
+): readonly SimpleInlineNode[] | null {
+  if (!Array.isArray(nodes))
+    return null
+
+  const allowEmpty = options.allowEmpty === true
+
+  if (nodes.length === 0)
+    return allowEmpty ? nodes : null
+
+  if (areSimpleInlineNodes(nodes))
+    return nodes
+
+  if (options.allowSingleParagraph === false || nodes.length !== 1)
+    return null
+
+  const only = nodes[0]
+  if (only?.type !== 'paragraph' || !Array.isArray(only.children))
+    return null
+
+  const paragraphChildren = only.children
+  if (!allowEmpty && paragraphChildren.length === 0)
+    return null
+
+  return areSimpleInlineNodes(paragraphChildren)
+    ? paragraphChildren
+    : null
 }
 
 export function getPlainTextContent(

--- a/src/components/SimpleInlineRenderer/simpleInline.ts
+++ b/src/components/SimpleInlineRenderer/simpleInline.ts
@@ -5,6 +5,12 @@ export interface SimpleInlineNode {
   [key: string]: unknown
 }
 
+export type SimpleInlineTextNode = SimpleInlineNode & {
+  type: 'text'
+  content?: unknown
+  center?: boolean
+}
+
 const SIMPLE_INLINE_TYPES = new Set([
   'checkbox',
   'checkbox_input',
@@ -51,4 +57,26 @@ export function isSimpleInlineNode(node: SimpleInlineNode) {
 
 export function areSimpleInlineNodes(nodes: readonly SimpleInlineNode[] | undefined) {
   return Array.isArray(nodes) && nodes.every(isSimpleInlineNode)
+}
+
+export function getPlainTextContent(
+  nodes: readonly SimpleInlineNode[] | undefined,
+) {
+  if (!Array.isArray(nodes) || nodes.length === 0)
+    return null
+
+  let content = ''
+
+  for (const node of nodes) {
+    if (node?.type !== 'text')
+      return null
+
+    const textNode = node as SimpleInlineTextNode
+    if (textNode.center === true)
+      return null
+
+    content += String(textNode.content ?? textNode.raw ?? '')
+  }
+
+  return content
 }

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
+import type { SimpleInlineNode } from '../SimpleInlineRenderer/simpleInline'
 import { computed, onBeforeUnmount, provide, ref, watch } from 'vue'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
-import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
+import { getPlainTextContent, resolveSimpleInlineChildren } from '../SimpleInlineRenderer/simpleInline'
+
+type TableCellChildNode = SimpleInlineNode & {
+  raw: string
+}
 
 interface TableCellNode {
   type: 'table_cell'
   header: boolean
-  children: {
-    type: string
-    raw: string
-  }[]
+  children: TableCellChildNode[]
   raw: string
   align?: 'left' | 'right' | 'center'
 }
@@ -37,9 +39,31 @@ const props = defineProps<{
   typewriter?: boolean
   fade?: boolean
   customId?: string
+  showTooltips?: boolean
 }>()
 
 defineEmits(['copy'])
+
+interface SimpleCellInfo {
+  simpleChildren: readonly SimpleInlineNode[] | null
+  plainText: string | null
+}
+
+interface RenderHeaderCell {
+  cell: TableCellNode
+  index: number
+  info: SimpleCellInfo
+}
+
+interface RenderBodyRow {
+  row: TableRowNode
+  rowIndex: number
+  cells: Array<{
+    cell: TableCellNode
+    cellIndex: number
+    info: SimpleCellInfo
+  }>
+}
 
 const isLoading = computed(() => props.node.loading ?? false)
 const bodyRows = computed(() => props.node.rows ?? [])
@@ -61,48 +85,80 @@ const columnStyles = computed(() =>
 )
 const hasColumnWidths = computed(() => columnWidths.value.length > 0)
 
-provide('markstreamShowTooltips', computed(() => true))
+provide('markstreamShowTooltips', computed(() => props.showTooltips))
 provide('markstreamFade', computed(() => props.fade))
 
 const customComponents = useCustomNodeComponents(() => props.customId)
+const hasTextOverride = computed(() =>
+  Boolean((customComponents.value as any).text),
+)
+const hasParagraphOverride = computed(() =>
+  Boolean((customComponents.value as any).paragraph),
+)
 const canRenderPlainTextCell = computed(() => {
-  return props.fade === false && !(customComponents.value as any).text
+  return props.fade === false && !hasTextOverride.value
 })
 
 const simpleCellCache = new WeakMap<TableCellNode, {
   children: TableCellNode['children']
   textFastPath: boolean
-  canRender: boolean
-  plainText: string | null
+  paragraphFastPath: boolean
+  info: SimpleCellInfo
 }>()
 
-function getSimpleCellInfo(cell: TableCellNode) {
+function getSimpleCellInfo(cell: TableCellNode): SimpleCellInfo {
   const textFastPath = canRenderPlainTextCell.value
-  const cached = simpleCellCache.get(cell)
-  if (cached?.children === cell.children && cached.textFastPath === textFastPath)
-    return cached
+  const paragraphFastPath = !hasParagraphOverride.value
 
-  const canRender = areSimpleInlineNodes(cell.children)
-  const info = {
-    children: cell.children,
-    textFastPath,
-    canRender,
-    plainText: canRender && textFastPath
-      ? getPlainTextContent(cell.children)
+  const cached = simpleCellCache.get(cell)
+  if (
+    cached?.children === cell.children
+    && cached.textFastPath === textFastPath
+    && cached.paragraphFastPath === paragraphFastPath
+  ) {
+    return cached.info
+  }
+
+  const simpleChildren = resolveSimpleInlineChildren(cell.children as any, {
+    allowSingleParagraph: paragraphFastPath,
+    allowEmpty: true,
+  })
+
+  const info: SimpleCellInfo = {
+    simpleChildren,
+    plainText: simpleChildren && textFastPath
+      ? getPlainTextContent(simpleChildren)
       : null,
   }
 
-  simpleCellCache.set(cell, info)
+  simpleCellCache.set(cell, {
+    children: cell.children,
+    textFastPath,
+    paragraphFastPath,
+    info,
+  })
   return info
 }
 
-function canRenderSimpleCell(cell: TableCellNode) {
-  return getSimpleCellInfo(cell).canRender
-}
+const headerRenderCells = computed<RenderHeaderCell[]>(() => {
+  return props.node.header.cells.map((cell, index) => ({
+    cell,
+    index,
+    info: getSimpleCellInfo(cell),
+  }))
+})
 
-function getSimpleCellPlainText(cell: TableCellNode) {
-  return getSimpleCellInfo(cell).plainText
-}
+const bodyRenderRows = computed<RenderBodyRow[]>(() => {
+  return bodyRows.value.map((row, rowIndex) => ({
+    row,
+    rowIndex,
+    cells: row.cells.map((cell, cellIndex) => ({
+      cell,
+      cellIndex,
+      info: getSimpleCellInfo(cell),
+    })),
+  }))
+})
 
 function measureHeaderWidths() {
   const cells = tableRef.value?.querySelectorAll('thead th')
@@ -192,82 +248,84 @@ onBeforeUnmount(stopColumnResize)
       <thead>
         <tr>
           <th
-            v-for="(cell, index) in node.header.cells"
-            :key="`header-${index}`"
+            v-for="item in headerRenderCells"
+            :key="`header-${item.index}`"
             dir="auto"
             :class="[
-              cell.align === 'right'
+              item.cell.align === 'right'
                 ? 'text-right'
-                : cell.align === 'center'
+                : item.cell.align === 'center'
                   ? 'text-center'
                   : 'text-left',
             ]"
           >
             <span
-              v-if="getSimpleCellPlainText(cell) !== null"
+              v-if="item.info.plainText !== null"
               class="simple-inline-text whitespace-pre-wrap break-words text-node"
               :custom-id="props.customId"
-            >{{ getSimpleCellPlainText(cell) }}</span>
+            >{{ item.info.plainText }}</span>
             <SimpleInlineRenderer
-              v-else-if="canRenderSimpleCell(cell)"
-              :nodes="cell.children"
+              v-else-if="item.info.simpleChildren"
+              :nodes="item.info.simpleChildren as any"
               :custom-id="props.customId"
-              :index-key="`table-th-${props.indexKey}-${index}`"
+              :index-key="`table-th-${props.indexKey}-${item.index}`"
             />
             <NodeRenderer
               v-else
-              :nodes="cell.children"
+              :nodes="item.cell.children"
               :index-key="`table-th-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"
               :fade="props.fade"
+              :show-tooltips="props.showTooltips"
               @copy="$emit('copy', $event)"
             />
             <button
-              v-if="index < node.header.cells.length - 1"
+              v-if="item.index < node.header.cells.length - 1"
               type="button"
               class="table-node__resize-handle"
-              :aria-label="`Resize columns ${index + 1} and ${index + 2}`"
-              @pointerdown="startColumnResize(index, $event)"
+              :aria-label="`Resize columns ${item.index + 1} and ${item.index + 2}`"
+              @pointerdown="startColumnResize(item.index, $event)"
             />
           </th>
         </tr>
       </thead>
       <tbody>
         <tr
-          v-for="(row, rowIndex) in bodyRows"
-          :key="`row-${rowIndex}`"
+          v-for="rowItem in bodyRenderRows"
+          :key="`row-${rowItem.rowIndex}`"
         >
           <td
-            v-for="(cell, cellIndex) in row.cells"
-            :key="`cell-${rowIndex}-${cellIndex}`"
+            v-for="item in rowItem.cells"
+            :key="`cell-${rowItem.rowIndex}-${item.cellIndex}`"
             :class="[
-              cell.align === 'right'
+              item.cell.align === 'right'
                 ? 'text-right'
-                : cell.align === 'center'
+                : item.cell.align === 'center'
                   ? 'text-center'
                   : 'text-left',
             ]"
             dir="auto"
           >
             <span
-              v-if="getSimpleCellPlainText(cell) !== null"
+              v-if="item.info.plainText !== null"
               class="simple-inline-text whitespace-pre-wrap break-words text-node"
               :custom-id="props.customId"
-            >{{ getSimpleCellPlainText(cell) }}</span>
+            >{{ item.info.plainText }}</span>
             <SimpleInlineRenderer
-              v-else-if="canRenderSimpleCell(cell)"
-              :nodes="cell.children"
+              v-else-if="item.info.simpleChildren"
+              :nodes="item.info.simpleChildren as any"
               :custom-id="props.customId"
-              :index-key="`table-td-${props.indexKey}-${rowIndex}-${cellIndex}`"
+              :index-key="`table-td-${props.indexKey}-${rowItem.rowIndex}-${item.cellIndex}`"
             />
             <NodeRenderer
               v-else
-              :nodes="cell.children"
+              :nodes="item.cell.children"
               :index-key="`table-td-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"
               :fade="props.fade"
+              :show-tooltips="props.showTooltips"
               @copy="$emit('copy', $event)"
             />
           </td>

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, provide, ref, watch } from 'vue'
+import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import NodeRenderer from '../NodeRenderer'
 import SimpleInlineRenderer from '../SimpleInlineRenderer'
-import { areSimpleInlineNodes } from '../SimpleInlineRenderer/simpleInline'
+import { areSimpleInlineNodes, getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 
 interface TableCellNode {
   type: 'table_cell'
@@ -63,22 +64,44 @@ const hasColumnWidths = computed(() => columnWidths.value.length > 0)
 provide('markstreamShowTooltips', computed(() => true))
 provide('markstreamFade', computed(() => props.fade))
 
+const customComponents = useCustomNodeComponents(() => props.customId)
+const canRenderPlainTextCell = computed(() => {
+  return props.fade === false && !(customComponents.value as any).text
+})
+
 const simpleCellCache = new WeakMap<TableCellNode, {
   children: TableCellNode['children']
-  result: boolean
+  textFastPath: boolean
+  canRender: boolean
+  plainText: string | null
 }>()
 
-function canRenderSimpleCell(cell: TableCellNode) {
+function getSimpleCellInfo(cell: TableCellNode) {
+  const textFastPath = canRenderPlainTextCell.value
   const cached = simpleCellCache.get(cell)
-  if (cached?.children === cell.children)
-    return cached.result
+  if (cached?.children === cell.children && cached.textFastPath === textFastPath)
+    return cached
 
-  const result = areSimpleInlineNodes(cell.children)
-  simpleCellCache.set(cell, {
+  const canRender = areSimpleInlineNodes(cell.children)
+  const info = {
     children: cell.children,
-    result,
-  })
-  return result
+    textFastPath,
+    canRender,
+    plainText: canRender && textFastPath
+      ? getPlainTextContent(cell.children)
+      : null,
+  }
+
+  simpleCellCache.set(cell, info)
+  return info
+}
+
+function canRenderSimpleCell(cell: TableCellNode) {
+  return getSimpleCellInfo(cell).canRender
+}
+
+function getSimpleCellPlainText(cell: TableCellNode) {
+  return getSimpleCellInfo(cell).plainText
 }
 
 function measureHeaderWidths() {
@@ -180,8 +203,13 @@ onBeforeUnmount(stopColumnResize)
                   : 'text-left',
             ]"
           >
+            <span
+              v-if="getSimpleCellPlainText(cell) !== null"
+              class="simple-inline-text whitespace-pre-wrap break-words text-node"
+              :custom-id="props.customId"
+            >{{ getSimpleCellPlainText(cell) }}</span>
             <SimpleInlineRenderer
-              v-if="canRenderSimpleCell(cell)"
+              v-else-if="canRenderSimpleCell(cell)"
               :nodes="cell.children"
               :custom-id="props.customId"
               :index-key="`table-th-${props.indexKey}-${index}`"
@@ -222,8 +250,13 @@ onBeforeUnmount(stopColumnResize)
             ]"
             dir="auto"
           >
+            <span
+              v-if="getSimpleCellPlainText(cell) !== null"
+              class="simple-inline-text whitespace-pre-wrap break-words text-node"
+              :custom-id="props.customId"
+            >{{ getSimpleCellPlainText(cell) }}</span>
             <SimpleInlineRenderer
-              v-if="canRenderSimpleCell(cell)"
+              v-else-if="canRenderSimpleCell(cell)"
               :nodes="cell.children"
               :custom-id="props.customId"
               :index-key="`table-td-${props.indexKey}-${rowIndex}-${cellIndex}`"

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -63,8 +63,22 @@ const hasColumnWidths = computed(() => columnWidths.value.length > 0)
 provide('markstreamShowTooltips', computed(() => true))
 provide('markstreamFade', computed(() => props.fade))
 
+const simpleCellCache = new WeakMap<TableCellNode, {
+  children: TableCellNode['children']
+  result: boolean
+}>()
+
 function canRenderSimpleCell(cell: TableCellNode) {
-  return areSimpleInlineNodes(cell.children)
+  const cached = simpleCellCache.get(cell)
+  if (cached?.children === cell.children)
+    return cached.result
+
+  const result = areSimpleInlineNodes(cell.children)
+  simpleCellCache.set(cell, {
+    children: cell.children,
+    result,
+  })
+  return result
 }
 
 function measureHeaderWidths() {

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -49,22 +49,6 @@ interface SimpleCellInfo {
   plainText: string | null
 }
 
-interface RenderHeaderCell {
-  cell: TableCellNode
-  index: number
-  info: SimpleCellInfo
-}
-
-interface RenderBodyRow {
-  row: TableRowNode
-  rowIndex: number
-  cells: Array<{
-    cell: TableCellNode
-    cellIndex: number
-    info: SimpleCellInfo
-  }>
-}
-
 const isLoading = computed(() => props.node.loading ?? false)
 const bodyRows = computed(() => props.node.rows ?? [])
 const tableRef = ref<HTMLTableElement | null>(null)
@@ -95,9 +79,9 @@ const hasTextOverride = computed(() =>
 const hasParagraphOverride = computed(() =>
   Boolean((customComponents.value as any).paragraph),
 )
-const canRenderPlainTextCell = computed(() => {
+function canRenderPlainTextCell() {
   return props.fade === false && !hasTextOverride.value
-})
+}
 
 const simpleCellCache = new WeakMap<TableCellNode, {
   children: TableCellNode['children']
@@ -107,7 +91,7 @@ const simpleCellCache = new WeakMap<TableCellNode, {
 }>()
 
 function getSimpleCellInfo(cell: TableCellNode): SimpleCellInfo {
-  const textFastPath = canRenderPlainTextCell.value
+  const textFastPath = canRenderPlainTextCell()
   const paragraphFastPath = !hasParagraphOverride.value
 
   const cached = simpleCellCache.get(cell)
@@ -119,10 +103,7 @@ function getSimpleCellInfo(cell: TableCellNode): SimpleCellInfo {
     return cached.info
   }
 
-  const simpleChildren = resolveSimpleInlineChildren(cell.children as any, {
-    allowSingleParagraph: paragraphFastPath,
-    allowEmpty: true,
-  })
+  const simpleChildren = resolveSimpleInlineChildren(cell.children as any, paragraphFastPath, true)
 
   const info: SimpleCellInfo = {
     simpleChildren,
@@ -139,26 +120,6 @@ function getSimpleCellInfo(cell: TableCellNode): SimpleCellInfo {
   })
   return info
 }
-
-const headerRenderCells = computed<RenderHeaderCell[]>(() => {
-  return props.node.header.cells.map((cell, index) => ({
-    cell,
-    index,
-    info: getSimpleCellInfo(cell),
-  }))
-})
-
-const bodyRenderRows = computed<RenderBodyRow[]>(() => {
-  return bodyRows.value.map((row, rowIndex) => ({
-    row,
-    rowIndex,
-    cells: row.cells.map((cell, cellIndex) => ({
-      cell,
-      cellIndex,
-      info: getSimpleCellInfo(cell),
-    })),
-  }))
-})
 
 function measureHeaderWidths() {
   const cells = tableRef.value?.querySelectorAll('thead th')
@@ -241,38 +202,38 @@ onBeforeUnmount(stopColumnResize)
       <colgroup v-if="hasColumnWidths">
         <col
           v-for="(_, index) in node.header.cells"
-          :key="`col-${index}`"
+          :key="index"
           :style="columnStyles[index]"
         >
       </colgroup>
       <thead>
         <tr>
           <th
-            v-for="item in headerRenderCells"
-            :key="`header-${item.index}`"
+            v-for="(cell, index) in node.header.cells"
+            :key="index"
             dir="auto"
             :class="[
-              item.cell.align === 'right'
+              cell.align === 'right'
                 ? 'text-right'
-                : item.cell.align === 'center'
+                : cell.align === 'center'
                   ? 'text-center'
                   : 'text-left',
             ]"
           >
             <span
-              v-if="item.info.plainText !== null"
-              class="simple-inline-text whitespace-pre-wrap break-words text-node"
+              v-if="getSimpleCellInfo(cell).plainText !== null"
+              class="text-node"
               :custom-id="props.customId"
-            >{{ item.info.plainText }}</span>
+            >{{ getSimpleCellInfo(cell).plainText }}</span>
             <SimpleInlineRenderer
-              v-else-if="item.info.simpleChildren"
-              :nodes="item.info.simpleChildren as any"
+              v-else-if="getSimpleCellInfo(cell).simpleChildren"
+              :nodes="getSimpleCellInfo(cell).simpleChildren as any"
               :custom-id="props.customId"
-              :index-key="`table-th-${props.indexKey}-${item.index}`"
+              :index-key="`table-th-${props.indexKey}-${index}`"
             />
             <NodeRenderer
               v-else
-              :nodes="item.cell.children"
+              :nodes="cell.children"
               :index-key="`table-th-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"
@@ -281,46 +242,46 @@ onBeforeUnmount(stopColumnResize)
               @copy="$emit('copy', $event)"
             />
             <button
-              v-if="item.index < node.header.cells.length - 1"
+              v-if="index < node.header.cells.length - 1"
               type="button"
               class="table-node__resize-handle"
-              :aria-label="`Resize columns ${item.index + 1} and ${item.index + 2}`"
-              @pointerdown="startColumnResize(item.index, $event)"
+              :aria-label="`Resize columns ${index + 1} and ${index + 2}`"
+              @pointerdown="startColumnResize(index, $event)"
             />
           </th>
         </tr>
       </thead>
       <tbody>
         <tr
-          v-for="rowItem in bodyRenderRows"
-          :key="`row-${rowItem.rowIndex}`"
+          v-for="(row, rowIndex) in bodyRows"
+          :key="rowIndex"
         >
           <td
-            v-for="item in rowItem.cells"
-            :key="`cell-${rowItem.rowIndex}-${item.cellIndex}`"
+            v-for="(cell, cellIndex) in row.cells"
+            :key="cellIndex"
             :class="[
-              item.cell.align === 'right'
+              cell.align === 'right'
                 ? 'text-right'
-                : item.cell.align === 'center'
+                : cell.align === 'center'
                   ? 'text-center'
                   : 'text-left',
             ]"
             dir="auto"
           >
             <span
-              v-if="item.info.plainText !== null"
-              class="simple-inline-text whitespace-pre-wrap break-words text-node"
+              v-if="getSimpleCellInfo(cell).plainText !== null"
+              class="text-node"
               :custom-id="props.customId"
-            >{{ item.info.plainText }}</span>
+            >{{ getSimpleCellInfo(cell).plainText }}</span>
             <SimpleInlineRenderer
-              v-else-if="item.info.simpleChildren"
-              :nodes="item.info.simpleChildren as any"
+              v-else-if="getSimpleCellInfo(cell).simpleChildren"
+              :nodes="getSimpleCellInfo(cell).simpleChildren as any"
               :custom-id="props.customId"
-              :index-key="`table-td-${props.indexKey}-${rowItem.rowIndex}-${item.cellIndex}`"
+              :index-key="`table-td-${props.indexKey}-${rowIndex}-${cellIndex}`"
             />
             <NodeRenderer
               v-else
-              :nodes="item.cell.children"
+              :nodes="cell.children"
               :index-key="`table-td-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, provide, ref, watch } from 'vue'
 import NodeRenderer from '../NodeRenderer'
+import SimpleInlineRenderer from '../SimpleInlineRenderer'
+import { areSimpleInlineNodes } from '../SimpleInlineRenderer/simpleInline'
 
 interface TableCellNode {
   type: 'table_cell'
@@ -57,6 +59,13 @@ const columnStyles = computed(() =>
   columnWidths.value.map(width => width > 0 ? { width: `${width}px` } : undefined),
 )
 const hasColumnWidths = computed(() => columnWidths.value.length > 0)
+
+provide('markstreamShowTooltips', computed(() => true))
+provide('markstreamFade', computed(() => props.fade))
+
+function canRenderSimpleCell(cell: TableCellNode) {
+  return areSimpleInlineNodes(cell.children)
+}
 
 function measureHeaderWidths() {
   const cells = tableRef.value?.querySelectorAll('thead th')
@@ -157,7 +166,14 @@ onBeforeUnmount(stopColumnResize)
                   : 'text-left',
             ]"
           >
+            <SimpleInlineRenderer
+              v-if="canRenderSimpleCell(cell)"
+              :nodes="cell.children"
+              :custom-id="props.customId"
+              :index-key="`table-th-${props.indexKey}-${index}`"
+            />
             <NodeRenderer
+              v-else
               :nodes="cell.children"
               :index-key="`table-th-${props.indexKey}`"
               :custom-id="props.customId"
@@ -192,7 +208,14 @@ onBeforeUnmount(stopColumnResize)
             ]"
             dir="auto"
           >
+            <SimpleInlineRenderer
+              v-if="canRenderSimpleCell(cell)"
+              :nodes="cell.children"
+              :custom-id="props.customId"
+              :index-key="`table-td-${props.indexKey}-${rowIndex}-${cellIndex}`"
+            />
             <NodeRenderer
+              v-else
               :nodes="cell.children"
               :index-key="`table-td-${props.indexKey}`"
               :custom-id="props.customId"

--- a/src/components/TextNode/TextNode.vue
+++ b/src/components/TextNode/TextNode.vue
@@ -105,7 +105,7 @@ const streamedDeltaClass = computed(() => (
 <template>
   <span
     :class="[katexReady && node.center ? 'text-node-center' : '']"
-    class="whitespace-pre-wrap break-words text-node"
+    class="text-node"
   >
     <span v-if="settledContent">{{ settledContent }}</span>
     <span

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,11 @@
   margin-left: calc(-1 * var(--ms-flow-list-indent));
 }
 
+.markstream-vue .text-node {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
 @tailwind components;
 @tailwind utilities;
 

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -656,10 +656,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             <!--v-if-->
             <thead data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
                   <!--v-if--></span><button data-v-8fb37ab3="" type="button" class="table-node__resize-handle" aria-label="Resize columns 1 and 2"></button>
                 </th>
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
                   <!--v-if--></span>
                   <!--v-if-->
                 </th>
@@ -667,10 +667,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             </thead>
             <tbody data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
                   <!--v-if--></span>
                 </td>
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
                   <!--v-if--></span>
                 </td>
               </tr>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -24,7 +24,7 @@ exports[`markdownRender node e2e coverage > renders admonition node 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="admonition-stable-renderer-0-0-0"><span data-v-a84b8095="">Admonition content</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="admonition-stable-renderer-0-0-0"><span data-v-a84b8095="">Admonition content</span>
                       <!--v-if--></span>
                     </p>
                   </transition-stub>
@@ -51,7 +51,7 @@ exports[`markdownRender node e2e coverage > renders blockquote node 1`] = `
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <blockquote data-v-8ae59609="" data-v-8dfe8a80="" class="blockquote blockquote-node" dir="auto" is-dark="false">
-          <p data-v-8ae59609="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-8ae59609="" class="whitespace-pre-wrap break-words text-node" index-key="blockquote-markdown-renderer-0-paragraph-0"><span data-v-a84b8095="">Blockquote rendered content.</span>
+          <p data-v-8ae59609="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="blockquote-markdown-renderer-0-paragraph-0"><span data-v-a84b8095="">Blockquote rendered content.</span>
             <!--v-if--></span>
           </p>
         </blockquote>
@@ -79,7 +79,7 @@ exports[`markdownRender node e2e coverage > renders checkbox nodes 1`] = `
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
                     <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-31e4c290="" data-v-93ee5c2d="" class="checkbox-node" role="img" aria-label="checked" index-key="list-item-markdown-renderer-0-0-0-0"><!-- Unchecked --><!-- Checked --><svg data-v-31e4c290="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" class="checkbox-icon checkbox-checked"><rect data-v-31e4c290="" x="3" y="3" width="18" height="18" rx="4" fill="currentColor"></rect><path data-v-31e4c290="" d="M9 12l2 2 4-4" stroke="hsl(var(--ms-background))" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>
-                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-2"><span data-v-a84b8095=""> Completed task</span>
+                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-0-0-2"><span data-v-a84b8095=""> Completed task</span>
                       <!--v-if--></span>
                       <!---->
                     </p>
@@ -98,7 +98,7 @@ exports[`markdownRender node e2e coverage > renders checkbox nodes 1`] = `
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
                     <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-31e4c290="" data-v-93ee5c2d="" class="checkbox-node" role="img" aria-label="unchecked" index-key="list-item-markdown-renderer-0-1-0-0"><!-- Unchecked --><svg data-v-31e4c290="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" class="checkbox-icon checkbox-unchecked"><rect data-v-31e4c290="" x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="2"></rect></svg></span>
-                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-0-2"><span data-v-a84b8095=""> Pending task</span>
+                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-1-0-2"><span data-v-a84b8095=""> Pending task</span>
                       <!--v-if--></span>
                       <!---->
                     </p>
@@ -141,11 +141,11 @@ exports[`markdownRender node e2e coverage > renders complex inline code with emp
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
               <!--v-if--></span>
             </p>
           </li>
@@ -172,7 +172,7 @@ exports[`markdownRender node e2e coverage > renders definition list node 1`] = `
               <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="whitespace-pre-wrap break-words text-node" index-key="definition-term-markdown-renderer-0-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Term</span>
+                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="text-node" index-key="definition-term-markdown-renderer-0-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Term</span>
                     <!--v-if--></span>
                   </transition-stub>
                 </div>
@@ -188,7 +188,7 @@ exports[`markdownRender node e2e coverage > renders definition list node 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="definition-desc-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Definition details</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="definition-desc-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Definition details</span>
                       <!--v-if--></span>
                     </p>
                   </transition-stub>
@@ -214,8 +214,8 @@ exports[`markdownRender node e2e coverage > renders emoji node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Smile with </span>
-          <!--v-if--></span><span data-v-b001e831="" data-v-93ee5c2d="" class="emoji-node" index-key="markdown-renderer-0-1">😄</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> emoji.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Smile with </span>
+          <!--v-if--></span><span data-v-b001e831="" data-v-93ee5c2d="" class="emoji-node" index-key="markdown-renderer-0-1">😄</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> emoji.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -233,8 +233,8 @@ exports[`markdownRender node e2e coverage > renders emphasis node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><em data-v-ca49685e="" data-v-93ee5c2d="" class="emphasis-node"><span data-v-a84b8095="" data-v-ca49685e="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">italic text</span><!--v-if--></span></em><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
+          <!--v-if--></span><em data-v-ca49685e="" data-v-93ee5c2d="" class="emphasis-node"><span data-v-a84b8095="" data-v-ca49685e="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">italic text</span><!--v-if--></span></em><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -252,8 +252,8 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">A footnote reference</span>
-          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">A footnote reference</span>
+          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -272,7 +272,7 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="footnote-markdown-renderer-1-0-0"><span data-v-a84b8095="">Footnote explanation</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="footnote-markdown-renderer-1-0-0"><span data-v-a84b8095="">Footnote explanation</span>
                       <!--v-if--></span><a data-v-31914872="" data-v-93ee5c2d="" class="footnote-anchor text-sm hover:underline cursor-pointer" href="#fnref-1" title="返回引用 1" index-key="footnote-markdown-renderer-1-0-1"> ↩︎ </a>
                     </p>
                   </transition-stub>
@@ -312,8 +312,8 @@ exports[`markdownRender node e2e coverage > renders hardbreak node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Line one</span>
-          <!--v-if--></span><br data-v-2587360c="" data-v-93ee5c2d="" class="hard-break" index-key="markdown-renderer-0-1"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">Line two</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Line one</span>
+          <!--v-if--></span><br data-v-2587360c="" data-v-93ee5c2d="" class="hard-break" index-key="markdown-renderer-0-1"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">Line two</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -331,7 +331,7 @@ exports[`markdownRender node e2e coverage > renders heading node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <h1 data-v-9f883140="" data-v-8dfe8a80="" class="heading-node heading-1" dir="auto" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-9f883140="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Heading Node Title</span>
+        <h1 data-v-9f883140="" data-v-8dfe8a80="" class="heading-node heading-1" dir="auto" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-9f883140="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Heading Node Title</span>
           <!--v-if--></span>
         </h1>
       </transition-stub>
@@ -349,10 +349,10 @@ exports[`markdownRender node e2e coverage > renders highlight node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Use </span>
-          <!--v-if--></span><mark data-v-9bc40b1b="" data-v-93ee5c2d="" class="highlight-node"><span data-v-a84b8095="" data-v-9bc40b1b="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">highlighted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Use </span>
+          <!--v-if--></span><mark data-v-9bc40b1b="" data-v-93ee5c2d="" class="highlight-node"><span data-v-a84b8095="" data-v-9bc40b1b="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">highlighted text</span>
             <!--v-if--></span>
-          </mark><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for emphasis.</span>
+          </mark><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for emphasis.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -398,8 +398,8 @@ exports[`markdownRender node e2e coverage > renders inline code node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here is </span>
-          <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="markdown-renderer-0-1"><span data-v-36040df8="">const answer = 42</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> inline.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here is </span>
+          <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="markdown-renderer-0-1"><span data-v-36040df8="">const answer = 42</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> inline.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -417,10 +417,10 @@ exports[`markdownRender node e2e coverage > renders insert node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here comes </span>
-          <!--v-if--></span><ins data-v-1e673445="" data-v-93ee5c2d="" class="insert-node"><span data-v-a84b8095="" data-v-1e673445="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">inserted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here comes </span>
+          <!--v-if--></span><ins data-v-1e673445="" data-v-93ee5c2d="" class="insert-node"><span data-v-a84b8095="" data-v-1e673445="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">inserted text</span>
             <!--v-if--></span>
-          </ins><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> in the paragraph.</span>
+          </ins><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> in the paragraph.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -438,10 +438,10 @@ exports[`markdownRender node e2e coverage > renders link node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Visit </span>
-          <!--v-if--></span><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://vuejs.org" title="" aria-label="Link: https://vuejs.org" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-a84b8095="" data-v-994bfd08="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">Vue</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Visit </span>
+          <!--v-if--></span><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://vuejs.org" title="" aria-label="Link: https://vuejs.org" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-a84b8095="" data-v-994bfd08="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">Vue</span>
             <!--v-if--></span>
-          </a><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> now.</span>
+          </a><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> now.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -459,9 +459,9 @@ exports[`markdownRender node e2e coverage > renders math inline node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Einstein wrote </span>
-          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1"><span data-v-a84b8095="">$E=mc^2$</span>
-          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Einstein wrote </span>
+          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-1"><span data-v-a84b8095="">$E=mc^2$</span>
+          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -481,12 +481,12 @@ exports[`markdownRender node e2e coverage > renders ordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="2">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
               <!--v-if--></span>
             </p>
           </li>
@@ -506,7 +506,7 @@ exports[`markdownRender node e2e coverage > renders paragraph and text node 1`] 
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Simple paragraph content rendered as plain text.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Simple paragraph content rendered as plain text.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -524,8 +524,8 @@ exports[`markdownRender node e2e coverage > renders reference node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span>
-          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span>
+          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -557,10 +557,10 @@ exports[`markdownRender node e2e coverage > renders strikethrough node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><del data-v-d7c2e36d="" data-v-93ee5c2d="" class="strikethrough-node"><span data-v-a84b8095="" data-v-d7c2e36d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">deleted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
+          <!--v-if--></span><del data-v-d7c2e36d="" data-v-93ee5c2d="" class="strikethrough-node"><span data-v-a84b8095="" data-v-d7c2e36d="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">deleted text</span>
             <!--v-if--></span>
-          </del><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+          </del><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -578,8 +578,8 @@ exports[`markdownRender node e2e coverage > renders strong node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">bold text</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
+          <!--v-if--></span><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">bold text</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -597,10 +597,10 @@ exports[`markdownRender node e2e coverage > renders subscript node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Chemical formula H</span>
-          <!--v-if--></span><sub data-v-40ad1ac6="" data-v-93ee5c2d="" class="subscript-node"><span data-v-a84b8095="" data-v-40ad1ac6="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Chemical formula H</span>
+          <!--v-if--></span><sub data-v-40ad1ac6="" data-v-93ee5c2d="" class="subscript-node"><span data-v-a84b8095="" data-v-40ad1ac6="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
             <!--v-if--></span>
-          </sub><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">O is familiar.</span>
+          </sub><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">O is familiar.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -618,10 +618,10 @@ exports[`markdownRender node e2e coverage > renders superscript node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Math uses x</span>
-          <!--v-if--></span><sup data-v-9c4a3c09="" data-v-93ee5c2d="" class="superscript-node"><span data-v-a84b8095="" data-v-9c4a3c09="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Math uses x</span>
+          <!--v-if--></span><sup data-v-9c4a3c09="" data-v-93ee5c2d="" class="superscript-node"><span data-v-a84b8095="" data-v-9c4a3c09="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
             <!--v-if--></span>
-          </sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> frequently.</span>
+          </sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> frequently.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -644,10 +644,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             <!--v-if-->
             <thead data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
                   <!--v-if--></span><button data-v-8fb37ab3="" type="button" class="table-node__resize-handle" aria-label="Resize columns 1 and 2"></button>
                 </th>
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
                   <!--v-if--></span>
                   <!--v-if-->
                 </th>
@@ -655,10 +655,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             </thead>
             <tbody data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
                   <!--v-if--></span>
                 </td>
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" data-v-8fb37ab3="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
                   <!--v-if--></span>
                 </td>
               </tr>
@@ -683,7 +683,7 @@ exports[`markdownRender node e2e coverage > renders thematic break node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">First section.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">First section.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -701,7 +701,7 @@ exports[`markdownRender node e2e coverage > renders thematic break node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="markdown-renderer-2-0"><span data-v-a84b8095="">Second section.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-2-0"><span data-v-a84b8095="">Second section.</span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -721,12 +721,12 @@ exports[`markdownRender node e2e coverage > renders unordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
               <!--v-if--></span>
             </p>
           </li>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -50,22 +50,10 @@ exports[`markdownRender node e2e coverage > renders blockquote node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <blockquote data-v-8ae59609="" data-v-8dfe8a80="" class="blockquote" dir="auto" is-dark="false">
-          <div data-v-8dfe8a80="" data-v-8ae59609="" class="markstream-vue markdown-renderer">
-            <!--v-if-->
-            <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-              <div data-v-8dfe8a80="" class="node-content">
-                <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                  <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="blockquote-markdown-renderer-0-0-0"><span data-v-a84b8095="">Blockquote rendered content.</span>
-                    <!--v-if--></span>
-                  </p>
-                </transition-stub>
-              </div>
-            </div>
-            <!--v-if-->
-            <!--v-if-->
-          </div>
+        <blockquote data-v-8ae59609="" data-v-8dfe8a80="" class="blockquote blockquote-node" dir="auto" is-dark="false">
+          <p data-v-8ae59609="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-8ae59609="" class="whitespace-pre-wrap break-words text-node" index-key="blockquote-markdown-renderer-0-paragraph-0"><span data-v-a84b8095="">Blockquote rendered content.</span>
+            <!--v-if--></span>
+          </p>
         </blockquote>
       </transition-stub>
     </div>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -153,25 +153,13 @@ exports[`markdownRender node e2e coverage > renders complex inline code with emp
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
-              <!--v-if-->
-              <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-                <div data-v-8dfe8a80="" class="node-content">
-                  <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-1"><span data-v-a84b8095=""> 将原</span>
-                      <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-0-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-3"><span data-v-a84b8095="">、</span>
-                      <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-0-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-5"><span data-v-a84b8095="">、</span>
-                      <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-0-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
-                      <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-0-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
-                      <!--v-if--></span>
-                    </p>
-                  </transition-stub>
-                </div>
-              </div>
-              <!--v-if-->
-              <!--v-if-->
-            </div>
+            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
+              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
+              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
+              <!--v-if--></span>
+            </p>
           </li>
         </ol>
       </transition-stub>
@@ -505,38 +493,14 @@ exports[`markdownRender node e2e coverage > renders ordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
-              <!--v-if-->
-              <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-                <div data-v-8dfe8a80="" class="node-content">
-                  <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">First entry</span>
-                      <!--v-if--></span>
-                    </p>
-                  </transition-stub>
-                </div>
-              </div>
-              <!--v-if-->
-              <!--v-if-->
-            </div>
+            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
+              <!--v-if--></span>
+            </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="2">
-            <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
-              <!--v-if-->
-              <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-                <div data-v-8dfe8a80="" class="node-content">
-                  <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-0-0"><span data-v-a84b8095="">Second entry</span>
-                      <!--v-if--></span>
-                    </p>
-                  </transition-stub>
-                </div>
-              </div>
-              <!--v-if-->
-              <!--v-if-->
-            </div>
+            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
+              <!--v-if--></span>
+            </p>
           </li>
         </ol>
       </transition-stub>
@@ -692,70 +656,22 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             <!--v-if-->
             <thead data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <th data-v-8fb37ab3="" dir="auto" class="text-left">
-                  <div data-v-8dfe8a80="" data-v-8fb37ab3="" class="markstream-vue markdown-renderer">
-                    <!--v-if-->
-                    <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
-                      <div data-v-8dfe8a80="" class="node-content">
-                        <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                        <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Name</span>
-                          <!--v-if--></span>
-                        </transition-stub>
-                      </div>
-                    </div>
-                    <!--v-if-->
-                    <!--v-if-->
-                  </div><button data-v-8fb37ab3="" type="button" class="table-node__resize-handle" aria-label="Resize columns 1 and 2"></button>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
+                  <!--v-if--></span><button data-v-8fb37ab3="" type="button" class="table-node__resize-handle" aria-label="Resize columns 1 and 2"></button>
                 </th>
-                <th data-v-8fb37ab3="" dir="auto" class="text-left">
-                  <div data-v-8dfe8a80="" data-v-8fb37ab3="" class="markstream-vue markdown-renderer">
-                    <!--v-if-->
-                    <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
-                      <div data-v-8dfe8a80="" class="node-content">
-                        <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                        <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Role</span>
-                          <!--v-if--></span>
-                        </transition-stub>
-                      </div>
-                    </div>
-                    <!--v-if-->
-                    <!--v-if-->
-                  </div>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
+                  <!--v-if--></span>
                   <!--v-if-->
                 </th>
               </tr>
             </thead>
             <tbody data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <td data-v-8fb37ab3="" class="text-left" dir="auto">
-                  <div data-v-8dfe8a80="" data-v-8fb37ab3="" class="markstream-vue markdown-renderer">
-                    <!--v-if-->
-                    <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
-                      <div data-v-8dfe8a80="" class="node-content">
-                        <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                        <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Alice</span>
-                          <!--v-if--></span>
-                        </transition-stub>
-                      </div>
-                    </div>
-                    <!--v-if-->
-                    <!--v-if-->
-                  </div>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
+                  <!--v-if--></span>
                 </td>
-                <td data-v-8fb37ab3="" class="text-left" dir="auto">
-                  <div data-v-8dfe8a80="" data-v-8fb37ab3="" class="markstream-vue markdown-renderer">
-                    <!--v-if-->
-                    <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
-                      <div data-v-8dfe8a80="" class="node-content">
-                        <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                        <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Developer</span>
-                          <!--v-if--></span>
-                        </transition-stub>
-                      </div>
-                    </div>
-                    <!--v-if-->
-                    <!--v-if-->
-                  </div>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
+                  <!--v-if--></span>
                 </td>
               </tr>
             </tbody>
@@ -817,38 +733,14 @@ exports[`markdownRender node e2e coverage > renders unordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
-              <!--v-if-->
-              <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-                <div data-v-8dfe8a80="" class="node-content">
-                  <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Item one</span>
-                      <!--v-if--></span>
-                    </p>
-                  </transition-stub>
-                </div>
-              </div>
-              <!--v-if-->
-              <!--v-if-->
-            </div>
+            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
+              <!--v-if--></span>
+            </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
-              <!--v-if-->
-              <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
-                <div data-v-8dfe8a80="" class="node-content">
-                  <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-0-0"><span data-v-a84b8095="">Item two</span>
-                      <!--v-if--></span>
-                    </p>
-                  </transition-stub>
-                </div>
-              </div>
-              <!--v-if-->
-              <!--v-if-->
-            </div>
+            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
+              <!--v-if--></span>
+            </p>
           </li>
         </ul>
       </transition-stub>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -153,11 +153,11 @@ exports[`markdownRender node e2e coverage > renders complex inline code with emp
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
-              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
-              <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
               <!--v-if--></span>
             </p>
           </li>
@@ -493,12 +493,12 @@ exports[`markdownRender node e2e coverage > renders ordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="2">
-            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
               <!--v-if--></span>
             </p>
           </li>
@@ -733,12 +733,12 @@ exports[`markdownRender node e2e coverage > renders unordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc" is-dark="false">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-93ee5c2d="" data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-93ee5c2d="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" data-v-d94d2511="" class="whitespace-pre-wrap break-words text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
               <!--v-if--></span>
             </p>
           </li>

--- a/test/list-item-value-attrs.test.ts
+++ b/test/list-item-value-attrs.test.ts
@@ -95,10 +95,10 @@ describe('list item value/customId attributes', () => {
       expect(item.attributes('custom-id')).toBeUndefined()
     }
 
-    const nestedRenderers = wrapper.findAll('[data-testid="node-renderer"]')
-    expect(nestedRenderers).toHaveLength(2)
-    expect(nestedRenderers[0]!.attributes('data-custom-id')).toBe('message-1')
-    expect(nestedRenderers[1]!.attributes('data-custom-id')).toBe('message-1')
+    const textNodes = wrapper.findAll('.text-node')
+    expect(textNodes).toHaveLength(2)
+    expect(textNodes[0]!.attributes('custom-id')).toBe('message-1')
+    expect(textNodes[1]!.attributes('custom-id')).toBe('message-1')
   })
 
   it('keeps explicit li values for ordered lists, including start=0', () => {
@@ -140,7 +140,7 @@ describe('list item value/customId attributes', () => {
 
     expect(wrapper.get('li').attributes('value')).toBe('3')
     expect(wrapper.get('li').attributes('custom-id')).toBeUndefined()
-    expect(wrapper.get('[data-testid="node-renderer"]').attributes('data-custom-id')).toBe(
+    expect(wrapper.get('.text-node').attributes('custom-id')).toBe(
       'message-3',
     )
 

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -30,6 +30,27 @@ describe('simple inline fast path', () => {
     expect(item.get('a[href="https://vuejs.org"]').attributes('title')).toBe('https://vuejs.org')
   })
 
+  it('uses a lightweight plain text node for simple list item paragraphs when fade is disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '- Fast path list item',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const item = wrapper.get('li.list-item')
+    expect(item.find('.markdown-renderer').exists()).toBe(false)
+
+    const paragraph = item.get('p.paragraph-node')
+    expect(paragraph.text()).toBe('Fast path list item')
+    expect(paragraph.get('.simple-inline-text').text()).toBe('Fast path list item')
+    expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
   it('renders simple table cells without nested renderer wrappers', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -69,6 +69,24 @@ describe('simple inline fast path', () => {
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
+  it('renders inline code without stream span wrappers when fade is disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '`code`',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const code = wrapper.get('code.inline-code')
+    expect(code.text()).toBe('code')
+    expect(code.element.childElementCount).toBe(0)
+    expect(code.find('.inline-code-stream-delta').exists()).toBe(false)
+  })
+
   it('does not bypass a custom text component for top-level paragraphs', async () => {
     const scopeId = 'simple-inline-paragraph-text-override'
 

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -96,6 +96,46 @@ describe('simple inline fast path', () => {
     expect(valueCell.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
+  it('renders simple blockquote paragraphs without nested renderer wrappers', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '> Final note with **bold** and `code`',
+        final: true,
+        batchRendering: false,
+        showTooltips: false,
+      },
+    })
+
+    await flushAll()
+
+    const quote = wrapper.get('blockquote.blockquote-node')
+    expect(quote.find('.markdown-renderer').exists()).toBe(false)
+    expect(quote.get('p.paragraph-node').text()).toContain('Final note with bold and code')
+    expect(quote.get('strong.strong-node').text()).toBe('bold')
+    expect(quote.get('code.inline-code').text()).toBe('code')
+  })
+
+  it('uses a lightweight plain text node for simple blockquotes when fade is disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '> Lightweight final note',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const quote = wrapper.get('blockquote.blockquote-node')
+    expect(quote.find('.markdown-renderer').exists()).toBe(false)
+
+    const paragraph = quote.get('p.paragraph-node')
+    expect(paragraph.text()).toBe('Lightweight final note')
+    expect(paragraph.get('.simple-inline-text').text()).toBe('Lightweight final note')
+    expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
   it('keeps the nested renderer path when paragraph has a custom component', async () => {
     const scopeId = 'simple-inline-paragraph-override'
     setCustomComponents(scopeId, {
@@ -161,5 +201,40 @@ describe('simple inline fast path', () => {
     await flushAll()
 
     expect(wrapper.findAll('.custom-text-node').map(node => node.text())).toContain('Fast path')
+  })
+
+  it('keeps nested blockquote rendering when paragraph has a custom component', async () => {
+    const scopeId = 'simple-inline-blockquote-paragraph-override'
+
+    setCustomComponents(scopeId, {
+      paragraph: defineComponent({
+        name: 'CustomBlockquoteParagraphNode',
+        props: {
+          node: { type: Object, required: true },
+        },
+        setup(props) {
+          return () => h(
+            'p',
+            { class: 'custom-blockquote-paragraph-node' },
+            String((props.node as any).raw ?? ''),
+          )
+        },
+      }),
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '> overridden quote',
+        customId: scopeId,
+        final: true,
+        batchRendering: false,
+      },
+    })
+
+    await flushAll()
+
+    const quote = wrapper.get('blockquote.blockquote-node')
+    expect(quote.get('.markdown-renderer').exists()).toBe(true)
+    expect(quote.get('.custom-blockquote-paragraph-node').text()).toBe('overridden quote')
   })
 })

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import NodeRenderer from '../src/components/NodeRenderer'
+import { clearGlobalCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
+import { flushAll } from './setup/flush-all'
+
+describe('simple inline fast path', () => {
+  afterEach(() => {
+    clearGlobalCustomComponents()
+  })
+
+  it('renders simple list item paragraphs without nested renderer wrappers', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '- Visit [Vue](https://vuejs.org) with **bold** and `code`',
+        final: true,
+        batchRendering: false,
+        showTooltips: false,
+      },
+    })
+
+    await flushAll()
+
+    const item = wrapper.get('li.list-item')
+    expect(item.find('.markdown-renderer').exists()).toBe(false)
+    expect(item.get('p.paragraph-node').text()).toContain('Visit Vue with bold and code')
+    expect(item.get('strong.strong-node').text()).toBe('bold')
+    expect(item.get('code.inline-code').text()).toBe('code')
+    expect(item.get('a[href="https://vuejs.org"]').attributes('title')).toBe('https://vuejs.org')
+  })
+
+  it('renders simple table cells without nested renderer wrappers', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: [
+          '| Name | Value |',
+          '| --- | --- |',
+          '| Vue | [Docs](https://vuejs.org) and **bold** `code` |',
+        ].join('\n'),
+        final: true,
+        batchRendering: false,
+        showTooltips: false,
+      },
+    })
+
+    await flushAll()
+
+    const table = wrapper.get('table.table-node')
+    expect(table.find('.markdown-renderer').exists()).toBe(false)
+    expect(table.get('a[href="https://vuejs.org"]').attributes('title')).toBe('')
+    expect(table.get('strong.strong-node').text()).toBe('bold')
+    expect(table.get('code.inline-code').text()).toBe('code')
+  })
+
+  it('keeps the nested renderer path when paragraph has a custom component', async () => {
+    const scopeId = 'simple-inline-paragraph-override'
+    setCustomComponents(scopeId, {
+      paragraph: defineComponent({
+        name: 'CustomParagraphNode',
+        props: {
+          node: { type: Object, required: true },
+        },
+        setup(props) {
+          return () => h('p', { class: 'custom-paragraph-node' }, String((props.node as any).raw ?? ''))
+        },
+      }),
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '- overridden',
+        customId: scopeId,
+        final: true,
+        batchRendering: false,
+      },
+    })
+
+    await flushAll()
+
+    const item = wrapper.get('li.list-item')
+    expect(item.get('.markdown-renderer').exists()).toBe(true)
+    expect(item.get('.custom-paragraph-node').text()).toBe('overridden')
+  })
+})

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -53,6 +53,28 @@ describe('simple inline fast path', () => {
     expect(table.get('code.inline-code').text()).toBe('code')
   })
 
+  it('uses a lightweight plain text node when simple table text has fade disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: [
+          '| Name | Value |',
+          '| --- | --- |',
+          '| Vue | Fast path |',
+        ].join('\n'),
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const valueCell = wrapper.get('tbody td:nth-child(2)')
+    expect(valueCell.text()).toBe('Fast path')
+    expect(valueCell.find('.markdown-renderer').exists()).toBe(false)
+    expect(valueCell.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
   it('keeps the nested renderer path when paragraph has a custom component', async () => {
     const scopeId = 'simple-inline-paragraph-override'
     setCustomComponents(scopeId, {

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -51,6 +51,26 @@ describe('simple inline fast path', () => {
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
+  it('renders simple nested list parents without wrapping the item in a nested renderer', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '- Parent **bold**\n  - Child `code`',
+        final: true,
+        batchRendering: false,
+        showTooltips: false,
+      },
+    })
+
+    await flushAll()
+
+    const item = wrapper.get('li.list-item')
+    expect(item.find('.markdown-renderer').exists()).toBe(false)
+    expect(item.get('p.paragraph-node').text()).toBe('Parent bold')
+    expect(item.get('strong.strong-node').text()).toBe('bold')
+    expect(item.get('ul.list-node').text()).toContain('Child code')
+    expect(item.get('code.inline-code').text()).toBe('code')
+  })
+
   it('uses a lightweight plain text node for top-level paragraphs when fade is disabled', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -51,6 +51,94 @@ describe('simple inline fast path', () => {
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
+  it('uses a lightweight plain text node for top-level paragraphs when fade is disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'Fast path paragraph',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const paragraph = wrapper.get('p.paragraph-node')
+    expect(paragraph.text()).toBe('Fast path paragraph')
+    expect(paragraph.get('.simple-inline-text').text()).toBe('Fast path paragraph')
+    expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
+  it('does not bypass a custom text component for top-level paragraphs', async () => {
+    const scopeId = 'simple-inline-paragraph-text-override'
+
+    setCustomComponents(scopeId, {
+      text: defineComponent({
+        name: 'CustomParagraphTextNode',
+        props: {
+          node: { type: Object, required: true },
+        },
+        setup(props) {
+          return () => h(
+            'span',
+            { class: 'custom-text-node' },
+            String((props.node as any).content ?? (props.node as any).raw ?? ''),
+          )
+        },
+      }),
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'Custom paragraph text',
+        customId: scopeId,
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.get('.custom-text-node').text()).toBe('Custom paragraph text')
+    expect(wrapper.find('.simple-inline-text').exists()).toBe(false)
+  })
+
+  it('uses a lightweight plain text node for headings when fade is disabled', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '# Fast heading',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const heading = wrapper.get('h1.heading-node')
+    expect(heading.text()).toBe('Fast heading')
+    expect(heading.get('.simple-inline-text').text()).toBe('Fast heading')
+    expect(heading.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
+  it('keeps heading inline rendering when heading is not plain text', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '# Fast **heading**',
+        final: true,
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const heading = wrapper.get('h1.heading-node')
+    expect(heading.get('strong.strong-node').text()).toBe('heading')
+    expect(heading.find('.simple-inline-text').exists()).toBe(false)
+  })
+
   it('renders simple table cells without nested renderer wrappers', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -10,6 +10,22 @@ describe('simple inline fast path', () => {
     clearGlobalCustomComponents()
   })
 
+  function textNode(content: string) {
+    return {
+      type: 'text',
+      raw: content,
+      content,
+    }
+  }
+
+  function paragraphNode(content: string) {
+    return {
+      type: 'paragraph',
+      raw: content,
+      children: [textNode(content)],
+    }
+  }
+
   it('renders simple list item paragraphs without nested renderer wrappers', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {
@@ -69,6 +85,44 @@ describe('simple inline fast path', () => {
     expect(item.get('strong.strong-node').text()).toBe('bold')
     expect(item.get('ul.list-node').text()).toContain('Child code')
     expect(item.get('code.inline-code').text()).toBe('code')
+  })
+
+  it('keeps the list item block wrapper when inline children become a paragraph', async () => {
+    const createList = (children: any[]) => ({
+      type: 'list',
+      ordered: false,
+      raw: '',
+      items: [
+        {
+          type: 'list_item',
+          raw: '',
+          children,
+        },
+      ],
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [createList([textNode('Direct item')])],
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const paragraph = wrapper.get('li.list-item > p.paragraph-node')
+    const paragraphElement = paragraph.element
+    expect(paragraph.text()).toBe('Direct item')
+
+    await wrapper.setProps({
+      nodes: [createList([paragraphNode('Paragraph item')])],
+    })
+    await flushAll()
+
+    const nextParagraph = wrapper.get('li.list-item > p.paragraph-node')
+    expect(nextParagraph.element).toBe(paragraphElement)
+    expect(nextParagraph.text()).toBe('Paragraph item')
   })
 
   it('uses a lightweight plain text node for top-level paragraphs when fade is disabled', async () => {
@@ -195,7 +249,7 @@ describe('simple inline fast path', () => {
 
     const table = wrapper.get('table.table-node')
     expect(table.find('.markdown-renderer').exists()).toBe(false)
-    expect(table.get('a[href="https://vuejs.org"]').attributes('title')).toBe('')
+    expect(table.get('a[href="https://vuejs.org"]').attributes('title')).toBe('https://vuejs.org')
     expect(table.get('strong.strong-node').text()).toBe('bold')
     expect(table.get('code.inline-code').text()).toBe('code')
   })
@@ -222,6 +276,59 @@ describe('simple inline fast path', () => {
     expect(valueCell.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
+  it('keeps table cells on the simple path when inline children become a paragraph', async () => {
+    const createCell = (children: any[], header = false) => ({
+      type: 'table_cell',
+      header,
+      raw: '',
+      children,
+    })
+    const createTable = (valueChildren: any[]) => ({
+      type: 'table',
+      raw: '',
+      loading: false,
+      header: {
+        type: 'table_row',
+        raw: '',
+        cells: [createCell([textNode('Name')], true)],
+      },
+      rows: [
+        {
+          type: 'table_row',
+          raw: '',
+          cells: [createCell(valueChildren)],
+        },
+      ],
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [createTable([textNode('Direct cell')])],
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const valueCell = wrapper.get('tbody td')
+    const valueCellElement = valueCell.element
+    const textElement = valueCell.get('.simple-inline-text').element
+    expect(valueCell.find('.markdown-renderer').exists()).toBe(false)
+    expect(valueCell.text()).toBe('Direct cell')
+
+    await wrapper.setProps({
+      nodes: [createTable([paragraphNode('Paragraph cell')])],
+    })
+    await flushAll()
+
+    const nextValueCell = wrapper.get('tbody td')
+    expect(nextValueCell.element).toBe(valueCellElement)
+    expect(nextValueCell.find('.markdown-renderer').exists()).toBe(false)
+    expect(nextValueCell.get('.simple-inline-text').element).toBe(textElement)
+    expect(nextValueCell.text()).toBe('Paragraph cell')
+  })
+
   it('renders simple blockquote paragraphs without nested renderer wrappers', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {
@@ -239,6 +346,37 @@ describe('simple inline fast path', () => {
     expect(quote.get('p.paragraph-node').text()).toContain('Final note with bold and code')
     expect(quote.get('strong.strong-node').text()).toBe('bold')
     expect(quote.get('code.inline-code').text()).toBe('code')
+  })
+
+  it('keeps the blockquote block wrapper when inline children become a paragraph', async () => {
+    const createBlockquote = (children: any[]) => ({
+      type: 'blockquote',
+      raw: '',
+      children,
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [createBlockquote([textNode('Direct quote')])],
+        batchRendering: false,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const paragraph = wrapper.get('blockquote.blockquote-node > p.paragraph-node')
+    const paragraphElement = paragraph.element
+    expect(paragraph.text()).toBe('Direct quote')
+
+    await wrapper.setProps({
+      nodes: [createBlockquote([paragraphNode('Paragraph quote')])],
+    })
+    await flushAll()
+
+    const nextParagraph = wrapper.get('blockquote.blockquote-node > p.paragraph-node')
+    expect(nextParagraph.element).toBe(paragraphElement)
+    expect(nextParagraph.text()).toBe('Paragraph quote')
   })
 
   it('uses a lightweight plain text node for simple blockquotes when fade is disabled', async () => {
@@ -260,6 +398,21 @@ describe('simple inline fast path', () => {
     expect(paragraph.text()).toBe('Lightweight final note')
     expect(paragraph.get('.simple-inline-text').text()).toBe('Lightweight final note')
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
+  })
+
+  it('passes tooltip visibility through blockquote fast paths', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '> Read [Docs](https://vuejs.org)',
+        final: true,
+        batchRendering: false,
+        showTooltips: false,
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.get('blockquote a[href="https://vuejs.org"]').attributes('title')).toBe('https://vuejs.org')
   })
 
   it('keeps the nested renderer path when paragraph has a custom component', async () => {

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -82,4 +82,41 @@ describe('simple inline fast path', () => {
     expect(item.get('.markdown-renderer').exists()).toBe(true)
     expect(item.get('.custom-paragraph-node').text()).toBe('overridden')
   })
+
+  it('does not bypass a custom text component in simple table cells', async () => {
+    const scopeId = 'simple-inline-text-override'
+
+    setCustomComponents(scopeId, {
+      text: defineComponent({
+        name: 'CustomTextNode',
+        props: {
+          node: { type: Object, required: true },
+        },
+        setup(props) {
+          return () => h(
+            'span',
+            { class: 'custom-text-node' },
+            String((props.node as any).content ?? (props.node as any).raw ?? ''),
+          )
+        },
+      }),
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: [
+          '| Name | Value |',
+          '| --- | --- |',
+          '| Vue | Fast path |',
+        ].join('\n'),
+        customId: scopeId,
+        final: true,
+        batchRendering: false,
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.findAll('.custom-text-node').map(node => node.text())).toContain('Fast path')
+  })
 })

--- a/test/simple-inline-fast-path.test.ts
+++ b/test/simple-inline-fast-path.test.ts
@@ -63,7 +63,7 @@ describe('simple inline fast path', () => {
 
     const paragraph = item.get('p.paragraph-node')
     expect(paragraph.text()).toBe('Fast path list item')
-    expect(paragraph.get('.simple-inline-text').text()).toBe('Fast path list item')
+    expect(paragraph.get('.text-node').text()).toBe('Fast path list item')
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
@@ -139,7 +139,7 @@ describe('simple inline fast path', () => {
 
     const paragraph = wrapper.get('p.paragraph-node')
     expect(paragraph.text()).toBe('Fast path paragraph')
-    expect(paragraph.get('.simple-inline-text').text()).toBe('Fast path paragraph')
+    expect(paragraph.get('.text-node').text()).toBe('Fast path paragraph')
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
@@ -193,7 +193,7 @@ describe('simple inline fast path', () => {
     await flushAll()
 
     expect(wrapper.get('.custom-text-node').text()).toBe('Custom paragraph text')
-    expect(wrapper.find('.simple-inline-text').exists()).toBe(false)
+    expect(wrapper.find('.text-node').exists()).toBe(false)
   })
 
   it('uses a lightweight plain text node for headings when fade is disabled', async () => {
@@ -210,7 +210,7 @@ describe('simple inline fast path', () => {
 
     const heading = wrapper.get('h1.heading-node')
     expect(heading.text()).toBe('Fast heading')
-    expect(heading.get('.simple-inline-text').text()).toBe('Fast heading')
+    expect(heading.get('.text-node').text()).toBe('Fast heading')
     expect(heading.find('.text-node-stream-delta').exists()).toBe(false)
   })
 
@@ -228,7 +228,6 @@ describe('simple inline fast path', () => {
 
     const heading = wrapper.get('h1.heading-node')
     expect(heading.get('strong.strong-node').text()).toBe('heading')
-    expect(heading.find('.simple-inline-text').exists()).toBe(false)
   })
 
   it('renders simple table cells without nested renderer wrappers', async () => {
@@ -313,7 +312,7 @@ describe('simple inline fast path', () => {
 
     const valueCell = wrapper.get('tbody td')
     const valueCellElement = valueCell.element
-    const textElement = valueCell.get('.simple-inline-text').element
+    const textElement = valueCell.get('.text-node').element
     expect(valueCell.find('.markdown-renderer').exists()).toBe(false)
     expect(valueCell.text()).toBe('Direct cell')
 
@@ -325,7 +324,7 @@ describe('simple inline fast path', () => {
     const nextValueCell = wrapper.get('tbody td')
     expect(nextValueCell.element).toBe(valueCellElement)
     expect(nextValueCell.find('.markdown-renderer').exists()).toBe(false)
-    expect(nextValueCell.get('.simple-inline-text').element).toBe(textElement)
+    expect(nextValueCell.get('.text-node').element).toBe(textElement)
     expect(nextValueCell.text()).toBe('Paragraph cell')
   })
 
@@ -396,7 +395,7 @@ describe('simple inline fast path', () => {
 
     const paragraph = quote.get('p.paragraph-node')
     expect(paragraph.text()).toBe('Lightweight final note')
-    expect(paragraph.get('.simple-inline-text').text()).toBe('Lightweight final note')
+    expect(paragraph.get('.text-node').text()).toBe('Lightweight final note')
     expect(paragraph.find('.text-node-stream-delta').exists()).toBe(false)
   })
 

--- a/test/virtual-timeline-restore-readiness.test.ts
+++ b/test/virtual-timeline-restore-readiness.test.ts
@@ -276,6 +276,87 @@ describe('virtual timeline restore visual readiness', () => {
     }
   })
 
+  it('keeps restored item height while restore DOM measures taller temporarily', async () => {
+    vi.useFakeTimers()
+    let wrapper: ReturnType<typeof mount> | undefined
+
+    try {
+      vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(300)
+      vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(800)
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function () {
+        const el = this as HTMLElement
+        const measured = el.hasAttribute('data-test-height')
+          ? Number(el.dataset.testHeight)
+          : Number(el.querySelector<HTMLElement>('[data-test-height]')?.dataset.testHeight)
+
+        return Number.isFinite(measured) && measured > 0 ? measured : 80
+      })
+      installRestoreGeometryStub(80)
+      vi.stubGlobal('ResizeObserver', class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      })
+
+      wrapper = mount(MarkstreamVirtualTimeline, {
+        attachTo: document.body,
+        props: {
+          items: [
+            { kind: 'assistant-markdown', id: 'm1', content: '# Ready', final: true, revision: 1 },
+          ],
+          threadKey: 'thread-a',
+          stickToBottom: false,
+          initialThreadState: {
+            threadKey: 'thread-a',
+            measurementKey: ':800',
+            widthBucket: 800,
+            outerAnchor: { type: 'item', itemKey: 'm1', offsetWithinItemPx: 0 },
+            itemHeights: { m1: 320 },
+            itemSizeSources: { m1: timelineMarkdownItemSource('thread-a', 'm1', 1) },
+            markdownStates: {},
+          },
+        },
+        slots: {
+          default(props: any) {
+            return h('div', {
+              'ref': props.measureRef,
+              'data-test-top': '0',
+              'data-test-height': '420',
+            }, [
+              h('div', { class: 'markdown-renderer' }, [
+                h('div', {
+                  'class': 'node-slot',
+                  'data-node-index': '0',
+                  'data-node-type': 'heading',
+                }, [
+                  h('div', { class: 'node-content' }, '# Ready'),
+                ]),
+              ]),
+            ])
+          },
+        },
+      })
+
+      await nextTick()
+
+      const timeline = wrapper.vm as unknown as { getItemSize: (key: string) => number | undefined }
+      expect(timeline.getItemSize('m1')).toBe(320)
+
+      const root = wrapper.find('[data-testid="markstream-virtual-timeline"]').element as HTMLElement
+      expect(root.classList.contains('is-restoring-thread')).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(1200)
+      await nextTick()
+
+      expect(root.classList.contains('is-restoring-thread')).toBe(false)
+      expect(timeline.getItemSize('m1')).toBe(320)
+    }
+    finally {
+      wrapper?.unmount()
+      vi.useRealTimers()
+    }
+  })
+
   it('does not treat an empty visible restore viewport as ready', async () => {
     vi.useFakeTimers()
     let wrapper: ReturnType<typeof mount> | undefined


### PR DESCRIPTION
## Summary
- add a conservative SimpleInlineRenderer for lightweight inline-only content
- bypass nested NodeRenderer wrappers for simple list item paragraphs and simple table cells
- keep complex/custom paths on the existing renderer path and add regression coverage

## Tests
- pnpm exec vitest --run test/simple-inline-fast-path.test.ts test/list-item-streaming-fade.test.ts test/node-renderer-show-tooltips.test.ts test/list-numeric-item-rendering.test.ts test/text-node-streaming-consistency.test.ts test/ssr-render-to-string.test.ts test/typewriter-cursor-position.test.ts test/node-renderer-smooth-streaming.test.ts
- pnpm exec vitest --run test/e2e/node-renderer.e2e.test.ts
- pnpm typecheck
- pnpm exec eslint src/components/SimpleInlineRenderer/SimpleInlineRenderer.vue src/components/SimpleInlineRenderer/simpleInline.ts src/components/ListItemNode/ListItemNode.vue src/components/TableNode/TableNode.vue test/simple-inline-fast-path.test.ts