### PR TITLE
feat: add simple typewriter cursor mode

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -397,9 +397,12 @@ const {
   isClient,
   scrollRoot: resolveVirtualScrollRoot,
 })
+const typewriterEnabled = computed(() => rendererProps.typewriter !== false)
+const isSimpleTypewriterCursor = computed(() => rendererProps.typewriter === 'simple')
+const isPreciseTypewriterCursor = computed(() => typewriterEnabled.value && !isSimpleTypewriterCursor.value)
 provide('markstreamShowTooltips', resolvedShowTooltips)
 provide('markstreamHtmlPolicy', resolvedHtmlPolicy)
-provide('markstreamTypewriter', computed(() => rendererProps.typewriter !== false))
+provide('markstreamTypewriter', typewriterEnabled)
 provide('markstreamFade', computed(() => rendererProps.fade !== false))
 provide('markstreamTypewriterCursor', computed(() => true))
 provide('markstreamTextStreamState', textStreamState)
@@ -5228,7 +5231,7 @@ const infographicBindings = computed(() => ({
   ...(rendererProps.infographicProps || {}),
 }))
 const nonCodeBindings = computed(() => ({
-  typewriter: rendererProps.typewriter,
+  typewriter: typewriterEnabled.value,
   fade: rendererProps.fade,
   // Forward customHtmlTags for non-whitelisted tag detection in child components
   customHtmlTags: mergedParseOptions.value.customHtmlTags,
@@ -5619,6 +5622,9 @@ let typewriterCursorRaf: number | null = null
 let typewriterCursorRafVersion = 0
 let lastTypewriterContentLength = 0
 let lastTypewriterVisibleLength = 0
+let lastTypewriterCursorMode = 'off'
+let simpleTypewriterCursorElement: HTMLElement | null = null
+const SIMPLE_TYPEWRITER_CURSOR_ATTR = 'data-typewriter-simple-cursor'
 const TYPEWRITER_CURSOR_EXCLUDED_NODE_TYPE_LIST = [
   'code_block',
   'admonition',
@@ -5702,10 +5708,52 @@ function clearTypewriterCursorRaf() {
   typewriterCursorRaf = null
 }
 
+function clearSimpleTypewriterCursorElement() {
+  simpleTypewriterCursorElement?.removeAttribute(SIMPLE_TYPEWRITER_CURSOR_ATTR)
+  simpleTypewriterCursorElement = null
+}
+
 function hideTypewriterCursorElement() {
   clearTypewriterCursorRaf()
+  clearSimpleTypewriterCursorElement()
   if (typewriterCursorRef.value)
     typewriterCursorRef.value.style.visibility = 'hidden'
+}
+
+function showSimpleTypewriterCursorElement() {
+  clearTypewriterCursorRaf()
+  clearSimpleTypewriterCursorElement()
+
+  const text = getTypewriterCursorTextTarget()
+  const parent = text?.parentElement
+  const target = parent?.closest<HTMLElement>('.text-node, .inline-code') ?? parent
+  if (!target)
+    return
+
+  target.setAttribute(SIMPLE_TYPEWRITER_CURSOR_ATTR, 'true')
+  simpleTypewriterCursorElement = target
+}
+
+function showPreciseTypewriterCursorElement() {
+  clearSimpleTypewriterCursorElement()
+  if (typewriterCursorRef.value)
+    typewriterCursorRef.value.style.visibility = 'hidden'
+  scheduleTypewriterCursorPositionUpdate()
+}
+
+function getTypewriterCursorMode() {
+  if (!typewriterEnabled.value)
+    return 'off'
+  return isSimpleTypewriterCursor.value ? 'simple' : 'precise'
+}
+
+function showCurrentTypewriterCursorElement() {
+  if (isSimpleTypewriterCursor.value) {
+    showSimpleTypewriterCursorElement()
+    return
+  }
+
+  showPreciseTypewriterCursorElement()
 }
 
 function isAcceptedTypewriterCursorTextNode(node: Node): node is Text {
@@ -5770,7 +5818,7 @@ function getTypewriterCursorTextTarget() {
 }
 
 function updateTypewriterCursorPosition() {
-  if (!isClient || !showTypewriterCursor.value || !containerRef.value || !typewriterCursorRef.value)
+  if (!isClient || !isPreciseTypewriterCursor.value || !showTypewriterCursor.value || !containerRef.value || !typewriterCursorRef.value)
     return
 
   const root = containerRef.value
@@ -5814,7 +5862,7 @@ function updateTypewriterCursorPosition() {
 }
 
 function scheduleTypewriterCursorPositionUpdate() {
-  if (!isClient || !showTypewriterCursor.value)
+  if (!isClient || !isPreciseTypewriterCursor.value || !showTypewriterCursor.value)
     return
   if (typewriterCursorRaf != null)
     return
@@ -5866,24 +5914,30 @@ watch(
     const cursorAllowed = shouldShowTypewriterCursorForCurrentNodes()
     const sourceGrowing = nextLength > lastTypewriterContentLength
     const visibleGrowing = nextVisibleLength > lastTypewriterVisibleLength
-    if (rendererProps.typewriter === false || !cursorAllowed || (!sourceGrowing && !visibleGrowing)) {
-      if (rendererProps.typewriter === false || !cursorAllowed) {
+    const cursorMode = getTypewriterCursorMode()
+    const cursorModeChanged = cursorMode !== lastTypewriterCursorMode
+    if (!typewriterEnabled.value || !cursorAllowed || (!sourceGrowing && !visibleGrowing)) {
+      if (!typewriterEnabled.value || !cursorAllowed) {
         showTypewriterCursor.value = false
         hideTypewriterCursorElement()
       }
+      else if (cursorModeChanged && showTypewriterCursor.value) {
+        await nextTick()
+        showCurrentTypewriterCursorElement()
+      }
       lastTypewriterContentLength = nextLength
       lastTypewriterVisibleLength = nextVisibleLength
+      lastTypewriterCursorMode = cursorMode
       return
     }
 
     lastTypewriterContentLength = nextLength
     lastTypewriterVisibleLength = nextVisibleLength
+    lastTypewriterCursorMode = cursorMode
     showTypewriterCursor.value = true
-    if (typewriterCursorRef.value)
-      typewriterCursorRef.value.style.visibility = 'hidden'
     clearTypewriterCursorTimeout()
     await nextTick()
-    scheduleTypewriterCursorPositionUpdate()
+    showCurrentTypewriterCursorElement()
     typewriterCursorTimeout = setTimeout(() => {
       typewriterCursorTimeout = undefined
       showTypewriterCursor.value = false
@@ -5900,7 +5954,7 @@ watch(
       return
     }
     await nextTick()
-    scheduleTypewriterCursorPositionUpdate()
+    showCurrentTypewriterCursorElement()
   },
   { flush: 'post' },
 )
@@ -5912,6 +5966,14 @@ watch(
       return
 
     await nextTick()
+    if (isSimpleTypewriterCursor.value) {
+      showSimpleTypewriterCursorElement()
+      return
+    }
+
+    if (!isPreciseTypewriterCursor.value)
+      return
+
     scheduleTypewriterCursorPositionUpdate()
   },
   { flush: 'post' },
@@ -5920,6 +5982,7 @@ watch(
 onBeforeUnmount(() => {
   clearTypewriterCursorTimeout()
   clearTypewriterCursorRaf()
+  clearSimpleTypewriterCursorElement()
   mathBlockMinHeightCache.clear()
 })
 </script>
@@ -6164,7 +6227,7 @@ onBeforeUnmount(() => {
       </div>
     </template>
     <span
-      v-if="showTypewriterCursor"
+      v-if="showTypewriterCursor && isPreciseTypewriterCursor"
       ref="typewriterCursorRef"
       class="typewriter-cursor"
       aria-hidden="true"
@@ -6268,6 +6331,18 @@ onBeforeUnmount(() => {
   border-right: 2px solid currentColor;
   pointer-events: none;
   visibility: hidden;
+  animation: typewriter-cursor-blink 1s steps(1, end) infinite;
+}
+
+.markdown-renderer :deep([data-typewriter-simple-cursor="true"])::after {
+  content: '';
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  margin-left: 0.08em;
+  vertical-align: -0.12em;
+  border-right: 2px solid currentColor;
+  pointer-events: none;
   animation: typewriter-cursor-blink 1s steps(1, end) infinite;
 }
 

--- a/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
+++ b/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
@@ -19,6 +19,10 @@ export interface SmoothStreamingBridge {
   effectiveFinal: ComputedRef<boolean | undefined>
 }
 
+function isTypewriterEnabled(typewriter: NodeRendererProps['typewriter']) {
+  return typewriter === true || typewriter === 'simple' || typewriter === 'precise'
+}
+
 export function useSmoothStreamingBridge(
   props: Readonly<NodeRendererProps>,
   options: SmoothStreamingBridgeOptions,
@@ -40,7 +44,7 @@ export function useSmoothStreamingBridge(
       return true
 
     // auto mode: enable only for typewriter or incremental mode.
-    return props.typewriter === true || (props.maxLiveNodes ?? 0) <= 0
+    return isTypewriterEnabled(props.typewriter) || (props.maxLiveNodes ?? 0) <= 0
   })
 
   // Prevent pacing initial static content on first client render.

--- a/src/types/node-renderer-props.ts
+++ b/src/types/node-renderer-props.ts
@@ -346,8 +346,13 @@ export interface NodeRendererProps {
   /** Scope key used by `setCustomComponents()` and `data-custom-id` style overrides. */
   customId?: string
   indexKey?: number | string
-  /** Show a blinking typewriter cursor while streamed content grows. Applies to `content` mode; ignored when non-empty `nodes` are provided. Default: false */
-  typewriter?: boolean
+  /**
+   * Show a blinking typewriter cursor while streamed content grows.
+   * - `true` / `'precise'`: position the cursor at the last rendered text using DOM Range measurements.
+   * - `'simple'`: render a lightweight inline cursor without DOM Range measurements.
+   * Applies to `content` mode; ignored when non-empty `nodes` are provided. Default: false
+   */
+  typewriter?: boolean | 'simple' | 'precise'
   /**
    * Enable built-in smooth pacing for streaming `content` updates.
    * - `true`: force-enable smooth streaming (content mode only)

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -124,6 +124,37 @@ describe('node renderer smooth streaming', () => {
     wrapper.unmount()
   })
 
+  it('smoothStreaming="auto" treats simple typewriter mode as enabled', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: 'auto',
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await nextTick()
+    queuedFrames.length = 0
+
+    await wrapper.setProps({ content: 'Simple smooth streaming markdown renderer.' })
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Simple smooth')
+    expect(queuedFrames.length).toBeGreaterThan(0)
+
+    wrapper.unmount()
+  })
+
   it('smoothStreaming="auto" does not enable without typewriter or maxLiveNodes<=0', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/public-api/public-api-usage.ts
+++ b/test/public-api/public-api-usage.ts
@@ -105,6 +105,12 @@ const props: NodeRendererProps = {
   },
 }
 
+const simpleTypewriterProps: NodeRendererProps = {
+  content: 'Streaming text',
+  typewriter: 'simple',
+}
+void simpleTypewriterProps
+
 const options: SmoothMarkdownStreamOptions = {}
 const customComponents: CustomComponents = {}
 const pluginLanguageIconResolver: LanguageIconResolver = lang => `custom-${lang}`

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -197,6 +197,208 @@ describe('typewriter cursor position', () => {
     wrapper.unmount()
   })
 
+  it('renders simple cursor mode without Range measurement', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    const createRangeSpy = vi.spyOn(document, 'createRange').mockImplementation(() => {
+      throw new Error('simple cursor mode should not create DOM Range')
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+
+    await wrapper.setProps({ content: 'hello' })
+    await flushAll()
+
+    const cursorHost = wrapper.get('[data-typewriter-simple-cursor="true"]')
+    expect(cursorHost.classes()).toContain('text-node')
+    expect(cursorHost.text()).toBe('hello')
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(createRangeSpy).not.toHaveBeenCalled()
+    expect(queuedFrames).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
+  it('keeps simple cursor mode measurement-free while smooth auto commits advance', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    const createRangeSpy = vi.spyOn(document, 'createRange').mockImplementation(() => {
+      throw new Error('simple cursor mode should not create DOM Range')
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: 'auto',
+        smoothStreamingOptions: {
+          startDelayMs: 0,
+          minCharsPerSecond: 1000,
+          maxCharsPerSecond: 1000,
+          maxCommitFps: 60,
+          maxCharsPerCommit: 4,
+        },
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    queuedFrames.length = 0
+
+    await wrapper.setProps({ content: 'abcdefghijklmnopqrst' })
+    await flushAll()
+
+    const baseline = performance.now()
+    await runNextFrame(queuedFrames, baseline + 50)
+    await runNextFrame(queuedFrames, baseline + 66)
+
+    const cursorHost = wrapper.get('[data-typewriter-simple-cursor="true"]')
+    expect(cursorHost.classes()).toContain('text-node')
+    expect(cursorHost.text().length).toBeGreaterThan(0)
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(false)
+    expect(createRangeSpy).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('keeps simple cursor on the stable text host after streamed delta settles', async () => {
+    const createRangeSpy = vi.spyOn(document, 'createRange').mockImplementation(() => {
+      throw new Error('simple cursor mode should not create DOM Range')
+    })
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'hello',
+        typewriter: 'simple',
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    await wrapper.setProps({ content: 'hello world' })
+    await flushAll()
+
+    expect(wrapper.get('[data-typewriter-simple-cursor="true"]').classes()).toContain('text-node')
+    expect(wrapper.get('.text-node-stream-delta').text()).toBe('world')
+
+    await wrapper.get('.text-node-stream-delta').trigger('animationend')
+    await flushAll()
+
+    const cursorHost = wrapper.get('[data-typewriter-simple-cursor="true"]')
+    expect(cursorHost.classes()).toContain('text-node')
+    expect(cursorHost.text()).toBe('hello world')
+    expect(createRangeSpy).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('resyncs the visible cursor when switching from simple to precise without content growth', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    await wrapper.setProps({ content: 'hello' })
+    await flushAll()
+    expect(wrapper.find('[data-typewriter-simple-cursor="true"]').exists()).toBe(true)
+    expect(queuedFrames).toHaveLength(0)
+
+    await wrapper.setProps({ typewriter: 'precise' })
+    await flushAll()
+
+    expect(wrapper.find('[data-typewriter-simple-cursor="true"]').exists()).toBe(false)
+    expect(wrapper.find('.typewriter-cursor').exists()).toBe(true)
+    expect(queuedFrames).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('retargets simple cursor when incremental rendering mounts the next slot', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+    process.env.NODE_ENV = 'development'
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: false,
+        batchRendering: true,
+        maxLiveNodes: 0,
+        initialRenderBatchSize: 1,
+        renderBatchSize: 1,
+        renderBatchDelay: 20,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      queuedFrames.length = 0
+
+      await wrapper.setProps({ content: 'first\n\nsecond' })
+      await flushAll()
+
+      expect(wrapper.get('[data-typewriter-simple-cursor="true"]').text()).toBe('first')
+      expect(wrapper.find('.node-slot[data-node-index="1"] .node-placeholder').exists()).toBe(true)
+
+      await runNextFrame(queuedFrames, performance.now() + 16)
+      await new Promise(resolve => setTimeout(resolve, 25))
+      await flushAll()
+
+      expect(wrapper.find('.node-slot[data-node-index="1"] .node-content').exists()).toBe(true)
+      expect(wrapper.get('[data-typewriter-simple-cursor="true"]').text()).toBe('second')
+    }
+    finally {
+      wrapper.unmount()
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
   it('coalesces cursor positioning into one RAF and measures latest content', async () => {
     const queuedFrames: FrameRequestCallback[] = []
     vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {


### PR DESCRIPTION
## Summary
- add `typewriter: 'simple'` as an opt-in lightweight cursor mode while keeping `true` / `'precise'` on the existing Range-measured cursor path
- render the simple cursor from the stable last text host via a pseudo cursor, with retargeting for smooth commits, streamed-delta settle, and incremental rendering
- treat `'simple'` / `'precise'` as typewriter-enabled for `smoothStreaming='auto'`

## Evidence
- `test/typewriter-cursor-position.test.ts` now asserts simple mode does not call `document.createRange()`, does not render the precise `.typewriter-cursor` span, avoids cursor positioning RAF when smooth streaming is off, survives streamed-delta settle, retargets on incremental rendering, and resyncs simple -> precise without content growth
- `test/node-renderer-smooth-streaming.test.ts` covers `smoothStreaming='auto'` eligibility for simple mode

## Verification
- `corepack pnpm exec vitest --run test/typewriter-cursor-position.test.ts`
- `corepack pnpm exec vitest --run test/node-renderer-smooth-streaming.test.ts`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm exec vue-tsc -p tsconfig.public-api.json --noEmit`
- `corepack pnpm exec vue-tsc -p tsconfig.public-api.package.json --noEmit`
- `node scripts/check-public-api.mjs --strict`
- `node scripts/check-public-api-runtime.mjs`
- `corepack pnpm test -- --run` (281 files, 2407 tests)

## Performance claim boundary
This PR has path-level evidence: simple mode avoids the existing cursor `Range#getClientRects()` / root rect measurement path and cursor-positioning RAF. It does not include a browser benchmark proving frame p95, long-task, or end-to-end streaming improvement.