### PR TITLE
fix: stabilize bracket math streaming close

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -718,6 +718,24 @@ function scanExplicitBracketMathStreamState(
 }
 
 function updateExplicitBracketMathStreamState(previous: ExplicitBracketMathStreamState, appended: string) {
+  if (
+    appended
+    && !previous.context.inMath
+    && !previous.context.inFence
+    && !previous.committedContext.inFence
+    && !/[\\`~\r\n]/.test(appended)
+    && !(previous.lineBuffer.endsWith('\\') && (appended[0] === '[' || appended[0] === ']'))
+  ) {
+    return {
+      closedOpenMath: false,
+      state: {
+        committedContext: cloneExplicitBracketMathContext(previous.committedContext),
+        context: cloneExplicitBracketMathContext(previous.context),
+        lineBuffer: previous.lineBuffer + appended,
+      },
+    }
+  }
+
   return scanExplicitBracketMathStreamState(
     previous.lineBuffer + appended,
     previous.committedContext,

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -372,27 +372,165 @@ function isEscapedDelimiterAt(source: string, index: number) {
   return backslashes % 2 === 1
 }
 
-function findLastUnescapedDelimiter(source: string, delimiter: string) {
-  let searchPos = source.length - delimiter.length
+function isIndentWhitespace(ch: string) {
+  return ch === ' ' || ch === '\t'
+}
 
-  while (searchPos >= 0) {
-    const index = source.lastIndexOf(delimiter, searchPos)
-    if (index === -1)
+function parseMarkdownFenceMarker(line: string) {
+  let index = 0
+  while (index < line.length && isIndentWhitespace(line[index]))
+    index++
+
+  const markerChar = line[index]
+  if (markerChar !== '`' && markerChar !== '~')
+    return null
+
+  let markerEnd = index
+  while (markerEnd < line.length && line[markerEnd] === markerChar)
+    markerEnd++
+
+  const markerLen = markerEnd - index
+  if (markerLen < 3)
+    return null
+
+  return { markerChar: markerChar as '`' | '~', markerLen, rest: line.slice(markerEnd) }
+}
+
+function stripMarkdownBlockquotePrefix(line: string) {
+  let index = 0
+  while (index < line.length && isIndentWhitespace(line[index]))
+    index++
+
+  let saw = false
+  while (index < line.length && line[index] === '>') {
+    saw = true
+    index++
+    while (index < line.length && isIndentWhitespace(line[index]))
+      index++
+  }
+
+  return saw ? line.slice(index) : null
+}
+
+function matchMarkdownFenceMarker(line: string) {
+  const direct = parseMarkdownFenceMarker(line)
+  if (direct)
+    return direct
+
+  const quoted = stripMarkdownBlockquotePrefix(line)
+  return quoted == null ? null : parseMarkdownFenceMarker(quoted)
+}
+
+function countRepeatedChar(source: string, index: number, ch: string) {
+  let end = index
+  while (end < source.length && source[end] === ch)
+    end++
+  return end - index
+}
+
+function findCodeSpanCloseIndex(line: string, start: number, markerLen: number) {
+  let index = start
+
+  while (index < line.length) {
+    const next = line.indexOf('`', index)
+    if (next === -1)
       return -1
-    if (!isEscapedDelimiterAt(source, index))
-      return index
-    searchPos = index - 1
+
+    const runLen = countRepeatedChar(line, next, '`')
+    if (runLen === markerLen)
+      return next
+
+    index = next + runLen
   }
 
   return -1
 }
 
-function hasUnclosedExplicitBracketMathOpen(source: string) {
-  const openIndex = findLastUnescapedDelimiter(source, '\\[')
-  if (openIndex === -1)
-    return false
+function scanLineForExplicitBracketMathState(line: string, lineStart: number, source: string, inMath: boolean) {
+  let index = 0
 
-  return findLastUnescapedDelimiter(source, '\\]') < openIndex
+  while (index < line.length) {
+    const sourceIndex = lineStart + index
+
+    if (inMath) {
+      if (line.startsWith('\\]', index) && !isEscapedDelimiterAt(source, sourceIndex)) {
+        inMath = false
+        index += 2
+        continue
+      }
+
+      index++
+      continue
+    }
+
+    if (line[index] === '`' && !isEscapedDelimiterAt(source, sourceIndex)) {
+      const markerLen = countRepeatedChar(line, index, '`')
+      const closeIndex = findCodeSpanCloseIndex(line, index + markerLen, markerLen)
+      if (closeIndex === -1)
+        break
+      index = closeIndex + markerLen
+      continue
+    }
+
+    if (line.startsWith('\\[', index) && !isEscapedDelimiterAt(source, sourceIndex)) {
+      inMath = true
+      index += 2
+      continue
+    }
+
+    index++
+  }
+
+  return inMath
+}
+
+function hasUnclosedExplicitBracketMathOpen(source: string) {
+  let inMath = false
+  let inFence = false
+  let fenceChar: '`' | '~' | '' = ''
+  let fenceLen = 0
+  let index = 0
+
+  while (index < source.length) {
+    const newlineIndex = source.indexOf('\n', index)
+    const hasNewline = newlineIndex !== -1
+    const lineEnd = hasNewline && newlineIndex > index && source[newlineIndex - 1] === '\r'
+      ? newlineIndex - 1
+      : hasNewline ? newlineIndex : source.length
+    const line = source.slice(index, lineEnd)
+
+    if (!inMath) {
+      const fenceMatch = matchMarkdownFenceMarker(line)
+      if (fenceMatch) {
+        if (inFence) {
+          if (
+            fenceMatch.markerChar === fenceChar
+            && fenceMatch.markerLen >= fenceLen
+            && /^\s*$/.test(fenceMatch.rest)
+          ) {
+            inFence = false
+            fenceChar = ''
+            fenceLen = 0
+          }
+        }
+        else {
+          inFence = true
+          fenceChar = fenceMatch.markerChar
+          fenceLen = fenceMatch.markerLen
+        }
+      }
+      else if (!inFence) {
+        inMath = scanLineForExplicitBracketMathState(line, index, source, inMath)
+      }
+    }
+    else {
+      inMath = scanLineForExplicitBracketMathState(line, index, source, inMath)
+    }
+
+    index = hasNewline ? newlineIndex + 1 : source.length
+  }
+
+  return inMath
 }
 
 function hasUnescapedDelimiterInAppendedChunk(previousSource: string, appended: string, delimiter: string) {

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -355,6 +355,83 @@ function appendedChunkMayAffectTolerantMathBoundary(previousSource: string, appe
   return false
 }
 
+function countTrailingBackslashes(source: string) {
+  let count = 0
+  for (let index = source.length - 1; index >= 0 && source[index] === '\\'; index--)
+    count++
+  return count
+}
+
+function isEscapedDelimiterAt(source: string, index: number) {
+  let cursor = index - 1
+  let backslashes = 0
+  while (cursor >= 0 && source[cursor] === '\\') {
+    backslashes++
+    cursor--
+  }
+  return backslashes % 2 === 1
+}
+
+function findLastUnescapedDelimiter(source: string, delimiter: string) {
+  let searchPos = source.length - delimiter.length
+
+  while (searchPos >= 0) {
+    const index = source.lastIndexOf(delimiter, searchPos)
+    if (index === -1)
+      return -1
+    if (!isEscapedDelimiterAt(source, index))
+      return index
+    searchPos = index - 1
+  }
+
+  return -1
+}
+
+function hasUnclosedExplicitBracketMathOpen(source: string) {
+  const openIndex = findLastUnescapedDelimiter(source, '\\[')
+  if (openIndex === -1)
+    return false
+
+  return findLastUnescapedDelimiter(source, '\\]') < openIndex
+}
+
+function hasUnescapedDelimiterInAppendedChunk(previousSource: string, appended: string, delimiter: string) {
+  let searchPos = 0
+
+  while (searchPos < appended.length) {
+    const index = appended.indexOf(delimiter, searchPos)
+    if (index === -1)
+      return false
+
+    let cursor = index - 1
+    let backslashes = 0
+    while (cursor >= 0 && appended[cursor] === '\\') {
+      backslashes++
+      cursor--
+    }
+    if (cursor === -1)
+      backslashes += countTrailingBackslashes(previousSource)
+
+    if (backslashes % 2 === 0)
+      return true
+
+    searchPos = index + Math.max(1, delimiter.length)
+  }
+
+  return false
+}
+
+function appendedChunkCompletesExplicitBracketMathClose(previousSource: string, appended: string) {
+  const completesInChunk = hasUnescapedDelimiterInAppendedChunk(previousSource, appended, '\\]')
+  const completesAcrossBoundary = appended[0] === ']'
+    && countTrailingBackslashes(previousSource) % 2 === 1
+
+  if (!completesInChunk && !completesAcrossBoundary)
+    return false
+
+  return hasUnclosedExplicitBracketMathOpen(previousSource)
+}
+
 function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
   if (!hasMarkstreamMathPlugin(md))
     return
@@ -369,12 +446,20 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
   if (previous?.source === source)
     return
 
-  if (previous && source.startsWith(previous.source)) {
-    const appended = source.slice(previous.source.length)
+  const sourceExtendsPrevious = previous ? source.startsWith(previous.source) : false
+  const appended = sourceExtendsPrevious && previous ? source.slice(previous.source.length) : ''
+  const completesExplicitBracketMathClose = sourceExtendsPrevious && previous
+    ? appendedChunkCompletesExplicitBracketMathClose(
+        previous.source,
+        appended,
+      )
+    : false
 
+  if (previous && sourceExtendsPrevious) {
     if (
       previous.key === null
       && previous.pendingCandidate === false
+      && !completesExplicitBracketMathClose
       && !appendedChunkMayAffectTolerantMathBoundary(previous.source, appended)
       && !sourceEndsWithSplitTolerantBoundaryPrefix(source)
     ) {
@@ -384,9 +469,9 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
   }
 
   const nextKey = getTolerantMathBlockBoundaryStreamKey(source)
-  const sourceWasReplaced = previous ? !source.startsWith(previous.source) : false
+  const sourceWasReplaced = previous ? !sourceExtendsPrevious : false
 
-  if (previous && (sourceWasReplaced || previous.key !== nextKey))
+  if (previous && (sourceWasReplaced || previous.key !== nextKey || completesExplicitBracketMathClose))
     stream.reset()
   else if (!previous && nextKey)
     stream.reset()

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -26,7 +26,26 @@ type ParsedNodeWithFields = ParsedNode & {
 }
 
 const streamParseEnvCache = new WeakMap<object, Map<string, Record<string, unknown>>>()
+
+interface ExplicitBracketMathContext {
+  fenceChar: '`' | '~' | ''
+  fenceInBlockquote: boolean
+  fenceInList: boolean
+  fenceLen: number
+  fenceListIndent: number
+  inFence: boolean
+  inMath: boolean
+  listContentIndent: number | null
+}
+
+interface ExplicitBracketMathStreamState {
+  committedContext: ExplicitBracketMathContext
+  context: ExplicitBracketMathContext
+  lineBuffer: string
+}
+
 const tolerantMathBoundaryStreamCache = new WeakMap<object, {
+  explicitBracketMath: ExplicitBracketMathStreamState
   source: string
   key: string | null
   pendingCandidate: boolean
@@ -310,12 +329,31 @@ function clearTolerantMathBoundaryStreamCache(md: MarkdownIt) {
   tolerantMathBoundaryStreamCache.delete(md as unknown as object)
 }
 
+function createExplicitBracketMathContext(): ExplicitBracketMathContext {
+  return {
+    fenceChar: '',
+    fenceInBlockquote: false,
+    fenceInList: false,
+    fenceLen: 0,
+    fenceListIndent: 0,
+    inFence: false,
+    inMath: false,
+    listContentIndent: null,
+  }
+}
+
+function cloneExplicitBracketMathContext(context: ExplicitBracketMathContext): ExplicitBracketMathContext {
+  return { ...context }
+}
+
 function setTolerantMathBoundaryStreamCache(
   md: MarkdownIt,
   source: string,
   key: string | null,
+  explicitBracketMath: ExplicitBracketMathStreamState = scanExplicitBracketMathStreamState(source).state,
 ) {
   tolerantMathBoundaryStreamCache.set(md as unknown as object, {
+    explicitBracketMath,
     source,
     key,
     pendingCandidate: key === null && mayContainTolerantMathBlockBoundaryOpener(source),
@@ -336,13 +374,13 @@ function appendedChunkMayAffectTolerantMathBoundary(previousSource: string, appe
   if (!appended)
     return false
 
-  if (appended.includes('$$') || appended.includes('\\[') || appended.includes('\\]'))
+  if (appended.includes('$$') || appended.includes('\\['))
     return true
 
   if (previousSource.endsWith('$') && appended[0] === '$')
     return true
 
-  if (previousSource.endsWith('\\') && (appended[0] === '[' || appended[0] === ']'))
+  if (previousSource.endsWith('\\') && appended[0] === '[')
     return true
 
   // The opener may have arrived in the previous chunk:
@@ -353,13 +391,6 @@ function appendedChunkMayAffectTolerantMathBoundary(previousSource: string, appe
     return true
 
   return false
-}
-
-function countTrailingBackslashes(source: string) {
-  let count = 0
-  for (let index = source.length - 1; index >= 0 && source[index] === '\\'; index--)
-    count++
-  return count
 }
 
 function isEscapedDelimiterAt(source: string, index: number) {
@@ -376,11 +407,33 @@ function isIndentWhitespace(ch: string) {
   return ch === ' ' || ch === '\t'
 }
 
-function parseMarkdownFenceMarker(line: string) {
-  let index = 0
-  while (index < line.length && isIndentWhitespace(line[index]))
-    index++
+function advanceMarkdownIndentColumn(column: number, ch: string) {
+  return ch === ' ' ? column + 1 : column + 4 - (column % 4)
+}
 
+function getMarkdownIndent(line: string) {
+  let index = 0
+  let column = 0
+
+  while (index < line.length && isIndentWhitespace(line[index])) {
+    column = advanceMarkdownIndentColumn(column, line[index])
+    index++
+  }
+
+  return { index, column }
+}
+
+function consumeMarkdownIndent(line: string) {
+  const indent = getMarkdownIndent(line)
+  return indent.column > 3 ? null : indent
+}
+
+function parseMarkdownFenceMarker(line: string) {
+  const indent = consumeMarkdownIndent(line)
+  if (!indent)
+    return null
+
+  const index = indent.index
   const markerChar = line[index]
   if (markerChar !== '`' && markerChar !== '~')
     return null
@@ -393,32 +446,78 @@ function parseMarkdownFenceMarker(line: string) {
   if (markerLen < 3)
     return null
 
-  return { markerChar: markerChar as '`' | '~', markerLen, rest: line.slice(markerEnd) }
+  const rest = line.slice(markerEnd)
+  if (markerChar === '`' && rest.includes('`'))
+    return null
+
+  return { markerChar: markerChar as '`' | '~', markerLen, rest }
+}
+
+function stripMarkdownListPrefix(line: string) {
+  const indent = consumeMarkdownIndent(line)
+  if (!indent)
+    return null
+
+  const rest = line.slice(indent.index)
+  const marker = /^(?:[-+*]|\d{1,9}[.)])(?=[\t ]|$)/.exec(rest)?.[0]
+  if (!marker)
+    return null
+
+  let index = indent.index + marker.length
+  let column = indent.column + marker.length
+  if (!isIndentWhitespace(line[index]))
+    return null
+
+  while (index < line.length && isIndentWhitespace(line[index])) {
+    column = advanceMarkdownIndentColumn(column, line[index])
+    index++
+  }
+
+  return {
+    content: line.slice(index),
+    contentIndent: column,
+  }
 }
 
 function stripMarkdownBlockquotePrefix(line: string) {
-  let index = 0
-  while (index < line.length && isIndentWhitespace(line[index]))
-    index++
-
+  let rest = line
   let saw = false
-  while (index < line.length && line[index] === '>') {
+
+  while (true) {
+    const indent = consumeMarkdownIndent(rest)
+    if (!indent)
+      return saw ? rest : null
+
+    let index = indent.index
+    if (rest[index] !== '>')
+      return saw ? rest : null
+
     saw = true
     index++
-    while (index < line.length && isIndentWhitespace(line[index]))
+    if (rest[index] === ' ' || rest[index] === '\t')
       index++
+    rest = rest.slice(index)
   }
-
-  return saw ? line.slice(index) : null
 }
 
 function matchMarkdownFenceMarker(line: string) {
   const direct = parseMarkdownFenceMarker(line)
   if (direct)
-    return direct
+    return { ...direct, inBlockquote: false, inList: false, listIndent: 0 }
 
   const quoted = stripMarkdownBlockquotePrefix(line)
-  return quoted == null ? null : parseMarkdownFenceMarker(quoted)
+  const quotedMarker = quoted == null ? null : parseMarkdownFenceMarker(quoted)
+  if (quotedMarker)
+    return { ...quotedMarker, inBlockquote: true, inList: false, listIndent: 0 }
+
+  const listed = stripMarkdownListPrefix(line)
+  if (!listed)
+    return null
+
+  const listedMarker = parseMarkdownFenceMarker(listed.content)
+  return listedMarker == null
+    ? null
+    : { ...listedMarker, inBlockquote: false, inList: true, listIndent: listed.contentIndent }
 }
 
 function countRepeatedChar(source: string, index: number, ch: string) {
@@ -446,15 +545,33 @@ function findCodeSpanCloseIndex(line: string, start: number, markerLen: number) 
   return -1
 }
 
-function scanLineForExplicitBracketMathState(line: string, lineStart: number, source: string, inMath: boolean) {
+function resetExplicitBracketFenceContext(context: ExplicitBracketMathContext) {
+  context.inFence = false
+  context.fenceChar = ''
+  context.fenceLen = 0
+  context.fenceInBlockquote = false
+  context.fenceInList = false
+  context.fenceListIndent = 0
+}
+
+function scanLineForExplicitBracketMathState(
+  line: string,
+  context: ExplicitBracketMathContext,
+  lineStart: number,
+  appendStart: number | null,
+  openAtAppendStart: boolean,
+) {
   let index = 0
+  let closedOpenMath = false
 
   while (index < line.length) {
-    const sourceIndex = lineStart + index
+    const sourceIndex = index
 
-    if (inMath) {
-      if (line.startsWith('\\]', index) && !isEscapedDelimiterAt(source, sourceIndex)) {
-        inMath = false
+    if (context.inMath) {
+      if (line.startsWith('\\]', index) && !isEscapedDelimiterAt(line, sourceIndex)) {
+        if (appendStart != null && openAtAppendStart && lineStart + index + 2 > appendStart)
+          closedOpenMath = true
+        context.inMath = false
         index += 2
         continue
       }
@@ -463,7 +580,7 @@ function scanLineForExplicitBracketMathState(line: string, lineStart: number, so
       continue
     }
 
-    if (line[index] === '`' && !isEscapedDelimiterAt(source, sourceIndex)) {
+    if (line[index] === '`' && !isEscapedDelimiterAt(line, sourceIndex)) {
       const markerLen = countRepeatedChar(line, index, '`')
       const closeIndex = findCodeSpanCloseIndex(line, index + markerLen, markerLen)
       if (closeIndex === -1)
@@ -472,8 +589,8 @@ function scanLineForExplicitBracketMathState(line: string, lineStart: number, so
       continue
     }
 
-    if (line.startsWith('\\[', index) && !isEscapedDelimiterAt(source, sourceIndex)) {
-      inMath = true
+    if (line.startsWith('\\[', index) && !isEscapedDelimiterAt(line, sourceIndex)) {
+      context.inMath = true
       index += 2
       continue
     }
@@ -481,14 +598,91 @@ function scanLineForExplicitBracketMathState(line: string, lineStart: number, so
     index++
   }
 
-  return inMath
+  return closedOpenMath
 }
 
-function hasUnclosedExplicitBracketMathOpen(source: string) {
-  let inMath = false
-  let inFence = false
-  let fenceChar: '`' | '~' | '' = ''
-  let fenceLen = 0
+function scanExplicitBracketMathLine(
+  line: string,
+  context: ExplicitBracketMathContext,
+  lineStart: number,
+  appendStart: number | null,
+  openAtAppendStart: boolean,
+) {
+  const lineIndent = getMarkdownIndent(line)
+  const listPrefix = stripMarkdownListPrefix(line)
+
+  if (context.inFence && context.fenceInBlockquote && line.trim() && stripMarkdownBlockquotePrefix(line) == null)
+    resetExplicitBracketFenceContext(context)
+
+  if (
+    context.inFence
+    && context.fenceInList
+    && line.trim()
+    && lineIndent.column < context.fenceListIndent
+    && !listPrefix
+  ) {
+    resetExplicitBracketFenceContext(context)
+  }
+
+  if (listPrefix) {
+    context.listContentIndent = listPrefix.contentIndent
+  }
+  else if (
+    line.trim()
+    && context.listContentIndent != null
+    && lineIndent.column < context.listContentIndent
+    && !context.inFence
+  ) {
+    context.listContentIndent = null
+  }
+
+  if (!context.inMath) {
+    const fenceMatch = matchMarkdownFenceMarker(line)
+    if (fenceMatch) {
+      if (context.inFence) {
+        if (
+          fenceMatch.markerChar === context.fenceChar
+          && fenceMatch.markerLen >= context.fenceLen
+          && /^\s*$/.test(fenceMatch.rest)
+        ) {
+          resetExplicitBracketFenceContext(context)
+        }
+      }
+      else {
+        context.inFence = true
+        context.fenceChar = fenceMatch.markerChar
+        context.fenceLen = fenceMatch.markerLen
+        context.fenceInBlockquote = fenceMatch.inBlockquote
+        context.fenceInList = fenceMatch.inList
+          || (
+            context.listContentIndent != null
+            && !fenceMatch.inBlockquote
+            && lineIndent.column >= context.listContentIndent
+          )
+        context.fenceListIndent = fenceMatch.listIndent || context.listContentIndent || 0
+      }
+    }
+    else if (!context.inFence) {
+      return scanLineForExplicitBracketMathState(line, context, lineStart, appendStart, openAtAppendStart)
+    }
+  }
+  else {
+    return scanLineForExplicitBracketMathState(line, context, lineStart, appendStart, openAtAppendStart)
+  }
+
+  return false
+}
+
+function scanExplicitBracketMathStreamState(
+  source: string,
+  initialContext: ExplicitBracketMathContext = createExplicitBracketMathContext(),
+  appendStart: number | null = null,
+  openAtAppendStart = false,
+) {
+  const context = cloneExplicitBracketMathContext(initialContext)
+  let committedContext = cloneExplicitBracketMathContext(initialContext)
+  let lineBuffer = ''
+  let closedOpenMath = false
   let index = 0
 
   while (index < source.length) {
@@ -499,75 +693,37 @@ function hasUnclosedExplicitBracketMathOpen(source: string) {
       : hasNewline ? newlineIndex : source.length
     const line = source.slice(index, lineEnd)
 
-    if (!inMath) {
-      const fenceMatch = matchMarkdownFenceMarker(line)
-      if (fenceMatch) {
-        if (inFence) {
-          if (
-            fenceMatch.markerChar === fenceChar
-            && fenceMatch.markerLen >= fenceLen
-            && /^\s*$/.test(fenceMatch.rest)
-          ) {
-            inFence = false
-            fenceChar = ''
-            fenceLen = 0
-          }
-        }
-        else {
-          inFence = true
-          fenceChar = fenceMatch.markerChar
-          fenceLen = fenceMatch.markerLen
-        }
-      }
-      else if (!inFence) {
-        inMath = scanLineForExplicitBracketMathState(line, index, source, inMath)
-      }
+    if (scanExplicitBracketMathLine(line, context, index, appendStart, openAtAppendStart))
+      closedOpenMath = true
+
+    if (hasNewline) {
+      committedContext = cloneExplicitBracketMathContext(context)
+      lineBuffer = ''
     }
     else {
-      inMath = scanLineForExplicitBracketMathState(line, index, source, inMath)
+      lineBuffer = line
     }
 
     index = hasNewline ? newlineIndex + 1 : source.length
   }
 
-  return inMath
-}
-
-function hasUnescapedDelimiterInAppendedChunk(previousSource: string, appended: string, delimiter: string) {
-  let searchPos = 0
-
-  while (searchPos < appended.length) {
-    const index = appended.indexOf(delimiter, searchPos)
-    if (index === -1)
-      return false
-
-    let cursor = index - 1
-    let backslashes = 0
-    while (cursor >= 0 && appended[cursor] === '\\') {
-      backslashes++
-      cursor--
-    }
-    if (cursor === -1)
-      backslashes += countTrailingBackslashes(previousSource)
-
-    if (backslashes % 2 === 0)
-      return true
-
-    searchPos = index + Math.max(1, delimiter.length)
+  return {
+    closedOpenMath,
+    state: {
+      committedContext,
+      context,
+      lineBuffer,
+    },
   }
-
-  return false
 }
 
-function appendedChunkCompletesExplicitBracketMathClose(previousSource: string, appended: string) {
-  const completesInChunk = hasUnescapedDelimiterInAppendedChunk(previousSource, appended, '\\]')
-  const completesAcrossBoundary = appended[0] === ']'
-    && countTrailingBackslashes(previousSource) % 2 === 1
-
-  if (!completesInChunk && !completesAcrossBoundary)
-    return false
-
-  return hasUnclosedExplicitBracketMathOpen(previousSource)
+function updateExplicitBracketMathStreamState(previous: ExplicitBracketMathStreamState, appended: string) {
+  return scanExplicitBracketMathStreamState(
+    previous.lineBuffer + appended,
+    previous.committedContext,
+    previous.lineBuffer.length,
+    previous.context.inMath,
+  )
 }
 
 function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
@@ -586,11 +742,12 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
 
   const sourceExtendsPrevious = previous ? source.startsWith(previous.source) : false
   const appended = sourceExtendsPrevious && previous ? source.slice(previous.source.length) : ''
+  const explicitBracketMathUpdate = sourceExtendsPrevious && previous
+    ? updateExplicitBracketMathStreamState(previous.explicitBracketMath, appended)
+    : scanExplicitBracketMathStreamState(source)
+  const nextExplicitBracketMath = explicitBracketMathUpdate.state
   const completesExplicitBracketMathClose = sourceExtendsPrevious && previous
-    ? appendedChunkCompletesExplicitBracketMathClose(
-        previous.source,
-        appended,
-      )
+    ? explicitBracketMathUpdate.closedOpenMath
     : false
 
   if (previous && sourceExtendsPrevious) {
@@ -602,6 +759,7 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
       && !sourceEndsWithSplitTolerantBoundaryPrefix(source)
     ) {
       previous.source = source
+      previous.explicitBracketMath = nextExplicitBracketMath
       return
     }
   }
@@ -614,7 +772,7 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
   else if (!previous && nextKey)
     stream.reset()
 
-  setTolerantMathBoundaryStreamCache(md, source, nextKey)
+  setTolerantMathBoundaryStreamCache(md, source, nextKey, nextExplicitBracketMath)
 }
 
 function shouldCloneTopLevelStreamTokens(options: ParseOptions) {

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -136,7 +136,7 @@ const SPAN_CURLY_RE = /span\{([^}]+)\}/
 const OPERATORNAME_SPAN_RE = /\\operatorname\{span\}\{((?:[^{}]|\{[^}]*\})+)\}/
 const SINGLE_BACKSLASH_NEWLINE_RE = /(^|[^\\])\\\r?\n/g
 const ENDING_SINGLE_BACKSLASH_RE = /(^|[^\\])\\$/g
-const FACTORIAL_PRECEDING_RE = /[\p{L}\p{M}\p{N})\]}'′″‴|]/u
+const FACTORIAL_PRECEDING_RE = /[\p{L}\p{M}\p{N}\p{Pe}\p{Pf}'′″‴|‖]/u
 
 // Cache for dynamically built regexes depending on commands list
 // Avoid lookbehind; capture possible prefix so replacements can preserve it.
@@ -206,10 +206,11 @@ function countUnescapedStrong(s: string) {
 }
 
 function escapeStandaloneExclamation(value: string) {
-  return value.replace(/(^|[^\\])!/gu, (match: string, prefix: string) => {
+  return value.replace(/(^|[^\\])!+/gu, (match: string, prefix: string) => {
     if (prefix && FACTORIAL_PRECEDING_RE.test(prefix))
       return match
-    return `${prefix}\\!`
+    const marks = prefix ? match.slice(prefix.length) : match
+    return `${prefix}${'\\!'.repeat(marks.length)}`
   })
 }
 

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -136,6 +136,7 @@ const SPAN_CURLY_RE = /span\{([^}]+)\}/
 const OPERATORNAME_SPAN_RE = /\\operatorname\{span\}\{((?:[^{}]|\{[^}]*\})+)\}/
 const SINGLE_BACKSLASH_NEWLINE_RE = /(^|[^\\])\\\r?\n/g
 const ENDING_SINGLE_BACKSLASH_RE = /(^|[^\\])\\$/g
+const FACTORIAL_PRECEDING_RE = /[\p{L}\p{M}\p{N})\]}'′″‴|]/u
 
 // Cache for dynamically built regexes depending on commands list
 // Avoid lookbehind; capture possible prefix so replacements can preserve it.
@@ -204,6 +205,14 @@ function countUnescapedStrong(s: string) {
   return c
 }
 
+function escapeStandaloneExclamation(value: string) {
+  return value.replace(/(^|[^\\])!/gu, (match: string, prefix: string) => {
+    if (prefix && FACTORIAL_PRECEDING_RE.test(prefix))
+      return match
+    return `${prefix}\\!`
+  })
+}
+
 function findLastUnescapedStrongMarker(s: string) {
   const re = /(^|[^\\])(__|\*\*)/g
   let m: RegExpExecArray | null
@@ -242,7 +251,7 @@ export function normalizeStandaloneBackslashT(s: string, opts?: MathOptions) {
 
   // Escape standalone '!' but don't double-escape already escaped ones.
   if (escapeExclamation)
-    out = out.replace(/(^|[^\\])!/g, '$1\\!')
+    out = escapeStandaloneExclamation(out)
 
   // Final pass: some TeX command names take a brace argument and may have
   // lost their leading backslash, e.g. "operatorname{span}". Ensure we

--- a/packages/markdown-parser/test/math-block-same-line-boundary.test.ts
+++ b/packages/markdown-parser/test/math-block-same-line-boundary.test.ts
@@ -165,6 +165,52 @@ $$ where $\\epsilon$ denotes the target accuracy, $n$ is the number of nodes, an
     expect(resetCount).toBeGreaterThanOrEqual(1)
   })
 
+  it('does not reset stream cache for bracket math delimiters inside code', () => {
+    const cases = [
+      [
+        'fenced',
+        [
+          '```tex\n\\[\n```\n\n',
+          '\\]\n\n',
+        ],
+      ],
+      [
+        'inline',
+        [
+          'Example `\\[`\n\n',
+          '\\]\n\n',
+        ],
+      ],
+    ] as const
+
+    for (const [name, chunks] of cases) {
+      const md = getMarkdown(`standard-bracket-code-delimiters-no-reset-${name}`)
+      ;(md as any).stream.reset()
+      ;(md as any).stream.resetStats?.()
+
+      const stream = (md as any).stream
+      const originalReset = stream.reset.bind(stream)
+      let resetCount = 0
+      stream.reset = () => {
+        resetCount++
+        return originalReset()
+      }
+
+      let source = ''
+      let nodes: any[] = []
+      for (const chunk of chunks) {
+        source += chunk
+        nodes = parseMarkdownToStructure(source, md, {
+          final: false,
+          streamParse: true,
+        }) as any[]
+      }
+
+      expect(resetCount, name).toBe(0)
+      expect(collectByType(nodes, 'math_block'), name).toHaveLength(0)
+    }
+  })
+
   it('ignores escaped bracket close before a later split close delimiter', () => {
     const md = getMarkdown('standard-bracket-escaped-close-before-split-close-reset')
     ;(md as any).stream.reset()

--- a/packages/markdown-parser/test/math-block-same-line-boundary.test.ts
+++ b/packages/markdown-parser/test/math-block-same-line-boundary.test.ts
@@ -126,6 +126,133 @@ $$ where $\\epsilon$ denotes the target accuracy, $n$ is the number of nodes, an
     expect(resetCount).toBeLessThanOrEqual(2)
   })
 
+  it('resets stream cache when a standard bracket math close delimiter is split', () => {
+    const md = getMarkdown('standard-bracket-split-close-reset')
+    ;(md as any).stream.reset()
+    ;(md as any).stream.resetStats?.()
+
+    const stream = (md as any).stream
+    const originalReset = stream.reset.bind(stream)
+    let resetCount = 0
+    stream.reset = () => {
+      resetCount++
+      return originalReset()
+    }
+
+    const chunks = [
+      '### 一般形式（在点 \\\\(x = a\\\\) 处展开）：\n\\[\n',
+      `f(x) = f(a) + f'(a)(x-a) + \\frac{f''(a)}{2!}(x-a)^2 + R_n(x)\n`,
+      '\\',
+      ']',
+    ]
+
+    let source = ''
+    let nodes: any[] = []
+
+    for (const chunk of chunks) {
+      source += chunk
+      nodes = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+      }) as any[]
+    }
+
+    const mathBlocks = collectByType(nodes, 'math_block')
+    expect(mathBlocks).toHaveLength(1)
+    expect(mathBlocks[0].loading).toBe(false)
+    expect(mathBlocks[0].content).toContain('2!')
+    expect(collectByType(nodes, 'text').map((node: any) => node.content)).not.toContain(']')
+    expect(resetCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('ignores escaped bracket close before a later split close delimiter', () => {
+    const md = getMarkdown('standard-bracket-escaped-close-before-split-close-reset')
+    ;(md as any).stream.reset()
+    ;(md as any).stream.resetStats?.()
+
+    const stream = (md as any).stream
+    const originalReset = stream.reset.bind(stream)
+    let resetCount = 0
+    stream.reset = () => {
+      resetCount++
+      return originalReset()
+    }
+
+    const chunks = [
+      '\\[\n',
+      'x + y \\\\',
+      ']\nz = 1\n',
+      '\\',
+      ']',
+    ]
+
+    let source = ''
+    let nodes: any[] = []
+    let resetCountBeforeEscapedClose = 0
+    let resetCountBeforeFinalClose = 0
+
+    for (const [index, chunk] of chunks.entries()) {
+      source += chunk
+      nodes = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+      }) as any[]
+
+      if (index === 1)
+        resetCountBeforeEscapedClose = resetCount
+      if (index === 2)
+        expect(resetCount).toBe(resetCountBeforeEscapedClose)
+      if (index === 3)
+        resetCountBeforeFinalClose = resetCount
+    }
+
+    const mathBlocks = collectByType(nodes, 'math_block')
+    expect(mathBlocks).toHaveLength(1)
+    expect(mathBlocks[0].loading).toBe(false)
+    expect(mathBlocks[0].content).toContain('x + y')
+    expect(mathBlocks[0].content).toContain('z = 1')
+    expect(collectByType(nodes, 'text').map((node: any) => node.content)).not.toContain(']')
+    expect(resetCount).toBeGreaterThan(resetCountBeforeFinalClose)
+  })
+
+  it('preserves suffix when a standard bracket math split close has trailing text', () => {
+    const md = getMarkdown('standard-bracket-split-close-suffix')
+    ;(md as any).stream.reset()
+    ;(md as any).stream.resetStats?.()
+
+    const chunks = [
+      'Before $a$ display\n\\[\n',
+      'x + y = z\n',
+      '\\',
+      '] where $b$ follows.',
+    ]
+
+    let source = ''
+    let nodes: any[] = []
+
+    for (const chunk of chunks) {
+      source += chunk
+      nodes = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+      }) as any[]
+    }
+
+    expect(nodes.map(node => node.type)).toEqual([
+      'paragraph',
+      'math_block',
+      'paragraph',
+    ])
+
+    const mathBlocks = collectByType(nodes, 'math_block')
+    expect(mathBlocks).toHaveLength(1)
+    expect(mathBlocks[0].loading).toBe(false)
+    expect(mathBlocks[0].content).toBe('x + y = z')
+    expect(mathBlocks[0].content).not.toContain('where')
+    expect(collectByType(nodes, 'math_inline').map((node: any) => node.content)).toEqual(['a', 'b'])
+    expect(collectByType(nodes, 'text').map((node: any) => node.content)).not.toContain(']')
+  })
+
   it('preserves suffix when close delimiter shares a line with formula content', () => {
     const md = getMarkdown('math-close-line-with-content-and-suffix')
     const source = [

--- a/packages/markdown-parser/test/math-block-streaming-close.test.ts
+++ b/packages/markdown-parser/test/math-block-streaming-close.test.ts
@@ -109,4 +109,30 @@ describe('math block streaming close handling', () => {
 
     expect(literalCloseMs).toBeLessThan(plainMs * 8 + 80)
   })
+
+  it('does not regress on long single-line streaming text without bracket math', () => {
+    const md = getMarkdown('long-single-line-no-bracket-math')
+    let markdown = `prefix\n\n${'x'.repeat(8_000)}`
+
+    parseMarkdownToStructure(markdown, md, {
+      final: false,
+      streamParse: true,
+    })
+    const before = md.stream?.stats?.() as { fullParses?: number, tailHits?: number } | undefined
+
+    const startedAt = performance.now()
+    for (let index = 0; index < 80; index++) {
+      markdown += ` token${index}`
+      parseMarkdownToStructure(markdown, md, {
+        final: false,
+        streamParse: true,
+      })
+    }
+    const elapsedMs = performance.now() - startedAt
+    const after = md.stream?.stats?.() as typeof before
+
+    expect((after?.tailHits ?? 0) - (before?.tailHits ?? 0)).toBe(80)
+    expect((after?.fullParses ?? 0) - (before?.fullParses ?? 0)).toBe(0)
+    expect(elapsedMs).toBeLessThan(1000)
+  })
 })

--- a/packages/markdown-parser/test/math-block-streaming-close.test.ts
+++ b/packages/markdown-parser/test/math-block-streaming-close.test.ts
@@ -46,4 +46,67 @@ describe('math block streaming close handling', () => {
     expect(mathBlocks[0].content).not.toMatch(/\]\s*$/)
     expect(textNodes.map(node => node.content)).not.toContain(']')
   })
+
+  it('closes bracket math after lines that should not keep a markdown fence open', () => {
+    const prefix = `${Array.from(
+      { length: 40 },
+      (_, index) => `Paragraph ${index + 1} before the bracket math streaming close regression.`,
+    ).join('\n\n')}\n\n`
+    const cases = [
+      { label: 'four spaces', firstChunk: `${prefix}    \`\`\`\n\\[\n` },
+      { label: 'tab indent', firstChunk: `${prefix}\t\`\`\`\n\\[\n` },
+      { label: 'backtick info', firstChunk: `${prefix}\`\`\` bad\`info\n\\[\n` },
+      { label: 'ended blockquote', firstChunk: `${prefix}> \`\`\`\n\\[\n` },
+      { label: 'ended list', firstChunk: `${prefix}- item\n  \`\`\`\n\\[\n` },
+    ]
+
+    for (const testCase of cases) {
+      const md = getMarkdown(`math-block-streaming-fence-rules-${testCase.label}`)
+      const chunks = [
+        testCase.firstChunk,
+        'x + y\n',
+        '\\',
+        ']',
+      ]
+      let markdown = ''
+      let nodes: any[] = []
+
+      for (const chunk of chunks) {
+        markdown += chunk
+        nodes = parseMarkdownToStructure(markdown, md, {
+          final: false,
+          streamParse: true,
+        }) as any[]
+      }
+
+      const mathBlocks = collect(nodes, 'math_block')
+
+      expect(mathBlocks, testCase.label).toHaveLength(1)
+      expect(mathBlocks[0].loading, testCase.label).toBe(false)
+      expect(mathBlocks[0].content, testCase.label).toBe('x + y')
+    }
+  })
+
+  it('does not repeatedly rescan previous source for literal bracket closes without an opener', () => {
+    const run = (chunk: string) => {
+      const md = getMarkdown(`math-block-streaming-close-perf-${chunk}`)
+      let markdown = ''
+      const startedAt = performance.now()
+
+      for (let index = 0; index < 240; index++) {
+        markdown += chunk
+        parseMarkdownToStructure(markdown, md, {
+          final: false,
+          streamParse: true,
+        })
+      }
+
+      return performance.now() - startedAt
+    }
+
+    const plainMs = run('plain text\n')
+    const literalCloseMs = run('\\]\n')
+
+    expect(literalCloseMs).toBeLessThan(plainMs * 8 + 80)
+  })
 })

--- a/test/normalize-backslash-direct.test.ts
+++ b/test/normalize-backslash-direct.test.ts
@@ -47,9 +47,22 @@ describe('normalizeStandaloneBackslashT direct tests', () => {
     expect(out).toMatchInlineSnapshot(`"atb"`)
   })
 
-  it('escapes exclamation to \\!', () => {
+  it('does not escape factorial exclamation marks', () => {
     const out = normalizeStandaloneBackslashT('a!b')
-    expect(out).toBe('a\\!b')
+    expect(out).toBe('a!b')
+    expect(normalizeStandaloneBackslashT('2! + n! + (n+1)!')).toBe('2! + n! + (n+1)!')
+    expect(normalizeStandaloneBackslashT('\\alpha!')).toBe('\\alpha!')
+    expect(normalizeStandaloneBackslashT('π!')).toBe('π!')
+    expect(normalizeStandaloneBackslashT('x\'!')).toBe('x\'!')
+    expect(normalizeStandaloneBackslashT('|x|!')).toBe('|x|!')
+    expect(normalizeStandaloneBackslashT('𝑛! + 𝟚! + x\u0301!')).toBe('𝑛! + 𝟚! + x\u0301!')
+  })
+
+  it('escapes standalone exclamation to \\!', () => {
+    const out = normalizeStandaloneBackslashT('!')
+    expect(out).toBe('\\!')
+    expect(normalizeStandaloneBackslashT('x ! y')).toBe('x \\! y')
+    expect(normalizeStandaloneBackslashT('x+! y')).toBe('x+\\! y')
   })
 
   it('span to \\{\\}', () => {

--- a/test/normalize-backslash-direct.test.ts
+++ b/test/normalize-backslash-direct.test.ts
@@ -56,6 +56,8 @@ describe('normalizeStandaloneBackslashT direct tests', () => {
     expect(normalizeStandaloneBackslashT('x\'!')).toBe('x\'!')
     expect(normalizeStandaloneBackslashT('|x|!')).toBe('|x|!')
     expect(normalizeStandaloneBackslashT('𝑛! + 𝟚! + x\u0301!')).toBe('𝑛! + 𝟚! + x\u0301!')
+    expect(normalizeStandaloneBackslashT('n!! + n!!!')).toBe('n!! + n!!!')
+    expect(normalizeStandaloneBackslashT('⌊n⌋! + ⟨x⟩! + ‖x‖!')).toBe('⌊n⌋! + ⟨x⟩! + ‖x‖!')
   })
 
   it('escapes standalone exclamation to \\!', () => {

--- a/test/normalize-backslash-t.test.ts
+++ b/test/normalize-backslash-t.test.ts
@@ -20,4 +20,12 @@ describe('normalizeStandaloneBackslashT', () => {
   it('escapes exclamation marks', () => {
     expect(normalizeStandaloneBackslashT('!')).toBe('\\!')
   })
+
+  it('preserves factorial exclamation marks', () => {
+    expect(normalizeStandaloneBackslashT('2! + n! + (n+1)! + \\alpha!')).toBe('2! + n! + (n+1)! + \\alpha!')
+    expect(normalizeStandaloneBackslashT('π!')).toBe('π!')
+    expect(normalizeStandaloneBackslashT('x\'!')).toBe('x\'!')
+    expect(normalizeStandaloneBackslashT('|x|!')).toBe('|x|!')
+    expect(normalizeStandaloneBackslashT('𝑛! + 𝟚! + x\u0301!')).toBe('𝑛! + 𝟚! + x\u0301!')
+  })
 })


### PR DESCRIPTION
## Summary
- reset stream parse cache when a standard `\[...\]` math block close delimiter arrives split across chunks
- preserve factorial exclamation marks during math normalization while still escaping standalone `!`
- add regression coverage for split bracket close delimiters, suffix handling, and factorial boundaries

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run`