### PR TITLE
fix: render trusted media html blocks

### DIFF
--- a/packages/markdown-parser/src/htmlTags.d.ts
+++ b/packages/markdown-parser/src/htmlTags.d.ts
@@ -6,7 +6,7 @@ export declare const EXTENDED_STANDARD_HTML_TAG_NAMES: readonly ["address", "aud
 export declare const DANGEROUS_HTML_ATTR_NAMES: readonly ["onclick", "onerror", "onload", "onmouseover", "onmouseout", "onmousedown", "onmouseup", "onkeydown", "onkeyup", "onfocus", "onblur", "onsubmit", "onreset", "onchange", "onselect", "ondblclick", "ontouchstart", "ontouchend", "ontouchmove", "ontouchcancel", "onwheel", "onscroll", "oncopy", "oncut", "onpaste", "oninput", "oninvalid", "onsearch", "srcdoc", "ping"];
 export declare const URL_HTML_ATTR_NAMES: readonly ["action", "data", "href", "src", "srcset", "poster", "xlink:href", "formaction"];
 export declare const BLOCKED_HTML_TAG_NAMES: readonly ["script"];
-export declare const NON_STRUCTURING_HTML_TAG_NAMES: readonly ["pre", "script", "style", "table", "tbody", "td", "tfoot", "th", "thead", "textarea", "tr", "title"];
+export declare const NON_STRUCTURING_HTML_TAG_NAMES: readonly ["pre", "iframe", "script", "style", "table", "tbody", "td", "tfoot", "th", "thead", "textarea", "tr", "title", "video"];
 export declare const VOID_HTML_TAGS: Set<string>;
 export declare const STANDARD_BLOCK_HTML_TAGS: Set<string>;
 export declare const STANDARD_HTML_TAGS: Set<string>;

--- a/packages/markdown-parser/src/htmlTags.ts
+++ b/packages/markdown-parser/src/htmlTags.ts
@@ -178,6 +178,7 @@ export const BLOCKED_HTML_TAG_NAMES = [
 
 export const NON_STRUCTURING_HTML_TAG_NAMES = [
   'pre',
+  'iframe',
   'script',
   'style',
   'table',
@@ -189,6 +190,7 @@ export const NON_STRUCTURING_HTML_TAG_NAMES = [
   'textarea',
   'tr',
   'title',
+  'video',
 ] as const
 
 export const VOID_HTML_TAGS = new Set<string>(VOID_HTML_TAG_NAMES)

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { HtmlPolicy } from 'stream-markdown-parser'
 import type { StreamSliceMode } from '../composables/createLocalTextStream'
 import type { StreamPresetId } from '../composables/streamPresets'
 import type { StreamTransportMode } from '../composables/useStreamSimulator'
@@ -58,6 +59,7 @@ const streamBurstiness = useLocalStorage<number>('vmr-settings-stream-burstiness
 const streamTransportMode = useLocalStorage<StreamTransportMode>('vmr-settings-stream-transport-mode', 'readable-stream')
 const streamSliceMode = useLocalStorage<StreamSliceMode>('vmr-settings-stream-slice-mode', 'pure-random')
 const smoothStreaming = useLocalStorage<boolean>('vmr-settings-smooth-streaming', true)
+const htmlPolicy = useLocalStorage<HtmlPolicy>('vmr-settings-html-policy', 'trusted')
 const normalizedChunkDelayRange = computed(() => normalizeStreamRange(
   Number(streamChunkDelayMin.value),
   Number(streamChunkDelayMax.value),
@@ -612,6 +614,25 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
+        <!-- HTML Policy -->
+        <div class="setting-group">
+          <label class="setting-label">HTML Policy</label>
+          <div class="setting-select-wrap">
+            <select v-model="htmlPolicy" class="setting-select" aria-label="HTML policy">
+              <option value="trusted">
+                Trusted
+              </option>
+              <option value="safe">
+                Safe
+              </option>
+              <option value="escape">
+                Escape
+              </option>
+            </select>
+            <Icon icon="carbon:chevron-down" class="setting-select-icon" />
+          </div>
+        </div>
+
         <!-- Stream Profile -->
         <div class="setting-group">
           <label class="setting-label">Stream Profile</label>
@@ -906,6 +927,7 @@ onBeforeUnmount(() => {
             :code-block-dark-theme="selectedTheme || undefined"
             :code-block-light-theme="selectedTheme || undefined"
             :code-block-monaco-options="playgroundMonacoOptions"
+            :html-policy="htmlPolicy"
             :themes="themes"
             :custom-html-tags="['thinking']"
             :escape-html-tags="['question', 'answer']"

--- a/playground/src/pages/test.vue
+++ b/playground/src/pages/test.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Brush, Drauu, DrawingMode } from 'drauu'
+import type { HtmlPolicy } from 'stream-markdown-parser'
 import type { TestLabFrameworkId, TestLabSampleId } from '../../../playground-shared/testLabFixtures'
 import type { TestPageViewMode } from '../../../playground-shared/testPageState'
 import type { SandboxFrameworkId, SandboxRenderSource } from '../../../playground-shared/versionSandbox'
@@ -158,6 +159,11 @@ const RENDER_MODE_OPTIONS = [
   { value: 'markdown', label: 'MarkdownCodeBlock' },
   { value: 'pre', label: 'PreCodeNode' },
 ] as const satisfies ReadonlyArray<{ value: 'monaco' | 'markdown' | 'pre', label: string }>
+const HTML_POLICY_OPTIONS = [
+  { value: 'trusted', label: 'Trusted' },
+  { value: 'safe', label: 'Safe' },
+  { value: 'escape', label: 'Escape' },
+] as const satisfies ReadonlyArray<{ value: HtmlPolicy, label: string }>
 type DiffLayoutMode = 'inline' | 'side-by-side'
 const DIFF_LAYOUT_OPTIONS = [
   { value: 'inline', label: 'Diff 1 列' },
@@ -229,6 +235,7 @@ const typewriter = useLocalStorage<boolean>('vmr-test-typewriter', true)
 const debugParse = useLocalStorage<boolean>('vmr-test-debug-parse', false)
 const mathEnabled = useLocalStorage<boolean>('vmr-test-math-enabled', isKatexEnabled())
 const mermaidEnabled = useLocalStorage<boolean>('vmr-test-mermaid-enabled', isMermaidEnabled())
+const htmlPolicy = useLocalStorage<HtmlPolicy>('vmr-test-html-policy', 'trusted')
 const testPageCustomHtmlTags = ['think', 'thinking'] as const
 
 if (!isBenchmarkMode)
@@ -2939,6 +2946,7 @@ watch(mermaidEnabled, (enabled) => {
                 <span class="stream-summary__item" :class="{ 'stream-summary__item--active': typewriter }">typewriter</span>
                 <span class="stream-summary__item" :class="{ 'stream-summary__item--active': mathEnabled }">KaTeX</span>
                 <span class="stream-summary__item" :class="{ 'stream-summary__item--active': mermaidEnabled }">Mermaid</span>
+                <span class="stream-summary__item stream-summary__item--active">HTML {{ htmlPolicy }}</span>
                 <span v-if="debugParse" class="stream-summary__item stream-summary__item--active">解析树 debug</span>
                 <span v-if="streamDebug" class="stream-summary__item stream-summary__item--active">chunk debug</span>
               </div>
@@ -3304,6 +3312,8 @@ watch(mermaidEnabled, (enabled) => {
                     v-if="benchmarkRenderPreview"
                     ref="previewRendererRef"
                     :content="previewContent"
+                    :final="!isStreaming"
+                    :html-policy="htmlPolicy"
                     :custom-html-tags="testPageCustomHtmlTags"
                     :is-dark="isDark"
                     :mermaid-props="previewMermaidProps"
@@ -3602,6 +3612,12 @@ watch(mermaidEnabled, (enabled) => {
               v-model="selectedStreamPresetId"
               label="流式画像 preset"
               :options="streamPresetOptions"
+            />
+
+            <LabSelect
+              v-model="htmlPolicy"
+              label="HTML Policy"
+              :options="HTML_POLICY_OPTIONS"
             />
 
             <p class="control-note">

--- a/src/components/__tests__/htmlNodes.integration.test.ts
+++ b/src/components/__tests__/htmlNodes.integration.test.ts
@@ -691,6 +691,42 @@ describe('component Behavior', () => {
     expect(wrapper.text()).toContain('前端重构')
   })
 
+  it('renders trusted video and iframe html while preserving text after video close', async () => {
+    const markdown = `<video controls width="250">
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />
+
+  <source src="/shared-assets/videos/flower.mp4" type="video/mp4" />
+
+  Download the
+  <a href="/shared-assets/videos/flower.webm">WEBM</a>
+  or
+  <a href="/shared-assets/videos/flower.mp4">MP4</a>
+  video.
+</video>
+1
+
+<iframe src="https://example.com"></iframe>`
+
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: markdown,
+        htmlPolicy: 'trusted',
+        final: true,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    await nextTick()
+
+    expect(wrapper.find('video').exists()).toBe(true)
+    expect(wrapper.findAll('video source')).toHaveLength(2)
+    expect(wrapper.find('iframe').exists()).toBe(true)
+    expect(wrapper.findAll('p.paragraph-node').some(p => p.text().trim() === '1')).toBe(true)
+    expect(wrapper.findAll('video ul')).toHaveLength(0)
+  })
+
   it('renders details summary as the first direct child for issue #397 content', async () => {
     const markdown = `# Structural Stress
 

--- a/test/html-block-regressions.test.ts
+++ b/test/html-block-regressions.test.ts
@@ -57,4 +57,54 @@ console.log(1)
     expect(nodes[0]?.children).toBeUndefined()
     expect(String(nodes[0]?.content ?? '')).toContain('rowspan="2"')
   })
+
+  it('keeps media html raw and preserves text after video close', () => {
+    const markdown = `<video controls width="250">
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />
+
+  <source src="/shared-assets/videos/flower.mp4" type="video/mp4" />
+
+  Download the
+  <a href="/shared-assets/videos/flower.webm">WEBM</a>
+  or
+  <a href="/shared-assets/videos/flower.mp4">MP4</a>
+  video.
+</video>
+1`
+
+    const nodes = parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+    expect(nodes).toHaveLength(2)
+    expect(nodes[0]?.type).toBe('html_block')
+    expect(nodes[0]?.tag).toBe('video')
+    expect(nodes[0]?.children).toBeUndefined()
+    expect(String(nodes[0]?.content ?? '')).toContain('<source src="/shared-assets/videos/flower.webm"')
+    expect(nodes[1]?.type).toBe('paragraph')
+    expect(nodes[1]?.raw).toBe('1')
+  })
+
+  it('keeps media html block type stable through streaming prefixes', () => {
+    const prefixes = [
+      `<video controls width="250">
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />`,
+      `<video controls width="250">
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />
+</video>`,
+      `<video controls width="250">
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />
+</video>
+1`,
+    ]
+
+    for (const markdown of prefixes) {
+      const nodes = parseMarkdownToStructure(markdown, md, { final: false }) as any[]
+      expect(nodes[0]?.type).toBe('html_block')
+      expect(nodes[0]?.tag).toBe('video')
+      expect(nodes[0]?.children).toBeUndefined()
+    }
+
+    const finalNodes = parseMarkdownToStructure(prefixes[2]!, md, { final: true }) as any[]
+    expect(finalNodes.map(node => node.type)).toEqual(['html_block', 'paragraph'])
+    expect(finalNodes[0]?.tag).toBe('video')
+    expect(finalNodes[1]?.raw).toBe('1')
+  })
 })

--- a/test/playground-test-page.smoke.test.ts
+++ b/test/playground-test-page.smoke.test.ts
@@ -31,6 +31,14 @@ vi.mock('../src/components/NodeRenderer', () => ({
         type: String,
         default: '',
       },
+      final: {
+        type: Boolean,
+        default: false,
+      },
+      htmlPolicy: {
+        type: String,
+        default: 'safe',
+      },
       mermaidProps: {
         type: Object,
         default: () => ({}),
@@ -513,6 +521,17 @@ describe('playground /test smoke', () => {
     expect(wrapper.find('textarea').exists()).toBe(true)
     expect(window.location.search).toBe('')
     expect(await decodeMarkdownHashAsync(window.location.hash)).toBe('## shared only')
+
+    wrapper.unmount()
+  })
+
+  it('uses trusted final rendering for static test page previews', async () => {
+    const wrapper = await mountTestPage()
+    const preview = wrapper.getComponent({ name: 'MarkdownRenderStub' })
+
+    expect(preview.props('htmlPolicy')).toBe('trusted')
+    expect(preview.props('final')).toBe(true)
+    expect(wrapper.text()).toContain('HTML trusted')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary
- Keep native media/embed HTML blocks like `<video>` and `<iframe>` raw so browser trusted rendering can mount them correctly.
- Add HTML Policy controls to the playground and `/test`, defaulting to `trusted` for browser demos.
- Add parser, component, playground, and streaming-prefix regressions for media HTML and trailing text after `</video>`.

## Scope
This supports content written as trusted HTML/SVG tags, such as `<video>`, `<iframe>`, and `<svg>`. It does not add a separate Markdown syntax for arbitrary video files.

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run build:parser && pnpm run build:core && pnpm test -- --run`
- `pnpm build`
- `pnpm play:deploy:check`
- `pnpm test:api`
- `pnpm run check:ssr && pnpm run test:smoke:core && pnpm run test:smoke:react && pnpm run test:smoke:vue2-cjs && MARKSTREAM_SMOKE_SKIP_BUILD=1 pnpm test:smoke:minimal && MARKSTREAM_SMOKE_SKIP_BUILD=1 pnpm test:smoke:pack:optional && pnpm size:check`
- `pnpm run test:e2e:virtual-scroll:ci`

Closes #515
Closes #514