### PR TITLE
fix: preserve custom protocol links

### DIFF
--- a/docs/guide/parser-api.md
+++ b/docs/guide/parser-api.md
@@ -157,6 +157,19 @@ const nodes = parseMarkdownToStructure(
 // "safe" is emitted as a link node; "unsafe" is emitted as plain text
 ```
 
+### Custom app protocols
+
+Links such as `myapp://open?id=1` or `taurussxxcpro://taurusclient/action/open_app?...` are treated as link URLs, not resource URLs. The built-in safe URL policy preserves them on link `href` values while still blocking dangerous schemes such as `javascript:`, `data:`, and `file:`.
+
+Preserving the `href` does not register the protocol with the browser or operating system. If the user clicks a custom-scheme link in an environment where no app has registered that scheme, the browser may report that the scheme has no registered handler. In that case, the application should install/register the target client, open the Markdown inside a WebView that supports the scheme, or use a custom `link` renderer to provide an HTTPS fallback.
+
+When a deep link contains another URL in a query parameter, encode the nested URL before building the Markdown link:
+
+```ts
+const targetUrl = 'https://example.com/page?seq_id=123&source=BBX#sharePage'
+const href = `taurussxxcpro://taurusclient/action/open_app?type=1&url=${encodeURIComponent(targetUrl)}`
+```
+
 ### Stray `$$` delimiters (empty math)
 
 Sometimes streams contain an accidental `$$` sequence, e.g.

--- a/docs/zh/guide/parser-api.md
+++ b/docs/zh/guide/parser-api.md
@@ -149,6 +149,19 @@ const nodes = parseMarkdownToStructure(
 // "safe" 会输出为 link 节点；"unsafe" 会降级为纯文本
 ```
 
+### 自定义 app 协议链接
+
+`myapp://open?id=1` 或 `taurussxxcpro://taurusclient/action/open_app?...` 这类链接会被当作链接 URL，而不是资源 URL。内置安全 URL 策略会在链接 `href` 上保留这类自定义协议，同时继续拦截 `javascript:`、`data:`、`file:` 等危险协议。
+
+保留 `href` 不等于浏览器或操作系统已经注册了对应协议。如果用户在没有注册该协议处理器的环境里点击自定义 scheme 链接，浏览器可能会提示该 scheme 没有可用的 handler。此时需要业务层安装/注册目标客户端、在支持该 scheme 的 WebView 中打开 Markdown，或通过自定义 `link` renderer 提供 HTTPS fallback。
+
+如果 deep link 的 query 参数里还包含另一个 URL，生成 Markdown 链接前应先编码内部 URL：
+
+```ts
+const targetUrl = 'https://example.com/page?seq_id=123&source=BBX#sharePage'
+const href = `taurussxxcpro://taurusclient/action/open_app?type=1&url=${encodeURIComponent(targetUrl)}`
+```
+
 ### `$$` 异常分隔符（空公式/误触发）的解释
 
 有些内容会出现“奇怪的 `$$`”，例如：

--- a/packages/markdown-parser/src/htmlTags.ts
+++ b/packages/markdown-parser/src/htmlTags.ts
@@ -254,6 +254,21 @@ const HREF_URL_PROTOCOLS = new Set([
   'mailto',
   'tel',
 ])
+const BLOCKED_HREF_URL_PROTOCOLS = new Set([
+  'javascript',
+  'vbscript',
+  'data',
+  'file',
+  'ftp',
+  'blob',
+  'filesystem',
+  'intent',
+  'chrome',
+  'chrome-extension',
+  'moz-extension',
+  'ms-browser-extension',
+  'view-source',
+])
 const RESOURCE_URL_PROTOCOLS = new Set([
   'http',
   'https',
@@ -269,12 +284,20 @@ function getUrlScheme(normalized: string) {
   return match?.[1]?.toLowerCase() ?? ''
 }
 
+function isLinkHrefUrlContext(tagName: string, attrName: string) {
+  if (!tagName)
+    return !attrName || attrName === 'href'
+
+  return (tagName === 'a' || tagName === 'area')
+    && (!attrName || attrName === 'href' || attrName === 'xlink:href')
+}
+
 function getAllowedUrlProtocols(tagName: string, attrName: string) {
   if (attrName === 'href')
-    return HREF_URL_PROTOCOLS
+    return isLinkHrefUrlContext(tagName, attrName) ? HREF_URL_PROTOCOLS : RESOURCE_URL_PROTOCOLS
 
   if (attrName === 'xlink:href')
-    return HREF_URL_PROTOCOLS
+    return isLinkHrefUrlContext(tagName, attrName) ? HREF_URL_PROTOCOLS : RESOURCE_URL_PROTOCOLS
 
   if (attrName === 'src')
     return RESOURCE_URL_PROTOCOLS
@@ -291,7 +314,7 @@ function getAllowedUrlProtocols(tagName: string, attrName: string) {
   if (attrName === 'data')
     return RESOURCE_URL_PROTOCOLS
 
-  if (tagName === 'a' || tagName === 'area')
+  if (isLinkHrefUrlContext(tagName, attrName))
     return HREF_URL_PROTOCOLS
 
   return HREF_URL_PROTOCOLS
@@ -328,6 +351,9 @@ export function isUnsafeHtmlUrl(value: string, context: HtmlUrlContext = {}) {
   const scheme = getUrlScheme(normalized)
   if (!scheme)
     return false
+
+  if (isLinkHrefUrlContext(tagName, attrName))
+    return BLOCKED_HREF_URL_PROTOCOLS.has(scheme)
 
   return !getAllowedUrlProtocols(tagName, attrName).has(scheme)
 }

--- a/test/markstream-angular-html.test.ts
+++ b/test/markstream-angular-html.test.ts
@@ -21,6 +21,21 @@ describe('markstream-angular html renderer', () => {
     expect(html).toContain('const value = 1')
   })
 
+  it('keeps custom-protocol href values in nested link html', () => {
+    const href = 'taurussxxcpro://taurusclient/action/open_app?type=1&offline=false&url=https%3A%2F%2Fexample.com%2Fa%3Fb%3D1%26c%3D2'
+    const html = renderMarkdownNodeToHtml({
+      type: 'link',
+      href,
+      title: null,
+      text: 'open',
+      raw: `[open](${href})`,
+      children: [{ type: 'text', content: 'open', raw: 'open' }],
+    } as any)
+
+    expect(html).toContain('href="taurussxxcpro://taurusclient/action/open_app?type=1&amp;offline=false')
+    expect(html).not.toContain('target="_blank"')
+  })
+
   it('preserves diff metadata on code fences for advanced enhancers', () => {
     const html = renderMarkdownToHtml({
       content: `\`\`\`diff ts

--- a/test/security/html-url-policy.test.ts
+++ b/test/security/html-url-policy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { sanitizeAttrs, sanitizeImageSrc } from '../../src/utils/htmlRenderer'
 
+const customAppHref = 'taurussxxcpro://taurusclient/action/open_app?type=1&offline=false&url=https%3A%2F%2Fexample.com%2Fa%3Fb%3D1%26c%3D2'
+
 describe('html URL policy', () => {
   it('rejects script protocols with whitespace and control characters', () => {
     expect(sanitizeAttrs({ href: 'java\nscript:alert(1)' }).href).toBeUndefined()
@@ -27,7 +29,7 @@ describe('html URL policy', () => {
       expect(sanitizeAttrs({ href: payload }, 'safe', 'a').href).toBeUndefined()
   })
 
-  it('rejects non-allowlisted absolute URL schemes', () => {
+  it('rejects unsafe absolute URL schemes', () => {
     const unsafe = [
       'file:///etc/passwd',
       'ftp://example.com/file',
@@ -47,6 +49,7 @@ describe('html URL policy', () => {
       'http://example.com',
       'mailto:a@example.com',
       'tel:+123456789',
+      customAppHref,
       '/docs',
       './relative',
       '../relative',
@@ -88,6 +91,16 @@ describe('html URL policy', () => {
     expect(sanitizeAttrs({ data: 'tel:+123456789' }, 'trusted', 'object').data).toBeUndefined()
     expect(sanitizeAttrs({ src: 'https://example.com/a.png' }, 'safe', 'img').src).toBe('https://example.com/a.png')
     expect(sanitizeAttrs({ poster: 'https://example.com/poster.png' }, 'trusted', 'video').poster).toBe('https://example.com/poster.png')
+    expect(sanitizeAttrs({ href: customAppHref }, 'safe', 'a').href).toBe(customAppHref)
+    expect(sanitizeAttrs({ 'xlink:href': customAppHref }, 'safe', 'a')['xlink:href']).toBe(customAppHref)
+    expect(sanitizeAttrs({ src: customAppHref }, 'safe', 'img').src).toBeUndefined()
+    expect(sanitizeAttrs({ srcset: `${customAppHref} 1x` }, 'safe', 'img').srcset).toBeUndefined()
+    expect(sanitizeAttrs({ poster: customAppHref }, 'trusted', 'video').poster).toBeUndefined()
+    expect(sanitizeAttrs({ action: customAppHref }, 'trusted', 'form').action).toBeUndefined()
+    expect(sanitizeAttrs({ formaction: customAppHref }, 'trusted', 'button').formaction).toBeUndefined()
+    expect(sanitizeAttrs({ data: customAppHref }, 'trusted', 'object').data).toBeUndefined()
+    expect(sanitizeAttrs({ href: customAppHref }, 'safe', 'image').href).toBeUndefined()
+    expect(sanitizeAttrs({ 'xlink:href': customAppHref }, 'safe', 'image')['xlink:href']).toBeUndefined()
   })
 
   it('rejects unsafe data documents but allows image data URLs', () => {

--- a/test/security/link-image-url-policy.test.ts
+++ b/test/security/link-image-url-policy.test.ts
@@ -68,6 +68,38 @@ describe('link and image URL policy', () => {
     expect(attrs.rel).toBeUndefined()
   })
 
+  it('keeps custom-protocol href values on direct link nodes', async () => {
+    const href = 'taurussxxcpro://taurusclient/action/open_app?type=1&offline=false&url=https%3A%2F%2Fexample.com%2Fa%3Fb%3D1%26c%3D2'
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        typewriter: false,
+        batchRendering: false,
+        nodes: [
+          {
+            type: 'paragraph',
+            raw: '',
+            children: [
+              {
+                type: 'link',
+                href,
+                title: null,
+                text: 'open',
+                raw: `[open](${href})`,
+                children: [{ type: 'text', content: 'open', raw: 'open' }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    await flushAll()
+    const attrs = wrapper.get('a.link-node').attributes()
+    expect(attrs.href).toBe(href)
+    expect(attrs.target).toBeUndefined()
+    expect(attrs.rel).toBeUndefined()
+  })
+
   it('does not forward ping from direct link node attrs', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/security/mermaid-svg-sanitizer.test.ts
+++ b/test/security/mermaid-svg-sanitizer.test.ts
@@ -8,6 +8,7 @@ import { isBrokenMermaidSvg, sanitizeMermaidSvg, toSafeMermaidSvgMarkup, toSafeS
 import { describe, expect, it } from 'vitest'
 
 const mermaidSvgFixtureDir = join(process.cwd(), 'test/fixtures/mermaid-svg')
+const customAppHref = 'taurussxxcpro://taurusclient/action/open_app'
 
 function readMermaidSvgFixtures() {
   return readdirSync(mermaidSvgFixtureDir)
@@ -252,22 +253,27 @@ describe('mermaid SVG sanitizer', () => {
 
   it('uses SVG tag and attribute context when sanitizing URL attributes', () => {
     const svg = sanitizeMermaidSvg(`
-      <svg viewBox="0 0 10 10">
+      <svg viewBox="0 0 10 10" xmlns:xlink="http://www.w3.org/1999/xlink">
         <image href="mailto:a@example.com" />
+        <image href="${customAppHref}" />
+        <image xlink:href="${customAppHref}" />
         <image src="data:image/png;base64,AAAA" />
         <use href="https://evil.example/sprite.svg#x" />
         <use href="#local-symbol" />
         <a href="mailto:a@example.com"><text>x</text></a>
+        <a href="${customAppHref}"><text>app</text></a>
         <rect width="10" height="10" />
       </svg>
     `)
 
     expect(svg).toBeTruthy()
     expect(svg).not.toMatch(/<image[^>]+mailto:/i)
+    expect(svg).not.toMatch(/<image[^>]+taurussxxcpro:/i)
     expect(svg).toMatch(/<image[^>]+data:image\/png/i)
     expect(svg).not.toMatch(/<use[^>]+https:/i)
     expect(svg).toMatch(/<use[^>]+#local-symbol/i)
     expect(svg).toMatch(/<a[^>]+mailto:/i)
+    expect(svg).toMatch(/<a[^>]+taurussxxcpro:/i)
   })
 
   it('allows local SVG references but rejects external paint-server URLs', () => {


### PR DESCRIPTION
## Summary
- Preserve non-dangerous custom protocol hrefs for Markdown/direct link rendering.
- Keep resource URL contexts on the stricter http/https policy, including image/srcset/poster/action/data and SVG image hrefs.
- Add regression coverage for Vue direct links, Angular nested link HTML, generic URL policy, and Mermaid SVG URL sanitization.

Closes #507

## Verification
- `pnpm exec vitest run test/security/html-url-policy.test.ts test/security/link-image-url-policy.test.ts test/security/mermaid-svg-sanitizer.test.ts test/markstream-angular-html.test.ts`
- `git diff --check && pnpm lint && pnpm typecheck && pnpm run build:parser && pnpm run build:core && pnpm exec vitest --run --testTimeout=10000 && pnpm run check:ssr && pnpm run test:api:strict && pnpm run test:smoke:core && pnpm run test:smoke:react && pnpm run test:smoke:vue2-cjs && pnpm run build:parser && pnpm build && pnpm play:deploy:check && pnpm run test:e2e:virtual-scroll:ci && MARKSTREAM_SMOKE_SKIP_BUILD=1 pnpm test:smoke:minimal && MARKSTREAM_SMOKE_SKIP_BUILD=1 pnpm test:smoke:pack:optional && pnpm size:check`
- `pnpm docs:check-zh && pnpm docs:check-llms && pnpm docs:build:ci`
- `pnpm benchmark:1.0`