### PR TITLE
fix: render sequence mermaid text semicolons

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -8,6 +8,7 @@ import { useViewportPriority } from '../../composables/viewportPriority'
 import mermaidIcon from '../../icon/mermaid.svg?raw'
 import { clampMermaidPreviewHeight, estimateMermaidPreviewHeight, getMermaidDiagramKind, parsePositiveNumber } from '../../utils/diagramHeight'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
+import { escapeSequenceTextSemicolons } from '../../utils/mermaidSequenceSemicolons'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { safeRaf } from '../../utils/safeRaf'
 import { canParseOffthread as canParseOffthreadClient, findPrefixOffthread as findPrefixOffthreadClient, terminateWorker as terminateMermaidWorker } from '../../workers/mermaidWorkerClient'
@@ -582,6 +583,14 @@ function isTimeoutError(error: unknown) {
   return typeof message === 'string' && /timed out/i.test(message)
 }
 
+function isAbortError(error: unknown) {
+  return (error as any)?.name === 'AbortError'
+}
+
+function shouldRetrySequenceSemicolonEscape(error: unknown) {
+  return !isTimeoutError(error) && !isAbortError(error)
+}
+
 const tooltipsEnabled = computed(() => props.showTooltips !== false)
 
 // Tooltip helpers (singleton)
@@ -708,19 +717,80 @@ async function canParseOnMain(
   const anyMermaid = mermaidInstance as any
   const themed = applyThemeTo(code, theme)
   if (typeof anyMermaid.parse === 'function') {
-    await withTimeoutSignal(() => anyMermaid.parse(themed), {
-      timeoutMs: opts?.timeoutMs ?? timeouts.value.parse,
-      signal: opts?.signal,
-    })
+    try {
+      await withTimeoutSignal(() => anyMermaid.parse(themed), {
+        timeoutMs: opts?.timeoutMs ?? timeouts.value.parse,
+        signal: opts?.signal,
+      })
+    }
+    catch (error) {
+      if (!shouldRetrySequenceSemicolonEscape(error))
+        throw error
+      const retryCode = escapeSequenceTextSemicolons(themed)
+      if (retryCode === themed)
+        throw error
+      try {
+        await withTimeoutSignal(() => anyMermaid.parse(retryCode), {
+          timeoutMs: opts?.timeoutMs ?? timeouts.value.parse,
+          signal: opts?.signal,
+        })
+      }
+      catch {
+        throw error
+      }
+    }
     return true
   }
   // Fallback: try a headless render (no target element) just to validate
   const id = `mermaid-parse-${Math.random().toString(36).slice(2, 9)}`
-  await withTimeoutSignal(() => (mermaidInstance as any).render(id, themed), {
-    timeoutMs: opts?.timeoutMs ?? timeouts.value.render,
-    signal: opts?.signal,
-  })
+  try {
+    await withTimeoutSignal(() => (mermaidInstance as any).render(id, themed), {
+      timeoutMs: opts?.timeoutMs ?? timeouts.value.render,
+      signal: opts?.signal,
+    })
+  }
+  catch (error) {
+    if (!shouldRetrySequenceSemicolonEscape(error))
+      throw error
+    const retryCode = escapeSequenceTextSemicolons(themed)
+    if (retryCode === themed)
+      throw error
+    try {
+      await withTimeoutSignal(() => (mermaidInstance as any).render(`${id}-retry`, retryCode), {
+        timeoutMs: opts?.timeoutMs ?? timeouts.value.render,
+        signal: opts?.signal,
+      })
+    }
+    catch {
+      throw error
+    }
+  }
   return true
+}
+
+async function renderMermaidWithSequenceRetry(mermaidInstance: any, id: string, code: string, timeoutMs: number) {
+  try {
+    return await withTimeoutSignal(
+      () => mermaidInstance.render(id, code),
+      { timeoutMs },
+    )
+  }
+  catch (error) {
+    if (!shouldRetrySequenceSemicolonEscape(error))
+      throw error
+    const retryCode = escapeSequenceTextSemicolons(code)
+    if (retryCode === code)
+      throw error
+    try {
+      return await withTimeoutSignal(
+        () => mermaidInstance.render(`${id}-retry`, retryCode),
+        { timeoutMs },
+      )
+    }
+    catch {
+      throw error
+    }
+  }
 }
 
 async function canParseOffthread(
@@ -1317,12 +1387,11 @@ async function initMermaid() {
       }
       const currentTheme = props.isDark ? 'dark' : 'light'
       const codeWithTheme = getCodeWithTheme(currentTheme)
-      const res: any = await withTimeoutSignal(
-        () => (mermaidInstance as any).render(
-          id,
-          codeWithTheme,
-        ),
-        { timeoutMs: timeouts.value.fullRender },
+      const res: any = await renderMermaidWithSequenceRetry(
+        mermaidInstance,
+        id,
+        codeWithTheme,
+        timeouts.value.fullRender,
       )
       const svg = res?.svg
 
@@ -1454,9 +1523,11 @@ async function renderPartial(code: string) {
     const safePrefix = getSafePrefixCandidate(code)
     const codeForRender = safePrefix && safePrefix.trim() ? safePrefix : code
     const codeWithTheme = applyThemeTo(codeForRender, theme)
-    const res: any = await withTimeoutSignal(
-      () => (mermaidInstance as any).render(id, codeWithTheme),
-      { timeoutMs: timeouts.value.render },
+    const res: any = await renderMermaidWithSequenceRetry(
+      mermaidInstance,
+      id,
+      codeWithTheme,
+      timeouts.value.render,
     )
     const svg = res?.svg
     if (mermaidContent.value && svg) {

--- a/src/utils/mermaidSequenceSemicolons.ts
+++ b/src/utils/mermaidSequenceSemicolons.ts
@@ -1,0 +1,94 @@
+import { getMermaidDiagramKind } from './diagramHeight'
+
+const SEMICOLON_ENTITY = '#59;'
+
+function isEscapedEntityBefore(text: string, index: number) {
+  return /(?:&#\d+|#\d+|&[a-z]+)$/i.test(text.slice(Math.max(0, index - 12), index))
+}
+
+function hasSequenceArrow(text: string) {
+  return text.includes('->')
+    || text.includes('-->')
+    || text.includes('->>')
+    || text.includes('-->>')
+    || text.includes('-x')
+    || text.includes('--x')
+    || text.includes('-)')
+    || text.includes('--)')
+    || text.includes('-+')
+    || text.includes('--+')
+}
+
+function startsSequenceMessage(text: string) {
+  const segment = text.split(';', 1)[0]
+  const colonIndex = segment.indexOf(':')
+  return colonIndex > 0 && hasSequenceArrow(segment.slice(0, colonIndex))
+}
+
+function startsSequenceStatement(text: string) {
+  const source = text.trimStart()
+  return /^(?:accDescr|accTitle|activate|actor|and|alt|autonumber|box|break|critical|create\s+(?:actor|participant)|deactivate|destroy|else|end|link|links|loop|Note|opt|option|par|participant|properties|rect)\b/i.test(source)
+    || startsSequenceMessage(source)
+}
+
+function isSequenceTextLine(line: string, colonIndex: number) {
+  const prefix = line.slice(0, colonIndex)
+  return /^\s*Note\b/i.test(prefix)
+    || hasSequenceArrow(prefix)
+}
+
+function escapeTextSemicolons(text: string) {
+  let escaped = ''
+  let changed = false
+
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index]
+    if (char !== ';' || isEscapedEntityBefore(text, index)) {
+      escaped += char
+      continue
+    }
+
+    if (startsSequenceStatement(text.slice(index + 1))) {
+      escaped += char
+      continue
+    }
+
+    escaped += SEMICOLON_ENTITY
+    changed = true
+  }
+
+  return changed ? escaped : text
+}
+
+function escapeLine(line: string) {
+  if (!line.includes(';'))
+    return line
+
+  const colonIndex = line.indexOf(':')
+  if (colonIndex === -1 || !isSequenceTextLine(line, colonIndex))
+    return line
+
+  const beforeText = line.slice(0, colonIndex + 1)
+  const text = line.slice(colonIndex + 1)
+  const escapedText = escapeTextSemicolons(text)
+  return escapedText === text ? line : `${beforeText}${escapedText}`
+}
+
+export function escapeSequenceTextSemicolons(code: string) {
+  if (getMermaidDiagramKind(code) !== 'sequencediagram')
+    return code
+
+  const parts = code.split(/(\r\n|\n|\r)/)
+  let changed = false
+
+  for (let index = 0; index < parts.length; index += 2) {
+    const line = parts[index]
+    const escapedLine = escapeLine(line)
+    if (escapedLine !== line) {
+      parts[index] = escapedLine
+      changed = true
+    }
+  }
+
+  return changed ? parts.join('') : code
+}

--- a/src/workers/mermaidCdnWorker.ts
+++ b/src/workers/mermaidCdnWorker.ts
@@ -91,6 +91,92 @@ function applyThemeTo(code, theme) {
   return themeConfig + code
 }
 
+function getMermaidDiagramKind(code) {
+  const lines = String(code || '').split(/\\r?\\n/)
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('%%'))
+      continue
+    const match = line.match(/^([A-Z][\\w-]*)\\b/i)
+    return (match && match[1] ? match[1].toLowerCase() : '')
+  }
+  return ''
+}
+
+function isEscapedEntityBefore(text, index) {
+  return /(?:&#\\d+|#\\d+|&[a-z]+)$/i.test(text.slice(Math.max(0, index - 12), index))
+}
+
+function hasSequenceArrow(text) {
+  return text.includes('->')
+    || text.includes('-->')
+    || text.includes('->>')
+    || text.includes('-->>')
+    || text.includes('-x')
+    || text.includes('--x')
+    || text.includes('-)')
+    || text.includes('--)')
+    || text.includes('-+')
+    || text.includes('--+')
+}
+
+function startsSequenceMessage(text) {
+  const segment = text.split(';', 1)[0]
+  const colonIndex = segment.indexOf(':')
+  return colonIndex > 0 && hasSequenceArrow(segment.slice(0, colonIndex))
+}
+
+function startsSequenceStatement(text) {
+  const source = text.trimStart()
+  return /^(?:accDescr|accTitle|activate|actor|and|alt|autonumber|box|break|critical|create\\s+(?:actor|participant)|deactivate|destroy|else|end|link|links|loop|Note|opt|option|par|participant|properties|rect)\\b/i.test(source)
+    || startsSequenceMessage(source)
+}
+
+function isSequenceTextLine(line, colonIndex) {
+  const prefix = line.slice(0, colonIndex)
+  return /^\\s*Note\\b/i.test(prefix) || hasSequenceArrow(prefix)
+}
+
+function escapeTextSemicolons(text) {
+  let escaped = ''
+  let changed = false
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index]
+    if (char !== ';' || isEscapedEntityBefore(text, index)) {
+      escaped += char
+      continue
+    }
+    if (startsSequenceStatement(text.slice(index + 1))) {
+      escaped += char
+      continue
+    }
+    escaped += '#59;'
+    changed = true
+  }
+  return changed ? escaped : text
+}
+
+function escapeSequenceTextSemicolons(code) {
+  if (getMermaidDiagramKind(code) !== 'sequencediagram')
+    return code
+  const parts = String(code || '').split(/(\\r\\n|\\n|\\r)/)
+  let changed = false
+  for (let index = 0; index < parts.length; index += 2) {
+    const line = parts[index]
+    if (!line.includes(';'))
+      continue
+    const colonIndex = line.indexOf(':')
+    if (colonIndex === -1 || !isSequenceTextLine(line, colonIndex))
+      continue
+    const escapedText = escapeTextSemicolons(line.slice(colonIndex + 1))
+    if (escapedText !== line.slice(colonIndex + 1)) {
+      parts[index] = line.slice(0, colonIndex + 1) + escapedText
+      changed = true
+    }
+  }
+  return changed ? parts.join('') : code
+}
+
 function findHeaderIndex(lines) {
   const headerRe = /^(?:graph|flowchart|flowchart\\s+tb|flowchart\\s+lr|sequenceDiagram|gantt|classDiagram|stateDiagram(?:-v2)?|erDiagram|journey|pie|quadrantChart|timeline|xychart(?:-beta)?)\\b/
   for (let i = 0; i < lines.length; i++) {
@@ -109,7 +195,15 @@ async function canParse(code, theme) {
   const themed = applyThemeTo(code, theme)
   const anyMermaid = mermaid
   if (anyMermaid && typeof anyMermaid.parse === 'function') {
-    await anyMermaid.parse(themed)
+    try {
+      await anyMermaid.parse(themed)
+    }
+    catch (error) {
+      const retryCode = escapeSequenceTextSemicolons(themed)
+      if (retryCode === themed)
+        throw error
+      await anyMermaid.parse(retryCode)
+    }
     return true
   }
   throw new Error('mermaid.parse not available in worker')

--- a/src/workers/mermaidParser.worker.ts
+++ b/src/workers/mermaidParser.worker.ts
@@ -2,6 +2,7 @@
 
 // Note: types may not be available in worker TS context in some setups; a local shim is provided.
 import mermaid from 'mermaid'
+import { escapeSequenceTextSemicolons } from '../utils/mermaidSequenceSemicolons'
 
 declare const self: DedicatedWorkerGlobalScope
 
@@ -48,7 +49,15 @@ async function canParse(code: string, theme: Theme) {
   const themed = applyThemeTo(code, theme)
   const anyMermaid = mermaid as any
   if (typeof anyMermaid.parse === 'function') {
-    await anyMermaid.parse?.(themed)
+    try {
+      await anyMermaid.parse?.(themed)
+    }
+    catch (error) {
+      const retryCode = escapeSequenceTextSemicolons(themed)
+      if (retryCode === themed)
+        throw error
+      await anyMermaid.parse?.(retryCode)
+    }
     return true
   }
   // If parse is unavailable in this mermaid version, signal fallback

--- a/test/mermaid-sequence-semicolon-retry.test.ts
+++ b/test/mermaid-sequence-semicolon-retry.test.ts
@@ -1,0 +1,156 @@
+import { mount } from '@vue/test-utils'
+import mermaid from 'mermaid'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+async function flushVueUpdates() {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('mermaid sequence semicolon retry', () => {
+  it('renders sequence messages with ASCII semicolons after the first Mermaid render failure', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    const render = vi.fn(async (_id: string, source: string) => {
+      if (source.includes('BEGIN; SELECT'))
+        throw new Error('Parse error on line 3')
+      return {
+        svg: '<svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>',
+      }
+    })
+
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render,
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread: vi.fn(async () => true),
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const code = [
+      'sequenceDiagram',
+      '  A->>B: BEGIN; SELECT ... FOR UPDATE',
+      '  A->>B: hello; B-->>A: ok',
+    ].join('\n')
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'mermaid',
+          code,
+          raw: `\`\`\`mermaid\n${code}\n\`\`\``,
+        },
+        loading: false,
+      },
+    })
+
+    await flushVueUpdates()
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).showSource = false
+    ;(wrapper.vm as any).viewportReady = true
+    await flushVueUpdates()
+    await vi.advanceTimersByTimeAsync(5000)
+    await flushVueUpdates()
+
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render.mock.calls[0]?.[1]).toContain('BEGIN; SELECT')
+    expect(render.mock.calls[1]?.[1]).toContain('BEGIN#59; SELECT')
+    expect(render.mock.calls[1]?.[1]).toContain('hello; B-->>A: ok')
+    expect(wrapper.find('div._mermaid svg').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('keeps the retry source parseable for Mermaid sequence diagrams', async () => {
+    const source = [
+      'sequenceDiagram',
+      '  OI->>DB: BEGIN; SELECT ... FOR UPDATE',
+      '  OI->>DB: use_count++ ; update status',
+      '  OI->>DB: BEGIN; SELECT; DB-->>OI: OK',
+      '  OI->>DB: BEGIN; SELECT; activate DB',
+      '  OI->>DB: hello; DB-->>OI: ok',
+    ].join('\n')
+
+    mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' })
+
+    const { escapeSequenceTextSemicolons } = await import('../src/utils/mermaidSequenceSemicolons')
+    const retrySource = escapeSequenceTextSemicolons(source)
+
+    expect(retrySource).not.toBe(source)
+    expect(retrySource).toContain('BEGIN#59; SELECT')
+    expect(retrySource).toContain('use_count++ #59; update status')
+    expect(retrySource).toContain('BEGIN#59; SELECT; DB-->>OI: OK')
+    expect(retrySource).toContain('BEGIN#59; SELECT; activate DB')
+    expect(retrySource).toContain('hello; DB-->>OI: ok')
+    const parsed = mermaid.parse(retrySource)
+    if (parsed && typeof (parsed as any).then === 'function')
+      await expect(parsed).resolves.not.toBe(false)
+    else
+      expect(parsed).not.toBe(false)
+  })
+
+  it('does not retry semicolon escaping after render timeouts', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const render = vi.fn(async () => {
+      throw new Error('Operation timed out')
+    })
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render,
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread: vi.fn(async () => true),
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const code = 'sequenceDiagram\n  A->>B: BEGIN; SELECT ... FOR UPDATE'
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'mermaid',
+          code,
+          raw: `\`\`\`mermaid\n${code}\n\`\`\``,
+        },
+        loading: false,
+      },
+    })
+
+    await flushVueUpdates()
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).showSource = false
+    ;(wrapper.vm as any).viewportReady = true
+    await flushVueUpdates()
+
+    expect(render).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+})

--- a/test/workers/mermaid-cdn-worker.test.ts
+++ b/test/workers/mermaid-cdn-worker.test.ts
@@ -21,6 +21,16 @@ describe('mermaid CDN worker factory', () => {
     expect(src).toContain('mermaid.esm.min.mjs')
   })
 
+  it('includes sequence text semicolon parse retry logic', () => {
+    const src = buildMermaidCDNWorkerSource({
+      mermaidUrl: 'https://cdn.example.com/mermaid.esm.min.mjs',
+      mode: 'module',
+    })
+
+    expect(src).toContain('function escapeSequenceTextSemicolons')
+    expect(src).toContain('await anyMermaid.parse(retryCode)')
+  })
+
   it('is SSR-safe and returns null worker when Worker is unavailable', () => {
     const prev = (globalThis as any).Worker
     try {


### PR DESCRIPTION
## Summary
- Retry Mermaid sequence diagram parse/render with semicolons in message text escaped as Mermaid entities.
- Keep legal one-line sequence statement separators intact, e.g. `A->>B: hello; B-->>A: ok`.
- Apply the same parse retry behavior to the ESM parser worker and generated CDN worker source.
- Avoid semicolon retry on timeout/abort so large diagrams keep the existing timeout/backoff behavior.

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest --run test/mermaid-sequence-semicolon-retry.test.ts test/workers/mermaid-cdn-worker.test.ts test/mermaid-static-performance.test.ts test/mermaid-streaming-preview-regression.test.ts test/mermaid-viewport-priority.test.ts test/security/mermaid-block-sanitizer.test.ts`
- `pnpm exec vitest --run --testTimeout=10000`
- `pnpm run release:verify`

## Review
- Two subagent code reviews were run.
- Initial review findings around legal semicolon-separated statements, timeout retry behavior, CDN worker parity, and coverage were addressed.
- Follow-up reviews reported no blocking findings and recommended merge.
