### PR TITLE
fix(MathBlockNode): drop min-height lock after KaTeX renders

### DIFF
--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -107,6 +107,22 @@ function updateLockedMinHeight(height: number) {
   if (!Number.isFinite(height) || height <= 0)
     return
 
+  // Once KaTeX has successfully rendered, drop the min-height lock.
+  // The real DOM height is authoritative; keeping a transiently large
+  // min-height from loading/fallback states causes permanent excessive
+  // whitespace (e.g. raw LaTeX fallback is much taller than the rendered
+  // formula). Use 0 so the scoped CSS fallback (--ms-size-math-min-height)
+  // still applies, but the oversized transient value does not stick.
+  if (renderedHtml.value) {
+    if (lockedMinHeight.value === 0)
+      return
+    lockedMinHeight.value = 0
+    const cacheKey = getHeightCacheKey()
+    if (cacheKey)
+      minHeightCacheContext?.cache.set(cacheKey, 0)
+    return
+  }
+
   const nextMinHeight = Math.max(lockedMinHeight.value, height)
   if (nextMinHeight === lockedMinHeight.value)
     return


### PR DESCRIPTION
## Problem

`MathBlockNode` caches the container's `offsetHeight` as an inline `min-height` to avoid layout shift while KaTeX renders. The cache update uses `Math.max(old, new)`, so once a transiently large height is measured (e.g. raw LaTeX fallback text during worker timeout/fallback), the block keeps that oversized `min-height` forever—even after KaTeX finishes and the real content is much smaller.

Fixes #525

## Reproduction

In the playground `/test` or `/markdown` page, paste a multi-line block math formula such as:

```markdown
\[
\mathbf{A}\mathbf{B} =
\begin{pmatrix}
1 & 2 \\
3 & 4
\end{pmatrix}
\begin{pmatrix}
5 & 6 \\
7 & 8
\end{pmatrix}
=
\begin{pmatrix}
19 & 22 \\
43 & 50
\end{pmatrix}
\]
```

Before this fix, the rendered `.math-block` gets an inline style like `min-height: 392px;` while the KaTeX content is only ~46 px tall, leaving ~346 px of blank space.

## Solution

Clear the `lockedMinHeight` once KaTeX successfully renders (`renderedHtml.value` is truthy). While the block is still loading or showing fallback text, the existing `Math.max` behavior is preserved so we still reserve enough vertical space. After KaTeX finishes, the real DOM height becomes authoritative and the oversized transient value no longer sticks.

When `lockedMinHeight` is set to `0`, the scoped CSS fallback `--ms-size-math-min-height` still applies, so the block retains a sensible minimum height.

## Verification

- Reproduced the bug in the playground: `min-height: 392px` with content height ~46 px.
- Applied the fix and reloaded the same formula: inline `min-height` is gone, only the CSS default `min-height: 40px` remains, and the blank space disappears.
