### PR TITLE
fix: clear math block min-height on render success

### DIFF
--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -103,25 +103,27 @@ function resolveCachedMinHeight() {
   return cacheKey ? (minHeightCacheContext?.cache.get(cacheKey) ?? 0) : 0
 }
 
-function updateLockedMinHeight(height: number) {
-  if (!Number.isFinite(height) || height <= 0)
+function clearLockedMinHeight() {
+  if (lockedMinHeight.value === 0)
     return
 
-  // Once KaTeX has successfully rendered, drop the min-height lock.
-  // The real DOM height is authoritative; keeping a transiently large
-  // min-height from loading/fallback states causes permanent excessive
-  // whitespace (e.g. raw LaTeX fallback is much taller than the rendered
-  // formula). Use 0 so the scoped CSS fallback (--ms-size-math-min-height)
-  // still applies, but the oversized transient value does not stick.
+  lockedMinHeight.value = 0
+  const cacheKey = getHeightCacheKey()
+  if (cacheKey)
+    minHeightCacheContext?.cache.set(cacheKey, 0)
+}
+
+if (initialState.html)
+  clearLockedMinHeight()
+
+function updateLockedMinHeight(height: number) {
   if (renderedHtml.value) {
-    if (lockedMinHeight.value === 0)
-      return
-    lockedMinHeight.value = 0
-    const cacheKey = getHeightCacheKey()
-    if (cacheKey)
-      minHeightCacheContext?.cache.set(cacheKey, 0)
+    clearLockedMinHeight()
     return
   }
+
+  if (!Number.isFinite(height) || height <= 0)
+    return
 
   const nextMinHeight = Math.max(lockedMinHeight.value, height)
   if (nextMinHeight === lockedMinHeight.value)
@@ -245,6 +247,7 @@ async function renderMath() {
       renderedText.value = ''
       hasRenderedOnce = true
       renderingLoading.value = false
+      clearLockedMinHeight()
       captureHeight()
     })
     .catch(async (err: any) => {
@@ -280,6 +283,7 @@ async function renderMath() {
             renderedText.value = ''
             hasRenderedOnce = true
             renderingLoading.value = false
+            clearLockedMinHeight()
             captureHeight()
             // populate worker client cache so future calls hit cache
             setKaTeXCache(mathContent.value, true, html)

--- a/test/math-block-min-height-cache-scope.test.ts
+++ b/test/math-block-min-height-cache-scope.test.ts
@@ -1,8 +1,13 @@
 import { mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import MathBlockNode from '../src/components/MathBlockNode/MathBlockNode.vue'
 import { createMathBlockMinHeightCache, MATH_BLOCK_MIN_HEIGHT_CACHE } from '../src/components/MathBlockNode/minHeightCache'
+import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../src/utils/nodeLifecycle'
 import { flushAll } from './setup/flush-all'
+
+const mocks = vi.hoisted(() => ({
+  renderKaTeXWithBackpressure: vi.fn(() => new Promise<string>(() => {})),
+}))
 
 vi.mock('../src/components/MathInlineNode/katex', () => ({
   getKatexSync: () => null,
@@ -13,22 +18,27 @@ vi.mock('../src/workers/katexWorkerClient', async () => {
   const actual: any = await vi.importActual('../src/workers/katexWorkerClient')
   return {
     ...actual,
-    renderKaTeXWithBackpressure: vi.fn(() => new Promise<string>(() => {})),
+    renderKaTeXWithBackpressure: mocks.renderKaTeXWithBackpressure,
   }
 })
 
 const originalOffsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
 
-function mockOffsetHeight(height: number) {
+function mockOffsetHeight(height: number | ((el: HTMLElement) => number)) {
   Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
     configurable: true,
     get() {
-      return height
+      return typeof height === 'function' ? height(this as HTMLElement) : height
     },
   })
 }
 
 describe('mathBlockNode min-height cache scope', () => {
+  beforeEach(() => {
+    mocks.renderKaTeXWithBackpressure.mockReset()
+    mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
+  })
+
   afterEach(() => {
     if (originalOffsetHeightDescriptor) {
       Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeightDescriptor)
@@ -79,5 +89,63 @@ describe('mathBlockNode min-height cache scope', () => {
     await flushAll()
     expect(second.attributes('style')).toContain('min-height: 40px;')
     second.unmount()
+  })
+
+  it('clears fallback min-height before reporting successful KaTeX render height', async () => {
+    let resolveRender!: (html: string) => void
+    mocks.renderKaTeXWithBackpressure.mockImplementationOnce(() => {
+      return new Promise<string>((resolve) => {
+        resolveRender = resolve
+      })
+    })
+
+    mockOffsetHeight((el) => {
+      const lockedHeight = Number.parseFloat(el.style.minHeight)
+      if (Number.isFinite(lockedHeight) && lockedHeight > 0)
+        return lockedHeight
+
+      return el.dataset.markstreamMode === 'katex' ? 64 : 392
+    })
+
+    const rendererCache = createMathBlockMinHeightCache('renderer-test')
+    const lifecycle = {
+      reportHeight: vi.fn(),
+      markPending: vi.fn(),
+      markSettled: vi.fn(),
+    }
+
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: 'x',
+          raw: '\\[x\\]',
+          loading: false,
+        },
+        indexKey: 'math-large-fallback',
+        cacheScope: 'msg-c',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+          [MARKSTREAM_NODE_LIFECYCLE_KEY as symbol]: lifecycle,
+        },
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.attributes('style')).toContain('min-height: 392px;')
+    expect(rendererCache.cache.get('msg-c:math-block:math-large-fallback')).toBe(392)
+
+    resolveRender('<span class="katex">x</span>')
+    await flushAll()
+
+    expect(wrapper.attributes('data-markstream-mode')).toBe('katex')
+    expect(wrapper.attributes('style') ?? '').not.toContain('min-height')
+    expect(rendererCache.cache.get('msg-c:math-block:math-large-fallback')).toBe(0)
+    expect(lifecycle.reportHeight).toHaveBeenCalledWith('math-large-fallback', 64)
+
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- clear MathBlock min-height lock synchronously after successful KaTeX renders
- reset stale cached min-height for initial sync-rendered HTML
- add regression coverage for fallback height shrinking after worker success

## Tests
- pnpm exec vitest --run test/math-block-min-height-cache-scope.test.ts
- pnpm exec vitest --run test/math-block-unicode-unit-render-regression.test.ts test/math-block-busy-fallback.test.ts test/math-block-spaces.test.ts test/math-block-loading-state.test.ts test/math-block-hydration.test.ts test/math-block-min-height-cache-scope.test.ts
- pnpm exec eslint src/components/MathBlockNode/MathBlockNode.vue test/math-block-min-height-cache-scope.test.ts
- pnpm typecheck