### PR TITLE
perf: tighten renderer performance followups

### DIFF
--- a/scripts/benchmark-1-0.mjs
+++ b/scripts/benchmark-1-0.mjs
@@ -258,6 +258,25 @@ function parsePerformanceSummary(row) {
   ].join('<br>')
 }
 
+function layoutReadsSummary(row) {
+  const layoutReads = row.layoutReads
+  if (!layoutReads)
+    return '-'
+
+  const byLabel = layoutReads.byLabel && typeof layoutReads.byLabel === 'object'
+    ? Object.entries(layoutReads.byLabel)
+        .filter(([, count]) => Number(count || 0) > 0)
+        .sort((a, b) => Number(b[1] || 0) - Number(a[1] || 0) || a[0].localeCompare(b[0]))
+        .slice(0, 3)
+    : []
+  const topLabels = byLabel.length
+    ? `<br>${byLabel.map(([label, count]) => `${label} ${formatNumber(count)}`).join('<br>')}`
+    : ''
+
+  const maxPerFrame = Math.max(Number(layoutReads.maxPerFrame || 0), Number(layoutReads.currentFrameTotal || 0))
+  return `total ${formatNumber(layoutReads.total)} / max-frame ${formatNumber(maxPerFrame)}${topLabels}`
+}
+
 function scenarioRows(entry) {
   const rows = []
   const result = entry.result
@@ -340,8 +359,8 @@ function renderMarkdownReport(report) {
   lines.push('')
   lines.push('## Results')
   lines.push('')
-  lines.push('| Scenario | Phase | Viewport | LCP ms | CLS | INP candidate ms | Max input delay ms | Max event processing ms | Settle ms | Frame samples | Frame p95 ms | Heavy settle frame samples | Heavy settle frame p95 ms | Max long task ms | Page DOM nodes | Renderer DOM nodes | Parse stream | Fallbacks | Heavy blocks readiness | Scroll drift px | Heap after renderer unmount + GC |')
-  lines.push('| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: |')
+  lines.push('| Scenario | Phase | Viewport | LCP ms | CLS | INP candidate ms | Max input delay ms | Max event processing ms | Settle ms | Frame samples | Frame p95 ms | Heavy settle frame samples | Heavy settle frame p95 ms | Max long task ms | Page DOM nodes | Renderer DOM nodes | Parse stream | Layout reads | Fallbacks | Heavy blocks readiness | Scroll drift px | Heap after renderer unmount + GC |')
+  lines.push('| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | --- | ---: | ---: |')
 
   for (const entry of report.scenarios) {
     for (const item of scenarioRows(entry)) {
@@ -349,7 +368,7 @@ function renderMarkdownReport(report) {
       const cls = row.cls ?? row.phaseCls
       const settleMs = row.settleTimeMs ?? row.phaseElapsedMs
       const viewport = row.viewport ?? item.viewport ?? report.environment.defaultViewport
-      lines.push(`| ${item.scenario} | ${item.phase} | ${formatViewport(viewport)} | ${formatMs(row.lcpMs)} | ${typeof cls === 'number' ? cls.toFixed(4) : '-'} | ${formatMs(row.eventTimingInpCandidateMs)} | ${formatMs(row.eventTimingMaxInputDelayMs)} | ${formatMs(row.eventTimingMaxProcessingMs)} | ${formatMs(settleMs)} | ${formatNumber(phaseFrameSampleCount(row))} | ${formatMs(phaseFrameP95Ms(row))} | ${formatNumber(row.heavySettleFrameSampleCount)} | ${formatMs(row.heavySettleFrameP95Ms)} | ${formatMs(row.longTaskMaxMs)} | ${formatNumber(row.pageDomNodeCount)} | ${formatNumber(row.rendererDomNodeCount)} | ${parsePerformanceSummary(row)} | ${fallbackSummary(row)} | ${heavyBlockSummary(row, item.heavyBlockScope)} | ${formatMs(row.scrollDriftPx)} | ${formatBytes(item.memoryAfterUnmountBytes)} |`)
+      lines.push(`| ${item.scenario} | ${item.phase} | ${formatViewport(viewport)} | ${formatMs(row.lcpMs)} | ${typeof cls === 'number' ? cls.toFixed(4) : '-'} | ${formatMs(row.eventTimingInpCandidateMs)} | ${formatMs(row.eventTimingMaxInputDelayMs)} | ${formatMs(row.eventTimingMaxProcessingMs)} | ${formatMs(settleMs)} | ${formatNumber(phaseFrameSampleCount(row))} | ${formatMs(phaseFrameP95Ms(row))} | ${formatNumber(row.heavySettleFrameSampleCount)} | ${formatMs(row.heavySettleFrameP95Ms)} | ${formatMs(row.longTaskMaxMs)} | ${formatNumber(row.pageDomNodeCount)} | ${formatNumber(row.rendererDomNodeCount)} | ${parsePerformanceSummary(row)} | ${layoutReadsSummary(row)} | ${fallbackSummary(row)} | ${heavyBlockSummary(row, item.heavyBlockScope)} | ${formatMs(row.scrollDriftPx)} | ${formatBytes(item.memoryAfterUnmountBytes)} |`)
     }
   }
 
@@ -389,7 +408,7 @@ function renderMarkdownReport(report) {
   for (const entry of report.scenarios)
     lines.push(`- **${entry.title}**: ${entry.notes}`)
   lines.push('')
-  lines.push('This report records measured release evidence from the shipped playgrounds. The environment viewport is mixed because Web Vitals scenarios use row-specific viewports; use the Results table viewport column when citing LCP, CLS, visible heavy-block readiness, or DOM-node counts. Initial rows report readiness for heavy blocks visible in the phase viewport, and show N/A when that viewport contains no heavy blocks. Full-scroll rows report all heavy blocks after the scroll pass. Page DOM nodes are recorded for diagnostics; renderer DOM nodes are scoped to the benchmark surface and are the value used by the release gate. Parse stream metrics record renderer parse commits, coalesced smooth-stream parse updates, and markdown-it stream parser full/append/tail/cache counters. Frame p95 is the phase-local p95 `requestAnimationFrame` delta; for full-scroll rows it covers only the active scroll loop. Heavy-settle frame p95 covers post-scroll heavy block readiness separately. Web Vitals frame p95/max and sample density are hard release-gate metrics. Raw scrollTop drift is recorded for diagnostics but is not a 1.0 release gate. Heap after renderer unmount is best-effort Chrome-only `performance.memory` after unmount plus GC. Keep benchmark claims tied to this environment disclosure and rerun before publishing 1.0.')
+  lines.push('This report records measured release evidence from the shipped playgrounds. The environment viewport is mixed because Web Vitals scenarios use row-specific viewports; use the Results table viewport column when citing LCP, CLS, visible heavy-block readiness, or DOM-node counts. Initial rows report readiness for heavy blocks visible in the phase viewport, and show N/A when that viewport contains no heavy blocks. Full-scroll rows report all heavy blocks after the scroll pass. Page DOM nodes are recorded for diagnostics; renderer DOM nodes are scoped to the benchmark surface and are the value used by the release gate. Parse stream metrics record renderer parse commits, coalesced smooth-stream parse updates, and markdown-it stream parser full/append/tail/cache counters. Layout reads are collected only when renderer debug performance mode is enabled and show total reads plus the largest observed frame bucket for the benchmark phase. Frame p95 is the phase-local p95 `requestAnimationFrame` delta; for full-scroll rows it covers only the active scroll loop. Heavy-settle frame p95 covers post-scroll heavy block readiness separately. Web Vitals frame p95/max and sample density are hard release-gate metrics. Raw scrollTop drift is recorded for diagnostics but is not a 1.0 release gate. Heap after renderer unmount is best-effort Chrome-only `performance.memory` after unmount plus GC. Keep benchmark claims tied to this environment disclosure and rerun before publishing 1.0.')
   return `${lines.join('\n')}\n`
 }
 

--- a/scripts/e2e-main-playground-performance.mjs
+++ b/scripts/e2e-main-playground-performance.mjs
@@ -128,6 +128,36 @@ function cloneParsePerformance(value) {
   return value == null ? null : JSON.parse(JSON.stringify(value))
 }
 
+function normalizeLayoutReadPerformance(value) {
+  if (!value || typeof value !== 'object')
+    return null
+
+  const byLabel = value.byLabel && typeof value.byLabel === 'object'
+    ? Object.fromEntries(
+        Object.entries(value.byLabel)
+          .map(([key, count]) => [key, Number(count || 0)])
+          .filter(([, count]) => count > 0)
+          .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+      )
+    : {}
+
+  return {
+    total: Number(value.total || 0),
+    maxPerFrame: Math.max(Number(value.maxPerFrame || 0), Number(value.currentFrameTotal || 0)),
+    byLabel,
+  }
+}
+
+async function resetLayoutReadPerformance(page) {
+  await page.evaluate(() => {
+    window.__markstreamLayoutReadPerformance = {
+      total: 0,
+      maxPerFrame: 0,
+      byLabel: {},
+    }
+  })
+}
+
 function diffNumber(after, before) {
   return Number(after || 0) - Number(before || 0)
 }
@@ -380,6 +410,7 @@ async function collectMetrics(page) {
       visibleD2Count: visibleD2Blocks.length,
       visibleRenderedD2Count: visibleD2Blocks.filter(element => element.querySelector('.d2-svg svg')).length,
       parsePerformance: state.parsePerformance ?? null,
+      layoutReads: window.__markstreamLayoutReadPerformance ?? null,
       topLayoutShifts: Array.isArray(state.layoutShifts)
         ? [...state.layoutShifts]
             .sort((a, b) => Number(b?.value || 0) - Number(a?.value || 0))
@@ -388,7 +419,9 @@ async function collectMetrics(page) {
     }
   }, initialFrameStats)
   initial.parsePerformance = cloneParsePerformance(initial.parsePerformance)
+  initial.layoutReads = normalizeLayoutReadPerformance(initial.layoutReads)
   const fullScrollParsePerformanceBaseline = cloneParsePerformance(initial.parsePerformance)
+  await resetLayoutReadPerformance(page)
 
   const scrollMetrics = await scrollThroughRoot(page, rootSelector, '__mainPlaygroundPerf')
   const heavySettleFrameBaseline = await frameBaseline(page, '__mainPlaygroundPerf')
@@ -419,6 +452,7 @@ async function collectMetrics(page) {
       renderedD2Count: d2Blocks.filter(element => element.querySelector('.d2-svg svg')).length,
       longTaskTotalMs: longTasks.reduce((sum, duration) => sum + Number(duration || 0), 0),
       parsePerformance: state.parsePerformance ?? null,
+      layoutReads: window.__markstreamLayoutReadPerformance ?? null,
       scrollDriftPx: null,
     }
   }, {
@@ -433,6 +467,7 @@ async function collectMetrics(page) {
     fullScroll.parsePerformance,
     fullScrollParsePerformanceBaseline,
   )
+  fullScroll.layoutReads = normalizeLayoutReadPerformance(fullScroll.layoutReads)
   fullScroll.scrollDriftPx = scrollMetrics.maxScrollDriftPx
 
   const replayButton = page.locator('button.nav-btn--stream')
@@ -458,6 +493,7 @@ async function collectMetrics(page) {
       : JSON.parse(JSON.stringify(state.parsePerformance))
     return state.replayParsePerformanceBaseline
   })
+  await resetLayoutReadPerformance(page)
   await page.locator('button.nav-btn--stream').click()
   await waitForVisibleBlocksReady(page, rootSelector)
   await page.waitForTimeout(250)
@@ -485,12 +521,14 @@ async function collectMetrics(page) {
       rendererDomNodeCount: root ? root.querySelectorAll('*').length : 0,
       jsHeapUsedBytes: performance.memory?.usedJSHeapSize ?? null,
       parsePerformance: state.parsePerformance ?? null,
+      layoutReads: window.__markstreamLayoutReadPerformance ?? null,
     }
   })
   replay.parsePerformance = diffParsePerformance(
     replay.parsePerformance,
     replayParsePerformanceBaseline,
   )
+  replay.layoutReads = normalizeLayoutReadPerformance(replay.layoutReads)
 
   const memoryBeforeUnmountBytes = await readUsedHeapBytes(page)
   const memoryAfterUnmountBytes = await measureAfterRendererUnmount(page)
@@ -614,6 +652,11 @@ async function run() {
         },
       }
 
+      window.__markstreamLayoutReadPerformance = {
+        total: 0,
+        maxPerFrame: 0,
+        byLabel: {},
+      }
       window.__mainPlaygroundPerf = state
 
       const originalInfo = console.info.bind(console)

--- a/scripts/e2e-main-playground-performance.mjs
+++ b/scripts/e2e-main-playground-performance.mjs
@@ -204,9 +204,12 @@ function assertTokenCloneBudget(parsePerformance) {
   }
 }
 
-function assertLayoutReadBudget(label, layoutReads) {
+function assertLayoutReadBudget(label, layoutReads, options = {}) {
   if (!layoutReads)
     throw new Error(`${label} should record layout read metrics.`)
+
+  if (options.requireReads && !(Number(layoutReads.total || 0) > 0))
+    throw new Error(`${label} should record at least one layout read.`)
 
   const maxPerFrame = Number(layoutReads.maxPerFrame || 0)
   if (!(maxPerFrame <= maxLayoutReadsPerFrame)) {
@@ -575,7 +578,7 @@ function assertScenario(result) {
     throw new Error(`Initial settle should stay within 7000ms. Got ${result.initial.settleTimeMs}.`)
   if (!(result.initial.rendererDomNodeCount <= 5000))
     throw new Error(`Initial renderer DOM node count budget exceeded. Got ${result.initial.rendererDomNodeCount}.`)
-  assertLayoutReadBudget('Initial', result.initial.layoutReads)
+  assertLayoutReadBudget('Initial', result.initial.layoutReads, { requireReads: true })
   if (result.fullScroll.fallbackCount !== 0)
     throw new Error('Code block fallbacks should be gone after full scroll settle.')
   if (result.fullScroll.renderedMermaidCount !== result.fullScroll.mermaidCount)

--- a/scripts/e2e-main-playground-performance.mjs
+++ b/scripts/e2e-main-playground-performance.mjs
@@ -123,6 +123,7 @@ const parsePerformanceStreamCounterKeys = [
   'chunkedParses',
 ]
 const tokenCloneTotalBudgetRatio = 0.35
+const maxLayoutReadsPerFrame = Number(process.env.MARKSTREAM_BENCHMARK_MAX_LAYOUT_READS_PER_FRAME || 50)
 
 function cloneParsePerformance(value) {
   return value == null ? null : JSON.parse(JSON.stringify(value))
@@ -199,6 +200,18 @@ function assertTokenCloneBudget(parsePerformance) {
   if (tokenCloneMs > totalMs * tokenCloneTotalBudgetRatio) {
     throw new Error(
       `Replay token clone cost too high: ${tokenCloneMs}ms of ${totalMs}ms.`,
+    )
+  }
+}
+
+function assertLayoutReadBudget(label, layoutReads) {
+  if (!layoutReads)
+    throw new Error(`${label} should record layout read metrics.`)
+
+  const maxPerFrame = Number(layoutReads.maxPerFrame || 0)
+  if (!(maxPerFrame <= maxLayoutReadsPerFrame)) {
+    throw new Error(
+      `${label} layout reads per frame exceeded ${maxLayoutReadsPerFrame}. Got ${maxPerFrame}.`,
     )
   }
 }
@@ -562,6 +575,7 @@ function assertScenario(result) {
     throw new Error(`Initial settle should stay within 7000ms. Got ${result.initial.settleTimeMs}.`)
   if (!(result.initial.rendererDomNodeCount <= 5000))
     throw new Error(`Initial renderer DOM node count budget exceeded. Got ${result.initial.rendererDomNodeCount}.`)
+  assertLayoutReadBudget('Initial', result.initial.layoutReads)
   if (result.fullScroll.fallbackCount !== 0)
     throw new Error('Code block fallbacks should be gone after full scroll settle.')
   if (result.fullScroll.renderedMermaidCount !== result.fullScroll.mermaidCount)
@@ -572,10 +586,12 @@ function assertScenario(result) {
     throw new Error('All d2 blocks should finish after full scroll settle.')
   if (!(result.fullScroll.rendererDomNodeCount <= 5000))
     throw new Error(`Full-scroll renderer DOM node count budget exceeded. Got ${result.fullScroll.rendererDomNodeCount}.`)
+  assertLayoutReadBudget('Full-scroll', result.fullScroll.layoutReads)
   if (!(result.replay.settleTimeMs <= 5000))
     throw new Error(`Replay settle should stay within 5000ms. Got ${result.replay.settleTimeMs}.`)
   if (!(result.replay.rendererDomNodeCount <= 5000))
     throw new Error(`Replay renderer DOM node count budget exceeded. Got ${result.replay.rendererDomNodeCount}.`)
+  assertLayoutReadBudget('Replay', result.replay.layoutReads)
   const parsePerformance = result.replay.parsePerformance
   if (!parsePerformance || !(parsePerformance.parseCommitCount > 0))
     throw new Error('Replay should record Markdown parse commit metrics.')

--- a/scripts/e2e-playground-performance.mjs
+++ b/scripts/e2e-playground-performance.mjs
@@ -127,6 +127,36 @@ function cloneParsePerformance(value) {
   return value == null ? null : JSON.parse(JSON.stringify(value))
 }
 
+function normalizeLayoutReadPerformance(value) {
+  if (!value || typeof value !== 'object')
+    return null
+
+  const byLabel = value.byLabel && typeof value.byLabel === 'object'
+    ? Object.fromEntries(
+        Object.entries(value.byLabel)
+          .map(([key, count]) => [key, Number(count || 0)])
+          .filter(([, count]) => count > 0)
+          .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+      )
+    : {}
+
+  return {
+    total: Number(value.total || 0),
+    maxPerFrame: Math.max(Number(value.maxPerFrame || 0), Number(value.currentFrameTotal || 0)),
+    byLabel,
+  }
+}
+
+async function resetLayoutReadPerformance(page) {
+  await page.evaluate(() => {
+    window.__markstreamLayoutReadPerformance = {
+      total: 0,
+      maxPerFrame: 0,
+      byLabel: {},
+    }
+  })
+}
+
 function diffNumber(after, before) {
   return Number(after || 0) - Number(before || 0)
 }
@@ -379,6 +409,11 @@ async function runScenario(browser, port, mode) {
       },
     }
 
+    window.__markstreamLayoutReadPerformance = {
+      total: 0,
+      maxPerFrame: 0,
+      byLabel: {},
+    }
     window.__playgroundPerfState = state
 
     const originalInfo = console.info.bind(console)
@@ -557,6 +592,7 @@ async function runScenario(browser, port, mode) {
       visibleRenderedD2Count: visibleD2Blocks.filter(element => element.querySelector('.d2-svg svg')).length,
       sandboxFrameMounted: Boolean(document.querySelector('.sandbox-frame')),
       parsePerformance: state.parsePerformance ?? null,
+      layoutReads: window.__markstreamLayoutReadPerformance ?? null,
       topLayoutShifts: Array.isArray(state.layoutShifts)
         ? [...state.layoutShifts]
             .sort((a, b) => Number(b?.value || 0) - Number(a?.value || 0))
@@ -565,7 +601,9 @@ async function runScenario(browser, port, mode) {
     }
   }, initialFrameStats)
   result.parsePerformance = cloneParsePerformance(result.parsePerformance)
+  result.layoutReads = normalizeLayoutReadPerformance(result.layoutReads)
   const fullScrollParsePerformanceBaseline = cloneParsePerformance(result.parsePerformance)
+  await resetLayoutReadPerformance(page)
 
   const scrollMetrics = await scrollThroughRoot(page, rootSelector, '__playgroundPerfState')
   const heavySettleFrameBaseline = await frameBaseline(page, '__playgroundPerfState')
@@ -595,6 +633,7 @@ async function runScenario(browser, port, mode) {
       renderedD2Count: d2Blocks.filter(element => element.querySelector('.d2-svg svg')).length,
       longTaskTotalMs: longTasks.reduce((sum, duration) => sum + Number(duration || 0), 0),
       parsePerformance: state.parsePerformance ?? null,
+      layoutReads: window.__markstreamLayoutReadPerformance ?? null,
       scrollDriftPx: null,
     }
   }, {
@@ -609,6 +648,7 @@ async function runScenario(browser, port, mode) {
     result.fullScroll.parsePerformance,
     fullScrollParsePerformanceBaseline,
   )
+  result.fullScroll.layoutReads = normalizeLayoutReadPerformance(result.fullScroll.layoutReads)
   result.fullScroll.scrollDriftPx = scrollMetrics.maxScrollDriftPx
   result.memoryBeforeUnmountBytes = await readUsedHeapBytes(page)
   result.memoryAfterUnmountBytes = await measureAfterRendererUnmount(page)

--- a/scripts/e2e-playground-performance.mjs
+++ b/scripts/e2e-playground-performance.mjs
@@ -190,9 +190,12 @@ function diffParsePerformance(after, before) {
   return out
 }
 
-function assertLayoutReadBudget(mode, phase, layoutReads) {
+function assertLayoutReadBudget(mode, phase, layoutReads, options = {}) {
   if (!layoutReads)
     throw new Error(`[${mode}] ${phase} should record layout read metrics.`)
+
+  if (options.requireReads && !(Number(layoutReads.total || 0) > 0))
+    throw new Error(`[${mode}] ${phase} should record at least one layout read.`)
 
   const maxPerFrame = Number(layoutReads.maxPerFrame || 0)
   if (!(maxPerFrame <= maxLayoutReadsPerFrame)) {
@@ -709,7 +712,7 @@ function assertScenario(result) {
     throw new Error(`[${result.mode}] Total long task time should stay within ${maxLongTaskTotalMs}ms. Got ${result.longTaskTotalMs}.`)
   if (!(result.rendererDomNodeCount <= 5000))
     throw new Error(`[${result.mode}] Renderer DOM node count budget exceeded. Got ${result.rendererDomNodeCount}.`)
-  assertLayoutReadBudget(result.mode, 'initial', result.layoutReads)
+  assertLayoutReadBudget(result.mode, 'initial', result.layoutReads, { requireReads: true })
   if (result.fullScroll.fallbackCount !== 0)
     throw new Error(`[${result.mode}] Code fallback should be gone after full scroll settle.`)
   if (result.fullScroll.renderedMermaidCount !== result.fullScroll.mermaidCount)

--- a/scripts/e2e-playground-performance.mjs
+++ b/scripts/e2e-playground-performance.mjs
@@ -122,6 +122,7 @@ const parsePerformanceStreamCounterKeys = [
   'fullParses',
   'chunkedParses',
 ]
+const maxLayoutReadsPerFrame = Number(process.env.MARKSTREAM_BENCHMARK_MAX_LAYOUT_READS_PER_FRAME || 50)
 
 function cloneParsePerformance(value) {
   return value == null ? null : JSON.parse(JSON.stringify(value))
@@ -187,6 +188,18 @@ function diffParsePerformance(after, before) {
     out.streamModes[key] = diffNumber(after.streamModes?.[key], before.streamModes?.[key])
 
   return out
+}
+
+function assertLayoutReadBudget(mode, phase, layoutReads) {
+  if (!layoutReads)
+    throw new Error(`[${mode}] ${phase} should record layout read metrics.`)
+
+  const maxPerFrame = Number(layoutReads.maxPerFrame || 0)
+  if (!(maxPerFrame <= maxLayoutReadsPerFrame)) {
+    throw new Error(
+      `[${mode}] ${phase} layout reads per frame exceeded ${maxLayoutReadsPerFrame}. Got ${maxPerFrame}.`,
+    )
+  }
 }
 
 function startDevServer(port) {
@@ -696,6 +709,7 @@ function assertScenario(result) {
     throw new Error(`[${result.mode}] Total long task time should stay within ${maxLongTaskTotalMs}ms. Got ${result.longTaskTotalMs}.`)
   if (!(result.rendererDomNodeCount <= 5000))
     throw new Error(`[${result.mode}] Renderer DOM node count budget exceeded. Got ${result.rendererDomNodeCount}.`)
+  assertLayoutReadBudget(result.mode, 'initial', result.layoutReads)
   if (result.fullScroll.fallbackCount !== 0)
     throw new Error(`[${result.mode}] Code fallback should be gone after full scroll settle.`)
   if (result.fullScroll.renderedMermaidCount !== result.fullScroll.mermaidCount)
@@ -706,6 +720,7 @@ function assertScenario(result) {
     throw new Error(`[${result.mode}] D2 blocks should all finish after full scroll settle.`)
   if (!(result.fullScroll.rendererDomNodeCount <= 5000))
     throw new Error(`[${result.mode}] Full-scroll renderer DOM node count budget exceeded. Got ${result.fullScroll.rendererDomNodeCount}.`)
+  assertLayoutReadBudget(result.mode, 'full-scroll', result.fullScroll.layoutReads)
 }
 
 async function run() {

--- a/scripts/e2e-web-vitals-performance.mjs
+++ b/scripts/e2e-web-vitals-performance.mjs
@@ -363,6 +363,11 @@ async function resetPhase(page, phase) {
     state.frames = []
     state.lastFrameAt = 0
     state.parseBaseline = JSON.parse(JSON.stringify(state.parsePerformance ?? null))
+    window.__markstreamLayoutReadPerformance = {
+      total: 0,
+      maxPerFrame: 0,
+      byLabel: {},
+    }
   }, phase)
   await waitForFrames(page, 1)
 }
@@ -417,6 +422,11 @@ async function installObservers(context) {
       },
     }
 
+    window.__markstreamLayoutReadPerformance = {
+      total: 0,
+      maxPerFrame: 0,
+      byLabel: {},
+    }
     window.__webVitalsProbeState = state
     window.__playgroundPerfState = state
 
@@ -639,6 +649,25 @@ async function captureVitalsSnapshot(page, label, performanceDelta = null) {
         streamModes,
       }
     }
+    const normalizeLayoutReadPerformance = (value) => {
+      if (!value || typeof value !== 'object')
+        return null
+
+      const byLabel = value.byLabel && typeof value.byLabel === 'object'
+        ? Object.fromEntries(
+            Object.entries(value.byLabel)
+              .map(([key, count]) => [key, Number(count || 0)])
+              .filter(([, count]) => count > 0)
+              .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+          )
+        : {}
+
+      return {
+        total: Number(value.total || 0),
+        maxPerFrame: Math.max(Number(value.maxPerFrame || 0), Number(value.currentFrameTotal || 0)),
+        byLabel,
+      }
+    }
 
     for (const event of events) {
       const key = Number(event.interactionId || 0) > 0
@@ -742,6 +771,7 @@ async function captureVitalsSnapshot(page, label, performanceDelta = null) {
       hasMonacoDom: Boolean(document.querySelector('.monaco-editor, .monaco-diff-editor')),
       jsHeapUsedBytes: null,
       parsePerformance: diffParsePerformance(state.parsePerformance, state.parseBaseline),
+      layoutReads: normalizeLayoutReadPerformance(window.__markstreamLayoutReadPerformance),
       topLayoutShifts: [...layoutShifts]
         .sort((a, b) => Number(b?.value || 0) - Number(a?.value || 0))
         .slice(0, 8),

--- a/src/components/D2BlockNode/d2.ts
+++ b/src/components/D2BlockNode/d2.ts
@@ -17,9 +17,16 @@ const defaultD2Loader: D2Loader = () => import('@terrastruct/d2')
 
 let cachedD2: any = null
 let d2Loader: D2Loader | null = defaultD2Loader
+let pendingD2: Promise<D2Module | null> | null = null
+let defaultD2LoadFailed = false
+let defaultD2WarningShown = false
+let d2LoaderVersion = 0
 
 function resetCachedD2() {
   cachedD2 = null
+  pendingD2 = null
+  defaultD2LoadFailed = false
+  defaultD2WarningShown = false
 }
 
 function normalizeD2Module(mod: any) {
@@ -39,6 +46,7 @@ function normalizeD2Module(mod: any) {
 
 export function setD2Loader(loader: D2Loader | null) {
   d2Loader = loader
+  d2LoaderVersion++
   resetCachedD2()
 }
 
@@ -54,27 +62,61 @@ export function isD2Enabled() {
   return typeof d2Loader === 'function'
 }
 
+function warnDefaultD2LoadFailed(err: unknown) {
+  if (defaultD2WarningShown)
+    return
+
+  defaultD2WarningShown = true
+  console.warn(
+    '[markstream-vue] Optional dependency "@terrastruct/d2" is not installed. D2 blocks will render as source.',
+    err,
+  )
+}
+
 export async function getD2(): Promise<D2Module | null> {
   if (cachedD2)
     return cachedD2
 
   const loader = d2Loader
+  const version = d2LoaderVersion
   if (!loader)
     return null
 
-  let mod: any
-  try {
-    mod = await loader()
-  }
-  catch (err) {
-    if (loader === defaultD2Loader) {
-      throw new Error('Optional dependency "@terrastruct/d2" is not installed. Please install it to enable D2 diagrams.')
-    }
-    throw err
-  }
-  if (!mod)
+  if (loader === defaultD2Loader && defaultD2LoadFailed)
     return null
 
-  cachedD2 = normalizeD2Module(mod)
-  return cachedD2
+  if (pendingD2)
+    return pendingD2
+
+  pendingD2 = (async () => {
+    let mod: any
+    try {
+      mod = await loader()
+    }
+    catch (err) {
+      if (loader === defaultD2Loader) {
+        if (version === d2LoaderVersion && loader === d2Loader) {
+          defaultD2LoadFailed = true
+          warnDefaultD2LoadFailed(err)
+        }
+        return null
+      }
+      throw err
+    }
+    finally {
+      if (version === d2LoaderVersion && loader === d2Loader)
+        pendingD2 = null
+    }
+
+    if (version !== d2LoaderVersion || loader !== d2Loader)
+      return null
+
+    if (!mod)
+      return null
+
+    cachedD2 = normalizeD2Module(mod)
+    return cachedD2
+  })()
+
+  return pendingD2
 }

--- a/src/components/InfographicBlockNode/infographic.ts
+++ b/src/components/InfographicBlockNode/infographic.ts
@@ -21,6 +21,8 @@ export type InfographicLoader = () => Promise<InfographicModuleLike> | Infograph
 
 let cachedInfographic: InfographicConstructor | null = null
 let infographicLoader: InfographicLoader | null = null
+let pendingInfographic: Promise<InfographicConstructor | null> | null = null
+let infographicLoadFailed = false
 let loaderVersion = 0
 
 function normalizeInfographicModule(mod: unknown): InfographicConstructor | null {
@@ -43,6 +45,8 @@ function normalizeInfographicModule(mod: unknown): InfographicConstructor | null
 export function setInfographicLoader(loader?: InfographicLoader | null) {
   infographicLoader = loader ?? null
   cachedInfographic = null
+  pendingInfographic = null
+  infographicLoadFailed = false
   loaderVersion++
 }
 
@@ -72,15 +76,31 @@ export async function getInfographic(): Promise<InfographicConstructor | null> {
   const version = loaderVersion
   if (!loader)
     return null
-  const mod: any = await loader()
-  if (version !== loaderVersion || loader !== infographicLoader)
-    return null
-  const resolved = normalizeInfographicModule(mod)
-  if (version !== loaderVersion || loader !== infographicLoader)
-    return null
-  if (!resolved)
+
+  if (infographicLoadFailed)
     return null
 
-  cachedInfographic = resolved
-  return cachedInfographic
+  if (pendingInfographic)
+    return pendingInfographic
+
+  pendingInfographic = (async () => {
+    const mod: any = await loader()
+    if (version !== loaderVersion || loader !== infographicLoader)
+      return null
+    const resolved = normalizeInfographicModule(mod)
+    if (version !== loaderVersion || loader !== infographicLoader)
+      return null
+    if (!resolved) {
+      infographicLoadFailed = true
+      return null
+    }
+
+    cachedInfographic = resolved
+    return cachedInfographic
+  })().finally(() => {
+    if (version === loaderVersion && loader === infographicLoader)
+      pendingInfographic = null
+  })
+
+  return pendingInfographic
 }

--- a/src/components/InfographicBlockNode/infographic.ts
+++ b/src/components/InfographicBlockNode/infographic.ts
@@ -22,7 +22,6 @@ export type InfographicLoader = () => Promise<InfographicModuleLike> | Infograph
 let cachedInfographic: InfographicConstructor | null = null
 let infographicLoader: InfographicLoader | null = null
 let pendingInfographic: Promise<InfographicConstructor | null> | null = null
-let infographicLoadFailed = false
 let loaderVersion = 0
 
 function normalizeInfographicModule(mod: unknown): InfographicConstructor | null {
@@ -46,7 +45,6 @@ export function setInfographicLoader(loader?: InfographicLoader | null) {
   infographicLoader = loader ?? null
   cachedInfographic = null
   pendingInfographic = null
-  infographicLoadFailed = false
   loaderVersion++
 }
 
@@ -77,9 +75,6 @@ export async function getInfographic(): Promise<InfographicConstructor | null> {
   if (!loader)
     return null
 
-  if (infographicLoadFailed)
-    return null
-
   if (pendingInfographic)
     return pendingInfographic
 
@@ -90,10 +85,8 @@ export async function getInfographic(): Promise<InfographicConstructor | null> {
     const resolved = normalizeInfographicModule(mod)
     if (version !== loaderVersion || loader !== infographicLoader)
       return null
-    if (!resolved) {
-      infographicLoadFailed = true
+    if (!resolved)
       return null
-    }
 
     cachedInfographic = resolved
     return cachedInfographic

--- a/src/components/MermaidBlockNode/mermaid.ts
+++ b/src/components/MermaidBlockNode/mermaid.ts
@@ -20,9 +20,16 @@ const defaultMermaidLoader: MermaidLoader = () => import('mermaid')
 
 let cachedMermaid: any = null
 let mermaidLoader: MermaidLoader | null = defaultMermaidLoader
+let pendingMermaid: Promise<MermaidModule | null> | null = null
+let defaultMermaidLoadFailed = false
+let defaultMermaidWarningShown = false
+let mermaidLoaderVersion = 0
 
 function resetCachedMermaid() {
   cachedMermaid = null
+  pendingMermaid = null
+  defaultMermaidLoadFailed = false
+  defaultMermaidWarningShown = false
 }
 
 function getGlobalMermaid() {
@@ -37,6 +44,7 @@ function getGlobalMermaid() {
 
 export function setMermaidLoader(loader: MermaidLoader | null) {
   mermaidLoader = loader
+  mermaidLoaderVersion++
   resetCachedMermaid()
 }
 
@@ -113,6 +121,17 @@ function patchInitialize(target: any) {
   }
 }
 
+function warnDefaultMermaidLoadFailed(err: unknown) {
+  if (defaultMermaidWarningShown)
+    return
+
+  defaultMermaidWarningShown = true
+  console.warn(
+    '[markstream-vue] Optional dependency "mermaid" is not installed. Mermaid blocks will render as source.',
+    err,
+  )
+}
+
 export async function getMermaid(): Promise<MermaidModule | null> {
   if (cachedMermaid)
     return cachedMermaid
@@ -125,21 +144,46 @@ export async function getMermaid(): Promise<MermaidModule | null> {
   }
 
   const loader = mermaidLoader
+  const version = mermaidLoaderVersion
   if (!loader)
     return null
-  let mod: any
-  try {
-    mod = await loader()
-  }
-  catch (err) {
-    if (loader === defaultMermaidLoader) {
-      throw new Error('Optional dependency "mermaid" is not installed. Please install it to enable mermaid diagrams.')
-    }
-    throw err
-  }
-  if (!mod)
+
+  if (loader === defaultMermaidLoader && defaultMermaidLoadFailed)
     return null
-  cachedMermaid = normalizeMermaidModule(mod)
-  patchInitialize(cachedMermaid)
-  return cachedMermaid
+
+  if (pendingMermaid)
+    return pendingMermaid
+
+  pendingMermaid = (async () => {
+    let mod: any
+    try {
+      mod = await loader()
+    }
+    catch (err) {
+      if (loader === defaultMermaidLoader) {
+        if (version === mermaidLoaderVersion && loader === mermaidLoader) {
+          defaultMermaidLoadFailed = true
+          warnDefaultMermaidLoadFailed(err)
+        }
+        return null
+      }
+      throw err
+    }
+    finally {
+      if (version === mermaidLoaderVersion && loader === mermaidLoader)
+        pendingMermaid = null
+    }
+
+    if (version !== mermaidLoaderVersion || loader !== mermaidLoader)
+      return null
+
+    if (!mod)
+      return null
+
+    cachedMermaid = normalizeMermaidModule(mod)
+    patchInitialize(cachedMermaid)
+    return cachedMermaid
+  })()
+
+  return pendingMermaid
 }

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ParsedNode } from 'stream-markdown-parser'
+import type { EstimatedNodeHeight } from '../../internal/heightEstimationExperiment'
 import type { CustomComponents } from '../../types'
 import type { CodeBlockPreviewPayload } from '../../types/component-props'
 import type {
@@ -1455,14 +1456,16 @@ function resolveCodeBlockShowHeader() {
   return showHeader !== false
 }
 
+const EMPTY_ESTIMATED_NODE_HEIGHTS: Array<EstimatedNodeHeight | null> = []
+
 const estimatedNodeHeights = computed(() => {
   const nodes = parsedNodes.value
   if (!nodes.length || !heightEstimationActive.value)
-    return nodes.map(() => null)
+    return EMPTY_ESTIMATED_NODE_HEIGHTS
 
   const width = experimentContainerWidth.value || readLayout('estimatedNodeHeights.clientWidth', () => containerRef.value?.clientWidth || 0)
   if (!Number.isFinite(width) || width <= 0)
-    return nodes.map(() => null)
+    return EMPTY_ESTIMATED_NODE_HEIGHTS
 
   return nodes.map((node, index) => {
     const measuredHeight = nodeHeights[index]

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -494,6 +494,18 @@ const layoutReadFrameCounts = new Map<string, number>()
 let layoutReadFrameScheduled = false
 let maxLayoutReadsPerFrame = 0
 
+interface BenchmarkLayoutReadPerformance {
+  total: number
+  maxPerFrame: number
+  byLabel: Record<string, number>
+  currentFrameTotal?: number
+  frameScheduled?: boolean
+}
+
+type BenchmarkLayoutReadWindow = Window & {
+  __markstreamLayoutReadPerformance?: BenchmarkLayoutReadPerformance
+}
+
 function getMapTotal(map: Map<string, number>) {
   let total = 0
   for (const count of map.values())
@@ -531,12 +543,65 @@ function scheduleLayoutReadFrameFlush() {
   setTimeout(flushLayoutReadFrameCounts, 0)
 }
 
+function getBenchmarkLayoutReadPerformance() {
+  if (!isClient || typeof window === 'undefined')
+    return null
+
+  const target = window as BenchmarkLayoutReadWindow
+  if (target.__markstreamLayoutReadPerformance)
+    return target.__markstreamLayoutReadPerformance
+
+  const created: BenchmarkLayoutReadPerformance = {
+    total: 0,
+    maxPerFrame: 0,
+    byLabel: {},
+  }
+  target.__markstreamLayoutReadPerformance = created
+  return created
+}
+
+function flushBenchmarkLayoutReadFrame(state: BenchmarkLayoutReadPerformance) {
+  state.maxPerFrame = Math.max(
+    Number(state.maxPerFrame || 0),
+    Number(state.currentFrameTotal || 0),
+  )
+  state.currentFrameTotal = 0
+  state.frameScheduled = false
+}
+
+function publishBenchmarkLayoutRead(label: string) {
+  const performance = getBenchmarkLayoutReadPerformance()
+  if (!performance)
+    return
+
+  performance.total = Number(performance.total || 0) + 1
+  performance.byLabel[label] = Number(performance.byLabel[label] || 0) + 1
+  performance.currentFrameTotal = Number(performance.currentFrameTotal || 0) + 1
+
+  if (performance.frameScheduled)
+    return
+
+  performance.frameScheduled = true
+  if (typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(() => flushBenchmarkLayoutReadFrame(performance))
+    return
+  }
+
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(() => flushBenchmarkLayoutReadFrame(performance))
+    return
+  }
+
+  setTimeout(() => flushBenchmarkLayoutReadFrame(performance), 0)
+}
+
 function recordLayoutRead(label: string) {
   if (!debugPerformanceEnabled.value)
     return
 
   layoutReadCounts.set(label, (layoutReadCounts.get(label) ?? 0) + 1)
   layoutReadFrameCounts.set(label, (layoutReadFrameCounts.get(label) ?? 0) + 1)
+  publishBenchmarkLayoutRead(label)
   scheduleLayoutReadFrameFlush()
 }
 
@@ -6231,6 +6296,12 @@ onBeforeUnmount(() => {
   background-image: linear-gradient(90deg, var(--loading-shimmer), transparent, var(--loading-shimmer));
   background-size: 200% 100%;
   animation: node-placeholder-shimmer 1.1s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .node-placeholder {
+    animation: none;
+  }
 }
 
 .node-placeholder:first-child {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1221,6 +1221,9 @@ function syncFocusToScroll(force = false) {
   const isViewportRoot = root === doc?.documentElement || root === doc?.body
 
   const total = parsedNodes.value.length
+  if (total <= 0)
+    return
+
   const reverseFlex = !isViewportRoot && total > 0 && isReverseFlexScrollRoot(root)
   if (reverseFlex) {
     // In reverse-flex scroll roots (chat UIs), `scrollTop` is effectively the
@@ -1234,10 +1237,13 @@ function syncFocusToScroll(force = false) {
     const offsetFromBottom = Math.max(0, distanceFromBottom) + Math.max(0, viewportHeight) * 0.5
     const estimated = estimateIndexForOffsetFromEnd(offsetFromBottom)
     const next = clamp(estimated, 0, Math.max(0, total - 1))
-    if (force || Math.abs(next - focusIndex.value) > 1) {
-      focusIndex.value = next
-      updateLiveRange()
-    }
+    applyScrollFocusIndex(next, force)
+    return
+  }
+
+  const estimated = estimateFocusIndexFromScroll(root, doc, view, isViewportRoot)
+  if (estimated != null) {
+    applyScrollFocusIndex(estimated, force)
     return
   }
 
@@ -1287,15 +1293,43 @@ function syncFocusToScroll(force = false) {
       : readLayout('syncFocusToScroll.fallback.root.clientHeight', () => root.clientHeight)
     const targetOffset = relativeScrollTop + Math.max(0, viewportHeight) * 0.5
     const estimated = estimateIndexForOffset(targetOffset)
-    focusIndex.value = clamp(estimated, 0, Math.max(0, parsedNodes.value.length - 1))
-    updateLiveRange()
+    applyScrollFocusIndex(clamp(estimated, 0, Math.max(0, parsedNodes.value.length - 1)), true)
     return
   }
   const midpoint = Math.round((firstVisible + lastVisible) / 2)
-  if (!force && Math.abs(midpoint - focusIndex.value) <= 1)
+  applyScrollFocusIndex(midpoint, force)
+}
+
+function applyScrollFocusIndex(index: number, force = false) {
+  const next = clamp(index, 0, Math.max(0, parsedNodes.value.length - 1))
+  if (!force && Math.abs(next - focusIndex.value) <= 1)
     return
-  focusIndex.value = clamp(midpoint, 0, Math.max(0, parsedNodes.value.length - 1))
+
+  focusIndex.value = next
   updateLiveRange()
+}
+
+function estimateFocusIndexFromScroll(
+  root: HTMLElement,
+  doc: Document,
+  view: Window | null,
+  isViewportRoot: boolean,
+) {
+  const container = containerRef.value
+  if (!container)
+    return null
+
+  const viewportTop = isViewportRoot
+    ? 0
+    : readLayout('syncFocusToScroll.model.root.getBoundingClientRect', () => root.getBoundingClientRect().top)
+  const containerTop = readLayout('syncFocusToScroll.model.container.getBoundingClientRect', () => container.getBoundingClientRect().top)
+  const relativeScrollTop = Math.max(0, viewportTop - containerTop)
+  const viewportHeight = isViewportRoot
+    ? readLayout('syncFocusToScroll.model.viewport.clientHeight', () => view?.innerHeight ?? doc.documentElement?.clientHeight ?? root.clientHeight ?? 0)
+    : readLayout('syncFocusToScroll.model.root.clientHeight', () => root.clientHeight)
+  const targetOffset = relativeScrollTop + Math.max(0, viewportHeight) * 0.5
+  const estimated = estimateIndexForOffset(targetOffset)
+  return clamp(estimated, 0, Math.max(0, parsedNodes.value.length - 1))
 }
 
 function clamp(value: number, min: number, max: number) {

--- a/test/optional-dependency-control.test.ts
+++ b/test/optional-dependency-control.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { disableD2, enableD2, getD2, isD2Enabled, setD2Loader } from '../src/components/D2BlockNode/d2'
 import { disableInfographic, enableInfographic, getInfographic, isInfographicEnabled, setInfographicLoader } from '../src/components/InfographicBlockNode/infographic'
 import { disableKatex, enableKatex, getKatex, isKatexEnabled, setKatexLoader } from '../src/components/MathInlineNode/katex'
 import { disableMermaid, enableMermaid, getMermaid, isMermaidEnabled, setMermaidLoader } from '../src/components/MermaidBlockNode/mermaid'
@@ -48,6 +49,113 @@ describe('optional dependency controllers', () => {
       const disabled = await getMermaid()
       expect(disabled).toBeNull()
       await expect(canParseOffthread('graph TD;A-->B', 'light')).rejects.toMatchObject({ code: 'MERMAID_DISABLED' })
+    })
+
+    it('shares an in-flight mermaid loader request', async () => {
+      const render = vi.fn()
+      const parse = vi.fn()
+      const initialize = vi.fn()
+      let resolveLoader: (value: object) => void = () => {}
+      const loader = vi.fn(() =>
+        new Promise<object>((r) => {
+          resolveLoader = r
+        }),
+      )
+
+      setMermaidLoader(loader)
+      const first = getMermaid()
+      const second = getMermaid()
+
+      resolveLoader({ render, parse, initialize })
+
+      const firstResolved = await first
+      const secondResolved = await second
+      expect(firstResolved).toBe(secondResolved)
+      expect(firstResolved?.render).toBe(render)
+      expect(loader).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not cache an in-flight mermaid loader result after disabling', async () => {
+      let resolveLoader: (value: object) => void = () => {}
+      const loader = vi.fn(() =>
+        new Promise<object>((r) => {
+          resolveLoader = r
+        }),
+      )
+
+      setMermaidLoader(loader)
+      const pending = getMermaid()
+
+      disableMermaid()
+      resolveLoader({ render: vi.fn() })
+
+      await expect(pending).resolves.toBeNull()
+      await expect(getMermaid()).resolves.toBeNull()
+    })
+  })
+
+  describe('d2 loader control', () => {
+    afterEach(() => {
+      enableD2()
+    })
+
+    it('allows overriding and disabling the D2 loader', async () => {
+      class CustomD2 {
+        compile() {}
+      }
+
+      setD2Loader(async () => ({ D2: CustomD2 }))
+
+      const api = await getD2()
+      expect(api).toBe(CustomD2)
+      expect(isD2Enabled()).toBe(true)
+
+      disableD2()
+      expect(isD2Enabled()).toBe(false)
+      await expect(getD2()).resolves.toBeNull()
+    })
+
+    it('shares an in-flight D2 loader request', async () => {
+      class CustomD2 {
+        compile() {}
+      }
+      let resolveLoader: (value: object) => void = () => {}
+      const loader = vi.fn(() =>
+        new Promise<object>((r) => {
+          resolveLoader = r
+        }),
+      )
+
+      setD2Loader(loader)
+      const first = getD2()
+      const second = getD2()
+
+      resolveLoader({ D2: CustomD2 })
+
+      await expect(first).resolves.toBe(CustomD2)
+      await expect(second).resolves.toBe(CustomD2)
+      expect(loader).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not cache an in-flight D2 loader result after disabling', async () => {
+      class CustomD2 {
+        compile() {}
+      }
+      let resolveLoader: (value: object) => void = () => {}
+      const loader = vi.fn(() =>
+        new Promise<object>((r) => {
+          resolveLoader = r
+        }),
+      )
+
+      setD2Loader(loader)
+      const pending = getD2()
+
+      disableD2()
+      resolveLoader({ D2: CustomD2 })
+
+      await expect(pending).resolves.toBeNull()
+      await expect(getD2()).resolves.toBeNull()
     })
   })
 
@@ -118,10 +226,36 @@ describe('optional dependency controllers', () => {
       await expect(getInfographic()).resolves.toBeNull()
     })
 
+    it('shares an in-flight infographic loader request', async () => {
+      class CustomInfographic {
+        render() {}
+      }
+
+      let resolveLoader: (value: object) => void = () => {}
+      const loader = vi.fn(() =>
+        new Promise<object>((r) => {
+          resolveLoader = r
+        }),
+      )
+
+      setInfographicLoader(loader)
+      const first = getInfographic()
+      const second = getInfographic()
+
+      resolveLoader({ Infographic: CustomInfographic })
+
+      await expect(first).resolves.toBe(CustomInfographic)
+      await expect(second).resolves.toBe(CustomInfographic)
+      expect(loader).toHaveBeenCalledTimes(1)
+    })
+
     it('returns null for an invalid infographic module shape', async () => {
-      setInfographicLoader(async () => ({}))
+      const loader = vi.fn(async () => ({}))
+      setInfographicLoader(loader)
 
       await expect(getInfographic()).resolves.toBeNull()
+      await expect(getInfographic()).resolves.toBeNull()
+      expect(loader).toHaveBeenCalledTimes(1)
     })
 
     it('requires an explicit loader when enabling infographic', () => {

--- a/test/optional-dependency-control.test.ts
+++ b/test/optional-dependency-control.test.ts
@@ -249,13 +249,19 @@ describe('optional dependency controllers', () => {
       expect(loader).toHaveBeenCalledTimes(1)
     })
 
-    it('returns null for an invalid infographic module shape', async () => {
-      const loader = vi.fn(async () => ({}))
+    it('does not cache an invalid infographic module shape', async () => {
+      class CustomInfographic {
+        render() {}
+      }
+
+      const loader = vi.fn()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Infographic: CustomInfographic })
       setInfographicLoader(loader)
 
       await expect(getInfographic()).resolves.toBeNull()
-      await expect(getInfographic()).resolves.toBeNull()
-      expect(loader).toHaveBeenCalledTimes(1)
+      await expect(getInfographic()).resolves.toBe(CustomInfographic)
+      expect(loader).toHaveBeenCalledTimes(2)
     })
 
     it('requires an explicit loader when enabling infographic', () => {

--- a/test/release-gates.test.ts
+++ b/test/release-gates.test.ts
@@ -271,6 +271,8 @@ describe('release dependency gates', () => {
     expect(benchmarkScript).toContain('processTokensMs')
     expect(diagnosticScript).toContain('__markstreamLayoutReadPerformance')
     expect(mainScript).toContain('__markstreamLayoutReadPerformance')
+    expect(diagnosticScript).toContain('MARKSTREAM_BENCHMARK_MAX_LAYOUT_READS_PER_FRAME')
+    expect(mainScript).toContain('MARKSTREAM_BENCHMARK_MAX_LAYOUT_READS_PER_FRAME')
     expect(benchmarkScript).toContain('layoutReadsSummary')
   })
 

--- a/test/release-gates.test.ts
+++ b/test/release-gates.test.ts
@@ -269,6 +269,9 @@ describe('release dependency gates', () => {
     expect(benchmarkScript).toContain('parsePerformanceSummary')
     expect(benchmarkScript).toContain('tokenCloneMs')
     expect(benchmarkScript).toContain('processTokensMs')
+    expect(diagnosticScript).toContain('__markstreamLayoutReadPerformance')
+    expect(mainScript).toContain('__markstreamLayoutReadPerformance')
+    expect(benchmarkScript).toContain('layoutReadsSummary')
   })
 
   it('does not create release tags for package versions already published on npm', () => {


### PR DESCRIPTION
## Summary
- Add debug-only layout read metrics to benchmark outputs and gate main/diagnostic playground layout reads per frame.
- Use the existing height model as the primary virtual focus sync path instead of scanning rendered slot rects on every scroll sync.
- Cache optional Mermaid/D2/Infographic loader requests and protect in-flight loader results from stale writes.
- Avoid empty height-estimate array allocations when height estimation is inactive or width is unavailable.
- Respect `prefers-reduced-motion` for node placeholder shimmer.

## Notes
- I intentionally did not implement parser AST patches, parser-owned node metadata, `domMode`, `minimal` entry, NodeRenderer splitting, typewriter simple/precise modes, SSR app-scoped config, or SEO landing pages in this PR. Those are valid larger directions but too broad for this performance-fix batch.

## Validation
- `CI=1 corepack pnpm lint`
- `CI=1 corepack pnpm run typecheck`
- `CI=1 corepack pnpm test -- --run` (281 files, 2407 tests)
- `CI=1 BENCHMARK_JSON_PATH=.tmp/main-playground-performance-budget.json corepack pnpm run test:e2e:main-playground-performance`
- `CI=1 PLAYGROUND_SAMPLE=stress BENCHMARK_JSON_PATH=.tmp/playground-stress-performance-budget.json corepack pnpm run test:e2e:playground-performance` (first run hit existing LCP=0 lab sampling failure, rerun passed)

Layout read baseline after budget wiring:
- Main playground: maxPerFrame 4 initial, 0 full-scroll/replay.
- Stress playground: maxPerFrame 4 initial, 0 full-scroll in both markdown and monaco modes.