### PR TITLE
fix: avoid extra rendered code block line

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -318,6 +318,11 @@ function resolveDiffRenderPair(original: string, updated: string) {
   }
 }
 
+function getDisplayCode(code: unknown, loading?: boolean) {
+  const value = String(code ?? '')
+  return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+}
+
 function isPendingDiffResultError(error: unknown) {
   return String((error as { message?: unknown } | null | undefined)?.message ?? error)
     .includes('no diff result available')
@@ -501,8 +506,17 @@ const restoreVisualPending = computed(() =>
   && (showPreWhileMonacoLoads.value || diffFallbackExitActive.value || diffFallbackFadingOut.value),
 )
 const showInlinePreview = ref(false)
+const displayCode = computed(() => getDisplayCode(props.node.code, props.node.loading === true))
 const preCodeNode = computed(() => {
-  if (!isDiff.value || props.node.diff === true)
+  if (!isDiff.value) {
+    if (displayCode.value === props.node.code)
+      return props.node
+    return {
+      ...props.node,
+      code: displayCode.value,
+    }
+  }
+  if (props.node.diff === true)
     return props.node
   return {
     ...props.node,
@@ -752,7 +766,7 @@ const preFallbackLocalMinHeight = computed(() => {
     return null
 
   return Math.ceil(
-    countLines(props.node.code) * (preFallbackLineHeight.value + LINE_EXTRA_PER_LINE)
+    countLines(displayCode.value) * (preFallbackLineHeight.value + LINE_EXTRA_PER_LINE)
     + PIXEL_EPSILON,
   )
 })
@@ -2411,7 +2425,7 @@ watch(
       catch {}
     }
 
-    updateCode(newCode, monacoLanguage.value)
+    updateCode(getDisplayCode(newCode, props.node.loading === true), monacoLanguage.value)
 
     if (isExpanded.value) {
       safeRaf(() => updateExpandedHeight())
@@ -2699,7 +2713,7 @@ async function runEditorCreation(el: HTMLElement) {
     }
   }
   else {
-    await createEditor(el as HTMLElement, props.node.code, monacoLanguage.value)
+    await createEditor(el as HTMLElement, displayCode.value, monacoLanguage.value)
   }
   if (isUnmounted)
     return
@@ -3197,7 +3211,7 @@ watch(
               scheduleEditorHeightSync()
             }
             else {
-              updateCode(String(props.node.code ?? ''), monacoLanguage.value)
+              updateCode(displayCode.value, monacoLanguage.value)
             }
           }
           syncEditorHostHeight(false)

--- a/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
+++ b/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
@@ -26,6 +26,7 @@ interface MarkdownCodeBlockNodeProps extends ShikiCodeBlockProps {
     language: string
     code: string
     raw: string
+    loading?: boolean
     diff?: boolean
     originalCode?: string
     updatedCode?: string
@@ -208,6 +209,13 @@ const contentStyle = computed(() => {
   }
 })
 const tooltipsEnabled = computed(() => props.showTooltips !== false)
+
+function getDisplayCode(code: unknown, loading?: boolean) {
+  const value = String(code ?? '')
+  return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+}
+
+const displayCode = computed(() => getDisplayCode(props.node.code, props.node.loading === true))
 
 function getPreferredColorScheme() {
   return props.isDark ? props.darkTheme : props.lightTheme
@@ -583,8 +591,10 @@ async function initRenderer(epoch: number) {
   if (!isCurrentRenderEpoch(epoch))
     return
 
+  const renderedCode = displayCode.value
+
   if (!viewportReady.value) {
-    renderFallback(props.node.code)
+    renderFallback(renderedCode)
     return
   }
 
@@ -593,7 +603,7 @@ async function initRenderer(epoch: number) {
     return
 
   if (!codeBlockContent.value || !rendererTarget.value) {
-    renderFallback(props.node.code)
+    renderFallback(renderedCode)
     return
   }
 
@@ -612,7 +622,7 @@ async function initRenderer(epoch: number) {
 
   let needsRendererReconfigure = Boolean(renderer && rendererConfigKey !== nextRendererConfigKey)
   if (needsRendererReconfigure)
-    renderFallback(props.node.code)
+    renderFallback(renderedCode)
 
   let highlightStatus = await waitForCurrentHighlightRegistration(runtimeConfig.registerOptions, nextRendererConfigKey)
 
@@ -642,7 +652,7 @@ async function initRenderer(epoch: number) {
     if (needsRendererReconfigure && renderer && hasRendererContent())
       clearFallback()
     else
-      renderFallback(props.node.code)
+      renderFallback(renderedCode)
     return
   }
 
@@ -659,27 +669,27 @@ async function initRenderer(epoch: number) {
   }
 
   if (!renderer) {
-    renderFallback(props.node.code)
+    renderFallback(renderedCode)
     return
   }
 
   if (props.stream === false && props.loading) {
-    renderFallback(props.node.code)
+    renderFallback(renderedCode)
     return
   }
 
-  renderFallback(props.node.code)
+  renderFallback(renderedCode)
   const previousMutationVersion = rendererMutationVersion
   const previousRendererHtml = rendererTarget.value?.innerHTML
   startRendererReadyObserver(epoch, previousMutationVersion)
-  const renderedLang = await updateRendererWithFallback(props.node.code, props.node.language, epoch)
+  const renderedLang = await updateRendererWithFallback(renderedCode, props.node.language, epoch)
   if (!isCurrentRenderEpoch(epoch))
     return
   if (renderedLang) {
     await clearFallbackWhenRendererReady(
       epoch,
       previousMutationVersion,
-      getRenderSignature(nextRendererConfigKey, renderedLang, props.node.code),
+      getRenderSignature(nextRendererConfigKey, renderedLang, renderedCode),
       previousRendererHtml,
     )
   }
@@ -698,15 +708,15 @@ async function safeInitRenderer(epoch = nextRenderEpoch()) {
       return
     if (isDevEnv)
       console.warn('[MarkdownCodeBlockNode] Failed to initialize Shiki renderer.', err)
-    renderFallback(props.node.code)
+    renderFallback(displayCode.value)
   }
 }
 
-renderFallback(props.node.code)
+renderFallback(displayCode.value)
 
 onMounted(() => {
   if (!viewportReady.value) {
-    renderFallback(props.node.code)
+    renderFallback(displayCode.value)
     return
   }
   void safeInitRenderer()
@@ -733,7 +743,7 @@ watch(() => props.loading, (loading) => {
   if (loading)
     return
   if (!viewportReady.value) {
-    renderFallback(props.node.code)
+    renderFallback(displayCode.value)
     return
   }
   void safeInitRenderer()
@@ -756,15 +766,16 @@ watch(() => props.autoScrollInitial, (enabled) => {
 
 watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
   const epoch = nextRenderEpoch()
+  const renderedCode = getDisplayCode(code, props.node.loading === true)
   const normalizedLang = normalizeLanguageIdentifier(lang)
   if (normalizedLang !== codeLanguage.value)
     codeLanguage.value = normalizedLang
   if (!viewportReady.value) {
-    renderFallback(code)
+    renderFallback(renderedCode)
     return
   }
   if (!codeBlockContent.value || !rendererTarget.value) {
-    renderFallback(code)
+    renderFallback(renderedCode)
     return
   }
 
@@ -774,7 +785,7 @@ watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
   }
 
   if (!renderer || rendererNeedsReconfigure()) {
-    renderFallback(code)
+    renderFallback(renderedCode)
     await safeInitRenderer(epoch)
     return
   }
@@ -786,18 +797,18 @@ watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
   if (props.stream === false && props.loading)
     return
 
-  renderFallback(code)
+  renderFallback(renderedCode)
   const previousMutationVersion = rendererMutationVersion
   const previousRendererHtml = rendererTarget.value?.innerHTML
   startRendererReadyObserver(epoch, previousMutationVersion)
-  const renderedLang = await updateRendererWithFallback(code, lang, epoch)
+  const renderedLang = await updateRendererWithFallback(renderedCode, lang, epoch)
   if (!isCurrentRenderEpoch(epoch))
     return
   if (renderedLang) {
     await clearFallbackWhenRendererReady(
       epoch,
       previousMutationVersion,
-      getRenderSignature(rendererConfigKey ?? highlightRegistrationKey.value, renderedLang, code),
+      getRenderSignature(rendererConfigKey ?? highlightRegistrationKey.value, renderedLang, renderedCode),
       previousRendererHtml,
     )
   }

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -5,6 +5,11 @@ import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps<PreCodeNodeProps>()
 
+function getDisplayCode(code: unknown, loading?: boolean) {
+  const value = String(code ?? '')
+  return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+}
+
 // Normalize language to a safe, lowercase token (fallback to 'plaintext')
 const normalizedLanguage = computed(() => {
   const raw = String(props.node?.language ?? '')
@@ -14,9 +19,13 @@ const normalizedLanguage = computed(() => {
 })
 
 const languageClass = computed(() => `language-${normalizedLanguage.value}`)
+const displayCode = computed(() => {
+  if (props.node?.diff === true)
+    return String(props.node?.code ?? '')
+  return getDisplayCode(props.node?.code, props.node?.loading === true)
+})
 const codeLines = computed(() => {
-  const code = String(props.node?.code ?? '')
-  return code.split(/\r\n|\n|\r/)
+  return displayCode.value.split(/\r\n|\n|\r/)
 })
 const lineNumbers = computed(() => {
   return Array.from({ length: Math.max(1, codeLines.value.length) }, (_, index) => index + 1)
@@ -527,7 +536,7 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
     :data-markstream-line-numbers="props.showLineNumbers ? '1' : undefined"
     data-markstream-pre="1"
     tabindex="0"
-  ><code v-if="isDiffPreview" translate="no" class="markstream-pre__diff-code"><span v-for="pane in diffPreviewPanes" :key="pane.key" class="markstream-pre__diff-pane" :class="pane.className"><span v-for="(line, index) in pane.lines" :key="line.key" class="markstream-pre__diff-line" :class="[`markstream-pre__diff-line--${line.kind}`, { 'markstream-pre__diff-line--empty': line.empty }]" :style="getDiffLineStyle(index, pane.key as 'original' | 'modified')"><span class="markstream-pre__diff-rail" aria-hidden="true" /><span class="markstream-pre__diff-number" aria-hidden="true">{{ line.number }}</span><span class="markstream-pre__diff-content"><span class="markstream-pre__diff-content-inner">{{ line.code }}</span></span></span></span></code><template v-else><span v-if="props.showLineNumbers" class="markstream-pre__line-numbers" aria-hidden="true"><span v-for="line in lineNumbers" :key="line" class="markstream-pre__line-number">{{ line }}</span></span><code translate="no" class="markstream-pre__code" v-text="node.code" /></template></pre>
+  ><code v-if="isDiffPreview" translate="no" class="markstream-pre__diff-code"><span v-for="pane in diffPreviewPanes" :key="pane.key" class="markstream-pre__diff-pane" :class="pane.className"><span v-for="(line, index) in pane.lines" :key="line.key" class="markstream-pre__diff-line" :class="[`markstream-pre__diff-line--${line.kind}`, { 'markstream-pre__diff-line--empty': line.empty }]" :style="getDiffLineStyle(index, pane.key as 'original' | 'modified')"><span class="markstream-pre__diff-rail" aria-hidden="true" /><span class="markstream-pre__diff-number" aria-hidden="true">{{ line.number }}</span><span class="markstream-pre__diff-content"><span class="markstream-pre__diff-content-inner">{{ line.code }}</span></span></span></span></code><template v-else><span v-if="props.showLineNumbers" class="markstream-pre__line-numbers" aria-hidden="true"><span v-for="line in lineNumbers" :key="line" class="markstream-pre__line-number">{{ line }}</span></span><code translate="no" class="markstream-pre__code" v-text="displayCode" /></template></pre>
 </template>
 
 <style>

--- a/src/internal/heightEstimationExperiment.ts
+++ b/src/internal/heightEstimationExperiment.ts
@@ -346,6 +346,11 @@ function countCodeLines(source: string) {
   return Math.max(1, lines.length)
 }
 
+function getDisplayCode(source: unknown, loading?: boolean) {
+  const value = String(source ?? '')
+  return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+}
+
 function getCodeBlockVisibleLineCount(node: ParsedNode) {
   if ((node as any).diff) {
     return Math.max(
@@ -354,7 +359,7 @@ function getCodeBlockVisibleLineCount(node: ParsedNode) {
       countCodeLines(String((node as any).code ?? '')),
     )
   }
-  return countCodeLines(String((node as any).code ?? ''))
+  return countCodeLines(getDisplayCode((node as any).code, (node as any).loading === true))
 }
 
 function resolveMonacoLineHeight(monacoOptions: Record<string, any> | null | undefined, isDiff: boolean) {

--- a/test/code-block-editor-lock.test.ts
+++ b/test/code-block-editor-lock.test.ts
@@ -110,7 +110,7 @@ describe('codeBlockNode editor creation locking', () => {
           code: 'console.log(1)',
           raw: '```js\nconsole.log(1)\n```',
         },
-        loading: true,
+        loading: false,
         stream: true,
         showHeader: false,
       },
@@ -135,6 +135,71 @@ describe('codeBlockNode editor creation locking', () => {
       expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-pending')).toBeUndefined()
       expect(wrapper.find('.code-editor-container').classes()).not.toContain('is-hidden')
     })
+
+    wrapper.unmount()
+  })
+
+  it('does not pass a terminal newline to ordinary Monaco renders', async () => {
+    const helpers = getStreamMonacoHelpers()
+    helpers.createEditor.mockImplementation(async () => {})
+
+    const wrapper = mount(CodeBlockNode, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'js',
+          code: 'console.log(1)\n',
+          raw: '```js\nconsole.log(1)\n```',
+        },
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flushPendingMicrotasks()
+    await waitForCreateEditorCalls(1, helpers)
+
+    expect(helpers.createEditor.mock.calls[0]?.[1]).toBe('console.log(1)')
+
+    helpers.updateCode.mockClear()
+    await wrapper.setProps({
+      node: {
+        type: 'code_block',
+        language: 'js',
+        code: 'console.log(2)\n',
+        raw: '```js\nconsole.log(2)\n```',
+      },
+    })
+    await flushPendingMicrotasks()
+
+    expect(helpers.updateCode).toHaveBeenCalledWith('console.log(2)', 'javascript')
+
+    wrapper.unmount()
+  })
+
+  it('keeps a terminal newline while an ordinary Monaco code block is still loading', async () => {
+    const helpers = getStreamMonacoHelpers()
+    helpers.createEditor.mockImplementation(async () => {})
+
+    const wrapper = mount(CodeBlockNode, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'js',
+          code: 'console.log(1)\n',
+          raw: '```js\nconsole.log(1)\n',
+          loading: true,
+        },
+        loading: true,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flushPendingMicrotasks()
+    await waitForCreateEditorCalls(1, helpers)
+
+    expect(helpers.createEditor.mock.calls[0]?.[1]).toBe('console.log(1)\n')
 
     wrapper.unmount()
   })

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -123,8 +123,7 @@ exports[`markdownRender node e2e coverage > renders code block node 1`] = `
   <!--v-if-->
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="code_block">
     <div data-v-8dfe8a80="" class="node-content">
-      <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals --><pre data-v-8dfe8a80="" class="language-ts" aria-busy="false" aria-label="Code block: ts" data-language="ts" data-markstream-pre="1" tabindex="0" loading="false" index-key="markdown-renderer-0" is-dark="false"><!--v-if--><code translate="no" class="markstream-pre__code">export const sum = (a: number, b: number) =&gt; a + b
-</code></pre>
+      <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals --><pre data-v-8dfe8a80="" class="language-ts" aria-busy="false" aria-label="Code block: ts" data-language="ts" data-markstream-pre="1" tabindex="0" loading="false" index-key="markdown-renderer-0" is-dark="false"><!--v-if--><code translate="no" class="markstream-pre__code">export const sum = (a: number, b: number) =&gt; a + b</code></pre>
     </div>
   </div>
   <!--v-if-->

--- a/test/height-estimation-experiment.test.ts
+++ b/test/height-estimation-experiment.test.ts
@@ -70,6 +70,62 @@ describe('height estimation experiment internals', () => {
     expect(estimated?.height).toBeGreaterThan(estimated?.contentHeight ?? 0)
   })
 
+  it('does not count a terminal newline as an extra ordinary code line', () => {
+    const withoutTerminalNewline = estimateCodeBlockHeight(
+      {
+        type: 'code_block',
+        language: 'ts',
+        code: 'one',
+        raw: '```ts\none\n```',
+      } as any,
+      {
+        rendererKind: 'monaco',
+        showHeader: false,
+      },
+    )
+    const withTerminalNewline = estimateCodeBlockHeight(
+      {
+        type: 'code_block',
+        language: 'ts',
+        code: 'one\n',
+        raw: '```ts\none\n```',
+      } as any,
+      {
+        rendererKind: 'monaco',
+        showHeader: false,
+      },
+    )
+    const withBlankLine = estimateCodeBlockHeight(
+      {
+        type: 'code_block',
+        language: 'ts',
+        code: 'one\n\n',
+        raw: '```ts\none\n\n```',
+      } as any,
+      {
+        rendererKind: 'monaco',
+        showHeader: false,
+      },
+    )
+    const loadingWithTerminalNewline = estimateCodeBlockHeight(
+      {
+        type: 'code_block',
+        language: 'ts',
+        code: 'one\n',
+        raw: '```ts\none\n',
+        loading: true,
+      } as any,
+      {
+        rendererKind: 'monaco',
+        showHeader: false,
+      },
+    )
+
+    expect(withTerminalNewline?.contentHeight).toBe(withoutTerminalNewline?.contentHeight)
+    expect(withBlankLine?.contentHeight).toBeGreaterThan(withTerminalNewline?.contentHeight ?? 0)
+    expect(loadingWithTerminalNewline?.contentHeight).toBe(withBlankLine?.contentHeight)
+  })
+
   it('caps monaco estimate by max height', () => {
     const estimated = estimateCodeBlockHeight(
       {

--- a/test/markdown-code-block-node.test.ts
+++ b/test/markdown-code-block-node.test.ts
@@ -31,6 +31,35 @@ async function flushCodeWatchers() {
 }
 
 describe('markdownCodeBlockNode props and features', () => {
+  it('does not render a terminal newline in the fallback code block', () => {
+    const wrapper = mount(MarkdownCodeBlockNode, {
+      props: {
+        loading: false,
+        node: makeNode('console.log(1)\n'),
+      },
+    })
+
+    expect(wrapper.get('.code-fallback-plain code').element.textContent).toBe('console.log(1)')
+
+    wrapper.unmount()
+  })
+
+  it('keeps a terminal newline in the fallback while the code block is loading', () => {
+    const wrapper = mount(MarkdownCodeBlockNode, {
+      props: {
+        loading: true,
+        node: {
+          ...makeNode('console.log(1)\n'),
+          loading: true,
+        },
+      },
+    })
+
+    expect(wrapper.get('.code-fallback-plain code').element.textContent).toBe('console.log(1)\n')
+
+    wrapper.unmount()
+  })
+
   it('should support all header control props', () => {
     const expectedProps = [
       'showHeader',

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -6,6 +6,50 @@ import { nextTick } from 'vue'
 import PreCodeNode from '../src/components/PreCodeNode'
 
 describe('pre code node diff preview', () => {
+  it('does not render a terminal newline as an extra ordinary line', async () => {
+    const wrapper = mount(PreCodeNode, {
+      props: {
+        showLineNumbers: true,
+        node: {
+          type: 'code_block',
+          language: 'ts',
+          code: 'const a = 1\n',
+          raw: '```ts\nconst a = 1\n```',
+        },
+      },
+    })
+
+    expect(wrapper.findAll('.markstream-pre__line-number').map(node => node.text())).toEqual(['1'])
+    expect(wrapper.get('.markstream-pre__code').element.textContent).toBe('const a = 1')
+
+    await wrapper.setProps({
+      node: {
+        type: 'code_block',
+        language: 'ts',
+        code: 'const a = 1\n\n',
+        raw: '```ts\nconst a = 1\n\n```',
+      },
+    })
+
+    expect(wrapper.findAll('.markstream-pre__line-number').map(node => node.text())).toEqual(['1', '2'])
+    expect(wrapper.get('.markstream-pre__code').element.textContent).toBe('const a = 1\n')
+
+    await wrapper.setProps({
+      node: {
+        type: 'code_block',
+        language: 'ts',
+        code: 'const a = 1\n',
+        raw: '```ts\nconst a = 1\n',
+        loading: true,
+      },
+    })
+
+    expect(wrapper.findAll('.markstream-pre__line-number').map(node => node.text())).toEqual(['1', '2'])
+    expect(wrapper.get('.markstream-pre__code').element.textContent).toBe('const a = 1\n')
+
+    wrapper.unmount()
+  })
+
   it('does not paint blank diff preview rows as added or removed', () => {
     const wrapper = mount(PreCodeNode, {
       props: {


### PR DESCRIPTION
## Summary

- Trim the display-only terminal newline for completed ordinary code blocks across Pre, Monaco, and Shiki renderers.
- Preserve terminal newlines while code blocks are still loading/streaming.
- Align code block height estimation and snapshots with the rendered line count.

close #499

## Verification

- `pnpm exec vitest --run test/pre-code-node-diff-preview.test.ts test/code-block-editor-lock.test.ts test/markdown-code-block-node.test.ts test/height-estimation-experiment.test.ts`
- `pnpm exec vitest --run` (after updating the expected code block snapshot)
- `pnpm lint`
- `pnpm typecheck`