### PR TITLE
fix: preserve natural size for loaded images

### DIFF
--- a/src/components/ImageNode/ImageNode.vue
+++ b/src/components/ImageNode/ImageNode.vue
@@ -220,6 +220,7 @@ onBeforeUnmount(() => {
       :class="{
         'is-loading': !useEagerImagePath && !imageLoaded,
         'is-loaded': useEagerImagePath || imageLoaded,
+        'has-natural-size': imageLoaded,
         'cursor-pointer': imageLoaded,
       }"
       :loading="props.lazy ? 'lazy' : undefined"
@@ -295,6 +296,11 @@ onBeforeUnmount(() => {
 
 .image-node__img.is-loaded {
   opacity: 1;
+}
+
+.image-node__img.has-natural-size {
+  min-width: 0;
+  min-height: 0;
 }
 
 .image-placeholder {

--- a/test/image-node-performance.test.ts
+++ b/test/image-node-performance.test.ts
@@ -29,6 +29,29 @@ describe('image node performance defaults', () => {
     expect(wrapper.get('img').classes()).not.toContain('transition-opacity')
   })
 
+  it('keeps the image size floor until the image actually loads', async () => {
+    const wrapper = mount(ImageNode, {
+      props: {
+        node: {
+          type: 'image',
+          src: 'https://example.com/badge.svg',
+          alt: 'Badge',
+          title: 'Badge',
+          raw: '![Badge](https://example.com/badge.svg)',
+        },
+      },
+    })
+
+    expect(wrapper.get('img').classes()).toContain('is-loaded')
+    expect(wrapper.get('img').classes()).not.toContain('is-loading')
+    expect(wrapper.get('img').classes()).not.toContain('has-natural-size')
+
+    await wrapper.get('img').trigger('load')
+    await nextTick()
+
+    expect(wrapper.get('img').classes()).toContain('has-natural-size')
+  })
+
   it('keeps the lower-priority async path for lazy images', () => {
     const wrapper = mount(ImageNode, {
       props: {
@@ -47,6 +70,7 @@ describe('image node performance defaults', () => {
     expect(wrapper.get('img').attributes('fetchpriority')).toBeUndefined()
     expect(wrapper.get('img').attributes('decoding')).toBe('async')
     expect(wrapper.get('img').classes()).toContain('is-loading')
+    expect(wrapper.get('img').classes()).not.toContain('has-natural-size')
   })
 
   it('reports image load lifecycle for virtual-scroll settling', async () => {


### PR DESCRIPTION
## Summary

- keep the existing image size floor while an image has not fired its actual load event
- add a `has-natural-size` state after load to release `min-width` and `min-height`
- cover the eager-image case where `is-loaded` is applied before the browser load event

Closes #495

## Tests

- `pnpm exec vitest --run test/image-node-performance.test.ts --reporter=dot`
- `pnpm exec vitest --run test/e2e/node-renderer.e2e.test.ts --reporter=dot`
- `pnpm exec eslint src/components/ImageNode/ImageNode.vue test/image-node-performance.test.ts`
- `pnpm typecheck`