### PR TITLE
fix: forward isDark to code blocks rendered inside lists

### DIFF
--- a/src/components/ListItemNode/ListItemNode.vue
+++ b/src/components/ListItemNode/ListItemNode.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
   fade?: boolean
   showTooltips?: boolean
   value?: number | null
+  isDark?: boolean
 }>()
 
 defineEmits<{
@@ -149,6 +150,7 @@ provide('markstreamFade', computed(() => props.fade))
         :show-tooltips="props.showTooltips"
         :typewriter="props.typewriter"
         :fade="props.fade"
+        :is-dark="props.isDark"
         :batch-rendering="false"
         :defer-nodes-until-visible="false"
         :render-as-fragment="true"
@@ -163,6 +165,7 @@ provide('markstreamFade', computed(() => props.fade))
       :custom-id="props.customId"
       :typewriter="props.typewriter"
       :fade="props.fade"
+      :is-dark="props.isDark"
       :batch-rendering="false"
       @copy="$emit('copy', $event)"
     />

--- a/src/components/ListNode/ListNode.vue
+++ b/src/components/ListNode/ListNode.vue
@@ -17,7 +17,7 @@ interface ListItem {
   raw: string
 }
 
-const { node, customId, indexKey, typewriter, fade, showTooltips } = defineProps<{
+const { node, customId, indexKey, typewriter, fade, showTooltips, isDark } = defineProps<{
   node: {
     type: 'list'
     ordered: boolean
@@ -30,6 +30,7 @@ const { node, customId, indexKey, typewriter, fade, showTooltips } = defineProps
   typewriter?: boolean
   fade?: boolean
   showTooltips?: boolean
+  isDark?: boolean
 }>()
 
 defineEmits(['copy'])
@@ -56,6 +57,7 @@ const listItemComponent = computed(() => {
       :index-key="`${indexKey || 'list'}-${index}`"
       :typewriter="typewriter"
       :fade="fade"
+      :is-dark="isDark"
       :value="node.ordered ? (node.start ?? 1) + index : undefined"
       @copy="$emit('copy', $event)"
     />

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -70,7 +70,7 @@ exports[`markdownRender node e2e coverage > renders checkbox nodes 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc" is-dark="false">
+        <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
             <div data-v-8dfe8a80="" data-v-d94d2511="" class="markstream-vue markdown-renderer">
               <!--v-if-->
@@ -139,7 +139,7 @@ exports[`markdownRender node e2e coverage > renders complex inline code with emp
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
+        <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
             <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
               <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
@@ -479,7 +479,7 @@ exports[`markdownRender node e2e coverage > renders ordered list node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal" is-dark="false">
+        <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
             <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
               <!--v-if--></span>
@@ -719,7 +719,7 @@ exports[`markdownRender node e2e coverage > renders unordered list node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc" is-dark="false">
+        <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
             <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
               <!--v-if--></span>

--- a/test/list-code-block-dark.test.ts
+++ b/test/list-code-block-dark.test.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import NodeRenderer from '../src/components/NodeRenderer'
+import { flushAll } from './setup/flush-all'
+
+const content = [
+  '1. First step:',
+  '',
+  '   ```js',
+  '   const x = 1',
+  '   ```',
+  '',
+  '2. Second step',
+].join('\n')
+
+describe('code block inside a list inherits dark mode', () => {
+  it('forwards isDark down to list-item children', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        isDark: true,
+        final: true,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    const nested = wrapper.find('.list-item .markdown-renderer')
+    expect(nested.exists()).toBe(true)
+    expect(nested.classes()).toContain('dark')
+  })
+
+  it('does not add dark when isDark is false', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        isDark: false,
+        final: true,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    const nested = wrapper.find('.list-item .markdown-renderer')
+    expect(nested.exists()).toBe(true)
+    expect(nested.classes()).not.toContain('dark')
+  })
+})


### PR DESCRIPTION
## Summary

Ensure codeblocks inside lists adhere to the page theme. `isDark` is prop-drilled from `NodeRenderer` down through every node component. Every nesting path forwarded it except for `ListNode.vue` and `ListItemNode.vue`.

_Note: used Claude Opus 4.8 to debug and fix_

## Changes

- [ ] Add an `isDark?: boolean` prop to `ListNode` and `ListItemNode`, and ensure it is forwarded.

## Screenshots / Demo (if UI/behavior changes)

https://markstream-vue.simonhe.me/test?view=preview#data=z:M9RTcMssKi5RKC5JLbDi4lJQUEhISMgqBjGS8_OAEhUKtgqGUHEuAA

**main**:

https://github.com/user-attachments/assets/99d5f668-a672-4fa3-b0fe-bda72f2b61dc

**this branch:**

https://github.com/user-attachments/assets/3f3ba9b0-0615-45d0-8f48-a46b4e5a6123

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)