### PR TITLE
fix: render raw html tables without markdown children

### DIFF
--- a/packages/markdown-parser/src/htmlTags.d.ts
+++ b/packages/markdown-parser/src/htmlTags.d.ts
@@ -6,7 +6,7 @@ export declare const EXTENDED_STANDARD_HTML_TAG_NAMES: readonly ["address", "aud
 export declare const DANGEROUS_HTML_ATTR_NAMES: readonly ["onclick", "onerror", "onload", "onmouseover", "onmouseout", "onmousedown", "onmouseup", "onkeydown", "onkeyup", "onfocus", "onblur", "onsubmit", "onreset", "onchange", "onselect", "ondblclick", "ontouchstart", "ontouchend", "ontouchmove", "ontouchcancel", "onwheel", "onscroll", "oncopy", "oncut", "onpaste", "oninput", "oninvalid", "onsearch", "srcdoc", "ping"];
 export declare const URL_HTML_ATTR_NAMES: readonly ["action", "data", "href", "src", "srcset", "poster", "xlink:href", "formaction"];
 export declare const BLOCKED_HTML_TAG_NAMES: readonly ["script"];
-export declare const NON_STRUCTURING_HTML_TAG_NAMES: readonly ["pre", "script", "style", "textarea", "title"];
+export declare const NON_STRUCTURING_HTML_TAG_NAMES: readonly ["pre", "script", "style", "table", "tbody", "td", "tfoot", "th", "thead", "textarea", "tr", "title"];
 export declare const VOID_HTML_TAGS: Set<string>;
 export declare const STANDARD_BLOCK_HTML_TAGS: Set<string>;
 export declare const STANDARD_HTML_TAGS: Set<string>;

--- a/packages/markdown-parser/src/htmlTags.ts
+++ b/packages/markdown-parser/src/htmlTags.ts
@@ -180,7 +180,14 @@ export const NON_STRUCTURING_HTML_TAG_NAMES = [
   'pre',
   'script',
   'style',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
   'textarea',
+  'tr',
   'title',
 ] as const
 

--- a/src/components/__tests__/htmlNodes.integration.test.ts
+++ b/src/components/__tests__/htmlNodes.integration.test.ts
@@ -654,6 +654,43 @@ describe('component Behavior', () => {
     expect(wrapper.text()).toContain('- alpha')
   })
 
+  it('renders raw html tables with row spans instead of markdown children', async () => {
+    const markdown = `<table border="1" cellpadding="8" cellspacing="0">
+  <thead>
+    <tr>
+      <th>姓名</th>
+      <th>部门</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">张三</td>
+      <td>技术部</td>
+    </tr>
+    <tr>
+      <td>前端重构</td>
+    </tr>
+  </tbody>
+</table>`
+
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: markdown,
+        final: true,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    await nextTick()
+
+    expect(wrapper.find('table').exists()).toBe(true)
+    expect(wrapper.find('td[rowspan="2"]').text()).toBe('张三')
+    expect(wrapper.findAll('pre')).toHaveLength(0)
+    expect(wrapper.text()).toContain('前端重构')
+  })
+
   it('renders details summary as the first direct child for issue #397 content', async () => {
     const markdown = `# Structural Stress
 

--- a/test/html-block-regressions.test.ts
+++ b/test/html-block-regressions.test.ts
@@ -30,4 +30,31 @@ console.log(1)
     expect(collect(nodes, 'reference').length).toBe(0)
     expect(textIncludes(nodes, '[14]')).toBe(true)
   })
+
+  it('keeps raw html tables out of structured markdown children', () => {
+    const markdown = `<table border="1" cellpadding="8" cellspacing="0">
+  <thead>
+    <tr>
+      <th>姓名</th>
+      <th>部门</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">张三</td>
+      <td>技术部</td>
+    </tr>
+    <tr>
+      <td>前端重构</td>
+    </tr>
+  </tbody>
+</table>`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.type).toBe('html_block')
+    expect(nodes[0]?.tag).toBe('table')
+    expect(nodes[0]?.children).toBeUndefined()
+    expect(String(nodes[0]?.content ?? '')).toContain('rowspan="2"')
+  })
 })


### PR DESCRIPTION
## Summary

- Treat table-related HTML tags as non-structuring so raw HTML tables render through the sanitized HTML path instead of Markdown child parsing.
- Add parser and Vue integration regressions for raw HTML tables with `rowspan`.

Closes #496

## Verification

- `pnpm exec vitest --run test/html-block-regressions.test.ts src/components/__tests__/htmlNodes.integration.test.ts test/html-block-details-regression.test.ts test/ssr-render-to-string.test.ts test/markstream-angular-html.test.ts test/vue2-html-nodes.test.ts`
- `pnpm typecheck`
- `pnpm exec vitest --run --testTimeout=10000`
- `pnpm lint`