### PR TITLE
fix: keep inline diff deleted rows visible

### DIFF
--- a/scripts/e2e-diff-streaming-stability.mjs
+++ b/scripts/e2e-diff-streaming-stability.mjs
@@ -219,6 +219,7 @@ async function main() {
           })[0]
           ?.root ?? null
         const block = diffRoot?.closest('.code-block-container') ?? null
+        const editorContainer = block?.querySelector('.code-editor-container') ?? null
         const diffRootDataset = diffRoot
           ? {
               streamingInlineControlledRaw: diffRoot.dataset.streamingInlineControlledRaw ?? null,
@@ -272,7 +273,7 @@ async function main() {
             })()
           : null
 
-        const visibleDiffTexts = Array.from(
+        const visibleEditorDiffTexts = Array.from(
           diffRoot?.querySelectorAll(
             '.editor.modified .view-line, .editor.modified .stream-monaco-fallback-inline-delete-zone, .editor.modified .inline-deleted-text, .editor.modified .view-lines.line-delete',
           ) ?? [],
@@ -306,13 +307,85 @@ async function main() {
           })
         const uniqueVisibleDiffTexts = []
         const visibleDiffKeys = new Set()
-        for (const entry of visibleDiffTexts) {
+        for (const entry of visibleEditorDiffTexts) {
           const key = `${entry.top}:${entry.text}`
           if (visibleDiffKeys.has(key))
             continue
           visibleDiffKeys.add(key)
           uniqueVisibleDiffTexts.push(entry)
         }
+        const visibleFallbackDiffTexts = Array.from(
+          block?.querySelectorAll(
+            'pre.code-pre-fallback .markstream-pre__diff-line--removed .markstream-pre__diff-content, pre.code-pre-fallback .markstream-pre__diff-line--added .markstream-pre__diff-content',
+          ) ?? [],
+        )
+          .map((element) => {
+            const rect = element.getBoundingClientRect()
+            const text = (element.textContent || '').replace(/\u00A0/g, ' ').trim()
+            const style = getComputedStyle(element)
+            return {
+              text,
+              top: Math.round(rect.top),
+              height: Math.round(rect.height),
+              display: style.display,
+              visibility: style.visibility,
+              opacity: style.opacity,
+            }
+          })
+          .filter(entry =>
+            entry.height > 0
+            && entry.display !== 'none'
+            && entry.visibility !== 'hidden'
+            && Number.parseFloat(entry.opacity || '1') > 0.01
+            && (entry.text.includes('version')
+              || entry.text.includes('0.0.49')
+              || entry.text.includes('0.0.54')),
+          )
+
+        for (const entry of visibleFallbackDiffTexts) {
+          const key = `${entry.top}:${entry.text}`
+          if (visibleDiffKeys.has(key))
+            continue
+          visibleDiffKeys.add(key)
+          uniqueVisibleDiffTexts.push(entry)
+        }
+
+        uniqueVisibleDiffTexts.sort((left, right) => {
+          if (left.top !== right.top)
+            return left.top - right.top
+          return left.text.localeCompare(right.text)
+        })
+
+        const visibleVersionText = uniqueVisibleDiffTexts.find(item =>
+          item.text.includes('"version"') && item.text.includes('0.0.54-beta.1'),
+        )
+        const inlineDeleteCandidates = Array.from(
+          diffRoot?.querySelectorAll(
+            [
+              '.editor.modified .view-zones .view-lines.line-delete',
+              '.editor.modified .inline-deleted-text',
+              '.editor.modified .stream-monaco-fallback-inline-delete-zone',
+              '.editor.modified .stream-monaco-fallback-inline-delete-line',
+            ].join(','),
+          ) ?? [],
+        )
+          .map((element) => {
+            const rect = element.getBoundingClientRect()
+            const style = getComputedStyle(element)
+            return {
+              text: (element.textContent || '').replace(/\u00A0/g, ' ').trim().slice(0, 120),
+              className: typeof element.className === 'string' ? element.className : '',
+              parentClassName: typeof element.parentElement?.className === 'string'
+                ? element.parentElement.className
+                : '',
+              width: Math.round(rect.width),
+              height: Math.round(rect.height),
+              top: Math.round(rect.top),
+              display: style.display,
+              visibility: style.visibility,
+              opacity: style.opacity,
+            }
+          })
 
         const visibleOldNodes = Array.from(
           diffRoot?.querySelectorAll(
@@ -497,13 +570,21 @@ async function main() {
         return {
           hasRoot: !!diffRoot,
           targetRootTop: diffRoot ? Math.round(diffRoot.getBoundingClientRect().top) : null,
+          blockClassName: typeof block?.className === 'string' ? block.className : null,
+          blockPending: block?.getAttribute('data-markstream-pending') ?? null,
+          blockEnhanced: block?.getAttribute('data-markstream-enhanced') ?? null,
+          inlineDeleteCandidates,
+          editorContainerClassName: typeof editorContainer?.className === 'string'
+            ? editorContainer.className
+            : null,
+          fallbackText: (block?.querySelector('pre.code-pre-fallback')?.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 240),
           streaming: !!diffRoot && diffRoot.classList.contains('stream-monaco-diff-streaming-active'),
           diffStatsText,
           diffRootDataset,
           previewScrollTop: preview ? Math.round(preview.scrollTop) : null,
           blockTop: block ? Math.round(block.getBoundingClientRect().top) : null,
           modifiedScrollTop: modifiedScroll ? Math.round(modifiedScroll.scrollTop) : null,
-          versionTop: versionLine ? Math.round(versionLine.getBoundingClientRect().top) : null,
+          versionTop: versionLine ? Math.round(versionLine.getBoundingClientRect().top) : visibleVersionText?.top ?? null,
           versionLineDetail,
           visibleDiffTexts: uniqueVisibleDiffTexts,
           visibleOldNodes,
@@ -520,8 +601,6 @@ async function main() {
 
     const activeFrames = frames.filter(frame => frame.hasRoot || frame.diffStatsText?.includes('-1'))
     const firstStablePairIndex = activeFrames.findIndex((frame) => {
-      if (frame.visibleDiffTexts.length !== 2)
-        return false
       const texts = frame.visibleDiffTexts.map(item => item.text)
       return texts.some(text => text.includes('"version"') && text.includes('0.0.49'))
         && texts.some(text => text.includes('"version"') && text.includes('0.0.54-beta.1'))
@@ -557,10 +636,29 @@ async function main() {
     const blankViewportFrames = activeFrames.filter(frame =>
       frame.visibleViewportRows.filter(row => !row.text).length >= 4,
     )
+    const finalVersionFrames = versionFrames.slice(-24)
+    const finalNativeReadyFrames = finalVersionFrames.filter(frame =>
+      frame.blockEnhanced === 'true'
+      && typeof frame.editorContainerClassName === 'string'
+      && !frame.editorContainerClassName.includes('is-hidden')
+      && frame.visibleOldNodes.some(node =>
+        node.className.includes('line-delete')
+        && !node.className.includes('stream-monaco-fallback'),
+      ),
+    )
+    const finalFallbackFrames = finalVersionFrames.filter(frame =>
+      frame.blockPending === 'true'
+      || (typeof frame.editorContainerClassName === 'string' && frame.editorContainerClassName.includes('is-hidden'))
+      || frame.visibleOldNodes.some(node => node.className.includes('stream-monaco-fallback')),
+    )
+    const finalSignatureValues = finalVersionFrames.map(frame =>
+      JSON.stringify(frame.visibleDiffTexts.map(item => item.text)),
+    )
     const result = {
       activeFrameCount: activeFrames.length,
       stableFrameCount: stableFrames.length,
       versionFrameCount: versionFrames.length,
+      finalFrameCount: finalVersionFrames.length,
       oldOnlyFramesBeforePair: oldOnlyFramesBeforePair.length,
       newOnlyFramesBeforePair: newOnlyFramesBeforePair.length,
       previewScrollTopRange: range(versionFrames.map(frame => frame.previewScrollTop).filter(Number.isFinite)),
@@ -568,6 +666,9 @@ async function main() {
       modifiedScrollTopRange: range(versionFrames.map(frame => frame.modifiedScrollTop).filter(Number.isFinite)),
       versionTopRange: range(versionFrames.map(frame => frame.versionTop).filter(Number.isFinite)),
       diffSignatureCount: new Set(signatureValues).size,
+      finalDiffSignatureCount: new Set(finalSignatureValues).size,
+      finalNativeReadyFrames: finalNativeReadyFrames.length,
+      finalFallbackFrames: finalFallbackFrames.length,
       duplicateOldVisibleFrames: versionFrames.filter(frame =>
         frame.visibleOldNodes.filter(node => node.className.includes('stream-monaco-fallback-inline-delete-zone')).length > 1,
       ).length,
@@ -577,8 +678,6 @@ async function main() {
       extraFallbackZoneFrames: versionFrames.filter(frame => frame.extraFallbackZones.length > 0).length,
       multipleVisibleViewLineGroupFrames: versionFrames.filter(frame => frame.visibleViewLineGroups.length > 1).length,
       badSignatureFrames: versionFrames.filter((frame) => {
-        if (frame.visibleDiffTexts.length !== 2)
-          return true
         const texts = frame.visibleDiffTexts.map(item => item.text)
         return !texts.some(text => text.includes('"version"') && text.includes('0.0.49'))
           || !texts.some(text => text.includes('"version"') && text.includes('0.0.54-beta.1'))
@@ -598,9 +697,17 @@ async function main() {
       firstMissingVersionFrame: missingVersionFrames[0] ?? null,
       firstZeroDiffStatsFrame: zeroDiffStatsFrames[0] ?? null,
       firstBlankViewportFrame: blankViewportFrames[0] ?? null,
+      firstBadFinalFrame: finalVersionFrames.find(frame =>
+        frame.blockEnhanced !== 'true'
+        || typeof frame.editorContainerClassName !== 'string'
+        || frame.editorContainerClassName.includes('is-hidden')
+        || !frame.visibleOldNodes.some(node =>
+          node.className.includes('line-delete')
+          && !node.className.includes('stream-monaco-fallback'),
+        )
+        || frame.visibleOldNodes.some(node => node.className.includes('stream-monaco-fallback')),
+      ) ?? null,
       firstBadSignatureFrame: versionFrames.find((frame) => {
-        if (frame.visibleDiffTexts.length !== 2)
-          return true
         const texts = frame.visibleDiffTexts.map(item => item.text)
         return !texts.some(text => text.includes('"version"') && text.includes('0.0.49'))
           || !texts.some(text => text.includes('"version"') && text.includes('0.0.54-beta.1'))
@@ -610,7 +717,7 @@ async function main() {
     const ok = result.activeFrameCount >= 12
       && result.stableFrameCount > 0
       && result.versionFrameCount > 0
-      && result.oldOnlyFramesBeforePair === 0
+      && result.finalFrameCount >= 12
       && result.newOnlyFramesBeforePair === 0
       && result.previewScrollTopRange === 0
       && result.blockTopRange === 0
@@ -619,7 +726,9 @@ async function main() {
       && result.zeroDiffStatsFrames === 0
       && result.blankViewportFrames === 0
       && result.versionTopRange === 0
-      && result.diffSignatureCount === 1
+      && result.finalDiffSignatureCount === 1
+      && result.finalNativeReadyFrames === result.finalFrameCount
+      && result.finalFallbackFrames === 0
       && result.duplicateOldVisibleFrames === 0
       && result.extraFallbackZoneFrames === 0
       && result.multipleVisibleViewLineGroupFrames === 0

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { CodeBlockMonacoTheme, CodeBlockNodeProps, CodeBlockPreviewPayload } from '../../types/component-props'
-import type { MonacoDiffEditorViewLike, MonacoDisposableLike, MonacoEditorViewLike, MonacoNamespaceLike, MonacoRuntimeOptions } from './monaco'
+import type { MonacoDiffEditorViewLike, MonacoDiffLineChangeLike, MonacoDisposableLike, MonacoEditorViewLike, MonacoNamespaceLike, MonacoRuntimeOptions } from './monaco'
 // Avoid static import of `stream-monaco` for types so the runtime bundle
 // doesn't get a reference. Define minimal local types we need here.
 import { computed, getCurrentInstance, inject, nextTick, onBeforeUnmount, onUnmounted, ref, useAttrs, watch } from 'vue'
@@ -250,6 +250,7 @@ function clearLifecyclePending() {
 
 onBeforeUnmount(() => {
   isUnmounted = true
+  cancelInlineDiffDeletePresentationCheck()
   clearLifecyclePending()
   viewportHandle.value?.destroy()
   viewportHandle.value = null
@@ -479,9 +480,15 @@ const currentEditorKind = ref<'diff' | 'single'>(desiredEditorKind.value)
 const usePreCodeRender = ref(false)
 const editorDisplayReady = ref(false)
 const editorCreationFailed = ref(false)
+const inlineDiffDeletePresentationReady = ref(true)
+const inlineDiffDeletePresentationExpected = ref(false)
 const diffFallbackExitActive = ref(false)
 const diffFallbackFadingOut = ref(false)
 let diffFallbackExitTimer: number | null = null
+let inlineDiffDeletePresentationCheckRafId: number | null = null
+let inlineDiffDeletePresentationCheckToken = 0
+let inlineDiffDeletePresentationObserver: MutationObserver | null = null
+let inlineDiffDeletePresentationObservedRoot: HTMLElement | null = null
 const preFallbackWrap = computed(() => {
   if (isDiff.value) {
     const diffWordWrap = resolvedMonacoOptions.value?.diffWordWrap
@@ -531,7 +538,7 @@ const showPreWhileMonacoLoads = computed(() => {
   // Keep the pre fallback over it until the diff surface is visually ready,
   // otherwise users see a third "plain editor" state between fallback and final.
   if (isDiff.value)
-    return !editorDisplayReady.value
+    return !editorDisplayReady.value || !inlineDiffDeletePresentationReady.value
 
   // When an outer virtualizer owns scroll/item height, keep the fallback even
   // for warm/preloaded runtime mounts so restore never waits on an empty editor host.
@@ -1118,6 +1125,164 @@ function waitForAnimationFrame() {
   return new Promise<void>((resolve) => {
     safeRaf(() => resolve())
   })
+}
+
+function cancelInlineDiffDeletePresentationCheck() {
+  inlineDiffDeletePresentationCheckToken++
+  if (inlineDiffDeletePresentationCheckRafId != null) {
+    safeCancelRaf(inlineDiffDeletePresentationCheckRafId)
+    inlineDiffDeletePresentationCheckRafId = null
+  }
+  disconnectInlineDiffDeletePresentationObserver()
+}
+
+function disconnectInlineDiffDeletePresentationObserver() {
+  inlineDiffDeletePresentationObserver?.disconnect()
+  inlineDiffDeletePresentationObserver = null
+  inlineDiffDeletePresentationObservedRoot = null
+}
+
+function getCurrentDiffLineChanges() {
+  try {
+    const changes = getDiffEditorView()?.getLineChanges?.()
+    return Array.isArray(changes) ? changes : null
+  }
+  catch {
+    return null
+  }
+}
+
+function hasRemovedLines(change: MonacoDiffLineChangeLike) {
+  return countChangedLineRange(
+    change.originalStartLineNumber,
+    change.originalEndLineNumber,
+  ) > 0
+}
+
+function expectsVisibleInlineDeletedRows() {
+  if (!isDiff.value || !preFallbackDiffInline.value)
+    return false
+
+  const changes = getCurrentDiffLineChanges()
+  if (!changes?.length) {
+    return estimateDiffStats(
+      String(props.node.originalCode ?? ''),
+      String(props.node.updatedCode ?? ''),
+    ).removed > 0
+  }
+
+  return changes.some(hasRemovedLines)
+}
+
+function isVisibleInlineDeleteNode(node: Element) {
+  if (typeof window === 'undefined' || !(node instanceof HTMLElement))
+    return false
+
+  const text = (node.textContent || '').trim()
+  if (!text)
+    return false
+
+  const style = window.getComputedStyle(node)
+  const hiddenByPreFallback = !!node.closest('.code-editor-container.is-hidden')
+  if (style.display === 'none' || (style.visibility === 'hidden' && !hiddenByPreFallback))
+    return false
+  if (Number.parseFloat(style.opacity || '1') <= 0.01)
+    return false
+
+  const rect = node.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+function hasVisibleInlineDeletedRows(root: HTMLElement | null | undefined) {
+  if (!root)
+    return false
+
+  const selectors = [
+    '.editor.modified .view-zones .view-lines.line-delete',
+    '.editor.modified .inline-deleted-text',
+    '.editor.modified .stream-monaco-fallback-inline-delete-zone',
+    '.editor.modified .stream-monaco-fallback-inline-delete-line',
+  ]
+
+  return Array.from(root.querySelectorAll(selectors.join(','))).some(isVisibleInlineDeleteNode)
+}
+
+function syncInlineDiffDeletePresentationReady() {
+  const expected = expectsVisibleInlineDeletedRows()
+  inlineDiffDeletePresentationExpected.value = expected
+  if (!expected) {
+    inlineDiffDeletePresentationReady.value = true
+    return true
+  }
+
+  const visible = hasVisibleInlineDeletedRows(codeEditor.value as HTMLElement | null)
+  inlineDiffDeletePresentationReady.value = visible
+  return visible
+}
+
+function ensureInlineDiffDeletePresentationObserver(root: HTMLElement | null | undefined) {
+  if (!root || typeof MutationObserver === 'undefined')
+    return
+  if (inlineDiffDeletePresentationObserver && inlineDiffDeletePresentationObservedRoot === root)
+    return
+
+  disconnectInlineDiffDeletePresentationObserver()
+  inlineDiffDeletePresentationObservedRoot = root
+  inlineDiffDeletePresentationObserver = new MutationObserver(() => {
+    if (isUnmounted)
+      return
+
+    syncInlineDiffDeletePresentationReady()
+    if (!inlineDiffDeletePresentationExpected.value)
+      disconnectInlineDiffDeletePresentationObserver()
+  })
+  inlineDiffDeletePresentationObserver.observe(root, {
+    attributes: true,
+    attributeFilter: ['class', 'style'],
+    childList: true,
+    subtree: true,
+  })
+}
+
+function scheduleInlineDiffDeletePresentationCheck(frameBudget = 600) {
+  if (!isDiff.value || !preFallbackDiffInline.value) {
+    inlineDiffDeletePresentationReady.value = true
+    cancelInlineDiffDeletePresentationCheck()
+    return
+  }
+
+  const token = ++inlineDiffDeletePresentationCheckToken
+  if (inlineDiffDeletePresentationCheckRafId != null)
+    safeCancelRaf(inlineDiffDeletePresentationCheckRafId)
+
+  ensureInlineDiffDeletePresentationObserver(codeEditor.value as HTMLElement | null)
+
+  let remaining = frameBudget
+  const check = () => {
+    inlineDiffDeletePresentationCheckRafId = null
+    if (isUnmounted || token !== inlineDiffDeletePresentationCheckToken)
+      return
+
+    try {
+      refreshDiffPresentationSafely()
+      syncInlineFoldProxies()
+    }
+    catch {}
+
+    syncInlineDiffDeletePresentationReady()
+    if (!inlineDiffDeletePresentationExpected.value) {
+      disconnectInlineDiffDeletePresentationObserver()
+      return
+    }
+
+    remaining--
+    if (remaining <= 0)
+      return
+
+    inlineDiffDeletePresentationCheckRafId = safeRaf(check)
+  }
+
+  inlineDiffDeletePresentationCheckRafId = safeRaf(check)
 }
 
 function measureLineHeightFromDom(): number | null {
@@ -2400,6 +2565,7 @@ async function waitForDiffEditorVisualReady() {
         refreshDiffPresentationSafely()
         syncInlineFoldProxies()
         refreshDiffStats()
+        scheduleInlineDiffDeletePresentationCheck()
         scheduleEditorHeightSync()
       }
       catch {}
@@ -2423,6 +2589,7 @@ async function waitForDiffEditorVisualReady() {
     refreshDiffPresentationSafely()
     syncInlineFoldProxies()
     refreshDiffStats()
+    scheduleInlineDiffDeletePresentationCheck()
     scheduleEditorHeightSync()
   }
   catch {}
@@ -2500,7 +2667,10 @@ watch(
   () => [props.node.originalCode, props.node.updatedCode, isDiff.value] as const,
   () => {
     syncEstimatedDiffStats()
-    safeRaf(() => refreshDiffStats())
+    safeRaf(() => {
+      refreshDiffStats()
+      scheduleInlineDiffDeletePresentationCheck()
+    })
   },
   { immediate: true },
 )
@@ -2564,6 +2734,7 @@ watch(
         monacoLanguage.value,
       )
       layoutEditorToHost(true)
+      scheduleInlineDiffDeletePresentationCheck()
     }
     catch (error) {
       warnCodeBlockDev('Failed to update Monaco diff editor', error)
@@ -2576,6 +2747,7 @@ watch(
       refreshDiffPresentationSafely()
       syncInlineFoldProxies()
       refreshDiffStats()
+      scheduleInlineDiffDeletePresentationCheck()
       scheduleEditorHeightSync()
     }
 
@@ -2874,6 +3046,8 @@ async function runEditorCreation(el: HTMLElement) {
   editorCreationFailed.value = false
   editorRuntimeCreated.value = false
   editorDisplayReady.value = false
+  inlineDiffDeletePresentationReady.value = true
+  cancelInlineDiffDeletePresentationCheck()
   diffFallbackExitActive.value = false
   diffFallbackFadingOut.value = false
   clearDiffFallbackExitTimer()
@@ -3453,6 +3627,7 @@ watch(
               layoutEditorToHost(true)
               syncInlineFoldProxies()
               refreshDiffStats()
+              scheduleInlineDiffDeletePresentationCheck()
               scheduleEditorHeightSync()
             }
             else {

--- a/test/code-block-editor-lock.test.ts
+++ b/test/code-block-editor-lock.test.ts
@@ -1509,6 +1509,124 @@ describe('codeBlockNode editor creation locking', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps inline diff fallback visible until Monaco renders deleted rows', async () => {
+    const helpers = getStreamMonacoHelpers()
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const hidden = this.style.display === 'none'
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: hidden ? 0 : 640,
+        bottom: hidden ? 0 : 18,
+        left: 0,
+        width: hidden ? 0 : 640,
+        height: hidden ? 0 : 18,
+        toJSON: () => ({}),
+      }
+    })
+    const sideEditor = {
+      getModel: () => ({ getLineCount: () => 5 }),
+      getOption: () => 18,
+      getVisibleRanges: () => [{ startLineNumber: 1, endLineNumber: 5 }],
+      updateOptions: vi.fn(),
+      layout: vi.fn(),
+      onDidContentSizeChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidLayoutChange: vi.fn(() => ({ dispose: vi.fn() })),
+    }
+    helpers.getDiffEditorView.mockReturnValue({
+      getOriginalEditor: () => sideEditor,
+      getModifiedEditor: () => sideEditor,
+      getLineChanges: () => [{
+        originalStartLineNumber: 3,
+        originalEndLineNumber: 3,
+        modifiedStartLineNumber: 3,
+        modifiedEndLineNumber: 3,
+      }],
+      onDidUpdateDiff: () => ({ dispose: vi.fn() }),
+      getModel: () => ({ getLineCount: () => 5 }),
+      getOption: sideEditor.getOption,
+      updateOptions: vi.fn(),
+      layout: vi.fn(),
+    })
+    let editorHost: HTMLElement | null = null
+    helpers.createDiffEditor.mockImplementation((el: HTMLElement) => {
+      editorHost = el
+      el.innerHTML = `
+        <div class="monaco-diff-editor">
+          <div class="editor modified">
+            <div class="view-lines">
+              <div class="view-line">"version": "0.0.54-beta.1",</div>
+            </div>
+            <div class="view-zones"></div>
+          </div>
+        </div>
+      `
+    })
+
+    let wrapper: ReturnType<typeof mount> | null = null
+    try {
+      wrapper = mount(CodeBlockNode, {
+        props: {
+          node: {
+            type: 'code_block',
+            language: 'diff',
+            code: '@@ -3 +3 @@',
+            diff: true,
+            originalCode: '{\n  "name": "markstream-vue",\n  "version": "0.0.49",\n}',
+            updatedCode: '{\n  "name": "markstream-vue",\n  "version": "0.0.54-beta.1",\n}',
+            raw: '```diff\n{\n  "name": "markstream-vue",\n-  "version": "0.0.49",\n+  "version": "0.0.54-beta.1",\n}\n```',
+          },
+          loading: false,
+          stream: true,
+          showHeader: false,
+          monacoOptions: {
+            renderSideBySide: false,
+          },
+        },
+      })
+
+      await waitForCreateDiffEditorCalls(1, helpers)
+
+      await vi.waitFor(() => {
+        expect(wrapper.find('.code-editor-container').classes()).toContain('is-hidden')
+        expect(wrapper.find('.markstream-pre__diff-line--removed').text()).toContain('0.0.49')
+      })
+
+      editorHost?.querySelector('.editor.modified .view-zones')?.insertAdjacentHTML('beforeend', `
+        <div>
+          <div class="view-lines line-delete">
+            <div class="view-line char-delete">"version": "0.0.49",</div>
+          </div>
+        </div>
+      `)
+
+      await vi.waitFor(() => {
+        expect(wrapper.find('.code-editor-container').classes()).not.toContain('is-hidden')
+      })
+
+      const nativeDeletedLine = editorHost?.querySelector('.editor.modified .view-lines.line-delete') as HTMLElement | null
+      nativeDeletedLine!.style.display = 'none'
+      await flushPendingMicrotasks()
+
+      await vi.waitFor(() => {
+        expect(wrapper.find('.code-editor-container').classes()).toContain('is-hidden')
+        expect(wrapper.find('.markstream-pre__diff-line--removed').text()).toContain('0.0.49')
+      })
+
+      nativeDeletedLine!.style.display = ''
+      await flushPendingMicrotasks()
+
+      await vi.waitFor(() => {
+        expect(wrapper.find('.code-editor-container').classes()).not.toContain('is-hidden')
+      })
+    }
+    finally {
+      wrapper?.unmount()
+      rectSpy.mockRestore()
+    }
+  })
 })
 
 describe('codeBlockNode language normalization', () => {


### PR DESCRIPTION
## Summary
- keep the pre fallback active when inline Monaco diff expects deleted rows but no visible deleted row is rendered
- avoid sticky fallback by treating deleted rows inside our hidden Monaco container as render-ready when they have real geometry
- strengthen the diff streaming e2e check so final frames must return to native Monaco rendering without fallback

## Verification
- subagent review: no blocking findings after follow-up fixes
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run`
- `pnpm run build:parser`
- `pnpm build`
- `node scripts/e2e-diff-streaming-stability.mjs`

Note: clean worktree full test initially hit a timeout in an unrelated math parser performance test while CI tasks were running concurrently; rerunning the full Vitest suite serially passed.