### PR TITLE
feat(react): add direct streaming and HTML component maps

### DIFF
--- a/docs/.vitepress/twoslash/markstream-react.d.ts
+++ b/docs/.vitepress/twoslash/markstream-react.d.ts
@@ -1,5 +1,30 @@
-import type { ComponentType } from 'react'
+import type { ComponentType, PropsWithChildren, ReactNode } from 'react'
 import type { BaseNode } from 'stream-markdown-parser'
+
+export type RenderNodeFn = (node: BaseNode, key: string | number, ctx: RenderContext) => ReactNode
+
+export interface RenderContext {
+  customId?: string
+  isDark?: boolean
+  final?: boolean
+}
+
+export interface NodeComponentProps<TNode = unknown> {
+  node: TNode
+  ctx?: RenderContext
+  renderNode?: RenderNodeFn
+  indexKey?: string | number
+  customId?: string
+  isDark?: boolean
+  typewriter?: boolean
+  fade?: boolean
+  children?: ReactNode
+}
+
+export type StreamingComponent<TNode = any> = ComponentType<NodeComponentProps<TNode>>
+export type StreamingComponentMap = Record<string, StreamingComponent<any>>
+export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
+export type HtmlComponentMap = Record<string, HtmlComponent<any>>
 
 export interface NodeRendererProps {
   content?: string
@@ -14,6 +39,8 @@ export interface NodeRendererProps {
 
 export declare const MarkdownRender: ComponentType<NodeRendererProps>
 export declare const NodeRenderer: ComponentType<NodeRendererProps>
+export declare function defineStreamingComponents<const T extends Record<string, ComponentType<any>>>(components: T): T
+export declare function defineHtmlComponents<const T extends Record<string, ComponentType<any>>>(components: T): T
 export declare function setMermaidWorker(worker: Worker): void
 export declare function setKaTeXWorker(worker: Worker): void
 export declare function enableMermaid(): void

--- a/docs/guide/react-components.md
+++ b/docs/guide/react-components.md
@@ -2,7 +2,7 @@
 
 markstream-react provides the same powerful components as markstream-vue, but built for React. All components support React 18+ with full TypeScript support.
 
-The root `markstream-react`, `markstream-react/next`, and `markstream-react/server` entrypoints all ship declaration files. Shared renderer and component types such as `NodeRendererProps`, `NodeRendererCodeBlockProps`, `NodeComponentProps`, `RenderContext`, `RenderNodeFn`, `CustomComponentMap`, `CodeBlockMonacoOptions`, `MarkdownCodeBlockNodeProps`, `ListItemNodeProps`, `HtmlPreviewFrameProps`, `TooltipProps`, `TooltipPlacement`, and `LinkNodeStyleProps` can be imported directly from the entrypoint you use.
+The root `markstream-react`, `markstream-react/next`, and `markstream-react/server` entrypoints all ship declaration files. Shared renderer and component types such as `NodeRendererProps`, `NodeRendererCodeBlockProps`, `NodeComponentProps`, `StreamingComponentMap`, `HtmlComponentMap`, `RenderContext`, `RenderNodeFn`, `CustomComponentMap`, `CodeBlockMonacoOptions`, `MarkdownCodeBlockNodeProps`, `ListItemNodeProps`, `HtmlPreviewFrameProps`, `TooltipProps`, `TooltipPlacement`, and `LinkNodeStyleProps` can be imported directly from the entrypoint you use.
 ## Main Component: MarkdownRender
 
 The primary component for rendering markdown content in React.
@@ -21,6 +21,8 @@ The primary component for rendering markdown content in React.
 | `final` | `boolean` | `false` | Marks end-of-stream; stops emitting streaming `loading` nodes |
 | `parseOptions` | `ParseOptions` | - | Parser options and token hooks (only when `content` is provided) |
 | `customHtmlTags` | `readonly string[]` | - | HTML-like tags emitted as custom nodes (e.g. `thinking`) |
+| `streamingComponents` | `StreamingComponentMap` | - | Renderer-local HTML-like tag components that receive `NodeComponentProps` and are automatically added to the parser's effective `customHtmlTags` |
+| `htmlComponents` | `HtmlComponentMap` | - | Renderer-local HTML-like tag components for the raw/dynamic HTML path; components receive normal React props and `children` |
 | `htmlPolicy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | Controls `html_block` / `html_inline` rendering. `safe` blocks active/embed/form tags, `escape` shows literal HTML text, and `trusted` restores the broader trusted HTML behavior while still stripping scripts and unsafe attrs. |
 | `customMarkdownIt` | `(md: MarkdownIt) => MarkdownIt` | - | Customize the internal MarkdownIt instance |
 | `debugPerformance` | `boolean` | `false` | Log parse/render timing and virtualization stats (dev only) |
@@ -147,6 +149,58 @@ This is markstream-react.`
   )
 }
 ```
+
+## Custom HTML-like Components
+
+For new React code, prefer renderer-local component maps when your content contains HTML-like custom tags.
+
+Use `streamingComponents` when the component needs the parser-backed streaming node contract. Keys are normalized like `customHtmlTags`, automatically added to the parser's effective custom tag list, and work with incomplete tags while content is streaming.
+
+Use `htmlComponents` when the component should render through the raw/dynamic HTML path and receive normal React props plus `children`. These components may still rerender while content streams, but they do not receive `node.loading` or the parser node contract.
+
+```tsx
+import type { NodeComponentProps } from 'markstream-react'
+import type React from 'react'
+import MarkdownRender from 'markstream-react'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string][]
+  content: string
+  loading?: boolean
+}
+
+function getAttr(attrs: [string, string][] | undefined, name: string) {
+  return attrs?.find(([key]) => key === name)?.[1]
+}
+
+function DocumentLink({ node }: NodeComponentProps<DocumentLinkNode>) {
+  return (
+    <a
+      href={`/documents/${getAttr(node.attrs, 'id')}`}
+      aria-busy={node.loading || undefined}
+    >
+      {node.content}
+    </a>
+  )
+}
+
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+<MarkdownRender
+  content={content}
+  final={isDone}
+  streamingComponents={{ documentlink: DocumentLink }}
+  htmlComponents={{ badge: Badge }}
+/>
+```
+
+`customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.
+
+This API split fixes discoverability and typing around the two component contracts. HTML safety is still handled by `htmlPolicy` and the existing sanitization rules; the split is not a security boundary.
 
 ## Code Block Components
 

--- a/docs/guide/react-components.md
+++ b/docs/guide/react-components.md
@@ -158,6 +158,8 @@ Use `streamingComponents` when the component needs the parser-backed streaming n
 
 Use `htmlComponents` when the component should render through the raw/dynamic HTML path and receive normal React props plus `children`. These components may still rerender while content streams, but they do not receive `node.loading` or the parser node contract.
 
+For typed component definitions, prefer `defineStreamingComponents(...)` and `defineHtmlComponents(...)`. `StreamingComponentMap` and `HtmlComponentMap` describe the broad runtime map shape accepted by the renderer; the helper functions perform the per-entry contract checks that catch mixing parser-backed `NodeComponentProps` components into the HTML props path.
+
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
 import type React from 'react'
@@ -210,7 +212,7 @@ function App({ content, isDone }: { content: string, isDone: boolean }) {
 }
 ```
 
-`customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.
+`customHtmlTags` remains available as a lower-level parser option. `htmlComponents` can also handle tags listed in `customHtmlTags`, but it still receives normal props and `children`; only `streamingComponents` receives `NodeComponentProps`. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.
 
 This API split fixes discoverability and typing around the two component contracts. HTML safety is still handled by `htmlPolicy` and the existing sanitization rules; the split is not a security boundary.
 

--- a/docs/guide/react-components.md
+++ b/docs/guide/react-components.md
@@ -22,7 +22,7 @@ The primary component for rendering markdown content in React.
 | `parseOptions` | `ParseOptions` | - | Parser options and token hooks (only when `content` is provided) |
 | `customHtmlTags` | `readonly string[]` | - | HTML-like tags emitted as custom nodes (e.g. `thinking`) |
 | `streamingComponents` | `StreamingComponentMap` | - | Renderer-local HTML-like tag components that receive `NodeComponentProps` and are automatically added to the parser's effective `customHtmlTags` |
-| `htmlComponents` | `HtmlComponentMap` | - | Renderer-local HTML-like tag components for the raw/dynamic HTML path; components receive normal React props and `children` |
+| `htmlComponents` | `HtmlComponentMap` | - | Renderer-local HTML-like tag components for the raw/dynamic HTML path; components receive sanitized HTML attributes and `children` |
 | `htmlPolicy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | Controls `html_block` / `html_inline` rendering. `safe` blocks active/embed/form tags, `escape` shows literal HTML text, and `trusted` restores the broader trusted HTML behavior while still stripping scripts and unsafe attrs. |
 | `customMarkdownIt` | `(md: MarkdownIt) => MarkdownIt` | - | Customize the internal MarkdownIt instance |
 | `debugPerformance` | `boolean` | `false` | Log parse/render timing and virtualization stats (dev only) |
@@ -156,7 +156,7 @@ For new React code, prefer renderer-local component maps when your content conta
 
 Use `streamingComponents` when the component needs the parser-backed streaming node contract. Keys are normalized like `customHtmlTags`, automatically added to the parser's effective custom tag list, and work with incomplete tags while content is streaming.
 
-Use `htmlComponents` when the component should render through the raw/dynamic HTML path and receive normal React props plus `children`. These components may still rerender while content streams, but they do not receive `node.loading` or the parser node contract.
+Use `htmlComponents` when the component should render through the raw/dynamic HTML path and receive sanitized HTML attributes plus `children`. Attribute values are converted to primitive prop values, but attribute names are preserved from the source HTML, so `class` remains `class`. These components may still rerender while content streams, but they do not receive `node.loading` or the parser node contract.
 
 For typed component definitions, prefer `defineStreamingComponents(...)` and `defineHtmlComponents(...)`. `StreamingComponentMap` and `HtmlComponentMap` describe the broad runtime map shape accepted by the renderer; the helper functions perform the per-entry contract checks that catch mixing parser-backed `NodeComponentProps` components into the HTML props path.
 
@@ -212,7 +212,7 @@ function App({ content, isDone }: { content: string, isDone: boolean }) {
 }
 ```
 
-`customHtmlTags` remains available as a lower-level parser option. `htmlComponents` can also handle tags listed in `customHtmlTags`, but it still receives normal props and `children`; only `streamingComponents` receives `NodeComponentProps`. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.
+`customHtmlTags` remains available as a lower-level parser option. `htmlComponents` can also handle tags listed in `customHtmlTags`, but it still receives sanitized HTML attributes and `children`; only `streamingComponents` receives `NodeComponentProps`. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.
 
 This API split fixes discoverability and typing around the two component contracts. HTML safety is still handled by `htmlPolicy` and the existing sanitization rules; the split is not a security boundary.
 

--- a/docs/guide/react-components.md
+++ b/docs/guide/react-components.md
@@ -161,7 +161,7 @@ Use `htmlComponents` when the component should render through the raw/dynamic HT
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
 import type React from 'react'
-import MarkdownRender from 'markstream-react'
+import MarkdownRender, { defineHtmlComponents, defineStreamingComponents } from 'markstream-react'
 
 interface DocumentLinkNode {
   type: 'documentlink'
@@ -190,12 +190,24 @@ function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
   return <span data-kind={kind}>{children}</span>
 }
 
-<MarkdownRender
-  content={content}
-  final={isDone}
-  streamingComponents={{ documentlink: DocumentLink }}
-  htmlComponents={{ badge: Badge }}
-/>
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+const htmlComponents = defineHtmlComponents({
+  badge: Badge,
+})
+
+function App({ content, isDone }: { content: string, isDone: boolean }) {
+  return (
+    <MarkdownRender
+      content={content}
+      final={isDone}
+      streamingComponents={streamingComponents}
+      htmlComponents={htmlComponents}
+    />
+  )
+}
 ```
 
 `customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and existing node overrides. If the same normalized tag appears in both `streamingComponents` and `htmlComponents`, `streamingComponents` wins and a development warning is emitted once.

--- a/docs/guide/react-markdown-migration.md
+++ b/docs/guide/react-markdown-migration.md
@@ -67,7 +67,7 @@ This means `components.h1` does not become `components.h1` again. It usually bec
 | `react-markdown` | `markstream-react` | Notes |
 |---|---|---|
 | `children` | `content` | Pass the Markdown string through `content`. |
-| `components` | `streamingComponents`, `htmlComponents`, or `setCustomComponents(id?, mapping)` | For HTML-like custom tags, prefer renderer-local maps. Use `streamingComponents` for parser-backed `NodeComponentProps`; use `htmlComponents` for normal React props and `children`. Legacy node overrides still use `setCustomComponents`. |
+| `components` | `streamingComponents`, `htmlComponents`, or `setCustomComponents(id?, mapping)` | For HTML-like custom tags, prefer renderer-local maps. Use `streamingComponents` for parser-backed `NodeComponentProps`; use `htmlComponents` for sanitized HTML attributes and `children`. Legacy node overrides still use `setCustomComponents`. |
 | `remarkPlugins` | `customMarkdownIt` | Use `markdown-it` plugins instead of `remark` plugins. Many common Markdown features already work without extra plugins. |
 | `remarkPlugins={[remarkGfm]}` | Often removable | Tables, task checkboxes, strikethrough, code fences, and other common constructs are already supported by the parser. Re-check edge cases before deleting plugin code. |
 | `rehypePlugins` | No direct equivalent | There is no public `rehype` stage. Use custom node renderers, `customHtmlTags`, `parseOptions`, or post-process `nodes` instead. |
@@ -106,7 +106,7 @@ const renderer = (
 
 `streamingComponents` selects the parser-backed streaming-node contract. Its keys are added to the parser's effective `customHtmlTags`, so incomplete tags can render with `node.attrs`, `node.content`, and `node.loading`.
 
-`htmlComponents` selects the raw/dynamic HTML contract. Components receive normal React props plus `children`, not `props.node`.
+`htmlComponents` selects the raw/dynamic HTML contract. Components receive sanitized HTML attributes plus `children`, not `props.node`. Attribute values are converted to primitive prop values, but names are preserved from source HTML, so `class` stays `class`.
 
 `customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and built-in node overrides.
 
@@ -210,7 +210,7 @@ Useful node-type translations:
 - `p` -> `paragraph`
 - `img` -> `image`
 - `code` / `pre` -> `code_block` or `inline_code`
-- Custom HTML-like tags -> `streamingComponents` for `NodeComponentProps`, or `htmlComponents` for normal props/children
+- Custom HTML-like tags -> `streamingComponents` for `NodeComponentProps`, or `htmlComponents` for sanitized HTML attributes/children
 
 ## Migrating code highlighting
 

--- a/docs/guide/react-markdown-migration.md
+++ b/docs/guide/react-markdown-migration.md
@@ -67,11 +67,11 @@ This means `components.h1` does not become `components.h1` again. It usually bec
 | `react-markdown` | `markstream-react` | Notes |
 |---|---|---|
 | `children` | `content` | Pass the Markdown string through `content`. |
-| `components` | `setCustomComponents(id?, mapping)` | `react-markdown` keys are HTML tags; `markstream-react` keys are node types such as `heading`, `link`, `paragraph`, `image`, `code_block`, `inline_code`. |
+| `components` | `streamingComponents`, `htmlComponents`, or `setCustomComponents(id?, mapping)` | For HTML-like custom tags, prefer renderer-local maps. Use `streamingComponents` for parser-backed `NodeComponentProps`; use `htmlComponents` for normal React props and `children`. Legacy node overrides still use `setCustomComponents`. |
 | `remarkPlugins` | `customMarkdownIt` | Use `markdown-it` plugins instead of `remark` plugins. Many common Markdown features already work without extra plugins. |
 | `remarkPlugins={[remarkGfm]}` | Often removable | Tables, task checkboxes, strikethrough, code fences, and other common constructs are already supported by the parser. Re-check edge cases before deleting plugin code. |
 | `rehypePlugins` | No direct equivalent | There is no public `rehype` stage. Use custom node renderers, `customHtmlTags`, `parseOptions`, or post-process `nodes` instead. |
-| `rehypeRaw` | Usually not needed | HTML-like tags are already parsed. For custom tags, prefer `customHtmlTags={['thinking']}` plus `setCustomComponents`. |
+| `rehypeRaw` | Usually not needed | HTML-like tags are already parsed. For custom tags, prefer `streamingComponents` or `htmlComponents` depending on the prop contract you need. |
 | `skipHtml` | No direct prop | HTML nodes render by default, with built-in blocking of dangerous attributes/tags and unsafe URLs in the HTML renderers. If you must remove HTML entirely, prefilter the input or parsed nodes yourself. |
 | `allowedElements` / `disallowedElements` / `allowElement` | No direct prop | Filter the parsed `nodes` tree yourself, or replace specific node renderers. |
 | `unwrapDisallowed` | Manual node filtering | Implement this in your node post-processing step if you need it. |
@@ -79,22 +79,65 @@ This means `components.h1` does not become `components.h1` again. It usually bec
 
 ## Upgrade note: custom HTML-like tags
 
-Current `markstream-react` releases no longer infer custom HTML tag names from `setCustomComponents(...)`. If your app renders model output such as `<DocumentLink id="...">title</DocumentLink>` and expects a custom component to receive `props.node`, add the tag to `customHtmlTags`:
+New applications should use renderer-local maps for HTML-like custom tags:
 
 ```tsx
+import type { NodeComponentProps } from 'markstream-react'
+import type React from 'react'
+import MarkdownRender from 'markstream-react'
+
+function DocumentLink({ node }: NodeComponentProps<any>) {
+  return <span>{node.content}</span>
+}
+
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+const renderer = (
+  <MarkdownRender
+    content={content}
+    final={isDone}
+    streamingComponents={{ documentlink: DocumentLink }}
+    htmlComponents={{ badge: Badge }}
+  />
+)
+```
+
+`streamingComponents` selects the parser-backed streaming-node contract. Its keys are added to the parser's effective `customHtmlTags`, so incomplete tags can render with `node.attrs`, `node.content`, and `node.loading`.
+
+`htmlComponents` selects the raw/dynamic HTML contract. Components receive normal React props plus `children`, not `props.node`.
+
+`customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` remain supported for compatibility, shared application-level registration, and built-in node overrides.
+
+Migration example:
+
+```tsx
+// Before
 setCustomComponents('chat', {
   documentlink: DocumentLink,
 })
 
-React.createElement(MarkdownRender, {
-  customId: 'chat',
-  content,
-  final: isDone,
-  customHtmlTags: ['documentlink'],
-})
+const before = (
+  <MarkdownRender
+    customId="chat"
+    customHtmlTags={['documentlink']}
+    content={content}
+  />
+)
+
+// After
+const after = (
+  <MarkdownRender
+    content={content}
+    streamingComponents={{
+      documentlink: DocumentLink,
+    }}
+  />
+)
 ```
 
-Without `customHtmlTags`, the tag stays on the raw HTML dynamic rendering path. The component can still render, but it receives HTML-style props such as `{ id, children }` instead of `NodeComponentProps`, and it will not receive `node.loading` for streaming partial renders. This auto-inference removal was an undocumented breaking change for apps that relied on the previous behavior.
+Current `markstream-react` releases no longer infer custom HTML tag names from `setCustomComponents(...)`. Without `customHtmlTags` or `streamingComponents`, a complete custom-looking tag stays on the raw HTML dynamic rendering path and receives HTML-style props such as `{ id, children }`. This auto-inference removal was an undocumented breaking change for apps that relied on the previous behavior. The new local maps make that contract explicit in types.
 
 ## Migrating `components`
 
@@ -167,7 +210,7 @@ Useful node-type translations:
 - `p` -> `paragraph`
 - `img` -> `image`
 - `code` / `pre` -> `code_block` or `inline_code`
-- Custom HTML-like tags -> `customHtmlTags` + `setCustomComponents`
+- Custom HTML-like tags -> `streamingComponents` for `NodeComponentProps`, or `htmlComponents` for normal props/children
 
 ## Migrating code highlighting
 
@@ -241,24 +284,23 @@ If your old `rehypeRaw` usage was mainly there to support custom tags such as `<
 
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
-import MarkdownRender, { setCustomComponents } from 'markstream-react'
+import MarkdownRender from 'markstream-react'
 
 function ThinkingNode({ node }: NodeComponentProps<any>) {
   return <aside className="thinking-box">{node.content}</aside>
 }
 
-setCustomComponents('chat', { thinking: ThinkingNode })
-
 export function Message({ markdown }: { markdown: string }) {
   return (
     <MarkdownRender
-      customId="chat"
       content={markdown}
-      customHtmlTags={['thinking']}
+      streamingComponents={{ thinking: ThinkingNode }}
     />
   )
 }
 ```
+
+This API split is about discoverability and typing. HTML safety is still handled by `htmlPolicy` and the existing sanitization rules; do not treat the component-map split as a security boundary.
 
 ## Streaming upgrade path
 
@@ -293,7 +335,7 @@ For most chat streams, the simpler `content` + smooth streaming path is the firs
 
 - Replace `<Markdown>{markdown}</Markdown>` with `<MarkdownRender content={markdown} />`.
 - Import `markstream-react/index.css`.
-- Move `components` overrides into `setCustomComponents(customId, mapping)`.
+- Move custom HTML-like tags into `streamingComponents` or `htmlComponents`; keep `setCustomComponents(customId, mapping)` for existing node overrides and shared registrations.
 - Remove plugins that are now redundant before re-adding custom ones.
 - Re-check any `rehype`-based HTML filtering or transformation logic.
 - If your app renders incremental output, evaluate `content` + smooth streaming first; upgrade to `nodes` when you need AST control or external parsing.

--- a/docs/guide/react-next-ssr.md
+++ b/docs/guide/react-next-ssr.md
@@ -27,6 +27,43 @@ export default function Page() {
 }
 ```
 
+Direct component maps contain React component functions, so keep them inside a local Client Component wrapper when you use `markstream-react/next` from an App Router Server Component. Server Components should only pass serializable props such as `content` into that wrapper, matching the [Next.js Client Component prop rules](https://nextjs.org/docs/app/api-reference/directives/use-client).
+
+```tsx
+// app/markdown-renderer.tsx
+'use client'
+
+import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
+import type { NodeComponentProps } from 'markstream-react/next'
+
+function DocumentLink(props: NodeComponentProps<{ content: string }>) {
+  return <a>{props.node.content}</a>
+}
+
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+export function ClientMarkdown({ content }: { content: string }) {
+  return (
+    <MarkdownRender
+      content={content}
+      final
+      streamingComponents={streamingComponents}
+    />
+  )
+}
+```
+
+```tsx
+// app/page.tsx
+import { ClientMarkdown } from './markdown-renderer'
+
+export default function Page() {
+  return <ClientMarkdown content="<DocumentLink>Open</DocumentLink>" />
+}
+```
+
 ## Pure Server Rendering with `markstream-react/server`
 
 ```tsx
@@ -40,6 +77,8 @@ export default function Page() {
   return <MarkdownRender content={markdown} final />
 }
 ```
+
+The pure server entry does not create a Client Component boundary, so server files can pass `streamingComponents` and `htmlComponents` directly when the render should remain server-only.
 
 ## Custom Components and Custom Tags
 

--- a/docs/guide/react-next-ssr.md
+++ b/docs/guide/react-next-ssr.md
@@ -33,8 +33,8 @@ Direct component maps contain React component functions, so keep them inside a l
 // app/markdown-renderer.tsx
 'use client'
 
-import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
 import type { NodeComponentProps } from 'markstream-react/next'
+import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
 
 function DocumentLink(props: NodeComponentProps<{ content: string }>) {
   return <a>{props.node.content}</a>

--- a/docs/zh/guide/react-components.md
+++ b/docs/zh/guide/react-components.md
@@ -161,7 +161,7 @@ function App() {
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
 import type React from 'react'
-import MarkdownRender from 'markstream-react'
+import MarkdownRender, { defineHtmlComponents, defineStreamingComponents } from 'markstream-react'
 
 interface DocumentLinkNode {
   type: 'documentlink'
@@ -190,12 +190,24 @@ function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
   return <span data-kind={kind}>{children}</span>
 }
 
-<MarkdownRender
-  content={content}
-  final={isDone}
-  streamingComponents={{ documentlink: DocumentLink }}
-  htmlComponents={{ badge: Badge }}
-/>
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+const htmlComponents = defineHtmlComponents({
+  badge: Badge,
+})
+
+function App({ content, isDone }: { content: string, isDone: boolean }) {
+  return (
+    <MarkdownRender
+      content={content}
+      final={isDone}
+      streamingComponents={streamingComponents}
+      htmlComponents={htmlComponents}
+    />
+  )
+}
 ```
 
 `customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。

--- a/docs/zh/guide/react-components.md
+++ b/docs/zh/guide/react-components.md
@@ -158,6 +158,8 @@ function App() {
 
 当组件应该走 raw/dynamic HTML 路径并接收普通 React props 与 `children` 时，使用 `htmlComponents`。这类组件仍可能随着 streaming 内容重渲染，但不会收到 `node.loading` 或 parser 节点合约。
 
+定义带类型的组件 map 时，优先使用 `defineStreamingComponents(...)` 和 `defineHtmlComponents(...)`。`StreamingComponentMap` 与 `HtmlComponentMap` 描述的是渲染器可接收的宽运行时 map 形状；逐项 props 合约校验由 helper 完成，可以捕获把 parser-backed `NodeComponentProps` 组件放进 HTML props 路径这类误用。
+
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
 import type React from 'react'
@@ -210,7 +212,7 @@ function App({ content, isDone }: { content: string, isDone: boolean }) {
 }
 ```
 
-`customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。
+`customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`htmlComponents` 也可以处理列在 `customHtmlTags` 中的标签，但它仍然接收普通 props 与 `children`；只有 `streamingComponents` 会收到 `NodeComponentProps`。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。
 
 这个 API 拆分解决的是可发现性和类型表达问题。HTML 安全仍由 `htmlPolicy` 和现有 sanitization 规则负责；这不是一个安全边界。
 

--- a/docs/zh/guide/react-components.md
+++ b/docs/zh/guide/react-components.md
@@ -22,7 +22,7 @@ markstream-react 提供与 markstream-vue 相同强大的组件，但专为 Reac
 | `parseOptions` | `ParseOptions` | - | 解析选项与 token hooks（仅在传入 `content` 时生效） |
 | `customHtmlTags` | `readonly string[]` | - | 作为自定义节点输出的 HTML-like 标签（如 `thinking`） |
 | `streamingComponents` | `StreamingComponentMap` | - | 渲染器实例本地的 HTML-like 标签组件，接收 `NodeComponentProps`，并会自动加入 parser 的有效 `customHtmlTags` |
-| `htmlComponents` | `HtmlComponentMap` | - | 渲染器实例本地的 HTML-like 标签组件，走 raw/dynamic HTML 路径；组件接收普通 React props 和 `children` |
+| `htmlComponents` | `HtmlComponentMap` | - | 渲染器实例本地的 HTML-like 标签组件，走 raw/dynamic HTML 路径；组件接收清洗后的 HTML 属性和 `children` |
 | `htmlPolicy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | 控制 `html_block` / `html_inline` 渲染。`safe` 阻止 active/embed/form 标签，`escape` 显示原始 HTML 文本，`trusted` 恢复更宽松的受信 HTML 行为但仍会剥离脚本和不安全属性。 |
 | `customMarkdownIt` | `(md: MarkdownIt) => MarkdownIt` | - | 自定义 MarkdownIt 实例 |
 | `debugPerformance` | `boolean` | `false` | 输出解析/渲染耗时与虚拟化统计（仅 dev） |
@@ -156,7 +156,7 @@ function App() {
 
 当组件需要 parser 支持的流式节点合约时，使用 `streamingComponents`。它的 key 会按 `customHtmlTags` 的规则归一化，并自动加入 parser 的有效自定义标签列表，因此不完整标签在 streaming 过程中也能渲染。
 
-当组件应该走 raw/dynamic HTML 路径并接收普通 React props 与 `children` 时，使用 `htmlComponents`。这类组件仍可能随着 streaming 内容重渲染，但不会收到 `node.loading` 或 parser 节点合约。
+当组件应该走 raw/dynamic HTML 路径并接收清洗后的 HTML 属性与 `children` 时，使用 `htmlComponents`。属性值会转换成 primitive prop 值，但属性名会保留源 HTML 写法，例如 `class` 仍然是 `class`。这类组件仍可能随着 streaming 内容重渲染，但不会收到 `node.loading` 或 parser 节点合约。
 
 定义带类型的组件 map 时，优先使用 `defineStreamingComponents(...)` 和 `defineHtmlComponents(...)`。`StreamingComponentMap` 与 `HtmlComponentMap` 描述的是渲染器可接收的宽运行时 map 形状；逐项 props 合约校验由 helper 完成，可以捕获把 parser-backed `NodeComponentProps` 组件放进 HTML props 路径这类误用。
 
@@ -212,7 +212,7 @@ function App({ content, isDone }: { content: string, isDone: boolean }) {
 }
 ```
 
-`customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`htmlComponents` 也可以处理列在 `customHtmlTags` 中的标签，但它仍然接收普通 props 与 `children`；只有 `streamingComponents` 会收到 `NodeComponentProps`。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。
+`customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`htmlComponents` 也可以处理列在 `customHtmlTags` 中的标签，但它仍然接收清洗后的 HTML 属性与 `children`；只有 `streamingComponents` 会收到 `NodeComponentProps`。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。
 
 这个 API 拆分解决的是可发现性和类型表达问题。HTML 安全仍由 `htmlPolicy` 和现有 sanitization 规则负责；这不是一个安全边界。
 

--- a/docs/zh/guide/react-components.md
+++ b/docs/zh/guide/react-components.md
@@ -2,7 +2,7 @@
 
 markstream-react 提供与 markstream-vue 相同强大的组件，但专为 React 构建。所有组件都支持 React 18+ 并包含完整的 TypeScript 支持。
 
-根入口、`markstream-react/next`、`markstream-react/server` 现在都会产出独立声明文件。像 `NodeRendererProps`、`NodeRendererCodeBlockProps`、`NodeComponentProps`、`RenderContext`、`RenderNodeFn`、`CustomComponentMap`、`CodeBlockMonacoOptions`、`MarkdownCodeBlockNodeProps`、`ListItemNodeProps`、`HtmlPreviewFrameProps`、`TooltipProps`、`TooltipPlacement`、`LinkNodeStyleProps` 这类共享渲染器与组件类型，都可以直接从你实际使用的入口导入。
+根入口、`markstream-react/next`、`markstream-react/server` 现在都会产出独立声明文件。像 `NodeRendererProps`、`NodeRendererCodeBlockProps`、`NodeComponentProps`、`StreamingComponentMap`、`HtmlComponentMap`、`RenderContext`、`RenderNodeFn`、`CustomComponentMap`、`CodeBlockMonacoOptions`、`MarkdownCodeBlockNodeProps`、`ListItemNodeProps`、`HtmlPreviewFrameProps`、`TooltipProps`、`TooltipPlacement`、`LinkNodeStyleProps` 这类共享渲染器与组件类型，都可以直接从你实际使用的入口导入。
 ## 主组件：MarkdownRender
 
 在 React 中渲染 markdown 内容的主要组件。
@@ -21,6 +21,8 @@ markstream-react 提供与 markstream-vue 相同强大的组件，但专为 Reac
 | `final` | `boolean` | `false` | 标记输入结束，停止输出 streaming `loading` 节点 |
 | `parseOptions` | `ParseOptions` | - | 解析选项与 token hooks（仅在传入 `content` 时生效） |
 | `customHtmlTags` | `readonly string[]` | - | 作为自定义节点输出的 HTML-like 标签（如 `thinking`） |
+| `streamingComponents` | `StreamingComponentMap` | - | 渲染器实例本地的 HTML-like 标签组件，接收 `NodeComponentProps`，并会自动加入 parser 的有效 `customHtmlTags` |
+| `htmlComponents` | `HtmlComponentMap` | - | 渲染器实例本地的 HTML-like 标签组件，走 raw/dynamic HTML 路径；组件接收普通 React props 和 `children` |
 | `htmlPolicy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | 控制 `html_block` / `html_inline` 渲染。`safe` 阻止 active/embed/form 标签，`escape` 显示原始 HTML 文本，`trusted` 恢复更宽松的受信 HTML 行为但仍会剥离脚本和不安全属性。 |
 | `customMarkdownIt` | `(md: MarkdownIt) => MarkdownIt` | - | 自定义 MarkdownIt 实例 |
 | `debugPerformance` | `boolean` | `false` | 输出解析/渲染耗时与虚拟化统计（仅 dev） |
@@ -147,6 +149,58 @@ function App() {
   )
 }
 ```
+
+## 自定义 HTML-like 组件
+
+新的 React 代码如果要渲染 HTML-like 自定义标签，优先使用渲染器实例本地的组件 map。
+
+当组件需要 parser 支持的流式节点合约时，使用 `streamingComponents`。它的 key 会按 `customHtmlTags` 的规则归一化，并自动加入 parser 的有效自定义标签列表，因此不完整标签在 streaming 过程中也能渲染。
+
+当组件应该走 raw/dynamic HTML 路径并接收普通 React props 与 `children` 时，使用 `htmlComponents`。这类组件仍可能随着 streaming 内容重渲染，但不会收到 `node.loading` 或 parser 节点合约。
+
+```tsx
+import type { NodeComponentProps } from 'markstream-react'
+import type React from 'react'
+import MarkdownRender from 'markstream-react'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string][]
+  content: string
+  loading?: boolean
+}
+
+function getAttr(attrs: [string, string][] | undefined, name: string) {
+  return attrs?.find(([key]) => key === name)?.[1]
+}
+
+function DocumentLink({ node }: NodeComponentProps<DocumentLinkNode>) {
+  return (
+    <a
+      href={`/documents/${getAttr(node.attrs, 'id')}`}
+      aria-busy={node.loading || undefined}
+    >
+      {node.content}
+    </a>
+  )
+}
+
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+<MarkdownRender
+  content={content}
+  final={isDone}
+  streamingComponents={{ documentlink: DocumentLink }}
+  htmlComponents={{ badge: Badge }}
+/>
+```
+
+`customHtmlTags` 仍然可以作为更底层的 parser 选项使用。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及已有 AST 节点覆盖。如果同一个归一化 tag 同时出现在 `streamingComponents` 和 `htmlComponents` 中，`streamingComponents` 会胜出，并在开发环境只告警一次。
+
+这个 API 拆分解决的是可发现性和类型表达问题。HTML 安全仍由 `htmlPolicy` 和现有 sanitization 规则负责；这不是一个安全边界。
 
 ## 代码块组件
 

--- a/docs/zh/guide/react-markdown-migration.md
+++ b/docs/zh/guide/react-markdown-migration.md
@@ -67,15 +67,77 @@ export function Article({ markdown }: { markdown: string }) {
 | `react-markdown` | `markstream-react` | 说明 |
 |---|---|---|
 | `children` | `content` | Markdown 字符串通过 `content` 传入。 |
-| `components` | `setCustomComponents(id?, mapping)` | `react-markdown` 的 key 是 HTML tag；`markstream-react` 的 key 是节点类型，如 `heading`、`link`、`paragraph`、`image`、`code_block`、`inline_code`。 |
+| `components` | `streamingComponents`、`htmlComponents` 或 `setCustomComponents(id?, mapping)` | HTML-like 自定义标签优先使用渲染器本地 map。需要 parser-backed `NodeComponentProps` 时用 `streamingComponents`；需要普通 React props 和 `children` 时用 `htmlComponents`。已有节点覆盖继续用 `setCustomComponents`。 |
 | `remarkPlugins` | `customMarkdownIt` | 改用 `markdown-it` 插件，而不是 `remark` 插件。很多常见 Markdown 能力本身已经内建。 |
 | `remarkPlugins={[remarkGfm]}` | 很多时候可以删掉 | 表格、任务列表、删除线、代码围栏等常见语法解析器本身已经支持。若你依赖某些边缘行为，删掉前请回归验证。 |
 | `rehypePlugins` | 没有直接等价物 | `markstream-react` 没有公开的 `rehype` 阶段。请改用自定义节点渲染器、`customHtmlTags`、`parseOptions` 或对 `nodes` 做后处理。 |
-| `rehypeRaw` | 通常不再需要 | HTML-like 标签本来就会被解析。如果是自定义标签，优先使用 `customHtmlTags={['thinking']}` + `setCustomComponents`。 |
+| `rehypeRaw` | 通常不再需要 | HTML-like 标签本来就会被解析。自定义标签按需要的 props 合约选择 `streamingComponents` 或 `htmlComponents`。 |
 | `skipHtml` | 没有直接 prop | HTML 节点默认会渲染，但内置 HTML 渲染器会拦截危险标签/属性和不安全 URL。如果你必须彻底禁用 HTML，请自行在输入阶段或节点阶段过滤。 |
 | `allowedElements` / `disallowedElements` / `allowElement` | 没有直接 prop | 需要你自己过滤 `nodes` 树，或者替换指定节点的渲染器。 |
 | `unwrapDisallowed` | 手动做节点过滤 | 如果你需要“去掉外层标签但保留子节点”的行为，需要在节点后处理阶段自己实现。 |
 | `urlTransform` | `parseOptions.validateLink` + 自定义 `link` 渲染器 | `validateLink` 适合做放行/拦截；如果你要改写 URL，请在自定义 `link` 渲染器或节点后处理里完成。 |
+
+## 升级提示：自定义 HTML-like 标签
+
+新的应用建议用渲染器本地 map 来处理 HTML-like 自定义标签：
+
+```tsx
+import type { NodeComponentProps } from 'markstream-react'
+import type React from 'react'
+import MarkdownRender from 'markstream-react'
+
+function DocumentLink({ node }: NodeComponentProps<any>) {
+  return <span>{node.content}</span>
+}
+
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+const renderer = (
+  <MarkdownRender
+    content={content}
+    final={isDone}
+    streamingComponents={{ documentlink: DocumentLink }}
+    htmlComponents={{ badge: Badge }}
+  />
+)
+```
+
+`streamingComponents` 选择 parser-backed streaming-node 合约。它的 key 会加入 parser 的有效 `customHtmlTags`，因此不完整标签也能以 `node.attrs`、`node.content`、`node.loading` 渲染。
+
+`htmlComponents` 选择 raw/dynamic HTML 合约。组件接收普通 React props 和 `children`，不会收到 `props.node`。
+
+`customHtmlTags` 仍可作为更底层的 parser 选项使用。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及内置节点覆盖。
+
+迁移示例：
+
+```tsx
+// Before
+setCustomComponents('chat', {
+  documentlink: DocumentLink,
+})
+
+const before = (
+  <MarkdownRender
+    customId="chat"
+    customHtmlTags={['documentlink']}
+    content={content}
+  />
+)
+
+// After
+const after = (
+  <MarkdownRender
+    content={content}
+    streamingComponents={{
+      documentlink: DocumentLink,
+    }}
+  />
+)
+```
+
+当前 `markstream-react` 不再从 `setCustomComponents(...)` 推断自定义 HTML 标签名。如果没有 `customHtmlTags` 或 `streamingComponents`，完整的自定义外观标签会留在 raw HTML dynamic 路径，并接收 `{ id, children }` 这类 HTML-style props。这对依赖旧行为的应用来说曾是一个未记录的 breaking change；新的本地 map 会在类型层把合约明确表达出来。
 
 ## 迁移 `components`
 
@@ -148,7 +210,7 @@ export function Article({ markdown }: { markdown: string }) {
 - `p` -> `paragraph`
 - `img` -> `image`
 - `code` / `pre` -> `code_block` 或 `inline_code`
-- 自定义 HTML-like 标签 -> `customHtmlTags` + `setCustomComponents`
+- 自定义 HTML-like 标签 -> 需要 `NodeComponentProps` 时用 `streamingComponents`，需要普通 props/children 时用 `htmlComponents`
 
 ## 迁移代码高亮
 
@@ -222,24 +284,23 @@ export function Article({ markdown }: { markdown: string }) {
 
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
-import MarkdownRender, { setCustomComponents } from 'markstream-react'
+import MarkdownRender from 'markstream-react'
 
 function ThinkingNode({ node }: NodeComponentProps<any>) {
   return <aside className="thinking-box">{node.content}</aside>
 }
 
-setCustomComponents('chat', { thinking: ThinkingNode })
-
 export function Message({ markdown }: { markdown: string }) {
   return (
     <MarkdownRender
-      customId="chat"
       content={markdown}
-      customHtmlTags={['thinking']}
+      streamingComponents={{ thinking: ThinkingNode }}
     />
   )
 }
 ```
+
+这个 API 拆分解决的是可发现性和类型表达问题。HTML 安全仍由 `htmlPolicy` 和现有 sanitization 规则负责；不要把组件 map 拆分当作安全边界。
 
 ## 流式升级路径
 
@@ -274,7 +335,7 @@ export function Message() {
 
 - 把 `<Markdown>{markdown}</Markdown>` 改成 `<MarkdownRender content={markdown} />`
 - 引入 `markstream-react/index.css`
-- 把 `components` 覆盖迁到 `setCustomComponents(customId, mapping)`
+- 把 HTML-like 自定义标签迁到 `streamingComponents` 或 `htmlComponents`；已有节点覆盖和共享注册继续使用 `setCustomComponents(customId, mapping)`
 - 先删除已经冗余的插件，再按需补回真正还需要的能力
 - 重新检查任何依赖 `rehype` 的 HTML 过滤或变换逻辑
 - 如果你的应用要渲染增量输出，先评估 `content` + smooth streaming；需要 AST 控制或外部解析时再升级到 `nodes`

--- a/docs/zh/guide/react-markdown-migration.md
+++ b/docs/zh/guide/react-markdown-migration.md
@@ -67,7 +67,7 @@ export function Article({ markdown }: { markdown: string }) {
 | `react-markdown` | `markstream-react` | 说明 |
 |---|---|---|
 | `children` | `content` | Markdown 字符串通过 `content` 传入。 |
-| `components` | `streamingComponents`、`htmlComponents` 或 `setCustomComponents(id?, mapping)` | HTML-like 自定义标签优先使用渲染器本地 map。需要 parser-backed `NodeComponentProps` 时用 `streamingComponents`；需要普通 React props 和 `children` 时用 `htmlComponents`。已有节点覆盖继续用 `setCustomComponents`。 |
+| `components` | `streamingComponents`、`htmlComponents` 或 `setCustomComponents(id?, mapping)` | HTML-like 自定义标签优先使用渲染器本地 map。需要 parser-backed `NodeComponentProps` 时用 `streamingComponents`；需要清洗后的 HTML 属性和 `children` 时用 `htmlComponents`。已有节点覆盖继续用 `setCustomComponents`。 |
 | `remarkPlugins` | `customMarkdownIt` | 改用 `markdown-it` 插件，而不是 `remark` 插件。很多常见 Markdown 能力本身已经内建。 |
 | `remarkPlugins={[remarkGfm]}` | 很多时候可以删掉 | 表格、任务列表、删除线、代码围栏等常见语法解析器本身已经支持。若你依赖某些边缘行为，删掉前请回归验证。 |
 | `rehypePlugins` | 没有直接等价物 | `markstream-react` 没有公开的 `rehype` 阶段。请改用自定义节点渲染器、`customHtmlTags`、`parseOptions` 或对 `nodes` 做后处理。 |
@@ -106,7 +106,7 @@ const renderer = (
 
 `streamingComponents` 选择 parser-backed streaming-node 合约。它的 key 会加入 parser 的有效 `customHtmlTags`，因此不完整标签也能以 `node.attrs`、`node.content`、`node.loading` 渲染。
 
-`htmlComponents` 选择 raw/dynamic HTML 合约。组件接收普通 React props 和 `children`，不会收到 `props.node`。
+`htmlComponents` 选择 raw/dynamic HTML 合约。组件接收清洗后的 HTML 属性和 `children`，不会收到 `props.node`。属性值会转换成 primitive prop 值，但属性名会保留源 HTML 写法，例如 `class` 仍然是 `class`。
 
 `customHtmlTags` 仍可作为更底层的 parser 选项使用。`setCustomComponents` 和 `customId` 也继续支持，用于兼容旧代码、应用级共享注册，以及内置节点覆盖。
 
@@ -210,7 +210,7 @@ export function Article({ markdown }: { markdown: string }) {
 - `p` -> `paragraph`
 - `img` -> `image`
 - `code` / `pre` -> `code_block` 或 `inline_code`
-- 自定义 HTML-like 标签 -> 需要 `NodeComponentProps` 时用 `streamingComponents`，需要普通 props/children 时用 `htmlComponents`
+- 自定义 HTML-like 标签 -> 需要 `NodeComponentProps` 时用 `streamingComponents`，需要清洗后的 HTML 属性/children 时用 `htmlComponents`
 
 ## 迁移代码高亮
 

--- a/docs/zh/guide/react-next-ssr.md
+++ b/docs/zh/guide/react-next-ssr.md
@@ -27,6 +27,43 @@ export default function Page() {
 }
 ```
 
+direct component map 中包含 React 组件函数，所以当 App Router Server Component 使用 `markstream-react/next` 时，应把 map 放在本地 Client Component wrapper 内。Server Component 只向 wrapper 传 `content` 这类可序列化 props，符合 [Next.js 对 Client Component props 的要求](https://nextjs.org/docs/app/api-reference/directives/use-client)。
+
+```tsx
+// app/markdown-renderer.tsx
+'use client'
+
+import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
+import type { NodeComponentProps } from 'markstream-react/next'
+
+function DocumentLink(props: NodeComponentProps<{ content: string }>) {
+  return <a>{props.node.content}</a>
+}
+
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+export function ClientMarkdown({ content }: { content: string }) {
+  return (
+    <MarkdownRender
+      content={content}
+      final
+      streamingComponents={streamingComponents}
+    />
+  )
+}
+```
+
+```tsx
+// app/page.tsx
+import { ClientMarkdown } from './markdown-renderer'
+
+export default function Page() {
+  return <ClientMarkdown content="<DocumentLink>Open</DocumentLink>" />
+}
+```
+
 ## 使用 `markstream-react/server` 做纯服务端渲染
 
 ```tsx
@@ -40,6 +77,8 @@ export default function Page() {
   return <MarkdownRender content={markdown} final />
 }
 ```
+
+纯 server 入口不会创建 Client Component 边界，所以如果渲染路径保持 server-only，服务端文件可以直接传 `streamingComponents` 和 `htmlComponents`。
 
 ## 自定义组件与自定义标签
 

--- a/docs/zh/guide/react-next-ssr.md
+++ b/docs/zh/guide/react-next-ssr.md
@@ -33,8 +33,8 @@ direct component map 中包含 React 组件函数，所以当 App Router Server 
 // app/markdown-renderer.tsx
 'use client'
 
-import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
 import type { NodeComponentProps } from 'markstream-react/next'
+import MarkdownRender, { defineStreamingComponents } from 'markstream-react/next'
 
 function DocumentLink(props: NodeComponentProps<{ content: string }>) {
   return <a>{props.node.content}</a>

--- a/packages/markdown-parser/src/htmlRenderUtils.ts
+++ b/packages/markdown-parser/src/htmlRenderUtils.ts
@@ -17,6 +17,8 @@ export interface HtmlToken {
   content?: string
 }
 
+const HTML_TOKEN_TAG_NAME_RE = /^([a-z][\w-]*)(?=[\t\n\f\r />]|$)/i
+
 const SAFE_BLOCKED_HTML_TAGS = new Set<string>([
   ...BLOCKED_HTML_TAGS,
   'base',
@@ -155,6 +157,21 @@ function serializeAttrs(attrs: Record<string, string>): string {
   return pairs
     .map(([name, value]) => value === '' ? ` ${name}` : ` ${name}="${escapeAttr(value)}"`)
     .join('')
+}
+
+function parseHtmlTokenTag(rawContent: string) {
+  const isClosing = rawContent.startsWith('/')
+  const source = isClosing ? rawContent.slice(1) : rawContent
+  const match = source.match(HTML_TOKEN_TAG_NAME_RE)
+  if (!match)
+    return null
+
+  return {
+    attrsStr: isClosing ? '' : source.slice(match[0].length).trimStart(),
+    isClosing,
+    isSelfClosing: !isClosing && rawContent.trimEnd().endsWith('/'),
+    tagName: match[1],
+  }
 }
 
 function isUnsafeSrcset(value: string, tagName?: string) {
@@ -368,32 +385,25 @@ export function tokenizeHtml(html: string): HtmlToken[] {
     if (tagEnd === -1)
       break
 
-    const tagContent = html.slice(tagStart + 1, tagEnd).trim()
-    const isClosingTag = tagContent.startsWith('/')
-    const isSelfClosing = tagContent.endsWith('/')
+    const tagContent = html.slice(tagStart + 1, tagEnd)
+    const parsedTag = parseHtmlTokenTag(tagContent)
+    if (!parsedTag) {
+      const rawTag = html.slice(tagStart, tagEnd + 1)
+      if (isMeaningfulText(rawTag))
+        tokens.push({ type: 'text', content: rawTag })
+      pos = tagEnd + 1
+      continue
+    }
 
-    if (isClosingTag) {
-      const tagName = tagContent.slice(1).trim()
-      tokens.push({ type: 'tag_close', tagName })
+    if (parsedTag.isClosing) {
+      tokens.push({ type: 'tag_close', tagName: parsedTag.tagName })
     }
     else {
-      const spaceIndex = tagContent.indexOf(' ')
-      let tagName: string
-      let attrsStr = ''
-
-      if (spaceIndex === -1) {
-        tagName = isSelfClosing ? tagContent.slice(0, -1).trim() : tagContent.trim()
-      }
-      else {
-        tagName = tagContent.slice(0, spaceIndex).trim()
-        attrsStr = tagContent.slice(spaceIndex + 1)
-      }
-
       const attrs: Record<string, string> = {}
-      if (attrsStr) {
+      if (parsedTag.attrsStr) {
         const attrRegex = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|(\S*)))?/g
         let attrMatch: RegExpExecArray | null
-        while ((attrMatch = attrRegex.exec(attrsStr)) !== null) {
+        while ((attrMatch = attrRegex.exec(parsedTag.attrsStr)) !== null) {
           const name = attrMatch[1]
           const value = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? ''
           if (name && !name.endsWith('/'))
@@ -402,8 +412,8 @@ export function tokenizeHtml(html: string): HtmlToken[] {
       }
 
       tokens.push({
-        type: isSelfClosing || VOID_HTML_TAGS.has(tagName.toLowerCase()) ? 'self_closing' : 'tag_open',
-        tagName,
+        type: parsedTag.isSelfClosing || VOID_HTML_TAGS.has(parsedTag.tagName.toLowerCase()) ? 'self_closing' : 'tag_open',
+        tagName: parsedTag.tagName,
         attrs,
       })
     }
@@ -461,38 +471,25 @@ function tokenizeHtmlPreservingText(html: string): HtmlToken[] {
     if (tagEnd === -1)
       break
 
-    const tagContent = html.slice(tagStart + 1, tagEnd).trim()
-    if (!tagContent) {
+    const tagContent = html.slice(tagStart + 1, tagEnd)
+    const parsedTag = parseHtmlTokenTag(tagContent)
+    if (!parsedTag) {
+      tokens.push({ type: 'text', content: html.slice(tagStart, tagEnd + 1) })
       pos = tagEnd + 1
       continue
     }
 
-    const isClosingTag = tagContent.startsWith('/')
-    const isSelfClosing = tagContent.endsWith('/')
-
-    if (isClosingTag) {
-      const tagName = tagContent.slice(1).trim()
-      tokens.push({ type: 'tag_close', tagName })
+    if (parsedTag.isClosing) {
+      tokens.push({ type: 'tag_close', tagName: parsedTag.tagName })
       pos = tagEnd + 1
       continue
-    }
-
-    const spaceIndex = tagContent.indexOf(' ')
-    let tagName = ''
-    let attrsStr = ''
-    if (spaceIndex === -1) {
-      tagName = isSelfClosing ? tagContent.slice(0, -1).trim() : tagContent.trim()
-    }
-    else {
-      tagName = tagContent.slice(0, spaceIndex).trim()
-      attrsStr = tagContent.slice(spaceIndex + 1)
     }
 
     const attrs: Record<string, string> = {}
-    if (attrsStr) {
+    if (parsedTag.attrsStr) {
       const attrRegex = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|(\S*)))?/g
       let attrMatch: RegExpExecArray | null
-      while ((attrMatch = attrRegex.exec(attrsStr)) !== null) {
+      while ((attrMatch = attrRegex.exec(parsedTag.attrsStr)) !== null) {
         const name = attrMatch[1]
         const value = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? ''
         if (name && !name.endsWith('/'))
@@ -501,8 +498,8 @@ function tokenizeHtmlPreservingText(html: string): HtmlToken[] {
     }
 
     tokens.push({
-      type: isSelfClosing || VOID_HTML_TAGS.has(tagName.toLowerCase()) ? 'self_closing' : 'tag_open',
-      tagName,
+      type: parsedTag.isSelfClosing || VOID_HTML_TAGS.has(parsedTag.tagName.toLowerCase()) ? 'self_closing' : 'tag_open',
+      tagName: parsedTag.tagName,
       attrs,
     })
 

--- a/packages/markdown-parser/src/htmlRenderUtils.ts
+++ b/packages/markdown-parser/src/htmlRenderUtils.ts
@@ -92,8 +92,6 @@ export const SAFE_ALLOWED_HTML_TAGS = new Set<string>([
   'ul',
 ])
 
-const CUSTOM_TAG_REGEX = /<([a-z][a-z0-9-]*)\b[^>]*>/gi
-
 function hasOwn(obj: Record<string, unknown>, key: string) {
   return Object.prototype.hasOwnProperty.call(obj, key)
 }
@@ -539,10 +537,8 @@ export function hasCustomHtmlComponents(
     return false
   if (!customComponents || Object.keys(customComponents).length === 0)
     return false
-  CUSTOM_TAG_REGEX.lastIndex = 0
-  let match: RegExpExecArray | null
-  while ((match = CUSTOM_TAG_REGEX.exec(content)) !== null) {
-    if (isCustomHtmlComponentTag(match[1], customComponents))
+  for (const token of tokenizeHtml(content)) {
+    if ((token.type === 'tag_open' || token.type === 'self_closing') && isCustomHtmlComponentTag(token.tagName ?? '', customComponents))
       return true
   }
   return false

--- a/packages/markdown-parser/test/html-render-utils.test.ts
+++ b/packages/markdown-parser/test/html-render-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { hasCustomHtmlComponents, tokenizeHtml } from '../src'
+
+describe('html render utilities', () => {
+  it('detects custom tags across valid HTML whitespace boundaries', () => {
+    const customComponents = {
+      badge: true,
+      my_component: true,
+    }
+
+    expect(hasCustomHtmlComponents('<badge kind="x">text</badge>', customComponents)).toBe(true)
+    expect(hasCustomHtmlComponents('<badge\tkind="x">text</badge>', customComponents)).toBe(true)
+    expect(hasCustomHtmlComponents('<badge\n  kind="x"\n>text</badge>', customComponents)).toBe(true)
+    expect(hasCustomHtmlComponents('<my_component kind="x">text</my_component>', customComponents)).toBe(true)
+    expect(hasCustomHtmlComponents('< badge>text</badge>', customComponents)).toBe(false)
+  })
+
+  it('tokenizes tag names and attrs with HTML whitespace boundaries', () => {
+    expect(tokenizeHtml('<badge\tkind="x">text</badge>')[0]).toMatchObject({
+      attrs: { kind: 'x' },
+      tagName: 'badge',
+      type: 'tag_open',
+    })
+    expect(tokenizeHtml('<badge\n  kind="x"\n>text</badge>')[0]).toMatchObject({
+      attrs: { kind: 'x' },
+      tagName: 'badge',
+      type: 'tag_open',
+    })
+    expect(tokenizeHtml('<my_component kind="x">text</my_component>')[0]).toMatchObject({
+      attrs: { kind: 'x' },
+      tagName: 'my_component',
+      type: 'tag_open',
+    })
+    expect(tokenizeHtml('< badge>text</badge>')[0]).toMatchObject({
+      content: '< badge>',
+      type: 'text',
+    })
+  })
+})

--- a/packages/markstream-react/README.md
+++ b/packages/markstream-react/README.md
@@ -165,30 +165,55 @@ module.exports = {
 
 ## Custom Components
 
-Register custom renderers with `setCustomComponents`. Custom tag-like blocks are exposed as nodes with `type` equal to the tag name when the parser is configured for that tag.
+For HTML-like custom tags in new React code, prefer renderer-local component maps:
+
+- `streamingComponents` receives parser-backed `NodeComponentProps`, including `node.attrs`, `node.content`, and `node.loading`.
+- `htmlComponents` renders through the raw/dynamic HTML path and receives normal React props plus `children`.
 
 ```tsx
 import type { NodeComponentProps } from 'markstream-react'
-import MarkdownRender, { setCustomComponents } from 'markstream-react'
+import type React from 'react'
+import MarkdownRender from 'markstream-react'
 
-function ThinkingNode(props: NodeComponentProps<{ type: 'thinking', content: string }>) {
-  return <MarkdownRender content={props.node.content} fade={false} />
+function DocumentLink(props: NodeComponentProps<{ type: 'documentlink', content: string, loading?: boolean }>) {
+  return <span aria-busy={props.node.loading || undefined}>{props.node.content}</span>
 }
 
-setCustomComponents('chat', { thinking: ThinkingNode })
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+const renderer = (
+  <MarkdownRender
+    content={content}
+    final={isDone}
+    streamingComponents={{ documentlink: DocumentLink }}
+    htmlComponents={{ badge: Badge }}
+  />
+)
 ```
 
-When rendering HTML-like tags from Markdown content, also pass the tag through `customHtmlTags`:
+`streamingComponents` keys are normalized and automatically added to the parser's effective `customHtmlTags`, so incomplete tags can render while content is streaming.
+
+`customHtmlTags` remains available as a lower-level parser option. `setCustomComponents` and `customId` also remain supported for compatibility, shared application-level registration, and existing node overrides:
 
 ```tsx
-React.createElement(MarkdownRender, {
-  customId: 'chat',
-  content: '<thinking>Working...</thinking>',
-  customHtmlTags: ['thinking'],
+import MarkdownRender, { setCustomComponents } from 'markstream-react'
+
+setCustomComponents('chat', {
+  documentlink: DocumentLink,
 })
+
+const legacyRenderer = (
+  <MarkdownRender
+    customId="chat"
+    customHtmlTags={['documentlink']}
+    content={content}
+  />
+)
 ```
 
-Without `customHtmlTags`, registered tag components render through the raw HTML path and receive HTML-style props/children instead of `props.node`.
+Without `customHtmlTags` or `streamingComponents`, registered tag components render through the raw HTML path and receive HTML-style props/children instead of `props.node`. HTML safety is still handled by `htmlPolicy` and sanitization; the API split is not a security boundary.
 
 ## When Not to Use It
 
@@ -196,7 +221,7 @@ Use `react-markdown`, `marked`, or `markdown-it` when you only render short stat
 
 ## Type Exports
 
-The package root exports the public component and renderer types, including `NodeRendererProps`, `NodeComponentProps`, `RenderContext`, `RenderNodeFn`, `CustomComponentMap`, and code-block option types.
+The package root exports the public component and renderer types, including `NodeRendererProps`, `NodeComponentProps`, `StreamingComponentMap`, `HtmlComponentMap`, `RenderContext`, `RenderNodeFn`, `CustomComponentMap`, and code-block option types.
 
 ## Development
 

--- a/packages/markstream-react/package.json
+++ b/packages/markstream-react/package.json
@@ -88,7 +88,7 @@
     "build:dts": "rollup -c ./scripts/rollup.dts.config.mjs && node ./scripts/clean-dts.cjs",
     "check:exports": "node ../../scripts/check-react-package-exports.mjs",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p ../../test/react-local-component-maps-types.tsconfig.json --noEmit",
     "size:check": "node ../../scripts/check-package-size.mjs",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -2,7 +2,7 @@ import type { HtmlPolicy, ParsedNode } from 'stream-markdown-parser'
 import type { CustomComponentMap } from '../../customComponents'
 import type { NodeComponentProps } from '../../types/node-component'
 import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import { isHtmlTagBlocked, NON_STRUCTURING_HTML_TAGS, sanitizeHtmlContent, sanitizeHtmlTokenAttrs } from 'stream-markdown-parser'
+import { convertHtmlAttrsToProps, isHtmlTagBlocked, NON_STRUCTURING_HTML_TAGS, normalizeCustomHtmlTagName, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { useViewportPriority } from '../../context/viewportPriority'
 import { getCustomComponentsRevision, getCustomNodeComponents, subscribeCustomComponents } from '../../customComponents'
 import { renderNodeChildren, tokenAttrsToProps } from '../../renderers/renderChildren'
@@ -101,10 +101,14 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     return rawAttrs ? normalizeDomAttrs(rawAttrs as Record<string, string>) : undefined
   }, [htmlPolicy, node.attrs])
   const structuredTag = useMemo(() => String(node.tag ?? '').trim(), [node.tag])
+  const normalizedStructuredTag = useMemo(() => normalizeCustomHtmlTagName(structuredTag), [structuredTag])
   const structuredBoundAttrs = useMemo(() => {
     const rawAttrs = tokenAttrsToProps(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, structuredTag))
     return rawAttrs ? normalizeDomAttrs(rawAttrs as Record<string, string>) : undefined
   }, [htmlPolicy, node.attrs, structuredTag])
+  const structuredHtmlComponentProps = useMemo(() => {
+    return convertHtmlAttrsToProps(tokenAttrsToRecord(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, normalizedStructuredTag)))
+  }, [htmlPolicy, node.attrs, normalizedStructuredTag])
   const structuredChildren = useMemo(() => Array.isArray(node.children) ? node.children : [], [node.children])
   const isStructured = structuredChildren.length > 0
     && !!structuredTag
@@ -127,8 +131,10 @@ export function HtmlBlockNode(props: NodeComponentProps<{
   const reactNodes = useMemo(() => {
     if (!useDynamic || !node.content)
       return null
-    return parseHtmlToReactNodes(node.content, effectiveCustomComponents, htmlPolicy)
-  }, [effectiveCustomComponents, htmlPolicy, node.content, useDynamic])
+    return parseHtmlToReactNodes(node.content, effectiveCustomComponents, htmlPolicy, {
+      propComponents: props.ctx?.htmlComponents,
+    })
+  }, [effectiveCustomComponents, htmlPolicy, node.content, props.ctx?.htmlComponents, useDynamic])
   const safeHtmlContent = useMemo(() => sanitizeHtmlContent(renderContent ?? '', htmlPolicy), [htmlPolicy, renderContent])
   const structuredContent = useMemo(() => {
     if (!isStructured || !props.ctx || !props.renderNode)
@@ -140,6 +146,9 @@ export function HtmlBlockNode(props: NodeComponentProps<{
       props.renderNode,
     )
   }, [isStructured, props.ctx, props.indexKey, props.renderNode, structuredChildren])
+  const StructuredHtmlComponent = normalizedStructuredTag
+    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
+    : undefined
 
   const placeholderNode = (
     <div className="html-block-node__placeholder">
@@ -152,6 +161,14 @@ export function HtmlBlockNode(props: NodeComponentProps<{
       )}
     </div>
   )
+
+  if (isStructured && StructuredHtmlComponent) {
+    return React.createElement(
+      StructuredHtmlComponent as any,
+      structuredHtmlComponentProps,
+      structuredContent,
+    )
+  }
 
   if (isStructured) {
     return React.createElement(

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -58,6 +58,10 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     props.customComponents,
     customComponentsRevision,
   ])
+  const dynamicCustomComponents = useMemo(() => ({
+    ...effectiveCustomComponents,
+    ...(props.ctx?.streamingComponents ?? {}),
+  }), [effectiveCustomComponents, props.ctx?.streamingComponents])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -125,16 +129,20 @@ export function HtmlBlockNode(props: NodeComponentProps<{
   const useDynamic = useMemo(() => {
     if (htmlPolicy === 'escape')
       return false
-    return hasCustomHtmlComponents(node.content ?? '', effectiveCustomComponents)
-  }, [effectiveCustomComponents, htmlPolicy, node.content])
+    return hasCustomHtmlComponents(node.content ?? '', dynamicCustomComponents)
+  }, [dynamicCustomComponents, htmlPolicy, node.content])
 
   const reactNodes = useMemo(() => {
     if (!useDynamic || !node.content)
       return null
     return parseHtmlToReactNodes(node.content, effectiveCustomComponents, htmlPolicy, {
+      ctx: props.ctx,
+      keyPrefix: String(props.indexKey ?? 'html-block'),
+      nodeComponents: props.ctx?.streamingComponents,
       propComponents: props.ctx?.htmlComponents,
+      renderNode: props.renderNode,
     })
-  }, [effectiveCustomComponents, htmlPolicy, node.content, props.ctx?.htmlComponents, useDynamic])
+  }, [effectiveCustomComponents, htmlPolicy, node.content, props.ctx, props.indexKey, props.renderNode, useDynamic])
   const safeHtmlContent = useMemo(() => sanitizeHtmlContent(renderContent ?? '', htmlPolicy), [htmlPolicy, renderContent])
   const structuredContent = useMemo(() => {
     if (!isStructured || !props.ctx || !props.renderNode)

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -44,9 +44,20 @@ export function HtmlBlockNode(props: NodeComponentProps<{
   )
 
   const effectiveCustomComponents = useMemo(() => {
-    // Allow explicit injection (primarily for tests), otherwise fall back to global store.
-    return props.customComponents ?? getCustomNodeComponents(customId)
-  }, [customId, props.customComponents, customComponentsRevision])
+    const legacyComponents = props.customComponents
+      ?? props.ctx?.customComponents
+      ?? getCustomNodeComponents(customId)
+    return {
+      ...legacyComponents,
+      ...(props.ctx?.htmlComponents ?? {}),
+    }
+  }, [
+    customId,
+    props.ctx?.customComponents,
+    props.ctx?.htmlComponents,
+    props.customComponents,
+    customComponentsRevision,
+  ])
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -141,6 +141,7 @@ export function HtmlBlockNode(props: NodeComponentProps<{
       nodeComponents: props.ctx?.streamingComponents,
       propComponents: props.ctx?.htmlComponents,
       renderNode: props.renderNode,
+      sourceNode: node as ParsedNode,
     })
   }, [effectiveCustomComponents, htmlPolicy, node.content, props.ctx, props.indexKey, props.renderNode, useDynamic])
   const safeHtmlContent = useMemo(() => sanitizeHtmlContent(renderContent ?? '', htmlPolicy), [htmlPolicy, renderContent])

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -143,7 +143,7 @@ export function HtmlBlockNode(props: NodeComponentProps<{
       renderNode: props.renderNode,
       sourceNode: node as ParsedNode,
     })
-  }, [effectiveCustomComponents, htmlPolicy, node.content, props.ctx, props.indexKey, props.renderNode, useDynamic])
+  }, [effectiveCustomComponents, htmlPolicy, (node as any).autoClosed, node.content, (node as any).loading, props.ctx, props.indexKey, props.renderNode, useDynamic])
   const safeHtmlContent = useMemo(() => sanitizeHtmlContent(renderContent ?? '', htmlPolicy), [htmlPolicy, renderContent])
   const structuredContent = useMemo(() => {
     if (!isStructured || !props.ctx || !props.renderNode)

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -1,6 +1,5 @@
 import type { ComponentType } from 'react'
 import type { HtmlPolicy } from 'stream-markdown-parser'
-import type { CustomComponentMap } from '../../customComponents'
 import type { NodeComponentProps } from '../../types/node-component'
 import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
@@ -58,7 +57,7 @@ function pushRenderedNode(target: React.ReactNode[], rendered: React.ReactNode |
  */
 function buildReactElementTree(
   tokens: HtmlToken[],
-  customComponents: CustomComponentMap,
+  customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
 ): React.ReactNode[] {
   let autoKeySeed = 0
@@ -184,7 +183,7 @@ function createReactElement(
   tagName: string,
   attrs: Record<string, string>,
   children: React.ReactNode[],
-  customComponents: CustomComponentMap,
+  customComponents: Record<string, ComponentType<any>>,
   autoKey: string,
   htmlPolicy: HtmlPolicy,
 ): React.ReactNode {
@@ -221,7 +220,7 @@ function createReactElement(
  */
 function parseHtmlToReactNodes(
   content: string,
-  customComponents: CustomComponentMap,
+  customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
 ): React.ReactNode[] | null {
   if (!content)
@@ -253,8 +252,13 @@ export function HtmlInlineNode(props: NodeComponentProps<{
     setIsClient(true)
   }, [])
 
-  // Get custom components from global registry
-  const customComponents = getCustomNodeComponents(customId)
+  const customComponents = React.useMemo(() => {
+    const legacyComponents = props.ctx?.customComponents ?? getCustomNodeComponents(customId)
+    return {
+      ...legacyComponents,
+      ...(props.ctx?.htmlComponents ?? {}),
+    }
+  }, [customId, props.ctx?.customComponents, props.ctx?.htmlComponents])
   const safeHtmlContent = React.useMemo(() => sanitizeHtmlContent(node.content ?? '', htmlPolicy), [htmlPolicy, node.content])
 
   // Computed property to determine render mode and content

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -110,6 +110,24 @@ function attrsToTokenPairs(attrs: Record<string, string>) {
   return Object.entries(attrs).map(([key, value]) => [key, value === '' ? null : value] as [string, string | null])
 }
 
+interface NodeComponentState {
+  loading: boolean
+  autoClosed: boolean
+}
+
+function getUnclosedNodeState(options: HtmlInlineRenderOptions): NodeComponentState {
+  const sourceNode = options.sourceNode as any
+  const loading = options.ctx?.final === true
+    ? false
+    : options.ctx?.final === false
+      ? true
+      : Boolean(sourceNode?.loading)
+  return {
+    loading,
+    autoClosed: loading || Boolean(sourceNode?.autoClosed),
+  }
+}
+
 function renderNodeComponent(
   tagName: string,
   attrs: Record<string, string>,
@@ -118,6 +136,7 @@ function renderNodeComponent(
   options: HtmlInlineRenderOptions,
   contentSource?: string,
   rawSource?: string,
+  state: NodeComponentState = getUnclosedNodeState(options),
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
   const content = contentSource ?? getTextContent(children)
@@ -127,8 +146,8 @@ function renderNodeComponent(
     attrs: attrsToTokenPairs(attrs),
     content,
     raw: rawSource ?? `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
-    loading: Boolean((options.sourceNode as any)?.loading),
-    autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
+    loading: state.loading,
+    autoClosed: state.autoClosed,
   } as ParsedNode
 
   if (options.ctx && options.renderNode)
@@ -185,7 +204,10 @@ function buildReactElementTree(
           stack[stack.length - 1].sourceParts.push(rawSource)
         continue
       }
-      const element = createReactElement(token.tagName!, rawAttrs, [], customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, '', rawSource)
+      const element = createReactElement(token.tagName!, rawAttrs, [], customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, '', rawSource, {
+        loading: false,
+        autoClosed: false,
+      })
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       pushRenderedNode(target, element)
       if (stack.length > 0)
@@ -235,7 +257,10 @@ function buildReactElementTree(
             ]
           }
           else {
-            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource)
+            const state = opening.tagName.toLowerCase() === closingTag
+              ? { loading: false, autoClosed: false }
+              : getUnclosedNodeState(options)
+            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource, state)
           }
 
           if (stack.length > 0)
@@ -275,7 +300,7 @@ function buildReactElementTree(
       ]
     }
     else {
-      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource)
+      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource, getUnclosedNodeState(options))
     }
     pushRenderedNode(rootNodes, element)
     if (stack.length > 0 && !unclosed.hardBlocked)
@@ -299,6 +324,7 @@ function createReactElement(
   options: HtmlInlineRenderOptions,
   contentSource?: string,
   rawSource?: string,
+  state?: NodeComponentState,
 ): React.ReactNode {
   const customComponent = isCustomHtmlComponent(tagName, customComponents)
   const nodeComponent = Boolean(getNodeComponent(tagName, options))
@@ -318,7 +344,7 @@ function createReactElement(
   const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : autoKey
 
   if (nodeComponent) {
-    return renderNodeComponent(tagName, attrs, children, String(elementKey), options, contentSource, rawSource)
+    return renderNodeComponent(tagName, attrs, children, String(elementKey), options, contentSource, rawSource, state)
   }
   else if (customComponent) {
     // It's a custom React component

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -4,7 +4,7 @@ import type { NodeComponentProps } from '../../types/node-component'
 import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
 import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, sanitizeHtmlContent } from 'stream-markdown-parser'
-import { getCustomNodeComponents } from '../../customComponents'
+import { getCustomComponentDisplay, getCustomNodeComponents } from '../../customComponents'
 import {
   hasCustomHtmlComponents,
   isCustomHtmlComponent,
@@ -48,21 +48,21 @@ function pushRenderedNode(target: React.ReactNode[], rendered: React.ReactNode |
     target.push(rendered)
 }
 
-function shouldUseHtmlPropContract(
-  tagName: string,
-  propComponents?: Record<string, ComponentType<any>>,
+function hasBlockCustomHtmlComponent(
+  content: string,
+  customComponents: Record<string, ComponentType<any>>,
 ) {
-  return Boolean(propComponents?.[tagName] || propComponents?.[tagName.toLowerCase()])
-}
-
-function getCustomComponentProps(
-  tagName: string,
-  attrs: Record<string, string>,
-  propComponents?: Record<string, ComponentType<any>>,
-) {
-  return shouldUseHtmlPropContract(tagName, propComponents)
-    ? convertHtmlAttrsToProps(attrs)
-    : attrs
+  for (const token of tokenizeHtml(content)) {
+    if (token.type !== 'tag_open' && token.type !== 'self_closing')
+      continue
+    const tagName = token.tagName ?? ''
+    if (!isCustomHtmlComponent(tagName, customComponents))
+      continue
+    const component = customComponents[tagName] || customComponents[tagName.toLowerCase()]
+    if (getCustomComponentDisplay(component as any) === 'block')
+      return true
+  }
+  return false
 }
 
 /**
@@ -72,7 +72,6 @@ function buildReactElementTree(
   tokens: HtmlToken[],
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
-  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode[] {
   let autoKeySeed = 0
   const stack: Array<{
@@ -101,7 +100,7 @@ function buildReactElementTree(
         target.push(renderLiteralTagText(token.tagName!, token.attrs || {}, true))
         continue
       }
-      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
+      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       pushRenderedNode(target, element)
     }
@@ -145,7 +144,7 @@ function buildReactElementTree(
             ]
           }
           else {
-            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
+            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
           }
 
           if (stack.length > 0)
@@ -181,7 +180,7 @@ function buildReactElementTree(
       ]
     }
     else {
-      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
+      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
     }
     pushRenderedNode(rootNodes, element)
     warn(`Auto-closing unclosed tag: <${unclosed.tagName}>`)
@@ -200,7 +199,6 @@ function createReactElement(
   customComponents: Record<string, ComponentType<any>>,
   autoKey: string,
   htmlPolicy: HtmlPolicy,
-  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode {
   const customComponent = isCustomHtmlComponent(tagName, customComponents)
   if (BLOCKED_TAGS.has(tagName.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(tagName, htmlPolicy)))
@@ -221,7 +219,7 @@ function createReactElement(
   if (customComponent) {
     // It's a custom React component
     const component = customComponents[tagName] || customComponents[tagName.toLowerCase()]
-    const componentProps = getCustomComponentProps(tagName, sanitizedAttrs, propComponents)
+    const componentProps = convertHtmlAttrsToProps(sanitizedAttrs)
     return React.createElement(component as ComponentType<Record<string, unknown>>, { ...componentProps, key: elementKey }, ...children)
   }
   else {
@@ -237,14 +235,13 @@ function parseHtmlToReactNodes(
   content: string,
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
-  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode[] | null {
   if (!content)
     return []
 
   try {
     const tokens = tokenizeHtml(content)
-    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy, propComponents)
+    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy)
     return nodes
   }
   catch (error) {
@@ -291,11 +288,15 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       return { mode: 'html', content }
 
     // Parse and build React element tree
-    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy, props.ctx?.htmlComponents)
+    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy)
     if (nodes === null)
       return { mode: 'html', content } // Fallback to dangerouslySetInnerHTML if parsing fails
 
-    return { mode: 'dynamic', nodes }
+    return {
+      mode: 'dynamic',
+      block: hasBlockCustomHtmlComponent(content, customComponents),
+      nodes,
+    }
   }, [customComponents, htmlPolicy, node.content])
 
   // Use DOM manipulation for pure HTML (mode: 'html')
@@ -321,6 +322,9 @@ export function HtmlInlineNode(props: NodeComponentProps<{
 
   // Dynamic rendering for custom components
   if (renderMode.mode === 'dynamic') {
+    if (renderMode.block)
+      return <>{renderMode.nodes}</>
+
     return (
       <span
         className="html-inline-node"

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -467,7 +467,7 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       block: hasBlockCustomHtmlComponent(content, dynamicCustomComponents),
       nodes,
     }
-  }, [customComponents, dynamicCustomComponents, htmlPolicy, node.content, props.ctx, props.indexKey, props.renderNode])
+  }, [customComponents, dynamicCustomComponents, htmlPolicy, node.autoClosed, node.content, node.loading, props.ctx, props.indexKey, props.renderNode])
 
   // Use DOM manipulation for pure HTML (mode: 'html')
   useEffect(() => {

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -116,15 +116,17 @@ function renderNodeComponent(
   children: React.ReactNode[],
   key: string,
   options: HtmlInlineRenderOptions,
+  contentSource?: string,
+  rawSource?: string,
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
-  const content = getTextContent(children)
+  const content = contentSource ?? getTextContent(children)
   const node = {
     type: normalizedTag,
     tag: normalizedTag,
     attrs: attrsToTokenPairs(attrs),
     content,
-    raw: `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
+    raw: rawSource ?? `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
     loading: Boolean((options.sourceNode as any)?.loading),
     autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
   } as ParsedNode
@@ -154,6 +156,7 @@ function buildReactElementTree(
     children: React.ReactNode[]
     attrs?: Record<string, string>
     hardBlocked?: boolean
+    sourceParts: string[]
     softBlocked?: boolean
     customComponent?: boolean
   }> = []
@@ -165,20 +168,28 @@ function buildReactElementTree(
         continue
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       target.push(token.content!)
+      if (stack.length > 0)
+        stack[stack.length - 1].sourceParts.push(token.content!)
     }
     else if (token.type === 'self_closing') {
+      const rawAttrs = token.attrs || {}
+      const rawSource = renderLiteralTagText(token.tagName!, rawAttrs, true)
       const customComponent = isCustomHtmlComponent(token.tagName!, customComponents)
       const nodeComponent = Boolean(getNodeComponent(token.tagName!, options))
       if (BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
         continue
       if (!customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
-        target.push(renderLiteralTagText(token.tagName!, token.attrs || {}, true))
+        target.push(rawSource)
+        if (stack.length > 0)
+          stack[stack.length - 1].sourceParts.push(rawSource)
         continue
       }
-      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
+      const element = createReactElement(token.tagName!, rawAttrs, [], customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, '', rawSource)
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       pushRenderedNode(target, element)
+      if (stack.length > 0)
+        stack[stack.length - 1].sourceParts.push(rawSource)
     }
     else if (token.type === 'tag_open') {
       const parentHardBlocked = stack.length > 0 && stack[stack.length - 1].hardBlocked
@@ -188,6 +199,7 @@ function buildReactElementTree(
         tagName: token.tagName!,
         children: [],
         attrs: token.attrs,
+        sourceParts: [],
         customComponent: customComponent || nodeComponent,
         hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
         softBlocked: !parentHardBlocked && !customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
@@ -209,6 +221,8 @@ function buildReactElementTree(
         // Pop all tags until the matched one (auto-closing intermediate tags)
         while (stack.length > matchedIndex) {
           const opening = stack.pop()!
+          const innerSource = opening.sourceParts.join('')
+          const rawSource = `${renderLiteralTagText(opening.tagName, opening.attrs || {})}${innerSource}</${opening.tagName}>`
           let element: React.ReactNode | React.ReactNode[] | null
           if (opening.hardBlocked) {
             element = null
@@ -221,13 +235,15 @@ function buildReactElementTree(
             ]
           }
           else {
-            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
+            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource)
           }
 
           if (stack.length > 0)
             pushRenderedNode(stack[stack.length - 1].children, element)
           else
             pushRenderedNode(rootNodes, element)
+          if (stack.length > 0 && !opening.hardBlocked)
+            stack[stack.length - 1].sourceParts.push(rawSource)
 
           // Warn if auto-closing tags
           if (opening.tagName.toLowerCase() !== closingTag && stack.length > matchedIndex) {
@@ -245,6 +261,8 @@ function buildReactElementTree(
   // Handle any remaining unclosed tags
   while (stack.length > 0) {
     const unclosed = stack.pop()!
+    const innerSource = unclosed.sourceParts.join('')
+    const rawSource = `${renderLiteralTagText(unclosed.tagName, unclosed.attrs || {})}${innerSource}`
     let element: React.ReactNode | React.ReactNode[] | null
     if (unclosed.hardBlocked) {
       element = null
@@ -257,9 +275,11 @@ function buildReactElementTree(
       ]
     }
     else {
-      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
+      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options, innerSource, rawSource)
     }
     pushRenderedNode(rootNodes, element)
+    if (stack.length > 0 && !unclosed.hardBlocked)
+      stack[stack.length - 1].sourceParts.push(rawSource)
     warn(`Auto-closing unclosed tag: <${unclosed.tagName}>`)
   }
 
@@ -277,6 +297,8 @@ function createReactElement(
   autoKey: string,
   htmlPolicy: HtmlPolicy,
   options: HtmlInlineRenderOptions,
+  contentSource?: string,
+  rawSource?: string,
 ): React.ReactNode {
   const customComponent = isCustomHtmlComponent(tagName, customComponents)
   const nodeComponent = Boolean(getNodeComponent(tagName, options))
@@ -296,7 +318,7 @@ function createReactElement(
   const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : autoKey
 
   if (nodeComponent) {
-    return renderNodeComponent(tagName, sanitizedAttrs, children, String(elementKey), options)
+    return renderNodeComponent(tagName, attrs, children, String(elementKey), options, contentSource, rawSource)
   }
   else if (customComponent) {
     // It's a custom React component

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -1,9 +1,10 @@
 import type { ComponentType } from 'react'
-import type { HtmlPolicy } from 'stream-markdown-parser'
+import type { HtmlPolicy, ParsedNode } from 'stream-markdown-parser'
+import type { RenderContext, RenderNodeFn } from '../../types'
 import type { NodeComponentProps } from '../../types/node-component'
 import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
-import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, sanitizeHtmlContent } from 'stream-markdown-parser'
+import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, normalizeCustomHtmlTagName, sanitizeHtmlContent } from 'stream-markdown-parser'
 import { getCustomComponentDisplay, getCustomNodeComponents } from '../../customComponents'
 import {
   hasCustomHtmlComponents,
@@ -65,6 +66,52 @@ function hasBlockCustomHtmlComponent(
   return false
 }
 
+interface HtmlInlineRenderOptions {
+  ctx?: RenderContext
+  keyPrefix?: string
+  nodeComponents?: Record<string, ComponentType<any>>
+  renderNode?: RenderNodeFn
+}
+
+function getNodeComponent(tagName: string, options: HtmlInlineRenderOptions) {
+  return options.nodeComponents?.[tagName] || options.nodeComponents?.[tagName.toLowerCase()]
+}
+
+function getTextContent(children: React.ReactNode[]) {
+  return children
+    .map(child => typeof child === 'string' || typeof child === 'number' ? String(child) : '')
+    .join('')
+}
+
+function attrsToTokenPairs(attrs: Record<string, string>) {
+  return Object.entries(attrs).map(([key, value]) => [key, value === '' ? null : value] as [string, string | null])
+}
+
+function renderNodeComponent(
+  tagName: string,
+  attrs: Record<string, string>,
+  children: React.ReactNode[],
+  key: string,
+  options: HtmlInlineRenderOptions,
+) {
+  const normalizedTag = normalizeCustomHtmlTagName(tagName)
+  const node = {
+    type: normalizedTag,
+    tag: normalizedTag,
+    attrs: attrsToTokenPairs(attrs),
+    content: getTextContent(children),
+    loading: false,
+  } as ParsedNode
+
+  if (options.ctx && options.renderNode)
+    return options.renderNode(node, key, options.ctx)
+
+  const component = getNodeComponent(tagName, options)
+  return component
+    ? React.createElement(component as ComponentType<Record<string, unknown>>, { key, node })
+    : null
+}
+
 /**
  * Build React element tree from tokens
  */
@@ -72,8 +119,10 @@ function buildReactElementTree(
   tokens: HtmlToken[],
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
+  options: HtmlInlineRenderOptions = {},
 ): React.ReactNode[] {
   let autoKeySeed = 0
+  const keyPrefix = options.keyPrefix ?? 'ms-html'
   const stack: Array<{
     tagName: string
     children: React.ReactNode[]
@@ -93,27 +142,29 @@ function buildReactElementTree(
     }
     else if (token.type === 'self_closing') {
       const customComponent = isCustomHtmlComponent(token.tagName!, customComponents)
-      if (BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
+      const nodeComponent = Boolean(getNodeComponent(token.tagName!, options))
+      if (BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
         continue
-      if (!customComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
+      if (!customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         target.push(renderLiteralTagText(token.tagName!, token.attrs || {}, true))
         continue
       }
-      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       pushRenderedNode(target, element)
     }
     else if (token.type === 'tag_open') {
       const parentHardBlocked = stack.length > 0 && stack[stack.length - 1].hardBlocked
       const customComponent = isCustomHtmlComponent(token.tagName!, customComponents)
+      const nodeComponent = Boolean(getNodeComponent(token.tagName!, options))
       stack.push({
         tagName: token.tagName!,
         children: [],
         attrs: token.attrs,
-        customComponent,
-        hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
-        softBlocked: !parentHardBlocked && !customComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
+        customComponent: customComponent || nodeComponent,
+        hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName!.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
+        softBlocked: !parentHardBlocked && !customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
       })
     }
     else if (token.type === 'tag_close') {
@@ -144,7 +195,7 @@ function buildReactElementTree(
             ]
           }
           else {
-            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
           }
 
           if (stack.length > 0)
@@ -180,7 +231,7 @@ function buildReactElementTree(
       ]
     }
     else {
-      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `${keyPrefix}-${autoKeySeed++}`, htmlPolicy, options)
     }
     pushRenderedNode(rootNodes, element)
     warn(`Auto-closing unclosed tag: <${unclosed.tagName}>`)
@@ -199,12 +250,14 @@ function createReactElement(
   customComponents: Record<string, ComponentType<any>>,
   autoKey: string,
   htmlPolicy: HtmlPolicy,
+  options: HtmlInlineRenderOptions,
 ): React.ReactNode {
   const customComponent = isCustomHtmlComponent(tagName, customComponents)
-  if (BLOCKED_TAGS.has(tagName.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(tagName, htmlPolicy)))
+  const nodeComponent = Boolean(getNodeComponent(tagName, options))
+  if (BLOCKED_TAGS.has(tagName.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(tagName, htmlPolicy)))
     return null
 
-  if (!customComponent && isHtmlTagBlocked(tagName, htmlPolicy)) {
+  if (!customComponent && !nodeComponent && isHtmlTagBlocked(tagName, htmlPolicy)) {
     return [
       renderLiteralTagText(tagName, attrs),
       ...children,
@@ -216,7 +269,10 @@ function createReactElement(
   const explicitKey = (sanitizedAttrs as any).key
   const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : autoKey
 
-  if (customComponent) {
+  if (nodeComponent) {
+    return renderNodeComponent(tagName, sanitizedAttrs, children, String(elementKey), options)
+  }
+  else if (customComponent) {
     // It's a custom React component
     const component = customComponents[tagName] || customComponents[tagName.toLowerCase()]
     const componentProps = convertHtmlAttrsToProps(sanitizedAttrs)
@@ -235,13 +291,14 @@ function parseHtmlToReactNodes(
   content: string,
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
+  options: HtmlInlineRenderOptions = {},
 ): React.ReactNode[] | null {
   if (!content)
     return []
 
   try {
     const tokens = tokenizeHtml(content)
-    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy)
+    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy, options)
     return nodes
   }
   catch (error) {
@@ -272,6 +329,10 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       ...(props.ctx?.htmlComponents ?? {}),
     }
   }, [customId, props.ctx?.customComponents, props.ctx?.htmlComponents])
+  const dynamicCustomComponents = React.useMemo(() => ({
+    ...customComponents,
+    ...(props.ctx?.streamingComponents ?? {}),
+  }), [customComponents, props.ctx?.streamingComponents])
   const safeHtmlContent = React.useMemo(() => sanitizeHtmlContent(node.content ?? '', htmlPolicy), [htmlPolicy, node.content])
 
   // Computed property to determine render mode and content
@@ -284,20 +345,25 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       return { mode: 'html', content }
 
     // Check if content contains custom components
-    if (!hasCustomHtmlComponents(content, customComponents))
+    if (!hasCustomHtmlComponents(content, dynamicCustomComponents))
       return { mode: 'html', content }
 
     // Parse and build React element tree
-    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy)
+    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy, {
+      ctx: props.ctx,
+      keyPrefix: String(props.indexKey ?? 'html-inline'),
+      nodeComponents: props.ctx?.streamingComponents,
+      renderNode: props.renderNode,
+    })
     if (nodes === null)
       return { mode: 'html', content } // Fallback to dangerouslySetInnerHTML if parsing fails
 
     return {
       mode: 'dynamic',
-      block: hasBlockCustomHtmlComponent(content, customComponents),
+      block: hasBlockCustomHtmlComponent(content, dynamicCustomComponents),
       nodes,
     }
-  }, [customComponents, htmlPolicy, node.content])
+  }, [customComponents, dynamicCustomComponents, htmlPolicy, node.content, props.ctx, props.indexKey, props.renderNode])
 
   // Use DOM manipulation for pure HTML (mode: 'html')
   useEffect(() => {

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -6,7 +6,7 @@ import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
 import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, normalizeCustomHtmlTagName, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { getCustomComponentDisplay, getCustomNodeComponents } from '../../customComponents'
-import { renderNodeChildren, tokenAttrsToProps } from '../../renderers/renderChildren'
+import { renderNodeChildren } from '../../renderers/renderChildren'
 import {
   hasCustomHtmlComponents,
   isCustomHtmlComponent,
@@ -414,19 +414,19 @@ export function HtmlInlineNode(props: NodeComponentProps<{
   const structuredTag = React.useMemo(() => String(node.tag ?? '').trim(), [node.tag])
   const normalizedStructuredTag = React.useMemo(() => normalizeCustomHtmlTagName(structuredTag), [structuredTag])
   const structuredChildren = React.useMemo(() => Array.isArray(node.children) ? node.children : [], [node.children])
-  const structuredBoundAttrs = React.useMemo(() => {
-    const rawAttrs = tokenAttrsToProps(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, structuredTag))
-    return rawAttrs ? normalizeDomAttrs(rawAttrs as Record<string, string>) : undefined
-  }, [htmlPolicy, node.attrs, structuredTag])
   const structuredHtmlComponentProps = React.useMemo(() => {
     return convertHtmlAttrsToProps(tokenAttrsToRecord(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, normalizedStructuredTag)))
   }, [htmlPolicy, node.attrs, normalizedStructuredTag])
+  const StructuredHtmlComponent = normalizedStructuredTag
+    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
+    : undefined
   const isStructured = structuredChildren.length > 0
     && !!structuredTag
     && htmlPolicy !== 'escape'
     && !isHtmlTagBlocked(structuredTag, htmlPolicy)
     && !!props.ctx
     && !!props.renderNode
+    && !!StructuredHtmlComponent
   const structuredContent = React.useMemo(() => {
     if (!isStructured || !props.ctx || !props.renderNode)
       return null
@@ -437,9 +437,6 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       props.renderNode,
     )
   }, [isStructured, props.ctx, props.indexKey, props.renderNode, structuredChildren])
-  const StructuredHtmlComponent = normalizedStructuredTag
-    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
-    : undefined
 
   // Computed property to determine render mode and content
   const renderMode = React.useMemo(() => {
@@ -493,18 +490,10 @@ export function HtmlInlineNode(props: NodeComponentProps<{
     )
   }
 
-  if (isStructured && StructuredHtmlComponent) {
+  if (isStructured) {
     return React.createElement(
       StructuredHtmlComponent as any,
       structuredHtmlComponentProps,
-      structuredContent,
-    )
-  }
-
-  if (isStructured) {
-    return React.createElement(
-      structuredTag,
-      structuredBoundAttrs as Record<string, unknown> | undefined,
       structuredContent,
     )
   }

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -4,8 +4,9 @@ import type { RenderContext, RenderNodeFn } from '../../types'
 import type { NodeComponentProps } from '../../types/node-component'
 import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
-import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, normalizeCustomHtmlTagName, sanitizeHtmlContent } from 'stream-markdown-parser'
+import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, isHtmlTagBlocked, isHtmlTagHardBlocked, normalizeCustomHtmlTagName, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { getCustomComponentDisplay, getCustomNodeComponents } from '../../customComponents'
+import { renderNodeChildren, tokenAttrsToProps } from '../../renderers/renderChildren'
 import {
   hasCustomHtmlComponents,
   isCustomHtmlComponent,
@@ -71,6 +72,7 @@ interface HtmlInlineRenderOptions {
   keyPrefix?: string
   nodeComponents?: Record<string, ComponentType<any>>
   renderNode?: RenderNodeFn
+  sourceNode?: ParsedNode
 }
 
 function getNodeComponent(tagName: string, options: HtmlInlineRenderOptions) {
@@ -79,8 +81,29 @@ function getNodeComponent(tagName: string, options: HtmlInlineRenderOptions) {
 
 function getTextContent(children: React.ReactNode[]) {
   return children
-    .map(child => typeof child === 'string' || typeof child === 'number' ? String(child) : '')
+    .map(serializeReactContent)
     .join('')
+}
+
+function serializeReactContent(child: React.ReactNode): string {
+  if (child == null || typeof child === 'boolean')
+    return ''
+  if (typeof child === 'string' || typeof child === 'number')
+    return String(child)
+  if (Array.isArray(child))
+    return child.map(serializeReactContent).join('')
+  if (!React.isValidElement(child))
+    return ''
+
+  const element = child as React.ReactElement<{ children?: React.ReactNode }>
+  if (typeof element.type !== 'string')
+    return serializeReactContent(element.props.children)
+
+  const attrs = Object.entries(element.props)
+    .filter(([name, value]) => name !== 'children' && name !== 'key' && name !== 'ref' && value != null && typeof value !== 'boolean')
+    .map(([name, value]) => ` ${name === 'className' ? 'class' : name}="${String(value)}"`)
+    .join('')
+  return `<${element.type}${attrs}>${serializeReactContent(element.props.children)}</${element.type}>`
 }
 
 function attrsToTokenPairs(attrs: Record<string, string>) {
@@ -95,12 +118,15 @@ function renderNodeComponent(
   options: HtmlInlineRenderOptions,
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
+  const content = getTextContent(children)
   const node = {
     type: normalizedTag,
     tag: normalizedTag,
     attrs: attrsToTokenPairs(attrs),
-    content: getTextContent(children),
-    loading: false,
+    content,
+    raw: `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
+    loading: Boolean((options.sourceNode as any)?.loading),
+    autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
   } as ParsedNode
 
   if (options.ctx && options.renderNode)
@@ -310,6 +336,9 @@ function parseHtmlToReactNodes(
 export function HtmlInlineNode(props: NodeComponentProps<{
   type: 'html_inline'
   content: string
+  tag?: string
+  attrs?: [string, string | null][] | null
+  children?: ParsedNode[]
   loading?: boolean
   autoClosed?: boolean
 }> & { htmlPolicy?: HtmlPolicy }) {
@@ -334,6 +363,35 @@ export function HtmlInlineNode(props: NodeComponentProps<{
     ...(props.ctx?.streamingComponents ?? {}),
   }), [customComponents, props.ctx?.streamingComponents])
   const safeHtmlContent = React.useMemo(() => sanitizeHtmlContent(node.content ?? '', htmlPolicy), [htmlPolicy, node.content])
+  const structuredTag = React.useMemo(() => String(node.tag ?? '').trim(), [node.tag])
+  const normalizedStructuredTag = React.useMemo(() => normalizeCustomHtmlTagName(structuredTag), [structuredTag])
+  const structuredChildren = React.useMemo(() => Array.isArray(node.children) ? node.children : [], [node.children])
+  const structuredBoundAttrs = React.useMemo(() => {
+    const rawAttrs = tokenAttrsToProps(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, structuredTag))
+    return rawAttrs ? normalizeDomAttrs(rawAttrs as Record<string, string>) : undefined
+  }, [htmlPolicy, node.attrs, structuredTag])
+  const structuredHtmlComponentProps = React.useMemo(() => {
+    return convertHtmlAttrsToProps(tokenAttrsToRecord(sanitizeHtmlTokenAttrs(node.attrs ?? undefined, htmlPolicy, normalizedStructuredTag)))
+  }, [htmlPolicy, node.attrs, normalizedStructuredTag])
+  const isStructured = structuredChildren.length > 0
+    && !!structuredTag
+    && htmlPolicy !== 'escape'
+    && !isHtmlTagBlocked(structuredTag, htmlPolicy)
+    && !!props.ctx
+    && !!props.renderNode
+  const structuredContent = React.useMemo(() => {
+    if (!isStructured || !props.ctx || !props.renderNode)
+      return null
+    return renderNodeChildren(
+      structuredChildren,
+      props.ctx,
+      `${String(props.indexKey ?? 'html-inline')}-structured`,
+      props.renderNode,
+    )
+  }, [isStructured, props.ctx, props.indexKey, props.renderNode, structuredChildren])
+  const StructuredHtmlComponent = normalizedStructuredTag
+    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
+    : undefined
 
   // Computed property to determine render mode and content
   const renderMode = React.useMemo(() => {
@@ -354,6 +412,7 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       keyPrefix: String(props.indexKey ?? 'html-inline'),
       nodeComponents: props.ctx?.streamingComponents,
       renderNode: props.renderNode,
+      sourceNode: node as ParsedNode,
     })
     if (nodes === null)
       return { mode: 'html', content } // Fallback to dangerouslySetInnerHTML if parsing fails
@@ -378,11 +437,27 @@ export function HtmlInlineNode(props: NodeComponentProps<{
   }, [renderMode.mode, isClient, safeHtmlContent])
 
   // Loading state handling
-  if (node.loading && !node.autoClosed) {
+  if (node.loading && !node.autoClosed && !isStructured && renderMode.mode !== 'dynamic') {
     return (
       <span className="html-inline-node html-inline-node--loading">
         {node.content}
       </span>
+    )
+  }
+
+  if (isStructured && StructuredHtmlComponent) {
+    return React.createElement(
+      StructuredHtmlComponent as any,
+      structuredHtmlComponentProps,
+      structuredContent,
+    )
+  }
+
+  if (isStructured) {
+    return React.createElement(
+      structuredTag,
+      structuredBoundAttrs as Record<string, unknown> | undefined,
+      structuredContent,
     )
   }
 

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -31,10 +31,6 @@ function logError(message: string, err: unknown) {
     console.error(message, err)
 }
 
-function convertAttrsToProps(attrs: Record<string, string>): Record<string, any> {
-  return convertHtmlAttrsToProps(attrs)
-}
-
 function renderLiteralTagText(tagName: string, attrs?: Record<string, string>, isSelfClosing = false) {
   const pairs = Object.entries(attrs ?? {})
   const serializedAttrs = pairs.length > 0
@@ -52,6 +48,23 @@ function pushRenderedNode(target: React.ReactNode[], rendered: React.ReactNode |
     target.push(rendered)
 }
 
+function shouldUseHtmlPropContract(
+  tagName: string,
+  propComponents?: Record<string, ComponentType<any>>,
+) {
+  return Boolean(propComponents?.[tagName] || propComponents?.[tagName.toLowerCase()])
+}
+
+function getCustomComponentProps(
+  tagName: string,
+  attrs: Record<string, string>,
+  propComponents?: Record<string, ComponentType<any>>,
+) {
+  return shouldUseHtmlPropContract(tagName, propComponents)
+    ? convertHtmlAttrsToProps(attrs)
+    : attrs
+}
+
 /**
  * Build React element tree from tokens
  */
@@ -59,6 +72,7 @@ function buildReactElementTree(
   tokens: HtmlToken[],
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
+  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode[] {
   let autoKeySeed = 0
   const stack: Array<{
@@ -87,7 +101,7 @@ function buildReactElementTree(
         target.push(renderLiteralTagText(token.tagName!, token.attrs || {}, true))
         continue
       }
-      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+      const element = createReactElement(token.tagName!, token.attrs || {}, [], customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
       const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
       pushRenderedNode(target, element)
     }
@@ -131,7 +145,7 @@ function buildReactElementTree(
             ]
           }
           else {
-            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+            element = createReactElement(opening.tagName, opening.attrs || {}, opening.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
           }
 
           if (stack.length > 0)
@@ -167,7 +181,7 @@ function buildReactElementTree(
       ]
     }
     else {
-      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy)
+      element = createReactElement(unclosed.tagName, unclosed.attrs || {}, unclosed.children, customComponents, `ms-html-${autoKeySeed++}`, htmlPolicy, propComponents)
     }
     pushRenderedNode(rootNodes, element)
     warn(`Auto-closing unclosed tag: <${unclosed.tagName}>`)
@@ -186,6 +200,7 @@ function createReactElement(
   customComponents: Record<string, ComponentType<any>>,
   autoKey: string,
   htmlPolicy: HtmlPolicy,
+  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode {
   const customComponent = isCustomHtmlComponent(tagName, customComponents)
   if (BLOCKED_TAGS.has(tagName.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(tagName, htmlPolicy)))
@@ -206,8 +221,8 @@ function createReactElement(
   if (customComponent) {
     // It's a custom React component
     const component = customComponents[tagName] || customComponents[tagName.toLowerCase()]
-    const convertedAttrs = convertAttrsToProps(sanitizedAttrs)
-    return React.createElement(component as ComponentType<Record<string, unknown>>, { ...convertedAttrs, key: elementKey }, ...children)
+    const componentProps = getCustomComponentProps(tagName, sanitizedAttrs, propComponents)
+    return React.createElement(component as ComponentType<Record<string, unknown>>, { ...componentProps, key: elementKey }, ...children)
   }
   else {
     // It's a standard HTML element
@@ -222,13 +237,14 @@ function parseHtmlToReactNodes(
   content: string,
   customComponents: Record<string, ComponentType<any>>,
   htmlPolicy: HtmlPolicy = 'safe',
+  propComponents?: Record<string, ComponentType<any>>,
 ): React.ReactNode[] | null {
   if (!content)
     return []
 
   try {
     const tokens = tokenizeHtml(content)
-    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy)
+    const nodes = buildReactElementTree(tokens, customComponents, htmlPolicy, propComponents)
     return nodes
   }
   catch (error) {
@@ -275,7 +291,7 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       return { mode: 'html', content }
 
     // Parse and build React element tree
-    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy)
+    const nodes = parseHtmlToReactNodes(content, customComponents, htmlPolicy, props.ctx?.htmlComponents)
     if (nodes === null)
       return { mode: 'html', content } // Fallback to dangerouslySetInnerHTML if parsing fails
 

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -110,6 +110,22 @@ function stabilizeParsedNodes(newNodes: ParsedNode[], prevNodes: ParsedNode[]): 
   return result
 }
 
+function componentMapsEqual<T>(prev: Record<string, T>, next: Record<string, T>) {
+  const prevKeys = Object.keys(prev)
+  const nextKeys = Object.keys(next)
+  if (prevKeys.length !== nextKeys.length)
+    return false
+  return prevKeys.every(key => prev[key] === next[key])
+}
+
+function useStableNormalizedComponentMap<T>(mapping?: Record<string, T>) {
+  const normalized = useMemo(() => normalizeComponentMap(mapping), [mapping])
+  const stableRef = useRef(normalized)
+  if (!componentMapsEqual(stableRef.current, normalized))
+    stableRef.current = normalized
+  return stableRef.current
+}
+
 // ---------------------------------------------------------------------------
 // NodeSlotContent – memoized wrapper around renderNode
 // ---------------------------------------------------------------------------
@@ -990,12 +1006,8 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
   const customComponents = useMemo(() => {
     return getCustomNodeComponents(props.customId)
   }, [props.customId, customComponentsRevision])
-  const streamingComponents = useMemo(() => {
-    return normalizeComponentMap(props.streamingComponents)
-  }, [props.streamingComponents])
-  const htmlComponents = useMemo(() => {
-    return normalizeComponentMap(props.htmlComponents)
-  }, [props.htmlComponents])
+  const streamingComponents = useStableNormalizedComponentMap(props.streamingComponents)
+  const htmlComponents = useStableNormalizedComponentMap(props.htmlComponents)
 
   useEffect(() => {
     warnComponentMapConflicts(

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -11,7 +11,13 @@ import {
 import { SmoothStreamingContext } from '../context/smoothStreaming'
 import { StreamStateRefContext } from '../context/streamState'
 import { useViewportPriority, ViewportPriorityProvider } from '../context/viewportPriority'
-import { getCustomComponentsRevision, getCustomNodeComponents, subscribeCustomComponents } from '../customComponents'
+import {
+  getCustomComponentsRevision,
+  getCustomNodeComponents,
+  normalizeComponentMap,
+  subscribeCustomComponents,
+  warnComponentMapConflicts,
+} from '../customComponents'
 import { useSmoothMarkdownStream } from '../hooks/useSmoothMarkdownStream'
 import { renderNode } from '../renderers/renderNode'
 import { normalizeLanguageIdentifier } from '../utils/languageIcon'
@@ -793,6 +799,7 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
   const previousRenderVersionSourceRef = useRef<unknown>(null)
   const smoothStream = useSmoothMarkdownStream(props.smoothStreamingOptions)
   const parentSmoothStreaming = React.useContext(SmoothStreamingContext)
+  const warnedComponentMapConflictsRef = useRef(new Set<string>())
   const [hasMountedForSmoothStreaming, setHasMountedForSmoothStreaming] = useState(
     () => props.smoothStreaming === true,
   )
@@ -983,6 +990,20 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
   const customComponents = useMemo(() => {
     return getCustomNodeComponents(props.customId)
   }, [props.customId, customComponentsRevision])
+  const streamingComponents = useMemo(() => {
+    return normalizeComponentMap(props.streamingComponents)
+  }, [props.streamingComponents])
+  const htmlComponents = useMemo(() => {
+    return normalizeComponentMap(props.htmlComponents)
+  }, [props.htmlComponents])
+
+  useEffect(() => {
+    warnComponentMapConflicts(
+      streamingComponents,
+      htmlComponents,
+      warnedComponentMapConflictsRef.current,
+    )
+  }, [htmlComponents, streamingComponents])
 
   const instanceMsgId = useMemo(() => {
     return props.customId
@@ -996,12 +1017,14 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
     return mergeCustomHtmlTags(
       props.customHtmlTags,
       Array.isArray(optionTags) ? optionTags : [],
+      Object.keys(streamingComponents),
     )
   }, [
     props.customId,
     props.customHtmlTags,
     props.parseOptions,
     customComponentsRevision,
+    streamingComponents,
   ])
 
   const mdBase = useMemo(() => {
@@ -1245,6 +1268,8 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
     textStreamState: textStreamStateRef.current,
     streamRenderVersion: streamRenderVersionRef.current,
     customComponents,
+    streamingComponents,
+    htmlComponents,
     customHtmlTags: effectiveCustomHtmlTags,
     htmlPolicy: props.htmlPolicy ?? 'safe',
     showTooltips: props.showTooltips,
@@ -1292,6 +1317,8 @@ export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
     props.onCopy,
     props.onHandleArtifactClick,
     customComponents,
+    streamingComponents,
+    htmlComponents,
   ])
 
   // Keep stream version and text state up-to-date via mutation so the

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -1,6 +1,7 @@
 import type { ParsedNode } from 'stream-markdown-parser'
 import type { StreamStateRef } from '../context/streamState'
 import type { VisibilityHandle } from '../context/viewportPriority'
+import type { HtmlComponentMap, StreamingComponentMap } from '../customComponents'
 import type { NodeRendererProps, RenderContext } from '../types'
 import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import {
@@ -806,7 +807,10 @@ function areNodeRendererInnerPropsEqual(prev: NodeRendererInnerProps, next: Node
 
 const MemoNodeRendererInner = React.memo(NodeRendererInner, areNodeRendererInnerPropsEqual)
 
-export const NodeRenderer: React.FC<NodeRendererProps> = (rawProps) => {
+export function NodeRenderer<
+  TStreamingComponents extends StreamingComponentMap = StreamingComponentMap,
+  THtmlComponents extends Record<string, any> = HtmlComponentMap,
+>(rawProps: NodeRendererProps<TStreamingComponents, THtmlComponents>) {
   const props = { ...DEFAULT_PROPS, ...rawProps } as ResolvedProps
   const containerRef = useRef<HTMLDivElement | null>(null)
   const desiredThemeKeyRef = useRef<string | null>(null)

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -73,10 +73,12 @@ function isNodeStable(prev: ParsedNode, next: ParsedNode): boolean {
   // changed the parsed output should be identical (parser is deterministic).
   if (prev.raw !== next.raw)
     return false
-  // Loading state on code blocks can flip independently of `raw`.
+  if ((prev as any).loading !== (next as any).loading)
+    return false
+  if ((prev as any).autoClosed !== (next as any).autoClosed)
+    return false
+  // Code block diff state can flip independently of `raw`.
   if (prev.type === 'code_block' || next.type === 'code_block') {
-    if ((prev as any).loading !== (next as any).loading)
-      return false
     if ((prev as any).diff !== (next as any).diff)
       return false
   }
@@ -1278,6 +1280,7 @@ export function NodeRenderer<
   const renderCtx = useMemo<RenderContext>(() => ({
     customId: props.customId,
     isDark: props.isDark,
+    final: effectiveFinal,
     indexKey: indexPrefix,
     typewriter: props.typewriter,
     fade: props.fade,
@@ -1311,6 +1314,7 @@ export function NodeRenderer<
   }), [
     props.customId,
     props.isDark,
+    effectiveFinal,
     indexPrefix,
     props.typewriter,
     props.fade,

--- a/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
+++ b/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
@@ -94,7 +94,9 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags)) {
+    const canUseHtmlDisplayMetadata = (ctx.htmlPolicy ?? 'safe') !== 'escape'
+      || (child.type !== 'html_inline' && child.type !== 'html_block')
+    if (BLOCK_LEVEL_TYPES.has(child.type) || (canUseHtmlDisplayMetadata && isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags))) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>

--- a/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
+++ b/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
@@ -73,8 +73,9 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
 
   const nodeChildren = node.children ?? []
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
-  const streamingAndLegacyComponents = {
+  const displayComponents = {
     ...customComponents,
+    ...(ctx.htmlComponents ?? {}),
     ...(ctx.streamingComponents ?? {}),
   }
   const parts: React.ReactNode[] = []
@@ -93,7 +94,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, streamingAndLegacyComponents, ctx.customHtmlTags)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>

--- a/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
+++ b/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
@@ -73,6 +73,10 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
 
   const nodeChildren = node.children ?? []
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
+  const streamingAndLegacyComponents = {
+    ...customComponents,
+    ...(ctx.streamingComponents ?? {}),
+  }
   const parts: React.ReactNode[] = []
   const inlineBuffer: ParsedNode[] = []
 
@@ -89,7 +93,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, customComponents, ctx.customHtmlTags)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, streamingAndLegacyComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -1,10 +1,17 @@
-import type { ComponentType } from 'react'
+import type { ComponentType, PropsWithChildren } from 'react'
+import type { NodeComponentProps } from './types/node-component'
+import { normalizeCustomHtmlTagName } from 'stream-markdown-parser'
+import { isDevEnvironment } from './utils/devEnv'
 
 export type CustomComponentDisplayMode = 'inline' | 'block'
 export type MarkstreamCustomComponent<P = never> = ComponentType<P> & {
   markstreamDisplay?: CustomComponentDisplayMode
 }
 export type CustomComponentMap = Record<string, MarkstreamCustomComponent>
+export type StreamingComponent<TNode = any> = ComponentType<NodeComponentProps<TNode>>
+export type StreamingComponentMap<TNode = any> = Record<string, StreamingComponent<TNode>>
+export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
+export type HtmlComponentMap<P extends object = any> = Record<string, HtmlComponent<P>>
 
 const GLOBAL_KEY = '__global__'
 
@@ -99,4 +106,36 @@ export function withMarkstreamComponentDisplay<T extends ComponentType<never>>(
 ) {
   ;(component as MarkstreamCustomComponent).markstreamDisplay = display
   return component as T & { markstreamDisplay: CustomComponentDisplayMode }
+}
+
+export function normalizeComponentMap<T>(mapping?: Record<string, T>): Record<string, T> {
+  if (!mapping)
+    return {}
+
+  const normalized: Record<string, T> = {}
+  for (const [rawKey, component] of Object.entries(mapping)) {
+    const key = normalizeCustomHtmlTagName(rawKey)
+    if (key)
+      normalized[key] = component
+  }
+  return normalized
+}
+
+export function warnComponentMapConflicts(
+  streamingComponents: StreamingComponentMap,
+  htmlComponents: HtmlComponentMap,
+  warnedTags: Set<string>,
+) {
+  if (!isDevEnvironment())
+    return
+
+  for (const tag of Object.keys(streamingComponents)) {
+    if (!htmlComponents[tag] || warnedTags.has(tag))
+      continue
+    warnedTags.add(tag)
+    console.warn(
+      `[markstream-react] "${tag}" was provided in both streamingComponents and htmlComponents. `
+      + 'The streamingComponents entry will be used for parser-backed rendering.',
+    )
+  }
 }

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -13,19 +13,32 @@ export type StreamingComponentMap = Record<string, StreamingComponent<any>>
 export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
 export type HtmlComponentMap = Record<string, ComponentType<any>>
 
-type StreamingComponentDefinitions<T extends Record<string, ComponentType<any>>> = {
-  [K in keyof T]: T[K] extends ComponentType<infer P>
-    ? P extends NodeComponentProps<any>
+type IsAny<T> = 0 extends (1 & T) ? true : false
+type ComponentProps<T> = T extends ComponentType<infer P>
+  ? P
+  : T extends (props: infer P) => any
+    ? P
+    : never
+
+export type StreamingComponentDefinitions<T extends Record<string, any>> = {
+  [K in keyof T]: ComponentProps<T[K]> extends infer P
+    ? IsAny<P> extends true
       ? T[K]
-      : never
+      : P extends NodeComponentProps<any>
+        ? NodeComponentProps<any> extends P
+          ? T[K]
+          : never
+        : never
     : never
 }
 
-type HtmlComponentDefinitions<T extends Record<string, ComponentType<any>>> = {
-  [K in keyof T]: T[K] extends ComponentType<infer P>
-    ? 'node' extends keyof P
-      ? never
-      : T[K]
+export type HtmlComponentDefinitions<T extends Record<string, any>> = {
+  [K in keyof T]: ComponentProps<T[K]> extends infer P
+    ? IsAny<P> extends true
+      ? T[K]
+      : 'node' extends keyof P
+        ? never
+        : T[K]
     : never
 }
 

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -8,10 +8,26 @@ export type MarkstreamCustomComponent<P = never> = ComponentType<P> & {
   markstreamDisplay?: CustomComponentDisplayMode
 }
 export type CustomComponentMap = Record<string, MarkstreamCustomComponent>
-export type StreamingComponent<TNode = any> = ComponentType<NodeComponentProps<TNode>>
-export type StreamingComponentMap<TNode = any> = Record<string, StreamingComponent<TNode>>
-export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
-export type HtmlComponentMap<P extends object = any> = Record<string, HtmlComponent<P>>
+export type StreamingComponent<TNode = unknown> = ComponentType<NodeComponentProps<TNode>>
+export type StreamingComponentMap<TNode = unknown> = Record<string, StreamingComponent<TNode>>
+export type HtmlComponent<P extends object = Record<string, never>> = ComponentType<PropsWithChildren<P>>
+export type HtmlComponentMap<P extends object = Record<string, never>> = Record<string, HtmlComponent<P>>
+
+type StreamingComponentDefinitions<T extends Record<string, ComponentType<any>>> = {
+  [K in keyof T]: T[K] extends ComponentType<infer P>
+    ? P extends NodeComponentProps<any>
+      ? T[K]
+      : never
+    : never
+}
+
+type HtmlComponentDefinitions<T extends Record<string, ComponentType<any>>> = {
+  [K in keyof T]: T[K] extends ComponentType<infer P>
+    ? 'node' extends keyof P
+      ? never
+      : T[K]
+    : never
+}
 
 const GLOBAL_KEY = '__global__'
 
@@ -106,6 +122,18 @@ export function withMarkstreamComponentDisplay<T extends ComponentType<never>>(
 ) {
   ;(component as MarkstreamCustomComponent).markstreamDisplay = display
   return component as T & { markstreamDisplay: CustomComponentDisplayMode }
+}
+
+export function defineStreamingComponents<const T extends Record<string, ComponentType<any>>>(
+  components: T & StreamingComponentDefinitions<T>,
+) {
+  return components
+}
+
+export function defineHtmlComponents<const T extends Record<string, ComponentType<any>>>(
+  components: T & HtmlComponentDefinitions<T>,
+) {
+  return components
 }
 
 export function normalizeComponentMap<T>(mapping?: Record<string, T>): Record<string, T> {

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -32,13 +32,15 @@ export type StreamingComponentDefinitions<T extends Record<string, any>> = {
     : never
 }
 
+type ParserComponentOnlyProp = Exclude<keyof NodeComponentProps<any>, 'children' | 'node'>
+
 export type HtmlComponentDefinitions<T extends Record<string, any>> = {
   [K in keyof T]: ComponentProps<T[K]> extends infer P
     ? IsAny<P> extends true
       ? T[K]
-      : 'node' extends keyof P
-        ? never
-        : T[K]
+      : Extract<keyof P, ParserComponentOnlyProp> extends never
+        ? T[K]
+        : never
     : never
 }
 

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -11,7 +11,7 @@ export type CustomComponentMap = Record<string, MarkstreamCustomComponent>
 export type StreamingComponent<TNode = any> = ComponentType<NodeComponentProps<TNode>>
 export type StreamingComponentMap = Record<string, StreamingComponent<any>>
 export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
-export type HtmlComponentMap = Record<string, ComponentType<any>>
+export type HtmlComponentMap = Record<string, HtmlComponent<any>>
 
 type IsAny<T> = 0 extends (1 & T) ? true : false
 type ComponentProps<T> = T extends ComponentType<infer P>

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -8,10 +8,10 @@ export type MarkstreamCustomComponent<P = never> = ComponentType<P> & {
   markstreamDisplay?: CustomComponentDisplayMode
 }
 export type CustomComponentMap = Record<string, MarkstreamCustomComponent>
-export type StreamingComponent<TNode = unknown> = ComponentType<NodeComponentProps<TNode>>
-export type StreamingComponentMap<TNode = unknown> = Record<string, StreamingComponent<TNode>>
-export type HtmlComponent<P extends object = Record<string, never>> = ComponentType<PropsWithChildren<P>>
-export type HtmlComponentMap<P extends object = Record<string, never>> = Record<string, HtmlComponent<P>>
+export type StreamingComponent<TNode = any> = ComponentType<NodeComponentProps<TNode>>
+export type StreamingComponentMap = Record<string, StreamingComponent<any>>
+export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
+export type HtmlComponentMap = Record<string, ComponentType<any>>
 
 type StreamingComponentDefinitions<T extends Record<string, ComponentType<any>>> = {
   [K in keyof T]: T[K] extends ComponentType<infer P>

--- a/packages/markstream-react/src/index.ts
+++ b/packages/markstream-react/src/index.ts
@@ -64,7 +64,11 @@ export {
 } from './customComponents'
 export type {
   CustomComponentDisplayMode,
+  HtmlComponent,
+  HtmlComponentMap,
   MarkstreamCustomComponent,
+  StreamingComponent,
+  StreamingComponentMap,
 } from './customComponents'
 export { useSmoothMarkdownStream } from './hooks/useSmoothMarkdownStream'
 export type {

--- a/packages/markstream-react/src/index.ts
+++ b/packages/markstream-react/src/index.ts
@@ -56,6 +56,8 @@ export type { TooltipPlacement, TooltipProps } from './components/Tooltip/Toolti
 export { VmrContainerNode } from './components/VmrContainerNode/VmrContainerNode'
 export {
   clearGlobalCustomComponents,
+  defineHtmlComponents,
+  defineStreamingComponents,
   getCustomComponentDisplay,
   getCustomNodeComponents,
   removeCustomComponents,

--- a/packages/markstream-react/src/next.ts
+++ b/packages/markstream-react/src/next.ts
@@ -47,6 +47,8 @@ import { Tooltip as ClientTooltip } from './components/Tooltip/Tooltip'
 import { VmrContainerNode as ClientVmrContainerNode } from './components/VmrContainerNode/VmrContainerNode'
 import {
   clearGlobalCustomComponents,
+  defineHtmlComponents,
+  defineStreamingComponents,
   getCustomNodeComponents,
   removeCustomComponents,
   setCustomComponents,
@@ -141,6 +143,8 @@ export type { D2Loader }
 export { disableD2, enableD2, isD2Enabled, setD2Loader }
 export {
   clearGlobalCustomComponents,
+  defineHtmlComponents,
+  defineStreamingComponents,
   getCustomNodeComponents,
   removeCustomComponents,
   setCustomComponents,

--- a/packages/markstream-react/src/next.ts
+++ b/packages/markstream-react/src/next.ts
@@ -151,6 +151,14 @@ export type { LinkNodeStyleProps } from './components/LinkNode/LinkNode'
 export type { ListItemNodeProps } from './components/ListItemNode/ListItemNode'
 export type { MarkdownCodeBlockNodeProps } from './components/MarkdownCodeBlockNode/MarkdownCodeBlockNode'
 export type { TooltipPlacement, TooltipProps } from './components/Tooltip/Tooltip'
+export type {
+  CustomComponentDisplayMode,
+  HtmlComponent,
+  HtmlComponentMap,
+  MarkstreamCustomComponent,
+  StreamingComponent,
+  StreamingComponentMap,
+} from './customComponents'
 export * from './i18n/useSafeI18n'
 export * from './renderers/renderNode'
 export type { NodeRendererCodeBlockProps, NodeRendererProps } from './types'

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -163,7 +163,7 @@ function renderHtmlComponentForCustomTagNode(
 ) {
   const attrs = sanitizeHtmlTokenAttrs((node as any).attrs ?? undefined, ctx.htmlPolicy ?? 'safe', tag)
   const props = convertHtmlAttrsToProps(tokenAttrsToRecord(attrs))
-  const children = Array.isArray((node as any).children) && (node as any).children.length > 0
+  const children = Array.isArray((node as any).children)
     ? renderNodeChildren((node as any).children, ctx, `${String(key)}-html`, renderNode)
     : ((node as any).content ?? null)
 

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -486,7 +486,7 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
     case 'html_inline':
       return node.type === 'html_block'
         ? <HtmlBlockNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} fade={ctx.fade} customId={ctx.customId} />
-        : <HtmlInlineNode key={key} node={node as any} ctx={ctx} typewriter={ctx.typewriter} fade={ctx.fade} customId={ctx.customId} />
+        : <HtmlInlineNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} fade={ctx.fade} customId={ctx.customId} />
     case 'vmr_container':
       return <VmrContainerNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} fade={ctx.fade} />
     case 'label_open':

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -259,9 +259,26 @@ function renderCodeBlock(
 
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
+  const streamingComponents = ctx.streamingComponents ?? {}
+  const streamingCustom = node.type === 'code_block'
+    ? null
+    : (streamingComponents as Record<string, any>)[node.type]
   const custom = node.type === 'code_block'
     ? null
     : (customComponents as Record<string, any>)[node.type]
+  if (streamingCustom) {
+    return React.createElement(streamingCustom, {
+      key,
+      node,
+      customId: ctx.customId,
+      isDark: ctx.isDark,
+      ctx,
+      renderNode,
+      indexKey: key,
+      typewriter: ctx.typewriter,
+      fade: ctx.fade,
+    })
+  }
   if (custom) {
     return React.createElement(custom, {
       key,
@@ -277,7 +294,11 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
   }
 
   if (node.type === 'html_block' || node.type === 'html_inline') {
-    const resolvedCustomTag = resolveCustomHtmlTag(node as any, customComponents as any, ctx.customHtmlTags)
+    const streamingAndLegacyComponents = {
+      ...(customComponents as Record<string, any>),
+      ...(streamingComponents as Record<string, any>),
+    }
+    const resolvedCustomTag = resolveCustomHtmlTag(node as any, streamingAndLegacyComponents as any, ctx.customHtmlTags)
     const fallbackTag = String((node as any).tag ?? '').trim().toLowerCase() || getHtmlTagFromContent((node as any).content)
     const tag = resolvedCustomTag?.tag ?? fallbackTag
     if (tag) {

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -2,7 +2,7 @@ import type { ParsedNode } from 'stream-markdown-parser'
 import type { RenderContext } from '../types'
 import { normalizeShikiLanguage } from 'markstream-core'
 import React from 'react'
-import { getHtmlTagFromContent, shouldRenderUnknownHtmlTagAsText, stripCustomHtmlWrapper } from 'stream-markdown-parser'
+import { convertHtmlAttrsToProps, getHtmlTagFromContent, normalizeCustomHtmlTagName, sanitizeHtmlTokenAttrs, shouldRenderUnknownHtmlTagAsText, stripCustomHtmlWrapper, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { AdmonitionNode } from '../components/AdmonitionNode/AdmonitionNode'
 import { BlockquoteNode } from '../components/BlockquoteNode/BlockquoteNode'
 import { CheckboxNode } from '../components/CheckboxNode/CheckboxNode'
@@ -145,6 +145,34 @@ function renderSpecialCodeBlockComponent(
   })
 }
 
+function getParserCustomTagNodeTag(node: ParsedNode) {
+  if (node.type === 'html_block' || node.type === 'html_inline')
+    return ''
+
+  const type = normalizeCustomHtmlTagName(node.type)
+  const tag = normalizeCustomHtmlTagName((node as any).tag)
+  return type && tag && type === tag ? type : ''
+}
+
+function renderHtmlComponentForCustomTagNode(
+  component: React.ComponentType<any>,
+  node: ParsedNode,
+  key: React.Key,
+  ctx: RenderContext,
+  tag: string,
+) {
+  const attrs = sanitizeHtmlTokenAttrs((node as any).attrs ?? undefined, ctx.htmlPolicy ?? 'safe', tag)
+  const props = convertHtmlAttrsToProps(tokenAttrsToRecord(attrs))
+  const children = Array.isArray((node as any).children) && (node as any).children.length > 0
+    ? renderNodeChildren((node as any).children, ctx, `${String(key)}-html`, renderNode)
+    : ((node as any).content ?? null)
+
+  return React.createElement(component, {
+    ...props,
+    key,
+  }, children)
+}
+
 function getMermaidRenderProps(node: any, ctx: RenderContext) {
   const next = { ...(ctx.mermaidProps || {}) } as Record<string, any>
   if (parsePositiveMermaidNumber(next.estimatedPreviewHeightPx) == null) {
@@ -260,9 +288,14 @@ function renderCodeBlock(
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
   const streamingComponents = ctx.streamingComponents ?? {}
-  const streamingCustom = node.type === 'code_block'
-    ? null
-    : (streamingComponents as Record<string, any>)[node.type]
+  const htmlComponents = ctx.htmlComponents ?? {}
+  const parserCustomTag = getParserCustomTagNodeTag(node)
+  const streamingCustom = parserCustomTag
+    ? (streamingComponents as Record<string, any>)[parserCustomTag]
+    : null
+  const htmlCustom = parserCustomTag && !streamingCustom
+    ? (htmlComponents as Record<string, any>)[parserCustomTag]
+    : null
   const custom = node.type === 'code_block'
     ? null
     : (customComponents as Record<string, any>)[node.type]
@@ -279,6 +312,8 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
       fade: ctx.fade,
     })
   }
+  if (htmlCustom)
+    return renderHtmlComponentForCustomTagNode(htmlCustom, node, key, ctx, parserCustomTag)
   if (custom) {
     return React.createElement(custom, {
       key,

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -11,7 +11,7 @@ import type {
 import type { HtmlPreviewFrameProps } from '../components/CodeBlockNode/HtmlPreviewFrame'
 import type { MarkdownCodeBlockNodeProps } from '../components/MarkdownCodeBlockNode/MarkdownCodeBlockNode'
 import type { TooltipProps } from '../components/Tooltip/Tooltip'
-import type { CustomComponentMap } from '../customComponents'
+import type { CustomComponentMap, HtmlComponentMap, StreamingComponentMap } from '../customComponents'
 import type { NodeRendererProps, RenderContext } from '../types'
 import type {
   CodeBlockNodeProps,
@@ -1399,7 +1399,10 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
   }
 }
 
-export function NodeRenderer(props: NodeRendererProps) {
+export function NodeRenderer<
+  TStreamingComponents extends StreamingComponentMap = StreamingComponentMap,
+  THtmlComponents extends Record<string, any> = HtmlComponentMap,
+>(props: NodeRendererProps<TStreamingComponents, THtmlComponents>) {
   const customComponents = getCustomNodeComponents(props.customId)
   const streamingComponents = normalizeComponentMap(props.streamingComponents)
   const htmlComponents = normalizeComponentMap(props.htmlComponents)

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -1081,7 +1081,11 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     ...(props.ctx?.htmlComponents ?? {}),
   }
   const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe', {
+    ctx: props.ctx,
+    keyPrefix: String(props.indexKey ?? 'html-block'),
+    nodeComponents: props.ctx?.streamingComponents,
     propComponents: props.ctx?.htmlComponents,
+    renderNode: props.renderNode,
   })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
@@ -1094,7 +1098,11 @@ export function HtmlInlineNode(props: NodeComponentProps<{ type: 'html_inline', 
     ...(props.ctx?.htmlComponents ?? {}),
   }
   const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe', {
+    ctx: props.ctx,
+    keyPrefix: String(props.indexKey ?? 'html-inline'),
+    nodeComponents: props.ctx?.streamingComponents,
     propComponents: props.ctx?.htmlComponents,
+    renderNode: props.renderNode,
   })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -59,7 +59,6 @@ import { parseHtmlToReactNodes } from './html'
 import { renderKatexToHtml } from './katex'
 
 const fallbackMarkdown = getMarkdown()
-const warnedComponentMapConflicts = new Set<string>()
 
 function formatLanguageLabel(language: unknown) {
   const normalized = normalizeLanguageIdentifier(String(language ?? ''))
@@ -1118,6 +1117,7 @@ export function HtmlInlineNode(props: NodeComponentProps<{
     && !isHtmlTagBlocked(structuredTag, htmlPolicy)
     && props.ctx
     && props.renderNode
+    && StructuredHtmlComponent
   ) {
     const structuredContent = renderNodeChildren(
       structuredChildren,
@@ -1125,19 +1125,10 @@ export function HtmlInlineNode(props: NodeComponentProps<{
       `${String(props.indexKey ?? 'html-inline')}-structured`,
       props.renderNode,
     )
-    if (StructuredHtmlComponent) {
-      const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, htmlPolicy, normalizedStructuredTag)
-      return React.createElement(
-        StructuredHtmlComponent as any,
-        convertHtmlAttrsToProps(tokenAttrsToRecord(attrs)),
-        structuredContent,
-      )
-    }
-
-    const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, htmlPolicy, structuredTag)
+    const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, htmlPolicy, normalizedStructuredTag)
     return React.createElement(
-      structuredTag,
-      normalizeDomAttrs((tokenAttrsToProps(attrs) as Record<string, string> | undefined) || {}),
+      StructuredHtmlComponent as any,
+      convertHtmlAttrsToProps(tokenAttrsToRecord(attrs)),
       structuredContent,
     )
   }
@@ -1388,9 +1379,9 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
     case 'reference':
       return <ReferenceNode key={key} node={node as any} ctx={ctx} typewriter={ctx.typewriter} />
     case 'html_block':
-      return <HtmlBlockNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} customId={ctx.customId} />
+      return <HtmlBlockNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} fade={ctx.fade} customId={ctx.customId} />
     case 'html_inline':
-      return <HtmlInlineNode key={key} node={node as any} ctx={ctx} typewriter={ctx.typewriter} customId={ctx.customId} />
+      return <HtmlInlineNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} fade={ctx.fade} customId={ctx.customId} />
     case 'vmr_container':
       return <VmrContainerNode key={key} node={node as any} ctx={ctx} renderNode={renderNode} indexKey={key} typewriter={ctx.typewriter} />
     case 'label_open':
@@ -1408,6 +1399,7 @@ export function NodeRenderer<
   const customComponents = getCustomNodeComponents(props.customId)
   const streamingComponents = normalizeComponentMap(props.streamingComponents)
   const htmlComponents = normalizeComponentMap(props.htmlComponents)
+  const warnedComponentMapConflicts = new Set<string>()
 
   warnComponentMapConflicts(
     streamingComponents,

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -154,6 +154,7 @@ function renderCustomCodeBlockComponent(
     renderNode,
     indexKey: key,
     typewriter: ctx.typewriter,
+    fade: ctx.fade,
   })
 }
 
@@ -216,6 +217,7 @@ function createRenderContext(
     isDark: props.isDark,
     indexKey: indexPrefix,
     typewriter: props.typewriter,
+    fade: props.fade,
     showTooltips: props.showTooltips,
     streamingComponents,
     htmlComponents,
@@ -453,8 +455,9 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
 
   const nodeChildren = node.children ?? []
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
-  const streamingAndLegacyComponents = {
+  const displayComponents = {
     ...customComponents,
+    ...(ctx.htmlComponents ?? {}),
     ...(ctx.streamingComponents ?? {}),
   }
   const parts: React.ReactNode[] = []
@@ -473,7 +476,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, streamingAndLegacyComponents, ctx.customHtmlTags)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>
@@ -1165,6 +1168,7 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
       renderNode,
       indexKey: key,
       typewriter: ctx.typewriter,
+      fade: ctx.fade,
     })
   }
   if (htmlCustom)
@@ -1179,6 +1183,7 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
       renderNode,
       indexKey: key,
       typewriter: ctx.typewriter,
+      fade: ctx.fade,
     })
   }
 
@@ -1207,6 +1212,7 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
         renderNode,
         indexKey: key,
         typewriter: ctx.typewriter,
+        fade: ctx.fade,
       })
     }
     const rawContent = String((node as any).content ?? (node as any).raw ?? '')

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -1086,23 +1086,71 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     nodeComponents: props.ctx?.streamingComponents,
     propComponents: props.ctx?.htmlComponents,
     renderNode: props.renderNode,
+    sourceNode: props.node as ParsedNode,
   })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
   return <>{nodes}</>
 }
 
-export function HtmlInlineNode(props: NodeComponentProps<{ type: 'html_inline', content?: string }>) {
+export function HtmlInlineNode(props: NodeComponentProps<{
+  type: 'html_inline'
+  content?: string
+  tag?: string
+  attrs?: [string, string | null][] | null
+  children?: ParsedNode[]
+}>) {
+  const htmlPolicy = props.ctx?.htmlPolicy ?? 'safe'
+  const structuredTag = String((props.node as any)?.tag ?? '').trim().toLowerCase()
+  const normalizedStructuredTag = normalizeCustomHtmlTagName(structuredTag)
+  const structuredChildren = Array.isArray((props.node as any)?.children)
+    ? ((props.node as any).children as ParsedNode[])
+    : []
+  const StructuredHtmlComponent = normalizedStructuredTag
+    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
+    : undefined
+  if (
+    structuredChildren.length > 0
+    && structuredTag
+    && htmlPolicy !== 'escape'
+    && !isHtmlTagBlocked(structuredTag, htmlPolicy)
+    && props.ctx
+    && props.renderNode
+  ) {
+    const structuredContent = renderNodeChildren(
+      structuredChildren,
+      props.ctx,
+      `${String(props.indexKey ?? 'html-inline')}-structured`,
+      props.renderNode,
+    )
+    if (StructuredHtmlComponent) {
+      const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, htmlPolicy, normalizedStructuredTag)
+      return React.createElement(
+        StructuredHtmlComponent as any,
+        convertHtmlAttrsToProps(tokenAttrsToRecord(attrs)),
+        structuredContent,
+      )
+    }
+
+    const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, htmlPolicy, structuredTag)
+    return React.createElement(
+      structuredTag,
+      normalizeDomAttrs((tokenAttrsToProps(attrs) as Record<string, string> | undefined) || {}),
+      structuredContent,
+    )
+  }
+
   const customComponents = {
     ...(props.ctx?.customComponents ?? getCustomNodeComponents(props.customId)),
     ...(props.ctx?.htmlComponents ?? {}),
   }
-  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe', {
+  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, htmlPolicy, {
     ctx: props.ctx,
     keyPrefix: String(props.indexKey ?? 'html-inline'),
     nodeComponents: props.ctx?.streamingComponents,
     propComponents: props.ctx?.htmlComponents,
     renderNode: props.renderNode,
+    sourceNode: props.node as ParsedNode,
   })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -208,9 +208,11 @@ function createRenderContext(
   htmlComponents: NonNullable<RenderContext['htmlComponents']>,
   indexPrefix: string,
   customHtmlTags: readonly string[],
+  final?: boolean,
 ): RenderContext {
   return {
     customId: props.customId,
+    final,
     customComponents,
     customHtmlTags,
     htmlPolicy: props.htmlPolicy ?? 'safe',
@@ -1452,6 +1454,7 @@ export function NodeRenderer<
     htmlComponents,
     indexPrefix,
     effectiveCustomHtmlTags,
+    resolvedFinal,
   )
 
   return (

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -28,10 +28,12 @@ import type { NodeComponentProps } from '../types/node-component'
 import { normalizeShikiLanguage } from 'markstream-core'
 import React from 'react'
 import {
+  convertHtmlAttrsToProps,
   getMarkdown,
   isHtmlTagBlocked,
   mergeCustomHtmlTags,
   NON_STRUCTURING_HTML_TAGS,
+  normalizeCustomHtmlTagName,
   parseMarkdownToStructure,
   sanitizeHtmlAttrs,
   sanitizeHtmlTokenAttrs,
@@ -39,6 +41,7 @@ import {
   shouldOpenLinkInNewTab,
   shouldRenderUnknownHtmlTagAsText,
   stripCustomHtmlWrapper,
+  tokenAttrsToRecord,
 } from 'stream-markdown-parser'
 import { clampInfographicPreviewHeight, estimateInfographicPreviewHeight, parsePositiveNumber as parsePositiveInfographicNumber } from '../components/InfographicBlockNode/height'
 import { clampMermaidPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber as parsePositiveMermaidNumber } from '../components/MermaidBlockNode/height'
@@ -167,6 +170,34 @@ function renderSpecialCodeBlockComponent(
     isDark: ctx.isDark,
     ...specialProps,
   })
+}
+
+function getParserCustomTagNodeTag(node: ParsedNode) {
+  if (node.type === 'html_block' || node.type === 'html_inline')
+    return ''
+
+  const type = normalizeCustomHtmlTagName(node.type)
+  const tag = normalizeCustomHtmlTagName((node as any).tag)
+  return type && tag && type === tag ? type : ''
+}
+
+function renderHtmlComponentForCustomTagNode(
+  component: React.ComponentType<any>,
+  node: ParsedNode,
+  key: React.Key,
+  ctx: RenderContext,
+  tag: string,
+) {
+  const attrs = sanitizeHtmlTokenAttrs((node as any).attrs ?? undefined, ctx.htmlPolicy ?? 'safe', tag)
+  const props = convertHtmlAttrsToProps(tokenAttrsToRecord(attrs))
+  const children = Array.isArray((node as any).children) && (node as any).children.length > 0
+    ? renderNodeChildren((node as any).children, ctx, `${String(key)}-html`, renderNode)
+    : ((node as any).content ?? null)
+
+  return React.createElement(component, {
+    ...props,
+    key,
+  }, children)
 }
 
 function createRenderContext(
@@ -1003,9 +1034,13 @@ export function HtmlBlockNode(props: NodeComponentProps<{
   children?: ParsedNode[]
 }>) {
   const structuredTag = String((props.node as any)?.tag ?? '').trim().toLowerCase()
+  const normalizedStructuredTag = normalizeCustomHtmlTagName(structuredTag)
   const structuredChildren = Array.isArray((props.node as any)?.children)
     ? ((props.node as any).children as ParsedNode[])
     : []
+  const StructuredHtmlComponent = normalizedStructuredTag
+    ? props.ctx?.htmlComponents?.[normalizedStructuredTag]
+    : undefined
   if (
     structuredChildren.length > 0
     && structuredTag
@@ -1014,15 +1049,25 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     && props.ctx
     && props.renderNode
   ) {
+    const structuredContent = renderNodeChildren(
+      structuredChildren,
+      props.ctx,
+      `${String(props.indexKey ?? 'html-block')}-structured`,
+      props.renderNode,
+    )
+    if (StructuredHtmlComponent) {
+      const attrs = sanitizeHtmlTokenAttrs((props.node as any)?.attrs ?? null, props.ctx?.htmlPolicy ?? 'safe', normalizedStructuredTag)
+      return React.createElement(
+        StructuredHtmlComponent as any,
+        convertHtmlAttrsToProps(tokenAttrsToRecord(attrs)),
+        structuredContent,
+      )
+    }
+
     return React.createElement(
       structuredTag,
       mergeHtmlBlockWrapperProps((props.node as any)?.attrs ?? null, props.ctx?.htmlPolicy ?? 'safe', structuredTag),
-      renderNodeChildren(
-        structuredChildren,
-        props.ctx,
-        `${String(props.indexKey ?? 'html-block')}-structured`,
-        props.renderNode,
-      ),
+      structuredContent,
     )
   }
 
@@ -1030,7 +1075,9 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     ...(props.ctx?.customComponents ?? getCustomNodeComponents(props.customId)),
     ...(props.ctx?.htmlComponents ?? {}),
   }
-  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe')
+  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe', {
+    propComponents: props.ctx?.htmlComponents,
+  })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
   return <>{nodes}</>
@@ -1041,7 +1088,9 @@ export function HtmlInlineNode(props: NodeComponentProps<{ type: 'html_inline', 
     ...(props.ctx?.customComponents ?? getCustomNodeComponents(props.customId)),
     ...(props.ctx?.htmlComponents ?? {}),
   }
-  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe')
+  const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe', {
+    propComponents: props.ctx?.htmlComponents,
+  })
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
   return <>{nodes}</>
@@ -1095,9 +1144,14 @@ export function FallbackComponent(props: NodeComponentProps<{ type: string }>) {
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
   const streamingComponents = ctx.streamingComponents ?? {}
-  const streamingCustom = node.type === 'code_block'
-    ? null
-    : (streamingComponents as Record<string, any>)[node.type]
+  const htmlComponents = ctx.htmlComponents ?? {}
+  const parserCustomTag = getParserCustomTagNodeTag(node)
+  const streamingCustom = parserCustomTag
+    ? (streamingComponents as Record<string, any>)[parserCustomTag]
+    : null
+  const htmlCustom = parserCustomTag && !streamingCustom
+    ? (htmlComponents as Record<string, any>)[parserCustomTag]
+    : null
   const custom = node.type === 'code_block'
     ? null
     : (customComponents as Record<string, any>)[node.type]
@@ -1113,6 +1167,8 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
       typewriter: ctx.typewriter,
     })
   }
+  if (htmlCustom)
+    return renderHtmlComponentForCustomTagNode(htmlCustom, node, key, ctx, parserCustomTag)
   if (custom) {
     return React.createElement(custom, {
       key,

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -42,7 +42,11 @@ import {
 } from 'stream-markdown-parser'
 import { clampInfographicPreviewHeight, estimateInfographicPreviewHeight, parsePositiveNumber as parsePositiveInfographicNumber } from '../components/InfographicBlockNode/height'
 import { clampMermaidPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber as parsePositiveMermaidNumber } from '../components/MermaidBlockNode/height'
-import { getCustomNodeComponents } from '../customComponents'
+import {
+  getCustomNodeComponents,
+  normalizeComponentMap,
+  warnComponentMapConflicts,
+} from '../customComponents'
 import { getCodeBlockExtraProps } from '../renderers/codeBlockExtraProps'
 import { BLOCK_LEVEL_TYPES, renderInline, renderNodeChildren, tokenAttrsToProps } from '../renderers/renderChildren'
 import { isParagraphBreakingCustomHtmlNode, resolveCustomHtmlTag } from '../utils/customHtmlTag'
@@ -52,6 +56,7 @@ import { parseHtmlToReactNodes } from './html'
 import { renderKatexToHtml } from './katex'
 
 const fallbackMarkdown = getMarkdown()
+const warnedComponentMapConflicts = new Set<string>()
 
 function formatLanguageLabel(language: unknown) {
   const normalized = normalizeLanguageIdentifier(String(language ?? ''))
@@ -167,6 +172,8 @@ function renderSpecialCodeBlockComponent(
 function createRenderContext(
   props: NodeRendererProps,
   customComponents: CustomComponentMap,
+  streamingComponents: NonNullable<RenderContext['streamingComponents']>,
+  htmlComponents: NonNullable<RenderContext['htmlComponents']>,
   indexPrefix: string,
   customHtmlTags: readonly string[],
 ): RenderContext {
@@ -179,6 +186,8 @@ function createRenderContext(
     indexKey: indexPrefix,
     typewriter: props.typewriter,
     showTooltips: props.showTooltips,
+    streamingComponents,
+    htmlComponents,
     renderCodeBlocksAsPre: props.renderCodeBlocksAsPre,
     codeBlockStream: props.codeBlockStream,
     codeBlockProps: {
@@ -413,6 +422,10 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
 
   const nodeChildren = node.children ?? []
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
+  const streamingAndLegacyComponents = {
+    ...customComponents,
+    ...(ctx.streamingComponents ?? {}),
+  }
   const parts: React.ReactNode[] = []
   const inlineBuffer: ParsedNode[] = []
 
@@ -429,7 +442,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, customComponents, ctx.customHtmlTags)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, streamingAndLegacyComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>
@@ -1013,7 +1026,10 @@ export function HtmlBlockNode(props: NodeComponentProps<{
     )
   }
 
-  const customComponents = getCustomNodeComponents(props.customId)
+  const customComponents = {
+    ...(props.ctx?.customComponents ?? getCustomNodeComponents(props.customId)),
+    ...(props.ctx?.htmlComponents ?? {}),
+  }
   const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe')
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
@@ -1021,7 +1037,10 @@ export function HtmlBlockNode(props: NodeComponentProps<{
 }
 
 export function HtmlInlineNode(props: NodeComponentProps<{ type: 'html_inline', content?: string }>) {
-  const customComponents = getCustomNodeComponents(props.customId)
+  const customComponents = {
+    ...(props.ctx?.customComponents ?? getCustomNodeComponents(props.customId)),
+    ...(props.ctx?.htmlComponents ?? {}),
+  }
   const nodes = parseHtmlToReactNodes(String(props.node.content ?? ''), customComponents, props.ctx?.htmlPolicy ?? 'safe')
   if (nodes == null)
     return <>{String(props.node.content ?? '')}</>
@@ -1075,9 +1094,25 @@ export function FallbackComponent(props: NodeComponentProps<{ type: string }>) {
 
 export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext) {
   const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
+  const streamingComponents = ctx.streamingComponents ?? {}
+  const streamingCustom = node.type === 'code_block'
+    ? null
+    : (streamingComponents as Record<string, any>)[node.type]
   const custom = node.type === 'code_block'
     ? null
     : (customComponents as Record<string, any>)[node.type]
+  if (streamingCustom) {
+    return React.createElement(streamingCustom, {
+      key,
+      node,
+      customId: ctx.customId,
+      isDark: ctx.isDark,
+      ctx,
+      renderNode,
+      indexKey: key,
+      typewriter: ctx.typewriter,
+    })
+  }
   if (custom) {
     return React.createElement(custom, {
       key,
@@ -1092,7 +1127,11 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
   }
 
   if (node.type === 'html_block' || node.type === 'html_inline') {
-    const resolvedCustomTag = resolveCustomHtmlTag(node as any, customComponents as any, ctx.customHtmlTags)
+    const streamingAndLegacyComponents = {
+      ...(customComponents as Record<string, any>),
+      ...(streamingComponents as Record<string, any>),
+    }
+    const resolvedCustomTag = resolveCustomHtmlTag(node as any, streamingAndLegacyComponents as any, ctx.customHtmlTags)
     const tag = resolvedCustomTag?.tag ?? ''
     const isWhitelisted = resolvedCustomTag?.isWhitelisted ?? false
     const customForTag = resolvedCustomTag?.component ?? null
@@ -1242,12 +1281,21 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
 
 export function NodeRenderer(props: NodeRendererProps) {
   const customComponents = getCustomNodeComponents(props.customId)
+  const streamingComponents = normalizeComponentMap(props.streamingComponents)
+  const htmlComponents = normalizeComponentMap(props.htmlComponents)
+
+  warnComponentMapConflicts(
+    streamingComponents,
+    htmlComponents,
+    warnedComponentMapConflicts,
+  )
 
   const baseParseOptions = props.parseOptions ?? {}
   const optionTags = (baseParseOptions as any).customHtmlTags ?? []
   const effectiveCustomHtmlTags = mergeCustomHtmlTags(
     props.customHtmlTags,
     Array.isArray(optionTags) ? optionTags : [],
+    Object.keys(streamingComponents),
   )
 
   const instanceMsgId = props.customId
@@ -1274,7 +1322,14 @@ export function NodeRenderer(props: NodeRendererProps) {
       : []
 
   const indexPrefix = props.indexKey != null ? String(props.indexKey) : 'markdown-renderer'
-  const renderCtx = createRenderContext(props, customComponents, indexPrefix, effectiveCustomHtmlTags)
+  const renderCtx = createRenderContext(
+    props,
+    customComponents,
+    streamingComponents,
+    htmlComponents,
+    indexPrefix,
+    effectiveCustomHtmlTags,
+  )
 
   return (
     <div

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -191,7 +191,7 @@ function renderHtmlComponentForCustomTagNode(
 ) {
   const attrs = sanitizeHtmlTokenAttrs((node as any).attrs ?? undefined, ctx.htmlPolicy ?? 'safe', tag)
   const props = convertHtmlAttrsToProps(tokenAttrsToRecord(attrs))
-  const children = Array.isArray((node as any).children) && (node as any).children.length > 0
+  const children = Array.isArray((node as any).children)
     ? renderNodeChildren((node as any).children, ctx, `${String(key)}-html`, renderNode)
     : ((node as any).content ?? null)
 
@@ -476,7 +476,9 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags)) {
+    const canUseHtmlDisplayMetadata = (ctx.htmlPolicy ?? 'safe') !== 'escape'
+      || (child.type !== 'html_inline' && child.type !== 'html_block')
+    if (BLOCK_LEVEL_TYPES.has(child.type) || (canUseHtmlDisplayMetadata && isParagraphBreakingCustomHtmlNode(child, displayComponents, ctx.customHtmlTags))) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>

--- a/packages/markstream-react/src/server.ts
+++ b/packages/markstream-react/src/server.ts
@@ -11,7 +11,14 @@ export {
   setCustomComponents,
   withMarkstreamComponentDisplay,
 } from './customComponents'
-export type { CustomComponentDisplayMode, MarkstreamCustomComponent } from './customComponents'
+export type {
+  CustomComponentDisplayMode,
+  HtmlComponent,
+  HtmlComponentMap,
+  MarkstreamCustomComponent,
+  StreamingComponent,
+  StreamingComponentMap,
+} from './customComponents'
 export { AdmonitionNode } from './server-renderer'
 export { BlockquoteNode } from './server-renderer'
 export { CheckboxNode } from './server-renderer'

--- a/packages/markstream-react/src/server.ts
+++ b/packages/markstream-react/src/server.ts
@@ -5,6 +5,8 @@ export type { MarkdownCodeBlockNodeProps } from './components/MarkdownCodeBlockN
 export type { TooltipPlacement, TooltipProps } from './components/Tooltip/Tooltip'
 export {
   clearGlobalCustomComponents,
+  defineHtmlComponents,
+  defineStreamingComponents,
   getCustomComponentDisplay,
   getCustomNodeComponents,
   removeCustomComponents,

--- a/packages/markstream-react/src/types.ts
+++ b/packages/markstream-react/src/types.ts
@@ -1,6 +1,6 @@
 import type React from 'react'
 import type { BaseNode, HtmlPolicy, MarkdownIt, ParsedNode, ParseOptions } from 'stream-markdown-parser'
-import type { CustomComponentMap } from './customComponents'
+import type { CustomComponentMap, HtmlComponentMap, StreamingComponentMap } from './customComponents'
 import type { SmoothMarkdownStreamOptions } from './hooks/useSmoothMarkdownStream'
 import type {
   CodeBlockMonacoOptions,
@@ -35,6 +35,8 @@ export interface NodeRendererProps {
   final?: boolean
   parseOptions?: ParseOptions
   customMarkdownIt?: (md: MarkdownIt) => MarkdownIt
+  streamingComponents?: StreamingComponentMap
+  htmlComponents?: HtmlComponentMap
   /** Log parse/render timing stats (dev only). */
   debugPerformance?: boolean
   /**
@@ -112,6 +114,8 @@ export interface RenderContext {
   textStreamState?: Map<string, string>
   streamRenderVersion?: number
   customComponents?: CustomComponentMap
+  streamingComponents?: StreamingComponentMap
+  htmlComponents?: HtmlComponentMap
   customHtmlTags?: readonly string[]
   htmlPolicy?: HtmlPolicy
   codeBlockProps?: NodeRendererCodeBlockProps

--- a/packages/markstream-react/src/types.ts
+++ b/packages/markstream-react/src/types.ts
@@ -111,6 +111,7 @@ export interface NodeRendererProps<
 export interface RenderContext {
   customId?: string
   isDark?: boolean
+  final?: boolean
   indexKey?: string
   typewriter?: boolean
   /** Enable/disable fade animations. Default: true */

--- a/packages/markstream-react/src/types.ts
+++ b/packages/markstream-react/src/types.ts
@@ -1,6 +1,7 @@
 import type React from 'react'
+import type { ComponentType } from 'react'
 import type { BaseNode, HtmlPolicy, MarkdownIt, ParsedNode, ParseOptions } from 'stream-markdown-parser'
-import type { CustomComponentMap, HtmlComponentMap, StreamingComponentMap } from './customComponents'
+import type { CustomComponentMap, HtmlComponentDefinitions, HtmlComponentMap, StreamingComponentDefinitions, StreamingComponentMap } from './customComponents'
 import type { SmoothMarkdownStreamOptions } from './hooks/useSmoothMarkdownStream'
 import type {
   CodeBlockMonacoOptions,
@@ -25,7 +26,10 @@ export type NodeRendererCodeBlockProps
     }
     & Record<string, unknown>
 
-export interface NodeRendererProps {
+export interface NodeRendererProps<
+  TStreamingComponents extends Record<string, ComponentType<any>> = StreamingComponentMap,
+  THtmlComponents extends Record<string, any> = HtmlComponentMap,
+> {
   content?: string
   nodes?: readonly BaseNode[] | null
   /**
@@ -35,8 +39,8 @@ export interface NodeRendererProps {
   final?: boolean
   parseOptions?: ParseOptions
   customMarkdownIt?: (md: MarkdownIt) => MarkdownIt
-  streamingComponents?: StreamingComponentMap
-  htmlComponents?: HtmlComponentMap
+  streamingComponents?: TStreamingComponents & StreamingComponentDefinitions<TStreamingComponents>
+  htmlComponents?: THtmlComponents & HtmlComponentDefinitions<THtmlComponents>
   /** Log parse/render timing stats (dev only). */
   debugPerformance?: boolean
   /**

--- a/packages/markstream-react/src/utils/customHtmlTag.ts
+++ b/packages/markstream-react/src/utils/customHtmlTag.ts
@@ -1,30 +1,31 @@
+import type { ComponentType } from 'react'
 import type { ParsedNode } from 'stream-markdown-parser'
-import type { CustomComponentDisplayMode, CustomComponentMap, MarkstreamCustomComponent } from '../customComponents'
-import { getHtmlTagFromContent } from 'stream-markdown-parser'
+import type { CustomComponentDisplayMode } from '../customComponents'
+import { getHtmlTagFromContent, normalizeCustomHtmlTagName } from 'stream-markdown-parser'
 import { getCustomComponentDisplay } from '../customComponents'
 
 export interface ResolvedCustomHtmlTag {
   tag: string
   isWhitelisted: boolean
-  component: MarkstreamCustomComponent | null
+  component: ComponentType<any> | null
   display: CustomComponentDisplayMode | undefined
 }
 
 export function resolveCustomHtmlTag(
   node: Pick<ParsedNode, 'type'> & { tag?: string | null, content?: unknown },
-  customComponents: CustomComponentMap,
+  customComponents: Record<string, ComponentType<any>>,
   customHtmlTags?: readonly string[],
 ): ResolvedCustomHtmlTag | null {
-  const normalizedType = String(node.type ?? '').trim().toLowerCase()
-  const normalizedTags = (customHtmlTags ?? []).map(tag => tag.toLowerCase())
+  const normalizedType = normalizeCustomHtmlTagName(node.type)
+  const normalizedTags = (customHtmlTags ?? []).map(tag => normalizeCustomHtmlTagName(tag)).filter(Boolean)
   const taggedNode = normalizedType === 'html_inline' || normalizedType === 'html_block'
 
   if (!taggedNode && !normalizedTags.includes(normalizedType))
     return null
 
   const tag = taggedNode
-    ? (String(node.tag ?? '').trim().toLowerCase() || getHtmlTagFromContent(node.content))
-    : (String(node.tag ?? '').trim().toLowerCase() || normalizedType)
+    ? (normalizeCustomHtmlTagName(node.tag) || getHtmlTagFromContent(node.content))
+    : (normalizeCustomHtmlTagName(node.tag) || normalizedType)
   if (!tag)
     return null
 
@@ -35,13 +36,13 @@ export function resolveCustomHtmlTag(
     tag,
     isWhitelisted,
     component,
-    display: getCustomComponentDisplay(component),
+    display: getCustomComponentDisplay(component as any),
   }
 }
 
 export function isParagraphBreakingCustomHtmlNode(
   node: Pick<ParsedNode, 'type'> & { tag?: string | null, content?: unknown },
-  customComponents: CustomComponentMap,
+  customComponents: Record<string, ComponentType<any>>,
   customHtmlTags?: readonly string[],
 ) {
   return resolveCustomHtmlTag(node, customComponents, customHtmlTags)?.display === 'block'

--- a/packages/markstream-react/src/utils/customHtmlTag.ts
+++ b/packages/markstream-react/src/utils/customHtmlTag.ts
@@ -30,7 +30,8 @@ export function resolveCustomHtmlTag(
     return null
 
   const isWhitelisted = normalizedTags.includes(tag)
-  const component = isWhitelisted ? (customComponents[tag] ?? customComponents[normalizedType] ?? null) : null
+  const registeredComponent = customComponents[tag] ?? customComponents[normalizedType] ?? null
+  const component = (isWhitelisted || taggedNode) ? registeredComponent : null
 
   return {
     tag,

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -1,9 +1,9 @@
 import type { ComponentType, ReactNode } from 'react'
 import type { HtmlPolicy } from 'stream-markdown-parser'
-import type { CustomComponentMap } from '../customComponents'
 import React from 'react'
 import {
   BLOCKED_HTML_TAGS as BLOCKED_TAGS,
+  convertHtmlAttrsToProps,
   hasCustomHtmlComponents as hasCustomHtmlComponentsBase,
   isCustomHtmlComponentTag,
   isHtmlTagBlocked,
@@ -13,6 +13,8 @@ import {
 } from 'stream-markdown-parser'
 
 export type { HtmlToken } from 'stream-markdown-parser'
+
+type HtmlReactComponentMap = Record<string, ComponentType<any>>
 
 function normalizeCssPropName(prop: string) {
   if (prop.startsWith('--'))
@@ -67,14 +69,14 @@ export const sanitizeHtmlAttrs = sanitizeHtmlAttrsBase
 
 export function isCustomHtmlComponent(
   tagName: string,
-  customComponents: CustomComponentMap,
+  customComponents: HtmlReactComponentMap,
 ) {
   return isCustomHtmlComponentTag(tagName, customComponents as Record<string, unknown>)
 }
 
 export function hasCustomHtmlComponents(
   content: string,
-  customComponents: CustomComponentMap,
+  customComponents: HtmlReactComponentMap,
 ) {
   return hasCustomHtmlComponentsBase(content, customComponents as Record<string, unknown>)
 }
@@ -98,7 +100,7 @@ function pushRenderedNode(target: ReactNode[], rendered: ReactNode | ReactNode[]
 
 export function parseHtmlToReactNodes(
   content: string,
-  customComponents: CustomComponentMap,
+  customComponents: HtmlReactComponentMap,
   htmlPolicy: HtmlPolicy = 'safe',
 ): ReactNode[] | null {
   if (!content)
@@ -145,7 +147,7 @@ export function parseHtmlToReactNodes(
           : undefined
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         if (Comp) {
-          target.push(React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...attrs, key: elementKey }))
+          target.push(React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }))
         }
         else {
           target.push(React.createElement(token.tagName, {
@@ -195,7 +197,7 @@ export function parseHtmlToReactNodes(
         ? (customComponents[opening.tagName] || customComponents[opening.tagName.toLowerCase()])
         : undefined
       const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...attrs, key: elementKey }, ...opening.children)
+        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }, ...opening.children)
         : React.createElement(opening.tagName, {
             ...normalizeDomAttrs(attrs),
             key: elementKey,
@@ -227,7 +229,7 @@ export function parseHtmlToReactNodes(
         ? (customComponents[unclosed.tagName] || customComponents[unclosed.tagName.toLowerCase()])
         : undefined
       const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...attrs, key: elementKey }, ...unclosed.children)
+        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }, ...unclosed.children)
         : React.createElement(unclosed.tagName, {
             ...normalizeDomAttrs(attrs),
             key: elementKey,

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -172,15 +172,17 @@ function renderNodeComponent(
   children: ReactNode[],
   key: string,
   options: HtmlToReactOptions,
+  contentSource?: string,
+  rawSource?: string,
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
-  const content = getTextContent(children)
+  const content = contentSource ?? getTextContent(children)
   const node = {
     type: normalizedTag,
     tag: normalizedTag,
     attrs: attrsToTokenPairs(attrs),
     content,
-    raw: `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
+    raw: rawSource ?? `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
     loading: Boolean((options.sourceNode as any)?.loading),
     autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
   } as ParsedNode
@@ -214,6 +216,7 @@ export function parseHtmlToReactNodes(
       children: ReactNode[]
       attrs?: Record<string, string>
       hardBlocked?: boolean
+      sourceParts: string[]
       softBlocked?: boolean
       customComponent?: boolean
     }> = []
@@ -225,20 +228,26 @@ export function parseHtmlToReactNodes(
           continue
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         target.push(token.content ?? '')
+        if (stack.length > 0)
+          stack[stack.length - 1].sourceParts.push(token.content ?? '')
         continue
       }
 
       if (token.type === 'self_closing') {
+        const rawAttrs = token.attrs || {}
+        const rawSource = renderLiteralTagText(token.tagName, rawAttrs, true)
         const customComponent = isCustomHtmlComponent(token.tagName, customComponents)
         const nodeComponent = Boolean(getNodeComponent(token.tagName, options))
         if (BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
           continue
         if (!customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
           const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
-          target.push(renderLiteralTagText(token.tagName, token.attrs, true))
+          target.push(rawSource)
+          if (stack.length > 0)
+            stack[stack.length - 1].sourceParts.push(rawSource)
           continue
         }
-        const attrs = sanitizeHtmlAttrs(token.attrs || {}, htmlPolicy, token.tagName)
+        const attrs = sanitizeHtmlAttrs(rawAttrs, htmlPolicy, token.tagName)
         const explicitKey = (attrs as any).key
         const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
         const Comp = customComponent
@@ -246,7 +255,7 @@ export function parseHtmlToReactNodes(
           : undefined
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         if (nodeComponent) {
-          target.push(renderNodeComponent(token.tagName, attrs, [], elementKey, options))
+          target.push(renderNodeComponent(token.tagName, rawAttrs, [], elementKey, options, '', rawSource))
         }
         else if (Comp) {
           const componentProps = getCustomComponentProps(token.tagName, attrs, options)
@@ -259,6 +268,8 @@ export function parseHtmlToReactNodes(
             suppressHydrationWarning: true,
           }))
         }
+        if (stack.length > 0)
+          stack[stack.length - 1].sourceParts.push(rawSource)
         continue
       }
 
@@ -270,6 +281,7 @@ export function parseHtmlToReactNodes(
           tagName: token.tagName,
           children: [],
           attrs: token.attrs,
+          sourceParts: [],
           customComponent: customComponent || nodeComponent,
           hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
           softBlocked: !parentHardBlocked && !customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
@@ -281,6 +293,8 @@ export function parseHtmlToReactNodes(
       if (!opening || opening.hardBlocked)
         continue
 
+      const innerSource = opening.sourceParts.join('')
+      const rawSource = `${renderLiteralTagText(opening.tagName, opening.attrs)}${innerSource}</${opening.tagName}>`
       if (opening.softBlocked) {
         const rendered = [
           renderLiteralTagText(opening.tagName, opening.attrs),
@@ -291,6 +305,8 @@ export function parseHtmlToReactNodes(
           pushRenderedNode(stack[stack.length - 1].children, rendered)
         else
           pushRenderedNode(rootNodes, rendered)
+        if (stack.length > 0)
+          stack[stack.length - 1].sourceParts.push(rawSource)
         continue
       }
 
@@ -303,7 +319,7 @@ export function parseHtmlToReactNodes(
       const nodeComponent = Boolean(getNodeComponent(opening.tagName, options))
       let element: ReactNode
       if (nodeComponent) {
-        element = renderNodeComponent(opening.tagName, attrs, opening.children, elementKey, options)
+        element = renderNodeComponent(opening.tagName, opening.attrs || {}, opening.children, elementKey, options, innerSource, rawSource)
       }
       else if (Comp) {
         element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
@@ -320,18 +336,24 @@ export function parseHtmlToReactNodes(
         stack[stack.length - 1].children.push(element)
       else
         rootNodes.push(element)
+      if (stack.length > 0)
+        stack[stack.length - 1].sourceParts.push(rawSource)
     }
 
     while (stack.length > 0) {
       const unclosed = stack.pop()
       if (!unclosed || unclosed.hardBlocked)
         continue
+      const innerSource = unclosed.sourceParts.join('')
+      const rawSource = `${renderLiteralTagText(unclosed.tagName, unclosed.attrs)}${innerSource}`
       if (unclosed.softBlocked) {
         pushRenderedNode(rootNodes, [
           renderLiteralTagText(unclosed.tagName, unclosed.attrs),
           ...unclosed.children,
           `</${unclosed.tagName}>`,
         ])
+        if (stack.length > 0)
+          stack[stack.length - 1].sourceParts.push(rawSource)
         continue
       }
       const attrs = sanitizeHtmlAttrs(unclosed.attrs || {}, htmlPolicy, unclosed.tagName)
@@ -343,7 +365,7 @@ export function parseHtmlToReactNodes(
       const nodeComponent = Boolean(getNodeComponent(unclosed.tagName, options))
       let element: ReactNode
       if (nodeComponent) {
-        element = renderNodeComponent(unclosed.tagName, attrs, unclosed.children, elementKey, options)
+        element = renderNodeComponent(unclosed.tagName, unclosed.attrs || {}, unclosed.children, elementKey, options, innerSource, rawSource)
       }
       else if (Comp) {
         element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(unclosed.tagName, attrs, options), key: elementKey }, ...unclosed.children)
@@ -356,6 +378,8 @@ export function parseHtmlToReactNodes(
         }, ...unclosed.children)
       }
       rootNodes.push(element)
+      if (stack.length > 0)
+        stack[stack.length - 1].sourceParts.push(rawSource)
     }
 
     return rootNodes

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -26,6 +26,7 @@ interface HtmlToReactOptions {
   nodeComponents?: HtmlReactNodeComponentMap
   propComponents?: HtmlReactPropComponentMap
   renderNode?: RenderNodeFn
+  sourceNode?: ParsedNode
 }
 
 function normalizeCssPropName(prop: string) {
@@ -126,8 +127,29 @@ function getNodeComponent(
 
 function getTextContent(children: ReactNode[]) {
   return children
-    .map(child => typeof child === 'string' || typeof child === 'number' ? String(child) : '')
+    .map(serializeReactContent)
     .join('')
+}
+
+function serializeReactContent(child: ReactNode): string {
+  if (child == null || typeof child === 'boolean')
+    return ''
+  if (typeof child === 'string' || typeof child === 'number')
+    return String(child)
+  if (Array.isArray(child))
+    return child.map(serializeReactContent).join('')
+  if (!React.isValidElement(child))
+    return ''
+
+  const element = child as React.ReactElement<{ children?: ReactNode }>
+  if (typeof element.type !== 'string')
+    return serializeReactContent(element.props.children)
+
+  const attrs = Object.entries(element.props)
+    .filter(([name, value]) => name !== 'children' && name !== 'key' && name !== 'ref' && value != null && typeof value !== 'boolean')
+    .map(([name, value]) => ` ${name === 'className' ? 'class' : name}="${String(value)}"`)
+    .join('')
+  return `<${element.type}${attrs}>${serializeReactContent(element.props.children)}</${element.type}>`
 }
 
 function attrsToTokenPairs(attrs: Record<string, string>) {
@@ -152,12 +174,15 @@ function renderNodeComponent(
   options: HtmlToReactOptions,
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
+  const content = getTextContent(children)
   const node = {
     type: normalizedTag,
     tag: normalizedTag,
     attrs: attrsToTokenPairs(attrs),
-    content: getTextContent(children),
-    loading: false,
+    content,
+    raw: `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
+    loading: Boolean((options.sourceNode as any)?.loading),
+    autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
   } as ParsedNode
 
   if (options.ctx && options.renderNode)

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, ReactNode } from 'react'
-import type { HtmlPolicy } from 'stream-markdown-parser'
+import type { HtmlPolicy, ParsedNode } from 'stream-markdown-parser'
+import type { RenderContext, RenderNodeFn } from '../types'
 import React from 'react'
 import {
   BLOCKED_HTML_TAGS as BLOCKED_TAGS,
@@ -8,6 +9,7 @@ import {
   isCustomHtmlComponentTag,
   isHtmlTagBlocked,
   isHtmlTagHardBlocked,
+  normalizeCustomHtmlTagName,
   sanitizeHtmlAttrs as sanitizeHtmlAttrsBase,
   tokenizeHtml as tokenizeHtmlBase,
 } from 'stream-markdown-parser'
@@ -16,9 +18,14 @@ export type { HtmlToken } from 'stream-markdown-parser'
 
 type HtmlReactComponentMap = Record<string, ComponentType<any>>
 type HtmlReactPropComponentMap = Record<string, ComponentType<any>>
+type HtmlReactNodeComponentMap = Record<string, ComponentType<any>>
 
 interface HtmlToReactOptions {
+  ctx?: RenderContext
+  keyPrefix?: string
+  nodeComponents?: HtmlReactNodeComponentMap
   propComponents?: HtmlReactPropComponentMap
+  renderNode?: RenderNodeFn
 }
 
 function normalizeCssPropName(prop: string) {
@@ -110,6 +117,23 @@ function shouldUseHtmlPropContract(
   return Boolean(options.propComponents?.[tagName] || options.propComponents?.[tagName.toLowerCase()])
 }
 
+function getNodeComponent(
+  tagName: string,
+  options: HtmlToReactOptions,
+) {
+  return options.nodeComponents?.[tagName] || options.nodeComponents?.[tagName.toLowerCase()]
+}
+
+function getTextContent(children: ReactNode[]) {
+  return children
+    .map(child => typeof child === 'string' || typeof child === 'number' ? String(child) : '')
+    .join('')
+}
+
+function attrsToTokenPairs(attrs: Record<string, string>) {
+  return Object.entries(attrs).map(([key, value]) => [key, value === '' ? null : value] as [string, string | null])
+}
+
 function getCustomComponentProps(
   tagName: string,
   attrs: Record<string, string>,
@@ -118,6 +142,31 @@ function getCustomComponentProps(
   return shouldUseHtmlPropContract(tagName, options)
     ? convertHtmlAttrsToProps(attrs)
     : attrs
+}
+
+function renderNodeComponent(
+  tagName: string,
+  attrs: Record<string, string>,
+  children: ReactNode[],
+  key: string,
+  options: HtmlToReactOptions,
+) {
+  const normalizedTag = normalizeCustomHtmlTagName(tagName)
+  const node = {
+    type: normalizedTag,
+    tag: normalizedTag,
+    attrs: attrsToTokenPairs(attrs),
+    content: getTextContent(children),
+    loading: false,
+  } as ParsedNode
+
+  if (options.ctx && options.renderNode)
+    return options.renderNode(node, key, options.ctx)
+
+  const component = getNodeComponent(tagName, options)
+  return component
+    ? React.createElement(component as ComponentType<Record<string, unknown>>, { key, node })
+    : null
 }
 
 export function parseHtmlToReactNodes(
@@ -134,6 +183,7 @@ export function parseHtmlToReactNodes(
   try {
     const tokens = tokenizeHtml(content)
     let autoKeySeed = 0
+    const keyPrefix = options.keyPrefix ?? 'ms-html'
     const stack: Array<{
       tagName: string
       children: ReactNode[]
@@ -155,21 +205,25 @@ export function parseHtmlToReactNodes(
 
       if (token.type === 'self_closing') {
         const customComponent = isCustomHtmlComponent(token.tagName, customComponents)
-        if (BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
+        const nodeComponent = Boolean(getNodeComponent(token.tagName, options))
+        if (BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)))
           continue
-        if (!customComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
+        if (!customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy)) {
           const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
           target.push(renderLiteralTagText(token.tagName, token.attrs, true))
           continue
         }
         const attrs = sanitizeHtmlAttrs(token.attrs || {}, htmlPolicy, token.tagName)
         const explicitKey = (attrs as any).key
-        const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `ms-html-${autoKeySeed++}`
+        const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
         const Comp = customComponent
           ? (customComponents[token.tagName] || customComponents[token.tagName.toLowerCase()])
           : undefined
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
-        if (Comp) {
+        if (nodeComponent) {
+          target.push(renderNodeComponent(token.tagName, attrs, [], elementKey, options))
+        }
+        else if (Comp) {
           const componentProps = getCustomComponentProps(token.tagName, attrs, options)
           target.push(React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...componentProps, key: elementKey }))
         }
@@ -186,13 +240,14 @@ export function parseHtmlToReactNodes(
       if (token.type === 'tag_open') {
         const parentHardBlocked = stack.length > 0 && stack[stack.length - 1].hardBlocked
         const customComponent = isCustomHtmlComponent(token.tagName, customComponents)
+        const nodeComponent = Boolean(getNodeComponent(token.tagName, options))
         stack.push({
           tagName: token.tagName,
           children: [],
           attrs: token.attrs,
-          customComponent,
-          hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
-          softBlocked: !parentHardBlocked && !customComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
+          customComponent: customComponent || nodeComponent,
+          hardBlocked: parentHardBlocked || BLOCKED_TAGS.has(token.tagName.toLowerCase()) || (!customComponent && !nodeComponent && isHtmlTagHardBlocked(token.tagName, htmlPolicy)),
+          softBlocked: !parentHardBlocked && !customComponent && !nodeComponent && isHtmlTagBlocked(token.tagName, htmlPolicy),
         })
         continue
       }
@@ -216,17 +271,25 @@ export function parseHtmlToReactNodes(
 
       const attrs = sanitizeHtmlAttrs(opening.attrs || {}, htmlPolicy, opening.tagName)
       const explicitKey = (attrs as any).key
-      const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `ms-html-${autoKeySeed++}`
+      const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
       const Comp = opening.customComponent
         ? (customComponents[opening.tagName] || customComponents[opening.tagName.toLowerCase()])
         : undefined
-      const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
-        : React.createElement(opening.tagName, {
-            ...normalizeDomAttrs(attrs),
-            key: elementKey,
-            suppressHydrationWarning: true,
-          }, ...opening.children)
+      const nodeComponent = Boolean(getNodeComponent(opening.tagName, options))
+      let element: ReactNode
+      if (nodeComponent) {
+        element = renderNodeComponent(opening.tagName, attrs, opening.children, elementKey, options)
+      }
+      else if (Comp) {
+        element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
+      }
+      else {
+        element = React.createElement(opening.tagName, {
+          ...normalizeDomAttrs(attrs),
+          key: elementKey,
+          suppressHydrationWarning: true,
+        }, ...opening.children)
+      }
 
       if (stack.length > 0)
         stack[stack.length - 1].children.push(element)
@@ -248,17 +311,25 @@ export function parseHtmlToReactNodes(
       }
       const attrs = sanitizeHtmlAttrs(unclosed.attrs || {}, htmlPolicy, unclosed.tagName)
       const explicitKey = (attrs as any).key
-      const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `ms-html-${autoKeySeed++}`
+      const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
       const Comp = unclosed.customComponent
         ? (customComponents[unclosed.tagName] || customComponents[unclosed.tagName.toLowerCase()])
         : undefined
-      const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(unclosed.tagName, attrs, options), key: elementKey }, ...unclosed.children)
-        : React.createElement(unclosed.tagName, {
-            ...normalizeDomAttrs(attrs),
-            key: elementKey,
-            suppressHydrationWarning: true,
-          }, ...unclosed.children)
+      const nodeComponent = Boolean(getNodeComponent(unclosed.tagName, options))
+      let element: ReactNode
+      if (nodeComponent) {
+        element = renderNodeComponent(unclosed.tagName, attrs, unclosed.children, elementKey, options)
+      }
+      else if (Comp) {
+        element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(unclosed.tagName, attrs, options), key: elementKey }, ...unclosed.children)
+      }
+      else {
+        element = React.createElement(unclosed.tagName, {
+          ...normalizeDomAttrs(attrs),
+          key: elementKey,
+          suppressHydrationWarning: true,
+        }, ...unclosed.children)
+      }
       rootNodes.push(element)
     }
 

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -15,6 +15,11 @@ import {
 export type { HtmlToken } from 'stream-markdown-parser'
 
 type HtmlReactComponentMap = Record<string, ComponentType<any>>
+type HtmlReactPropComponentMap = Record<string, ComponentType<any>>
+
+interface HtmlToReactOptions {
+  propComponents?: HtmlReactPropComponentMap
+}
 
 function normalizeCssPropName(prop: string) {
   if (prop.startsWith('--'))
@@ -98,10 +103,28 @@ function pushRenderedNode(target: ReactNode[], rendered: ReactNode | ReactNode[]
     target.push(rendered)
 }
 
+function shouldUseHtmlPropContract(
+  tagName: string,
+  options: HtmlToReactOptions,
+) {
+  return Boolean(options.propComponents?.[tagName] || options.propComponents?.[tagName.toLowerCase()])
+}
+
+function getCustomComponentProps(
+  tagName: string,
+  attrs: Record<string, string>,
+  options: HtmlToReactOptions,
+) {
+  return shouldUseHtmlPropContract(tagName, options)
+    ? convertHtmlAttrsToProps(attrs)
+    : attrs
+}
+
 export function parseHtmlToReactNodes(
   content: string,
   customComponents: HtmlReactComponentMap,
   htmlPolicy: HtmlPolicy = 'safe',
+  options: HtmlToReactOptions = {},
 ): ReactNode[] | null {
   if (!content)
     return []
@@ -147,7 +170,8 @@ export function parseHtmlToReactNodes(
           : undefined
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         if (Comp) {
-          target.push(React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }))
+          const componentProps = getCustomComponentProps(token.tagName, attrs, options)
+          target.push(React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...componentProps, key: elementKey }))
         }
         else {
           target.push(React.createElement(token.tagName, {
@@ -197,7 +221,7 @@ export function parseHtmlToReactNodes(
         ? (customComponents[opening.tagName] || customComponents[opening.tagName.toLowerCase()])
         : undefined
       const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }, ...opening.children)
+        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
         : React.createElement(opening.tagName, {
             ...normalizeDomAttrs(attrs),
             key: elementKey,
@@ -229,7 +253,7 @@ export function parseHtmlToReactNodes(
         ? (customComponents[unclosed.tagName] || customComponents[unclosed.tagName.toLowerCase()])
         : undefined
       const element = Comp
-        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...convertHtmlAttrsToProps(attrs), key: elementKey }, ...unclosed.children)
+        ? React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(unclosed.tagName, attrs, options), key: elementKey }, ...unclosed.children)
         : React.createElement(unclosed.tagName, {
             ...normalizeDomAttrs(attrs),
             key: elementKey,

--- a/packages/markstream-react/src/utils/htmlToReact.ts
+++ b/packages/markstream-react/src/utils/htmlToReact.ts
@@ -156,6 +156,24 @@ function attrsToTokenPairs(attrs: Record<string, string>) {
   return Object.entries(attrs).map(([key, value]) => [key, value === '' ? null : value] as [string, string | null])
 }
 
+interface NodeComponentState {
+  loading: boolean
+  autoClosed: boolean
+}
+
+function getUnclosedNodeState(options: HtmlToReactOptions): NodeComponentState {
+  const sourceNode = options.sourceNode as any
+  const loading = options.ctx?.final === true
+    ? false
+    : options.ctx?.final === false
+      ? true
+      : Boolean(sourceNode?.loading)
+  return {
+    loading,
+    autoClosed: loading || Boolean(sourceNode?.autoClosed),
+  }
+}
+
 function getCustomComponentProps(
   tagName: string,
   attrs: Record<string, string>,
@@ -174,6 +192,7 @@ function renderNodeComponent(
   options: HtmlToReactOptions,
   contentSource?: string,
   rawSource?: string,
+  state: NodeComponentState = getUnclosedNodeState(options),
 ) {
   const normalizedTag = normalizeCustomHtmlTagName(tagName)
   const content = contentSource ?? getTextContent(children)
@@ -183,8 +202,8 @@ function renderNodeComponent(
     attrs: attrsToTokenPairs(attrs),
     content,
     raw: rawSource ?? `${renderLiteralTagText(tagName, attrs)}${content}</${tagName}>`,
-    loading: Boolean((options.sourceNode as any)?.loading),
-    autoClosed: Boolean((options.sourceNode as any)?.autoClosed ?? (options.sourceNode as any)?.loading),
+    loading: state.loading,
+    autoClosed: state.autoClosed,
   } as ParsedNode
 
   if (options.ctx && options.renderNode)
@@ -255,7 +274,10 @@ export function parseHtmlToReactNodes(
           : undefined
         const target = stack.length > 0 ? stack[stack.length - 1].children : rootNodes
         if (nodeComponent) {
-          target.push(renderNodeComponent(token.tagName, rawAttrs, [], elementKey, options, '', rawSource))
+          target.push(renderNodeComponent(token.tagName, rawAttrs, [], elementKey, options, '', rawSource, {
+            loading: false,
+            autoClosed: false,
+          }))
         }
         else if (Comp) {
           const componentProps = getCustomComponentProps(token.tagName, attrs, options)
@@ -289,55 +311,68 @@ export function parseHtmlToReactNodes(
         continue
       }
 
-      const opening = stack.pop()
-      if (!opening || opening.hardBlocked)
+      const closingTag = token.tagName.toLowerCase()
+      let matchedIndex = -1
+      for (let i = stack.length - 1; i >= 0; i--) {
+        if (stack[i].tagName.toLowerCase() === closingTag) {
+          matchedIndex = i
+          break
+        }
+      }
+      if (matchedIndex === -1)
         continue
 
-      const innerSource = opening.sourceParts.join('')
-      const rawSource = `${renderLiteralTagText(opening.tagName, opening.attrs)}${innerSource}</${opening.tagName}>`
-      if (opening.softBlocked) {
-        const rendered = [
-          renderLiteralTagText(opening.tagName, opening.attrs),
-          ...opening.children,
-          `</${opening.tagName}>`,
-        ]
+      while (stack.length > matchedIndex) {
+        const opening = stack.pop()
+        if (!opening)
+          continue
+
+        const innerSource = opening.sourceParts.join('')
+        const rawSource = `${renderLiteralTagText(opening.tagName, opening.attrs)}${innerSource}</${opening.tagName}>`
+        let element: ReactNode | ReactNode[] | null
+        if (opening.hardBlocked) {
+          element = null
+        }
+        else if (opening.softBlocked) {
+          element = [
+            renderLiteralTagText(opening.tagName, opening.attrs),
+            ...opening.children,
+            `</${opening.tagName}>`,
+          ]
+        }
+        else {
+          const attrs = sanitizeHtmlAttrs(opening.attrs || {}, htmlPolicy, opening.tagName)
+          const explicitKey = (attrs as any).key
+          const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
+          const Comp = opening.customComponent
+            ? (customComponents[opening.tagName] || customComponents[opening.tagName.toLowerCase()])
+            : undefined
+          const nodeComponent = Boolean(getNodeComponent(opening.tagName, options))
+          if (nodeComponent) {
+            const state = opening.tagName.toLowerCase() === closingTag
+              ? { loading: false, autoClosed: false }
+              : getUnclosedNodeState(options)
+            element = renderNodeComponent(opening.tagName, opening.attrs || {}, opening.children, elementKey, options, innerSource, rawSource, state)
+          }
+          else if (Comp) {
+            element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
+          }
+          else {
+            element = React.createElement(opening.tagName, {
+              ...normalizeDomAttrs(attrs),
+              key: elementKey,
+              suppressHydrationWarning: true,
+            }, ...opening.children)
+          }
+        }
+
         if (stack.length > 0)
-          pushRenderedNode(stack[stack.length - 1].children, rendered)
+          pushRenderedNode(stack[stack.length - 1].children, element)
         else
-          pushRenderedNode(rootNodes, rendered)
-        if (stack.length > 0)
+          pushRenderedNode(rootNodes, element)
+        if (stack.length > 0 && !opening.hardBlocked)
           stack[stack.length - 1].sourceParts.push(rawSource)
-        continue
       }
-
-      const attrs = sanitizeHtmlAttrs(opening.attrs || {}, htmlPolicy, opening.tagName)
-      const explicitKey = (attrs as any).key
-      const elementKey = explicitKey != null && explicitKey !== '' ? explicitKey : `${keyPrefix}-${autoKeySeed++}`
-      const Comp = opening.customComponent
-        ? (customComponents[opening.tagName] || customComponents[opening.tagName.toLowerCase()])
-        : undefined
-      const nodeComponent = Boolean(getNodeComponent(opening.tagName, options))
-      let element: ReactNode
-      if (nodeComponent) {
-        element = renderNodeComponent(opening.tagName, opening.attrs || {}, opening.children, elementKey, options, innerSource, rawSource)
-      }
-      else if (Comp) {
-        element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(opening.tagName, attrs, options), key: elementKey }, ...opening.children)
-      }
-      else {
-        element = React.createElement(opening.tagName, {
-          ...normalizeDomAttrs(attrs),
-          key: elementKey,
-          suppressHydrationWarning: true,
-        }, ...opening.children)
-      }
-
-      if (stack.length > 0)
-        stack[stack.length - 1].children.push(element)
-      else
-        rootNodes.push(element)
-      if (stack.length > 0)
-        stack[stack.length - 1].sourceParts.push(rawSource)
     }
 
     while (stack.length > 0) {
@@ -365,7 +400,7 @@ export function parseHtmlToReactNodes(
       const nodeComponent = Boolean(getNodeComponent(unclosed.tagName, options))
       let element: ReactNode
       if (nodeComponent) {
-        element = renderNodeComponent(unclosed.tagName, unclosed.attrs || {}, unclosed.children, elementKey, options, innerSource, rawSource)
+        element = renderNodeComponent(unclosed.tagName, unclosed.attrs || {}, unclosed.children, elementKey, options, innerSource, rawSource, getUnclosedNodeState(options))
       }
       else if (Comp) {
         element = React.createElement(Comp as ComponentType<Record<string, unknown>>, { ...getCustomComponentProps(unclosed.tagName, attrs, options), key: elementKey }, ...unclosed.children)

--- a/packages/markstream-react/tsconfig.json
+++ b/packages/markstream-react/tsconfig.json
@@ -14,6 +14,6 @@
     "allowJs": false,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "../../test/react-local-component-maps-types.tsx"],
   "exclude": ["dist", "node_modules"]
 }

--- a/playground-next14/app/direct-maps/page.tsx
+++ b/playground-next14/app/direct-maps/page.tsx
@@ -1,0 +1,15 @@
+import { DirectMapsClient } from '../../src/direct-maps-client'
+
+const content = [
+  '<DocumentLink id="app-router">Streaming Map</DocumentLink>',
+  '',
+  '<badge tone="warm">HTML Map</badge>',
+].join('\n')
+
+export default function DirectMapsPage() {
+  return (
+    <main data-next-direct-map="page">
+      <DirectMapsClient content={content} />
+    </main>
+  )
+}

--- a/playground-next14/src/direct-maps-client.tsx
+++ b/playground-next14/src/direct-maps-client.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import type { NodeComponentProps } from 'markstream-react/next'
+import { defineHtmlComponents, defineStreamingComponents, NodeRenderer } from 'markstream-react/next'
+import React from 'react'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string | null][]
+  content: string
+}
+
+function readAttr(node: DocumentLinkNode, name: string) {
+  return node.attrs?.find(([key]) => key === name)?.[1] ?? undefined
+}
+
+function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+  return (
+    <span
+      data-next-direct-map="streaming"
+      data-next-direct-map-id={readAttr(props.node, 'id')}
+    >
+      {props.node.content}
+    </span>
+  )
+}
+
+function Badge(props: React.PropsWithChildren<{ tone?: string }>) {
+  return (
+    <span
+      data-next-direct-map="html"
+      data-next-direct-map-tone={props.tone}
+    >
+      {props.children}
+    </span>
+  )
+}
+
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+const htmlComponents = defineHtmlComponents({
+  badge: Badge,
+})
+
+export function DirectMapsClient({ content }: { content: string }) {
+  return (
+    <NodeRenderer
+      content={content}
+      final
+      htmlComponents={htmlComponents}
+      smoothStreaming={false}
+      streamingComponents={streamingComponents}
+    />
+  )
+}

--- a/playground-next15/app/direct-maps/page.tsx
+++ b/playground-next15/app/direct-maps/page.tsx
@@ -1,0 +1,15 @@
+import { DirectMapsClient } from '../../src/direct-maps-client'
+
+const content = [
+  '<DocumentLink id="app-router">Streaming Map</DocumentLink>',
+  '',
+  '<badge tone="warm">HTML Map</badge>',
+].join('\n')
+
+export default function DirectMapsPage() {
+  return (
+    <main data-next-direct-map="page">
+      <DirectMapsClient content={content} />
+    </main>
+  )
+}

--- a/playground-next15/src/direct-maps-client.tsx
+++ b/playground-next15/src/direct-maps-client.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import type { NodeComponentProps } from 'markstream-react/next'
+import { defineHtmlComponents, defineStreamingComponents, NodeRenderer } from 'markstream-react/next'
+import React from 'react'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string | null][]
+  content: string
+}
+
+function readAttr(node: DocumentLinkNode, name: string) {
+  return node.attrs?.find(([key]) => key === name)?.[1] ?? undefined
+}
+
+function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+  return (
+    <span
+      data-next-direct-map="streaming"
+      data-next-direct-map-id={readAttr(props.node, 'id')}
+    >
+      {props.node.content}
+    </span>
+  )
+}
+
+function Badge(props: React.PropsWithChildren<{ tone?: string }>) {
+  return (
+    <span
+      data-next-direct-map="html"
+      data-next-direct-map-tone={props.tone}
+    >
+      {props.children}
+    </span>
+  )
+}
+
+const streamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+const htmlComponents = defineHtmlComponents({
+  badge: Badge,
+})
+
+export function DirectMapsClient({ content }: { content: string }) {
+  return (
+    <NodeRenderer
+      content={content}
+      final
+      htmlComponents={htmlComponents}
+      smoothStreaming={false}
+      streamingComponents={streamingComponents}
+    />
+  )
+}

--- a/scripts/e2e-next-ssr.mjs
+++ b/scripts/e2e-next-ssr.mjs
@@ -316,6 +316,16 @@ function assertRawHtml(html, version, router) {
     assertIncludes(html, `data-ssr-export="${name}"`, `${name} export marker`)
 }
 
+function assertDirectMapsHtml(html) {
+  assertIncludes(html, 'data-next-direct-map="page"', 'direct map page')
+  assertIncludes(html, 'data-next-direct-map="streaming"', 'direct streaming map')
+  assertIncludes(html, 'data-next-direct-map-id="app-router"', 'direct streaming attrs')
+  assertIncludes(html, 'Streaming Map', 'direct streaming text')
+  assertIncludes(html, 'data-next-direct-map="html"', 'direct html map')
+  assertIncludes(html, 'data-next-direct-map-tone="warm"', 'direct html attrs')
+  assertIncludes(html, 'HTML Map', 'direct html text')
+}
+
 async function waitForHydration(page, route) {
   await page.goto(route, { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('[data-ssr-case="hydration"][data-ssr-entry="next"][data-ssr-status="enhanced"]', { timeout: 90000 })
@@ -404,6 +414,10 @@ async function runBrowserChecks(baseUrl) {
     await waitForHydration(page, pagesRoute)
     await assertHydratedUi(page)
 
+    await page.goto(`${baseUrl}/direct-maps`, { waitUntil: 'domcontentloaded' })
+    await page.waitForSelector('[data-next-direct-map="streaming"][data-next-direct-map-id="app-router"]', { timeout: 90000 })
+    await page.waitForSelector('[data-next-direct-map="html"][data-next-direct-map-tone="warm"]', { timeout: 90000 })
+
     await waitForHydration(page, appRoute)
     await assertHydratedUi(page)
 
@@ -429,8 +443,10 @@ async function runMode({ playgroundDir, version, mode }) {
 
     const appHtml = await fetchText(`${baseUrl}/app-ssr-lab`)
     const pagesHtml = await fetchText(`${baseUrl}/pages-ssr-lab`)
+    const directMapsHtml = await fetchText(`${baseUrl}/direct-maps`)
     assertRawHtml(appHtml, version, 'app')
     assertRawHtml(pagesHtml, version, 'pages')
+    assertDirectMapsHtml(directMapsHtml)
     await runBrowserChecks(baseUrl)
   }
   catch (error) {

--- a/test/react-local-component-maps-types.tsconfig.json
+++ b/test/react-local-component-maps-types.tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../packages/markstream-react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "noEmit": true,
+    "strict": true,
+    "paths": {
+      "markstream-core": ["packages/markstream-core/src/index.ts"],
+      "markstream-core/*": ["packages/markstream-core/src/*"],
+      "stream-markdown-parser": ["test/stream-markdown-parser-type-shim.d.ts"]
+    }
+  },
+  "include": [
+    "./react-local-component-maps-types.tsx",
+    "./stream-markdown-parser-type-shim.d.ts"
+  ]
+}

--- a/test/react-local-component-maps-types.tsx
+++ b/test/react-local-component-maps-types.tsx
@@ -1,13 +1,14 @@
 import type React from 'react'
 import type {
   HtmlComponentMap,
-  NodeComponentProps,
   StreamingComponentMap,
-} from '../packages/markstream-react/src'
+} from '../packages/markstream-react/src/customComponents'
+import type { NodeRendererProps } from '../packages/markstream-react/src/types'
+import type { NodeComponentProps } from '../packages/markstream-react/src/types/node-component'
 import {
   defineHtmlComponents,
   defineStreamingComponents,
-} from '../packages/markstream-react/src'
+} from '../packages/markstream-react/src/customComponents'
 
 interface DocumentLinkNode {
   type: 'documentlink'
@@ -25,17 +26,19 @@ function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
   return <span data-kind={kind}>{children}</span>
 }
 
+declare const NodeRenderer: React.ComponentType<NodeRendererProps>
+
+function RequiredLink({ url, children }: React.PropsWithChildren<{ url: string }>) {
+  return <a href={url}>{children}</a>
+}
+
 const streamingComponents = {
   documentlink: DocumentLink,
 } satisfies StreamingComponentMap
 
 const htmlComponents = {
   badge: Badge,
-} satisfies HtmlComponentMap
-
-const wrongHtmlComponents = {
-  // @ts-expect-error html component maps must not require parser-backed props.node.
-  documentlink: DocumentLink,
+  requiredlink: RequiredLink,
 } satisfies HtmlComponentMap
 
 const definedStreamingComponents = defineStreamingComponents({
@@ -44,6 +47,7 @@ const definedStreamingComponents = defineStreamingComponents({
 
 const definedHtmlComponents = defineHtmlComponents({
   badge: Badge,
+  requiredlink: RequiredLink,
 })
 
 defineStreamingComponents({
@@ -56,8 +60,17 @@ defineHtmlComponents({
   documentlink: DocumentLink,
 })
 
+const rendererElement = (
+  <NodeRenderer
+    content="<DocumentLink>typed</DocumentLink>"
+    final
+    htmlComponents={htmlComponents}
+    streamingComponents={streamingComponents}
+  />
+)
+
 void streamingComponents
 void htmlComponents
-void wrongHtmlComponents
 void definedStreamingComponents
 void definedHtmlComponents
+void rendererElement

--- a/test/react-local-component-maps-types.tsx
+++ b/test/react-local-component-maps-types.tsx
@@ -1,0 +1,33 @@
+import type React from 'react'
+import type {
+  HtmlComponentMap,
+  NodeComponentProps,
+  StreamingComponentMap,
+} from '../packages/markstream-react/src'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string][]
+  content: string
+  loading?: boolean
+}
+
+function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+  return <span>{props.node.content}</span>
+}
+
+function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
+  return <span data-kind={kind}>{children}</span>
+}
+
+const streamingComponents = {
+  documentlink: DocumentLink,
+} satisfies StreamingComponentMap
+
+const htmlComponents = {
+  badge: Badge,
+} satisfies HtmlComponentMap
+
+void streamingComponents
+void htmlComponents

--- a/test/react-local-component-maps-types.tsx
+++ b/test/react-local-component-maps-types.tsx
@@ -30,6 +30,10 @@ function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
   return <span data-kind={kind}>{children}</span>
 }
 
+function TreeNode({ node, children }: React.PropsWithChildren<{ node: string }>) {
+  return <span data-node={node}>{children}</span>
+}
+
 declare function NodeRenderer<
   TStreamingComponents extends StreamingComponentMap = StreamingComponentMap,
   THtmlComponents extends Record<string, any> = HtmlComponentMap,
@@ -44,8 +48,9 @@ const streamingComponents = {
 } satisfies StreamingComponentMap
 
 const htmlComponents = {
-  badge: Badge,
-  requiredlink: RequiredLink,
+  'badge': Badge,
+  'requiredlink': RequiredLink,
+  'tree-node': TreeNode,
 } satisfies HtmlComponentMap
 
 const definedStreamingComponents = defineStreamingComponents({
@@ -53,8 +58,9 @@ const definedStreamingComponents = defineStreamingComponents({
 })
 
 const definedHtmlComponents = defineHtmlComponents({
-  badge: Badge,
-  requiredlink: RequiredLink,
+  'badge': Badge,
+  'requiredlink': RequiredLink,
+  'tree-node': TreeNode,
 })
 
 defineStreamingComponents({

--- a/test/react-local-component-maps-types.tsx
+++ b/test/react-local-component-maps-types.tsx
@@ -22,11 +22,18 @@ function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
   return <span>{props.node.content}</span>
 }
 
+function TenantDocumentLink(props: NodeComponentProps<DocumentLinkNode> & { tenantId: string }) {
+  return <span data-tenant-id={props.tenantId}>{props.node.content}</span>
+}
+
 function Badge({ kind, children }: React.PropsWithChildren<{ kind?: string }>) {
   return <span data-kind={kind}>{children}</span>
 }
 
-declare const NodeRenderer: React.ComponentType<NodeRendererProps>
+declare function NodeRenderer<
+  TStreamingComponents extends StreamingComponentMap = StreamingComponentMap,
+  THtmlComponents extends Record<string, any> = HtmlComponentMap,
+>(props: NodeRendererProps<TStreamingComponents, THtmlComponents>): React.ReactElement | null
 
 function RequiredLink({ url, children }: React.PropsWithChildren<{ url: string }>) {
   return <a href={url}>{children}</a>
@@ -55,6 +62,11 @@ defineStreamingComponents({
   badge: Badge,
 })
 
+defineStreamingComponents({
+  // @ts-expect-error streamingComponents cannot require props the renderer never supplies.
+  documentlink: TenantDocumentLink,
+})
+
 defineHtmlComponents({
   // @ts-expect-error htmlComponents must not require parser-backed props.node.
   documentlink: DocumentLink,
@@ -69,8 +81,32 @@ const rendererElement = (
   />
 )
 
+const wrongHtmlRendererElement = (
+  <NodeRenderer
+    content="<DocumentLink>typed</DocumentLink>"
+    final
+    htmlComponents={{
+      // @ts-expect-error htmlComponents must not receive parser-backed NodeComponentProps.
+      documentlink: DocumentLink,
+    }}
+  />
+)
+
+const wrongStreamingRendererElement = (
+  <NodeRenderer
+    content="<DocumentLink>typed</DocumentLink>"
+    final
+    streamingComponents={{
+      // @ts-expect-error streamingComponents cannot require props the renderer never supplies.
+      documentlink: TenantDocumentLink,
+    }}
+  />
+)
+
 void streamingComponents
 void htmlComponents
 void definedStreamingComponents
 void definedHtmlComponents
 void rendererElement
+void wrongHtmlRendererElement
+void wrongStreamingRendererElement

--- a/test/react-local-component-maps-types.tsx
+++ b/test/react-local-component-maps-types.tsx
@@ -4,6 +4,10 @@ import type {
   NodeComponentProps,
   StreamingComponentMap,
 } from '../packages/markstream-react/src'
+import {
+  defineHtmlComponents,
+  defineStreamingComponents,
+} from '../packages/markstream-react/src'
 
 interface DocumentLinkNode {
   type: 'documentlink'
@@ -29,5 +33,31 @@ const htmlComponents = {
   badge: Badge,
 } satisfies HtmlComponentMap
 
+const wrongHtmlComponents = {
+  // @ts-expect-error html component maps must not require parser-backed props.node.
+  documentlink: DocumentLink,
+} satisfies HtmlComponentMap
+
+const definedStreamingComponents = defineStreamingComponents({
+  documentlink: DocumentLink,
+})
+
+const definedHtmlComponents = defineHtmlComponents({
+  badge: Badge,
+})
+
+defineStreamingComponents({
+  // @ts-expect-error streamingComponents require parser-backed NodeComponentProps.
+  badge: Badge,
+})
+
+defineHtmlComponents({
+  // @ts-expect-error htmlComponents must not require parser-backed props.node.
+  documentlink: DocumentLink,
+})
+
 void streamingComponents
 void htmlComponents
+void wrongHtmlComponents
+void definedStreamingComponents
+void definedHtmlComponents

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -117,6 +117,47 @@ describe('react local component maps', () => {
     await unmountRoot(root)
   })
 
+  it('updates streaming component loading when only final changes', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return (
+        <span data-loading={String(props.node.loading)}>
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const content = '<DocumentLink id="123">partial'
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final={false}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-loading="true"]')?.textContent).toBe('partial')
+    expect(seen.at(-1)?.node.loading).toBe(true)
+
+    await updateRoot(
+      root,
+      <NodeRenderer
+        content={content}
+        final
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-loading="false"]')?.textContent).toBe('partial')
+    expect(seen.at(-1)?.node.loading).toBe(false)
+
+    await unmountRoot(root)
+  })
+
   it('renders html components with normal props and children without registry', async () => {
     const seen: Array<React.PropsWithChildren<{ kind?: string, node?: unknown }>> = []
     function Badge(props: React.PropsWithChildren<{ kind?: string, node?: unknown }>) {
@@ -614,6 +655,53 @@ describe('react local component maps', () => {
     expect(seen.at(-1)?.node.autoClosed).toBe(true)
   })
 
+  it('keeps closed nested streamingComponents non-loading when the html wrapper is still streaming', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return (
+        <span
+          data-closed-nested-loading={String(props.node.loading)}
+          data-closed-nested-auto-closed={String(props.node.autoClosed)}
+        >
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const content = '<span><DocumentLink id="1">complete</DocumentLink>still streaming'
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final={false}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-closed-nested-loading="false"]')?.textContent).toBe('complete')
+    expect(host.querySelector('[data-closed-nested-auto-closed="false"]')?.textContent).toBe('complete')
+    expect(seen.at(-1)?.node.loading).toBe(false)
+    expect(seen.at(-1)?.node.autoClosed).toBe(false)
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final={false}
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-closed-nested-loading="false"]')?.textContent).toBe('complete')
+    expect(ssrHost.querySelector('[data-closed-nested-auto-closed="false"]')?.textContent).toBe('complete')
+    expect(seen.at(-1)?.node.loading).toBe(false)
+    expect(seen.at(-1)?.node.autoClosed).toBe(false)
+  })
+
   it('preserves structured children for streamingComponents nested inside html wrappers', async () => {
     const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
     function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
@@ -727,7 +815,7 @@ describe('react local component maps', () => {
     expect(getAttr(rawSeen?.node.attrs, 'style')).toBe('color:red')
     expect(getAttr(rawSeen?.node.attrs, 'href')).toBe('javascript:alert(1)')
     expect(rawSeen?.node.content).toBe('Hello <strong>world</strong>')
-    expect(rawSeen?.node.loading).toBe(true)
+    expect(rawSeen?.node.loading).toBe(false)
     expect(structuredSeen?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
 
     await unmountRoot(root)
@@ -747,7 +835,7 @@ describe('react local component maps', () => {
     expect(getAttr(ssrRawSeen?.node.attrs, 'style')).toBe('color:red')
     expect(getAttr(ssrRawSeen?.node.attrs, 'href')).toBe('javascript:alert(1)')
     expect(ssrRawSeen?.node.content).toBe('Hello <strong>world</strong>')
-    expect(ssrRawSeen?.node.loading).toBe(true)
+    expect(ssrRawSeen?.node.loading).toBe(false)
     expect(ssrStructuredSeen?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
   })
 

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -805,6 +805,69 @@ describe('react local component maps', () => {
     expect(seen.at(-1)?.node.autoClosed).toBe(false)
   })
 
+  it('updates nested streamingComponents loading when pre-parsed html node state changes without content changes', async () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return (
+        <span
+          data-preparsed-loading-id={getAttr(props.node.attrs, 'id') ?? ''}
+          data-preparsed-loading={String(props.node.loading)}
+          data-preparsed-auto-closed={String(props.node.autoClosed)}
+        >
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const nodes = [
+      {
+        type: 'html_inline',
+        content: '<span><DocumentLink id="inline">partial',
+        loading: true,
+      },
+      {
+        type: 'html_block',
+        content: '<span><DocumentLink id="block">partial',
+        loading: true,
+      },
+    ] as any[]
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        nodes={nodes}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+        viewportPriority={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-preparsed-loading-id="inline"]')?.getAttribute('data-preparsed-loading')).toBe('true')
+    expect(host.querySelector('[data-preparsed-loading-id="block"]')?.getAttribute('data-preparsed-loading')).toBe('true')
+
+    nodes[0] = { ...nodes[0], autoClosed: false, loading: false }
+    nodes[1] = { ...nodes[1], autoClosed: false, loading: false }
+
+    await updateRoot(
+      root,
+      <NodeRenderer
+        // Re-clone the same nodes array without changing renderCtx, so this exercises HtmlInlineNode/HtmlBlockNode memo deps.
+        debugPerformance
+        nodes={nodes}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+        viewportPriority={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-preparsed-loading-id="inline"]')?.getAttribute('data-preparsed-loading')).toBe('false')
+    expect(host.querySelector('[data-preparsed-loading-id="inline"]')?.getAttribute('data-preparsed-auto-closed')).toBe('false')
+    expect(host.querySelector('[data-preparsed-loading-id="block"]')?.getAttribute('data-preparsed-loading')).toBe('false')
+    expect(host.querySelector('[data-preparsed-loading-id="block"]')?.getAttribute('data-preparsed-auto-closed')).toBe('false')
+
+    await unmountRoot(root)
+  })
+
   it('preserves structured children for streamingComponents nested inside html wrappers', async () => {
     const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
     function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -16,7 +16,9 @@ interface DocumentLinkNode {
   tag: 'documentlink'
   attrs?: [string, string | null][]
   content: string
+  children?: any[]
   loading?: boolean
+  autoClosed?: boolean
 }
 
 function getAttr(attrs: [string, string | null][] | undefined, name: string) {
@@ -563,6 +565,109 @@ describe('react local component maps', () => {
       ['1', 'InlineNested'],
       ['2', 'BlockNested'],
     ])
+  })
+
+  it('preserves loading metadata for streamingComponents nested inside structured html wrappers', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return (
+        <span
+          data-nested-loading={String(props.node.loading)}
+          data-nested-auto-closed={String(props.node.autoClosed)}
+        >
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const content = '<span><DocumentLink id="1">partial'
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final={false}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-nested-loading="true"]')?.textContent).toBe('partial')
+    expect(host.querySelector('[data-nested-auto-closed="true"]')?.textContent).toBe('partial')
+    expect(seen.at(-1)?.node.loading).toBe(true)
+    expect(seen.at(-1)?.node.autoClosed).toBe(true)
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final={false}
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-nested-loading="true"]')?.textContent).toBe('partial')
+    expect(ssrHost.querySelector('[data-nested-auto-closed="true"]')?.textContent).toBe('partial')
+    expect(seen.at(-1)?.node.loading).toBe(true)
+    expect(seen.at(-1)?.node.autoClosed).toBe(true)
+  })
+
+  it('preserves structured children for streamingComponents nested inside html wrappers', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return (
+        <span
+          data-nested-id={getAttr(props.node.attrs, 'id') ?? ''}
+          data-nested-content={props.node.content}
+          data-nested-child-types={props.node.children?.map(child => child.type).join(',') ?? ''}
+        >
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const content = [
+      '<span><DocumentLink id="inline">Hello <strong>world</strong></DocumentLink></span>',
+      '',
+      '<div>',
+      '',
+      '<DocumentLink id="block">Block <strong>world</strong></DocumentLink>',
+      '',
+      '</div>',
+    ].join('\n')
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-nested-id="inline"]')?.getAttribute('data-nested-content')).toBe('Hello <strong>world</strong>')
+    expect(host.querySelector('[data-nested-id="block"]')?.getAttribute('data-nested-content')).toBe('Block <strong>world</strong>')
+    expect(seen.find(props => getAttr(props.node.attrs, 'id') === 'inline')?.node.content).toBe('Hello <strong>world</strong>')
+    expect(seen.find(props => getAttr(props.node.attrs, 'id') === 'block')?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-nested-id="inline"]')?.getAttribute('data-nested-content')).toBe('Hello <strong>world</strong>')
+    expect(ssrHost.querySelector('[data-nested-id="block"]')?.getAttribute('data-nested-content')).toBe('Block <strong>world</strong>')
+    expect(seen.find(props => getAttr(props.node.attrs, 'id') === 'inline')?.node.content).toBe('Hello <strong>world</strong>')
+    expect(seen.find(props => getAttr(props.node.attrs, 'id') === 'block')?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
   })
 
   it('keeps legacy custom component html attr contracts per render path', async () => {

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -608,6 +608,78 @@ describe('react local component maps', () => {
     ])
   })
 
+  it('passes renderer context props to streamingComponents nested inside inline html wrappers on client and server', async () => {
+    const seen: Array<{
+      customId?: string
+      fade?: boolean
+      hasCtx: boolean
+      hasRenderNode: boolean
+      indexKey?: unknown
+      isDark?: boolean
+      typewriter?: boolean
+    }> = []
+
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push({
+        customId: props.customId,
+        fade: props.fade,
+        hasCtx: Boolean(props.ctx),
+        hasRenderNode: Boolean(props.renderNode),
+        indexKey: props.indexKey,
+        isDark: props.isDark,
+        typewriter: props.typewriter,
+      })
+      return <span data-inline-context>{props.node.content}</span>
+    }
+
+    const content = '<span><DocumentLink id="1">Inline</DocumentLink></span>'
+    const streamingComponents = { documentlink: DocumentLink }
+    const expected = {
+      customId: 'chat',
+      fade: false,
+      hasCtx: true,
+      hasRenderNode: true,
+      isDark: true,
+      typewriter: true,
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        customId="chat"
+        fade={false}
+        final
+        isDark
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+        typewriter
+      />,
+    )
+
+    expect(host.querySelector('[data-inline-context]')?.textContent).toBe('Inline')
+    expect(seen.at(-1)).toMatchObject(expected)
+    expect(seen.at(-1)?.indexKey).not.toBeUndefined()
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        customId="chat"
+        fade={false}
+        final
+        isDark
+        streamingComponents={streamingComponents}
+        typewriter
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-inline-context]')?.textContent).toBe('Inline')
+    expect(seen.at(-1)).toMatchObject(expected)
+    expect(seen.at(-1)?.indexKey).not.toBeUndefined()
+  })
+
   it('preserves loading metadata for streamingComponents nested inside structured html wrappers', async () => {
     const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
     function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -670,6 +670,87 @@ describe('react local component maps', () => {
     expect(seen.find(props => getAttr(props.node.attrs, 'id') === 'block')?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
   })
 
+  it('preserves raw attrs and source for streamingComponents nested inside pre-parsed html nodes', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return (
+        <span
+          data-preparsed-streaming={getAttr(props.node.attrs, 'id') ?? ''}
+          data-preparsed-content={props.node.content}
+        >
+          {props.node.content}
+        </span>
+      )
+    }
+
+    const inlineNode = {
+      type: 'html_inline',
+      content: '<span><DocumentLink id="raw" style="color:red" href="javascript:alert(1)">Hello <strong>world</strong></DocumentLink></span>',
+      loading: true,
+    } as any
+    const structuredBlockNode = {
+      type: 'html_block',
+      tag: 'div',
+      content: '<div><DocumentLink id="structured">Structured <strong>world</strong></DocumentLink></div>',
+      children: [
+        {
+          type: 'documentlink',
+          tag: 'documentlink',
+          attrs: [['id', 'structured']],
+          content: 'Structured <strong>world</strong>',
+          children: [
+            { type: 'text', content: 'Structured ' },
+            {
+              type: 'html_inline',
+              tag: 'strong',
+              content: '<strong>world</strong>',
+              children: [{ type: 'text', content: 'world' }],
+            },
+          ],
+        },
+      ],
+    } as any
+    const streamingComponents = { documentlink: DocumentLink }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        final={false}
+        nodes={[inlineNode, structuredBlockNode]}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    const rawSeen = seen.find(props => getAttr(props.node.attrs, 'id') === 'raw')
+    const structuredSeen = seen.find(props => getAttr(props.node.attrs, 'id') === 'structured')
+    expect(host.querySelector('[data-preparsed-streaming="raw"]')?.getAttribute('data-preparsed-content')).toBe('Hello <strong>world</strong>')
+    expect(getAttr(rawSeen?.node.attrs, 'style')).toBe('color:red')
+    expect(getAttr(rawSeen?.node.attrs, 'href')).toBe('javascript:alert(1)')
+    expect(rawSeen?.node.content).toBe('Hello <strong>world</strong>')
+    expect(rawSeen?.node.loading).toBe(true)
+    expect(structuredSeen?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        final={false}
+        nodes={[inlineNode, structuredBlockNode]}
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    const ssrRawSeen = seen.find(props => getAttr(props.node.attrs, 'id') === 'raw')
+    const ssrStructuredSeen = seen.find(props => getAttr(props.node.attrs, 'id') === 'structured')
+    expect(ssrHost.querySelector('[data-preparsed-streaming="raw"]')?.getAttribute('data-preparsed-content')).toBe('Hello <strong>world</strong>')
+    expect(getAttr(ssrRawSeen?.node.attrs, 'style')).toBe('color:red')
+    expect(getAttr(ssrRawSeen?.node.attrs, 'href')).toBe('javascript:alert(1)')
+    expect(ssrRawSeen?.node.content).toBe('Hello <strong>world</strong>')
+    expect(ssrRawSeen?.node.loading).toBe(true)
+    expect(ssrStructuredSeen?.node.children?.map(child => child.type)).toEqual(['text', 'html_inline'])
+  })
+
   it('keeps legacy custom component html attr contracts per render path', async () => {
     const scopeId = 'react-local-component-legacy-attrs'
     const seen: Array<{ width?: unknown, disabled?: unknown }> = []

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -508,6 +508,63 @@ describe('react local component maps', () => {
     await unmountRoot(root)
   })
 
+  it('renders streamingComponents nested inside standard html wrappers on client and server', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return <span data-nested-streaming={getAttr(props.node.attrs, 'id') ?? ''}>{props.node.content}</span>
+    }
+    function HtmlDocumentLink(props: React.PropsWithChildren<{ id?: string }>) {
+      return <span data-nested-html={props.id}>{props.children}</span>
+    }
+
+    const content = [
+      '<span><DocumentLink id="1">InlineNested</DocumentLink></span>',
+      '',
+      '<div><DocumentLink id="2">BlockNested</DocumentLink></div>',
+    ].join('\n')
+    const streamingComponents = { documentlink: DocumentLink }
+    const htmlComponents = { documentlink: HtmlDocumentLink }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('[data-nested-streaming="1"]')?.textContent).toBe('InlineNested')
+    expect(host.querySelector('[data-nested-streaming="2"]')?.textContent).toBe('BlockNested')
+    expect(host.querySelector('[data-nested-html]')).toBeNull()
+    expect(seen.map(props => [getAttr(props.node.attrs, 'id'), props.node.content])).toEqual([
+      ['1', 'InlineNested'],
+      ['2', 'BlockNested'],
+    ])
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-nested-streaming="1"]')?.textContent).toBe('InlineNested')
+    expect(ssrHost.querySelector('[data-nested-streaming="2"]')?.textContent).toBe('BlockNested')
+    expect(ssrHost.querySelector('[data-nested-html]')).toBeNull()
+    expect(seen.map(props => [getAttr(props.node.attrs, 'id'), props.node.content])).toEqual([
+      ['1', 'InlineNested'],
+      ['2', 'BlockNested'],
+    ])
+  })
+
   it('keeps legacy custom component html attr contracts per render path', async () => {
     const scopeId = 'react-local-component-legacy-attrs'
     const seen: Array<{ width?: unknown, disabled?: unknown }> = []

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { NodeComponentProps } from '../packages/markstream-react/src/types/node-component'
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../packages/markstream-react/src/customComponents'
+import { NodeRenderer as ServerNodeRenderer } from '../packages/markstream-react/src/server-renderer'
+
+interface DocumentLinkNode {
+  type: 'documentlink'
+  tag: 'documentlink'
+  attrs?: [string, string | null][]
+  content: string
+  loading?: boolean
+}
+
+function getAttr(attrs: [string, string | null][] | undefined, name: string) {
+  return attrs?.find(([key]) => key === name)?.[1]
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderIntoRoot(element: React.ReactElement) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  await act(async () => {
+    root.render(element)
+  })
+  await flushReact()
+  return { host, root }
+}
+
+async function updateRoot(root: ReturnType<typeof createRoot>, element: React.ReactElement) {
+  await act(async () => {
+    root.render(element)
+  })
+  await flushReact()
+}
+
+async function unmountRoot(root: ReturnType<typeof createRoot>) {
+  await act(async () => {
+    root.unmount()
+  })
+}
+
+describe('react local component maps', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+    ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = false
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders parser-backed streaming components without registry', async () => {
+    const seen: Array<NodeComponentProps<DocumentLinkNode>> = []
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      seen.push(props)
+      return <span data-document-link={getAttr(props.node.attrs, 'id') ?? ''}>{props.node.content}</span>
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={'<DocumentLink id="123">Rasmus'}
+        final={false}
+        smoothStreaming={false}
+        streamingComponents={{ documentlink: DocumentLink }}
+      />,
+    )
+
+    expect(host.querySelector('[data-document-link="123"]')?.textContent).toBe('Rasmus')
+    expect(getAttr(seen.at(-1)?.node.attrs, 'id')).toBe('123')
+    expect(seen.at(-1)?.node.content).toBe('Rasmus')
+    expect(seen.at(-1)?.node.loading).toBe(true)
+
+    await updateRoot(
+      root,
+      <NodeRenderer
+        content={'<DocumentLink id="123">Rasmus Schultz</DocumentLink>'}
+        final
+        smoothStreaming={false}
+        streamingComponents={{ documentlink: DocumentLink }}
+      />,
+    )
+
+    expect(host.querySelector('[data-document-link="123"]')?.textContent).toBe('Rasmus Schultz')
+    expect(seen.at(-1)?.node.content).toBe('Rasmus Schultz')
+    expect(seen.at(-1)?.node.loading).toBe(false)
+
+    await unmountRoot(root)
+  })
+
+  it('renders html components with normal props and children without registry', async () => {
+    const seen: Array<React.PropsWithChildren<{ kind?: string, node?: unknown }>> = []
+    function Badge(props: React.PropsWithChildren<{ kind?: string, node?: unknown }>) {
+      seen.push(props)
+      return <span data-badge-kind={props.kind}>{props.children}</span>
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={'<badge kind="info">Stable</badge>'}
+        final
+        smoothStreaming={false}
+        htmlComponents={{ badge: Badge }}
+      />,
+    )
+
+    expect(host.querySelector('[data-badge-kind="info"]')?.textContent).toBe('Stable')
+    expect(seen.at(-1)?.kind).toBe('info')
+    expect(seen.at(-1)?.children).toBe('Stable')
+    expect('node' in (seen.at(-1) ?? {})).toBe(false)
+
+    await unmountRoot(root)
+  })
+
+  it('keeps same-tag streaming components isolated per renderer instance', async () => {
+    function FirstDocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-owner="first">{props.node.content}</span>
+    }
+    function SecondDocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-owner="second">{props.node.content}</span>
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <div>
+        <NodeRenderer
+          content="<DocumentLink>One</DocumentLink>"
+          final
+          smoothStreaming={false}
+          streamingComponents={{ documentlink: FirstDocumentLink }}
+        />
+        <NodeRenderer
+          content="<DocumentLink>Two</DocumentLink>"
+          final
+          smoothStreaming={false}
+          streamingComponents={{ documentlink: SecondDocumentLink }}
+        />
+      </div>,
+    )
+
+    expect(host.querySelector('[data-owner="first"]')?.textContent).toBe('One')
+    expect(host.querySelector('[data-owner="second"]')?.textContent).toBe('Two')
+
+    await unmountRoot(root)
+  })
+
+  it('prefers streamingComponents over the legacy scoped registry', async () => {
+    const scopeId = 'react-local-component-precedence'
+    function LegacyDocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-source="legacy">{props.node.content}</span>
+    }
+    function DirectDocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-source="direct">{props.node.content}</span>
+    }
+
+    setCustomComponents(scopeId, { documentlink: LegacyDocumentLink })
+    try {
+      const { host, root } = await renderIntoRoot(
+        <NodeRenderer
+          customId={scopeId}
+          content="<DocumentLink>Direct</DocumentLink>"
+          final
+          smoothStreaming={false}
+          streamingComponents={{ documentlink: DirectDocumentLink }}
+        />,
+      )
+
+      expect(host.querySelector('[data-source="direct"]')?.textContent).toBe('Direct')
+      expect(host.querySelector('[data-source="legacy"]')).toBeNull()
+
+      await unmountRoot(root)
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('warns once and selects streamingComponents when both maps use the same tag', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    function StreamingConflict(props: NodeComponentProps<{ content: string }>) {
+      return <span data-contract="streaming">{props.node.content}</span>
+    }
+    function HtmlConflict(props: React.PropsWithChildren) {
+      return <span data-contract="html">{props.children}</span>
+    }
+
+    const element = (
+      <NodeRenderer
+        content="<ConflictTag>Conflict</ConflictTag>"
+        final
+        smoothStreaming={false}
+        streamingComponents={{ conflicttag: StreamingConflict }}
+        htmlComponents={{ conflicttag: HtmlConflict }}
+      />
+    )
+    const { host, root } = await renderIntoRoot(element)
+    await updateRoot(root, element)
+
+    expect(host.querySelector('[data-contract="streaming"]')?.textContent).toBe('Conflict')
+    expect(host.querySelector('[data-contract="html"]')).toBeNull()
+    expect(warn.mock.calls.filter(([message]) => String(message).includes('conflicttag'))).toHaveLength(1)
+
+    await unmountRoot(root)
+  })
+
+  it('keeps legacy scoped customHtmlTags behavior working', async () => {
+    const scopeId = 'react-local-component-legacy'
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-legacy-document-link={getAttr(props.node.attrs, 'id') ?? ''}>{props.node.content}</span>
+    }
+
+    setCustomComponents(scopeId, { documentlink: DocumentLink })
+    try {
+      const { host, root } = await renderIntoRoot(
+        <NodeRenderer
+          customId={scopeId}
+          customHtmlTags={['documentlink']}
+          content={'<DocumentLink id="123">Legacy</DocumentLink>'}
+          final
+          smoothStreaming={false}
+        />,
+      )
+
+      expect(host.querySelector('[data-legacy-document-link="123"]')?.textContent).toBe('Legacy')
+
+      await unmountRoot(root)
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('normalizes component map keys before parsing', async () => {
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-normalized-type={props.node.type}>{props.node.content}</span>
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content="<DocumentLink>Case</DocumentLink>"
+        final
+        smoothStreaming={false}
+        streamingComponents={{ DocumentLink }}
+      />,
+    )
+
+    expect(host.querySelector('[data-normalized-type="documentlink"]')?.textContent).toBe('Case')
+
+    await unmountRoot(root)
+  })
+
+  it('supports streamingComponents and htmlComponents during SSR without registry', () => {
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      return <span data-ssr-streaming={getAttr(props.node.attrs, 'id') ?? ''}>{props.node.content}</span>
+    }
+    function Badge(props: React.PropsWithChildren<{ kind?: string }>) {
+      return <span data-ssr-badge={props.kind}>{props.children}</span>
+    }
+
+    const streamingHtml = renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={'<DocumentLink id="ssr">Server Stream</DocumentLink>'}
+        final
+        streamingComponents={{ documentlink: DocumentLink }}
+      />,
+    )
+    const htmlComponentHtml = renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={'<badge kind="ssr">Server HTML</badge>'}
+        final
+        htmlComponents={{ badge: Badge }}
+      />,
+    )
+
+    expect(streamingHtml).toContain('data-ssr-streaming="ssr"')
+    expect(streamingHtml).toContain('Server Stream')
+    expect(htmlComponentHtml).toContain('data-ssr-badge="ssr"')
+    expect(htmlComponentHtml).toContain('Server HTML')
+  })
+})

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -369,6 +369,45 @@ describe('react local component maps', () => {
     expect(ssrHost.querySelector('[data-option-callout="option"]')?.textContent).toBe('Option')
   })
 
+  it('passes empty children to self-closing parser-backed htmlComponents', async () => {
+    const seen: Array<React.PropsWithChildren<{ kind?: string }>> = []
+    function Badge(props: React.PropsWithChildren<{ kind?: string }>) {
+      seen.push(props)
+      return <span data-self-closing-badge={props.kind}>{Array.isArray(props.children) ? props.children.length : String(props.children ?? '')}</span>
+    }
+
+    const element = (
+      <NodeRenderer
+        content={'<badge kind="info" />'}
+        customHtmlTags={['badge']}
+        final
+        htmlComponents={{ badge: Badge }}
+        smoothStreaming={false}
+      />
+    )
+    const { host, root } = await renderIntoRoot(element)
+
+    expect(host.querySelector('[data-self-closing-badge="info"]')?.textContent).toBe('')
+    expect(seen.at(-1)?.children).toBe('')
+    expect(seen.at(-1)?.children).not.toBe('<badge kind="info" />')
+
+    await unmountRoot(root)
+    seen.length = 0
+
+    const ssrHtml = renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={'<badge kind="info" />'}
+        customHtmlTags={['badge']}
+        final
+        htmlComponents={{ badge: Badge }}
+      />,
+    )
+
+    expect(ssrHtml).toContain('data-self-closing-badge="info"')
+    expect(seen.at(-1)?.children).toBe('')
+    expect(seen.at(-1)?.children).not.toBe('<badge kind="info" />')
+  })
+
   it('prefers htmlComponents before trusted structured html wrappers', async () => {
     function Card(props: React.PropsWithChildren<{ tone?: string }>) {
       return <section data-card={props.tone}>{props.children}</section>
@@ -571,6 +610,42 @@ describe('react local component maps', () => {
     expect(ssrHost.querySelector('p [data-html-card]')).toBeNull()
     expect(ssrHost.querySelectorAll('p.paragraph-node')[0]?.textContent.trim()).toBe('before')
     expect(ssrHost.querySelectorAll('p.paragraph-node')[1]?.textContent.trim()).toBe('after')
+  })
+
+  it('does not let htmlComponents block display split escaped raw html nodes', async () => {
+    const Card = withMarkstreamComponentDisplay((props: React.PropsWithChildren) => (
+      <div data-escape-card>{props.children}</div>
+    ), 'block')
+    const content = 'before <card>content</card> after'
+    const htmlComponents = { card: Card }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        htmlPolicy="escape"
+        smoothStreaming={false}
+      />,
+    )
+
+    expect(host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(host.querySelector('[data-escape-card]')).toBeNull()
+    expect(host.querySelector('p.paragraph-node')?.textContent).toBe(content)
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        htmlPolicy="escape"
+      />,
+    ))
+
+    expect(ssrHost.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(ssrHost.querySelector('[data-escape-card]')).toBeNull()
+    expect(ssrHost.querySelector('p.paragraph-node')?.textContent).toBe(content)
   })
 
   it('passes fade to server-side streaming and coerced custom components', () => {

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -8,7 +8,7 @@ import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
-import { removeCustomComponents, setCustomComponents } from '../packages/markstream-react/src/customComponents'
+import { removeCustomComponents, setCustomComponents, withMarkstreamComponentDisplay } from '../packages/markstream-react/src/customComponents'
 import { NodeRenderer as ServerNodeRenderer } from '../packages/markstream-react/src/server-renderer'
 
 interface DocumentLinkNode {
@@ -469,12 +469,19 @@ describe('react local component maps', () => {
     await unmountRoot(root)
   })
 
-  it('does not coerce legacy custom component html attrs', async () => {
+  it('keeps legacy custom component html attr contracts per render path', async () => {
     const scopeId = 'react-local-component-legacy-attrs'
-    const seen: Array<{ width?: unknown }> = []
-    function LegacyBadge(props: React.PropsWithChildren<{ width?: unknown }>) {
+    const seen: Array<{ width?: unknown, disabled?: unknown }> = []
+    function LegacyBadge(props: React.PropsWithChildren<{ disabled?: unknown, width?: unknown }>) {
       seen.push(props)
-      return <span data-legacy-width={String(props.width)}>{props.children}</span>
+      return (
+        <span
+          data-legacy-disabled={String(props.disabled)}
+          data-legacy-width={String(props.width)}
+        >
+          {props.children}
+        </span>
+      )
     }
 
     setCustomComponents(scopeId, { legacybadge: LegacyBadge as any })
@@ -494,6 +501,22 @@ describe('react local component maps', () => {
       await unmountRoot(root)
       seen.length = 0
 
+      const inline = await renderIntoRoot(
+        <NodeRenderer
+          customId={scopeId}
+          content={'before <legacybadge width="001" disabled>Inline</legacybadge> after'}
+          final
+          smoothStreaming={false}
+        />,
+      )
+
+      expect(inline.host.querySelector('[data-legacy-width="1"]')?.textContent).toBe('Inline')
+      expect(seen.at(-1)?.width).toBe(1)
+      expect(seen.at(-1)?.disabled).toBe(true)
+
+      await unmountRoot(inline.root)
+      seen.length = 0
+
       const ssrHtml = renderToStaticMarkup(
         <ServerNodeRenderer
           customId={scopeId}
@@ -504,6 +527,107 @@ describe('react local component maps', () => {
 
       expect(ssrHtml).toContain('data-legacy-width="001"')
       expect(seen.at(-1)?.width).toBe('001')
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('lets block-marked htmlComponents break out of paragraph wrappers on client and server', async () => {
+    const Card = withMarkstreamComponentDisplay((props: React.PropsWithChildren) => (
+      <div data-html-card>{props.children}</div>
+    ), 'block')
+
+    const content = 'before <card>content</card> after'
+    const htmlComponents = { card: Card }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        smoothStreaming={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-html-card]')?.textContent).toBe('content')
+    expect(host.querySelectorAll('p.paragraph-node')).toHaveLength(2)
+    expect(host.querySelector('p [data-html-card]')).toBeNull()
+    expect(host.querySelector('span.html-inline-node [data-html-card]')).toBeNull()
+    expect(host.querySelectorAll('p.paragraph-node')[0]?.textContent.trim()).toBe('before')
+    expect(host.querySelectorAll('p.paragraph-node')[1]?.textContent.trim()).toBe('after')
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-html-card]')?.textContent).toBe('content')
+    expect(ssrHost.querySelectorAll('p.paragraph-node')).toHaveLength(2)
+    expect(ssrHost.querySelector('p [data-html-card]')).toBeNull()
+    expect(ssrHost.querySelectorAll('p.paragraph-node')[0]?.textContent.trim()).toBe('before')
+    expect(ssrHost.querySelectorAll('p.paragraph-node')[1]?.textContent.trim()).toBe('after')
+  })
+
+  it('passes fade to server-side streaming and coerced custom components', () => {
+    const scopeId = 'react-local-component-ssr-fade'
+    const seen: Array<{ fade?: boolean, type?: string }> = []
+    function DirectTag(props: NodeComponentProps<{ content?: string, type: string }>) {
+      seen.push({ fade: props.fade, type: props.node.type })
+      return <span data-direct-fade={props.fade === false ? 'off' : 'on'}>{props.node.content}</span>
+    }
+    function CoercedTag(props: NodeComponentProps<{ content?: string, type: string }>) {
+      seen.push({ fade: props.fade, type: props.node.type })
+      return <span data-coerced-fade={props.fade === false ? 'off' : 'on'}>{props.node.content}</span>
+    }
+
+    setCustomComponents(scopeId, {
+      coercedblock: CoercedTag,
+      coercedinline: CoercedTag,
+    } as any)
+    try {
+      const directHtml = renderToStaticMarkup(
+        <ServerNodeRenderer
+          content="<DirectTag>Direct</DirectTag>"
+          fade={false}
+          final
+          streamingComponents={{ directtag: DirectTag }}
+        />,
+      )
+      const coercedHtml = renderToStaticMarkup(
+        <ServerNodeRenderer
+          customHtmlTags={['coercedblock', 'coercedinline']}
+          customId={scopeId}
+          fade={false}
+          final
+          nodes={[
+            {
+              type: 'html_inline',
+              tag: 'coercedinline',
+              content: '<coercedinline>Inline</coercedinline>',
+              raw: '<coercedinline>Inline</coercedinline>',
+            } as any,
+            {
+              type: 'html_block',
+              tag: 'coercedblock',
+              content: '<coercedblock>Block</coercedblock>',
+              raw: '<coercedblock>Block</coercedblock>',
+            } as any,
+          ]}
+        />,
+      )
+
+      expect(directHtml).toContain('data-direct-fade="off"')
+      expect(coercedHtml).toContain('data-coerced-fade="off"')
+      expect(seen).toEqual([
+        { fade: false, type: 'directtag' },
+        { fade: false, type: 'coercedinline' },
+        { fade: false, type: 'coercedblock' },
+      ])
     }
     finally {
       removeCustomComponents(scopeId)

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -54,6 +54,12 @@ async function unmountRoot(root: ReturnType<typeof createRoot>) {
   })
 }
 
+function hostFromStaticMarkup(html: string) {
+  const host = document.createElement('div')
+  host.innerHTML = html
+  return host
+}
+
 describe('react local component maps', () => {
   beforeEach(() => {
     vi.stubGlobal('IntersectionObserver', class {
@@ -267,6 +273,241 @@ describe('react local component maps', () => {
     expect(host.querySelector('[data-normalized-type="documentlink"]')?.textContent).toBe('Case')
 
     await unmountRoot(root)
+  })
+
+  it('does not let streamingComponents replace built-in markdown node types', async () => {
+    function TextTag(props: NodeComponentProps<{ content: string }>) {
+      return <span data-streaming-text>{props.node.content}</span>
+    }
+    function HeadingTag(props: NodeComponentProps<{ content: string }>) {
+      return <span data-streaming-heading>{props.node.content}</span>
+    }
+
+    const content = [
+      '# Native heading',
+      '',
+      '<text>Custom text</text>',
+      '',
+      '<heading>Custom heading</heading>',
+    ].join('\n')
+    const streamingComponents = {
+      text: TextTag,
+      heading: HeadingTag,
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        smoothStreaming={false}
+        streamingComponents={streamingComponents}
+      />,
+    )
+
+    expect(host.querySelector('h1')?.textContent).toBe('Native heading')
+    expect(host.querySelector('h1 [data-streaming-text]')).toBeNull()
+    expect(Array.from(host.querySelectorAll('[data-streaming-text]')).map(el => el.textContent)).toEqual(['Custom text'])
+    expect(host.querySelector('[data-streaming-heading]')?.textContent).toBe('Custom heading')
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        streamingComponents={streamingComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('h1')?.textContent).toBe('Native heading')
+    expect(ssrHost.querySelector('h1 [data-streaming-text]')).toBeNull()
+    expect(Array.from(ssrHost.querySelectorAll('[data-streaming-text]')).map(el => el.textContent)).toEqual(['Custom text'])
+    expect(ssrHost.querySelector('[data-streaming-heading]')?.textContent).toBe('Custom heading')
+  })
+
+  it('uses htmlComponents for tags parsed through customHtmlTags and parseOptions', async () => {
+    function Badge(props: React.PropsWithChildren<{ kind?: string, node?: unknown }>) {
+      return <span data-direct-badge={props.kind}>{props.children}</span>
+    }
+    function Callout(props: React.PropsWithChildren<{ tone?: string, node?: unknown }>) {
+      return <section data-option-callout={props.tone}>{props.children}</section>
+    }
+
+    const content = [
+      '<badge kind="direct">Direct</badge>',
+      '',
+      '<callout tone="option">Option</callout>',
+    ].join('\n')
+
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        customHtmlTags={['badge']}
+        final
+        htmlComponents={{ badge: Badge, callout: Callout }}
+        parseOptions={{ customHtmlTags: ['callout'] }}
+        smoothStreaming={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-direct-badge="direct"]')?.textContent).toBe('Direct')
+    expect(host.querySelector('[data-option-callout="option"]')?.textContent).toBe('Option')
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        customHtmlTags={['badge']}
+        final
+        htmlComponents={{ badge: Badge, callout: Callout }}
+        parseOptions={{ customHtmlTags: ['callout'] }}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-direct-badge="direct"]')?.textContent).toBe('Direct')
+    expect(ssrHost.querySelector('[data-option-callout="option"]')?.textContent).toBe('Option')
+  })
+
+  it('prefers htmlComponents before trusted structured html wrappers', async () => {
+    function Card(props: React.PropsWithChildren<{ tone?: string }>) {
+      return <section data-card={props.tone}>{props.children}</section>
+    }
+
+    const content = '<card tone="warm">\n\n- item\n\n</card>'
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        htmlComponents={{ card: Card }}
+        htmlPolicy="trusted"
+        smoothStreaming={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-card="warm"] li')?.textContent).toBe('item')
+    expect(host.querySelector('card')).toBeNull()
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        htmlComponents={{ card: Card }}
+        htmlPolicy="trusted"
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-card="warm"] li')?.textContent).toBe('item')
+    expect(ssrHost.querySelector('card')).toBeNull()
+  })
+
+  it('matches underscore html component tags on client and server', async () => {
+    function UnderscoreTag(props: React.PropsWithChildren<{ kind?: string }>) {
+      return <span data-underscore={props.kind}>{props.children}</span>
+    }
+
+    const content = '<div><my_component kind="ok">Under</my_component></div>'
+    const htmlComponents = { my_component: UnderscoreTag }
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+        smoothStreaming={false}
+      />,
+    )
+
+    expect(host.querySelector('[data-underscore="ok"]')?.textContent).toBe('Under')
+
+    await unmountRoot(root)
+
+    const ssrHost = hostFromStaticMarkup(renderToStaticMarkup(
+      <ServerNodeRenderer
+        content={content}
+        final
+        htmlComponents={htmlComponents}
+      />,
+    ))
+
+    expect(ssrHost.querySelector('[data-underscore="ok"]')?.textContent).toBe('Under')
+  })
+
+  it('keeps normalized inline component maps stable across renders', async () => {
+    let renders = 0
+    function DocumentLink(props: NodeComponentProps<DocumentLinkNode>) {
+      renders++
+      return <span data-stable-map>{props.node.content}</span>
+    }
+
+    const content = '<DocumentLink>Stable</DocumentLink>'
+    const { host, root } = await renderIntoRoot(
+      <NodeRenderer
+        content={content}
+        final
+        smoothStreaming={false}
+        streamingComponents={{ DocumentLink }}
+      />,
+    )
+
+    expect(host.querySelector('[data-stable-map]')?.textContent).toBe('Stable')
+    expect(renders).toBe(1)
+
+    await updateRoot(
+      root,
+      <NodeRenderer
+        content={content}
+        final
+        smoothStreaming={false}
+        streamingComponents={{ DocumentLink }}
+      />,
+    )
+
+    expect(renders).toBe(1)
+
+    await unmountRoot(root)
+  })
+
+  it('does not coerce legacy custom component html attrs', async () => {
+    const scopeId = 'react-local-component-legacy-attrs'
+    const seen: Array<{ width?: unknown }> = []
+    function LegacyBadge(props: React.PropsWithChildren<{ width?: unknown }>) {
+      seen.push(props)
+      return <span data-legacy-width={String(props.width)}>{props.children}</span>
+    }
+
+    setCustomComponents(scopeId, { legacybadge: LegacyBadge as any })
+    try {
+      const { host, root } = await renderIntoRoot(
+        <NodeRenderer
+          customId={scopeId}
+          content={'<legacybadge width="001">Legacy</legacybadge>'}
+          final
+          smoothStreaming={false}
+        />,
+      )
+
+      expect(host.querySelector('[data-legacy-width="001"]')?.textContent).toBe('Legacy')
+      expect(seen.at(-1)?.width).toBe('001')
+
+      await unmountRoot(root)
+      seen.length = 0
+
+      const ssrHtml = renderToStaticMarkup(
+        <ServerNodeRenderer
+          customId={scopeId}
+          content={'<legacybadge width="001">Legacy</legacybadge>'}
+          final
+        />,
+      )
+
+      expect(ssrHtml).toContain('data-legacy-width="001"')
+      expect(seen.at(-1)?.width).toBe('001')
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
   })
 
   it('supports streamingComponents and htmlComponents during SSR without registry', () => {

--- a/test/react-local-component-maps.test.tsx
+++ b/test/react-local-component-maps.test.tsx
@@ -213,6 +213,37 @@ describe('react local component maps', () => {
     await unmountRoot(root)
   })
 
+  it('keeps same-tag htmlComponents isolated per renderer instance', async () => {
+    function FirstBadge(props: React.PropsWithChildren) {
+      return <span data-owner="first">{props.children}</span>
+    }
+    function SecondBadge(props: React.PropsWithChildren) {
+      return <span data-owner="second">{props.children}</span>
+    }
+
+    const { host, root } = await renderIntoRoot(
+      <div>
+        <NodeRenderer
+          content="<badge>One</badge>"
+          final
+          htmlComponents={{ badge: FirstBadge }}
+          smoothStreaming={false}
+        />
+        <NodeRenderer
+          content="<badge>Two</badge>"
+          final
+          htmlComponents={{ badge: SecondBadge }}
+          smoothStreaming={false}
+        />
+      </div>,
+    )
+
+    expect(host.querySelector('[data-owner="first"]')?.textContent).toBe('One')
+    expect(host.querySelector('[data-owner="second"]')?.textContent).toBe('Two')
+
+    await unmountRoot(root)
+  })
+
   it('prefers streamingComponents over the legacy scoped registry', async () => {
     const scopeId = 'react-local-component-precedence'
     function LegacyDocumentLink(props: NodeComponentProps<DocumentLinkNode>) {

--- a/test/stream-markdown-parser-type-shim.d.ts
+++ b/test/stream-markdown-parser-type-shim.d.ts
@@ -1,0 +1,18 @@
+export interface BaseNode {
+  type: string
+  [key: string]: unknown
+}
+
+export interface ParsedNode extends BaseNode {}
+
+export interface CodeBlockNode extends BaseNode {
+  code?: string
+  language?: string
+  raw?: string
+}
+
+export type HtmlPolicy = 'safe' | 'trusted' | 'escape'
+export type MarkdownIt = unknown
+export type ParseOptions = Record<string, unknown>
+
+export function normalizeCustomHtmlTagName(tagName: string): string


### PR DESCRIPTION
## Problem

Issue #519 surfaced that React custom HTML-like tags had two different contracts hidden behind `customHtmlTags` and the legacy `setCustomComponents` registry. That made it hard to discover whether a component would receive parser-backed `NodeComponentProps` or normal HTML props.

## New API

```tsx
<MarkdownRender
  content={content}
  final={isDone}
  streamingComponents={{
    documentlink: DocumentLink,
  }}
  htmlComponents={{
    badge: Badge,
  }}
/>
```

`streamingComponents` is renderer-local and parser-backed. Keys are normalized with the parser custom HTML tag utilities and added to the effective `customHtmlTags`, so incomplete tags can render while streaming. Components receive `NodeComponentProps`, including `node.attrs`, `node.content`, and `node.loading`.

`htmlComponents` is renderer-local and uses the raw/dynamic HTML path. Components receive normal React props and `children`; they do not receive the parser streaming-node contract.

If the same normalized tag appears in both maps, `streamingComponents` wins and a development warning is emitted once.

## Backward compatibility

- Keeps `setCustomComponents`, `removeCustomComponents`, `clearGlobalCustomComponents`, `customId`, `customHtmlTags`, and `parseOptions.customHtmlTags` intact.
- Does not mutate or call the global custom component registry for the new local maps.
- Keeps legacy scoped/global precedence behind the new direct prop precedence.
- Keeps HTML sanitization and `htmlPolicy` behavior unchanged; this API split is not a security boundary.

## Tests and validation

- `pnpm exec vitest --run test/react-local-component-maps.test.tsx`
- `pnpm --dir packages/markstream-react typecheck`
- `pnpm exec vitest --run test/react-local-component-maps.test.tsx test/react-non-whitelisted-html-tag.test.tsx test/markstream-react-next-ssr.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` - 280 files / 2379 tests passed
- `pnpm build`
- `pnpm --dir packages/markstream-react build`
- `pnpm --dir packages/markstream-react check:exports`

## Documentation

Updated React component docs, React migration docs, Chinese docs, and the `markstream-react` README with the preferred renderer-local API, legacy migration example, and contract distinction.

Closes #519