### PR TITLE
feat: add app-scoped SSR config

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -8,9 +8,11 @@ import { useSafeI18n } from '../../composables/useSafeI18n'
 // Tooltip is provided as a singleton via composable to avoid many DOM nodes
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
-import { getLanguageIcon, languageIconsRevision, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../../utils'
+import { languageIconsRevision, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../../utils'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY } from '../../utils/languageIconContext'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
+import { resolveLanguageIcon } from '../../utils/resolveLanguageIcon'
 import { safeCancelRaf, safeRaf } from '../../utils/safeRaf'
 import PreCodeNode from '../PreCodeNode'
 import CodeBlockShell from './CodeBlockShell.vue'
@@ -54,6 +56,7 @@ const emits = defineEmits<{
 const attrs = useAttrs()
 const lifecycle = inject(MARKSTREAM_NODE_LIFECYCLE_KEY, null)
 const hostScrollManaged = inject<{ value: boolean } | null>('markstreamHostScrollManaged', null)
+const appLanguageIconResolver = inject(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, undefined)
 const lifecycleIndexKey = computed(() => {
   return resolveLifecycleIndexKey(props, attrs)
 })
@@ -2699,7 +2702,7 @@ const headerCaption = computed(() => {
 // Computed property for language icon
 const languageIcon = computed(() => {
   void languageIconsRevision.value
-  return getLanguageIcon(codeLanguage.value || '')
+  return resolveLanguageIcon(codeLanguage.value || '', appLanguageIconResolver)
 })
 
 // Compute inline style for container to respect optional min/max width

--- a/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
+++ b/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
@@ -7,17 +7,18 @@ import {
   normalizeShikiLanguage,
   registerHighlightOnce,
 } from 'markstream-core'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { isDevEnvironment } from '../../utils/devEnv'
 import {
-  getLanguageIcon,
   languageIconsRevision,
   languageMap,
   normalizeLanguageIdentifier,
 } from '../../utils/languageIcon'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY } from '../../utils/languageIconContext'
+import { resolveLanguageIcon } from '../../utils/resolveLanguageIcon'
 import CodeBlockShell from '../CodeBlockNode/CodeBlockShell.vue'
 
 interface MarkdownCodeBlockNodeProps extends ShikiCodeBlockProps {
@@ -80,6 +81,7 @@ const emits = defineEmits<{
   (e: 'copy', code: string): void
 }>()
 const { t } = useSafeI18n()
+const appLanguageIconResolver = inject(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, undefined)
 
 const codeLanguage = ref<string>(resolveStreamingCodeLanguage(props.node.language, props.node.code, isCodeBlockLoading()))
 const copyText = ref(false)
@@ -164,7 +166,7 @@ const displayLanguage = computed(() => {
 const languageIcon = computed(() => {
   void languageIconsRevision.value
   const lang = codeLanguage.value.trim().toLowerCase()
-  return getLanguageIcon(lang.split(':')[0])
+  return resolveLanguageIcon(lang.split(':')[0], appLanguageIconResolver)
 })
 
 // Check if the language is previewable (HTML or SVG)

--- a/src/composables/useSafeI18n.ts
+++ b/src/composables/useSafeI18n.ts
@@ -1,3 +1,4 @@
+import type { InjectionKey } from 'vue'
 import { getCurrentInstance } from 'vue'
 
 function humanizeKey(key: string) {
@@ -30,6 +31,9 @@ const defaultMap: Record<string, string> = {
   'image.loading': 'Loading image...',
 
 }
+
+export type MarkstreamI18nMap = Partial<Record<string, string>>
+export const MARKSTREAM_I18N_FALLBACK_KEY: InjectionKey<MarkstreamI18nMap> = Symbol('markstreamI18nFallback')
 
 /**
  * Replace default fallback translations.
@@ -71,24 +75,42 @@ function resolveComponentTranslator() {
   return null
 }
 
-const fallbackT = (key: string) => defaultMap[key] ?? humanizeKey(key)
+function resolveAppFallbackMap(): MarkstreamI18nMap | null {
+  try {
+    const instance = getCurrentInstance()
+    const key = MARKSTREAM_I18N_FALLBACK_KEY as symbol
+    const provides = (instance as unknown as { provides?: Record<symbol, unknown> } | null)?.provides
+    const appProvides = instance?.appContext?.provides as Record<symbol, unknown> | undefined
+    return (provides?.[key] ?? appProvides?.[key] ?? null) as MarkstreamI18nMap | null
+  }
+  catch {}
+  return null
+}
 
-function withFallback(translator: Translator) {
+function resolveFallbackValue(key: string, appFallbackMap?: MarkstreamI18nMap | null) {
+  return appFallbackMap?.[key] ?? defaultMap[key]
+}
+
+const fallbackT = (key: string, appFallbackMap?: MarkstreamI18nMap | null) => resolveFallbackValue(key, appFallbackMap) ?? humanizeKey(key)
+
+function withFallback(translator: Translator, appFallbackMap?: MarkstreamI18nMap | null) {
   return {
     t(key: string) {
-      if (translator.te && defaultMap[key] && !translator.te(key))
-        return fallbackT(key)
+      const fallback = resolveFallbackValue(key, appFallbackMap)
+      if (translator.te && fallback != null && !translator.te(key))
+        return fallbackT(key, appFallbackMap)
 
       const translated = translator.t(key)
-      return translated === key && defaultMap[key] ? fallbackT(key) : translated
+      return translated === key && fallback != null ? fallbackT(key, appFallbackMap) : translated
     },
   }
 }
 
 export function useSafeI18n() {
+  const appFallbackMap = resolveAppFallbackMap()
   const translator = resolveComponentTranslator()
   if (translator)
-    return withFallback(translator)
+    return withFallback(translator, appFallbackMap)
 
   // Synchronous fallback in case `vue-i18n` is not installed.
   try {
@@ -104,7 +126,7 @@ export function useSafeI18n() {
           return withFallback({
             t: (i18n.t as any).bind(i18n),
             te: typeof i18n.te === 'function' ? (i18n.te as any).bind(i18n) : undefined,
-          })
+          }, appFallbackMap)
         }
       }
       catch {}
@@ -112,5 +134,5 @@ export function useSafeI18n() {
   }
   catch {}
 
-  return { t: fallbackT }
+  return { t: (key: string) => fallbackT(key, appFallbackMap) }
 }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -52,7 +52,7 @@ import TextNode from './components/TextNode'
 import ThematicBreakNode from './components/ThematicBreakNode'
 import VmrContainerNode from './components/VmrContainerNode'
 import { useMarkstreamVirtualAdapter } from './composables/useMarkstreamVirtualAdapter'
-import { setDefaultI18nMap } from './composables/useSafeI18n'
+import { MARKSTREAM_I18N_FALLBACK_KEY, setDefaultI18nMap } from './composables/useSafeI18n'
 import { useSmoothMarkdownStream } from './composables/useSmoothMarkdownStream'
 import { setIconTheme } from './icon-themes'
 import { setLanguageIconResolver } from './utils/languageIcon'
@@ -171,6 +171,11 @@ export interface MarkstreamVuePluginOptions {
    * App-scoped custom components.
    */
   components?: Partial<MarkstreamCustomComponents>
+
+  /**
+   * App-scoped fallback translations used when vue-i18n is unavailable or a key is missing.
+   */
+  defaultI18nMap?: Partial<Record<string, string>>
 
   /**
    * App-scoped language icon resolver for code block headers.
@@ -341,6 +346,9 @@ export const VueRendererMarkdown: Plugin<[options?: MarkstreamVuePluginOptions]>
       setDefaultMathOptions(options.mathOptions)
     if (options && 'infographicLoader' in options)
       setInfographicLoader(options.infographicLoader ?? null)
+
+    if (options?.defaultI18nMap)
+      app.provide(MARKSTREAM_I18N_FALLBACK_KEY, options.defaultI18nMap)
 
     if (options?.components)
       app.provide(MARKSTREAM_CUSTOM_COMPONENTS_KEY, createCustomComponentsRef(options.components))

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -56,6 +56,7 @@ import { setDefaultI18nMap } from './composables/useSafeI18n'
 import { useSmoothMarkdownStream } from './composables/useSmoothMarkdownStream'
 import { setIconTheme } from './icon-themes'
 import { setLanguageIconResolver } from './utils/languageIcon'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY } from './utils/languageIconContext'
 import { clearGlobalCustomComponents, createCustomComponentsRef, getCustomNodeComponents, MARKSTREAM_CUSTOM_COMPONENTS_KEY, removeCustomComponents, setCustomComponents } from './utils/nodeComponents'
 
 function definePublicAsyncComponent<TProps extends object>(
@@ -170,6 +171,14 @@ export interface MarkstreamVuePluginOptions {
    * App-scoped custom components.
    */
   components?: Partial<MarkstreamCustomComponents>
+
+  /**
+   * App-scoped language icon resolver for code block headers.
+   *
+   * Prefer this in SSR and multi-tenant apps; when configured, misses fall back
+   * to the active icon theme instead of the legacy process-global resolver.
+   */
+  languageIconResolver?: LanguageIconResolver | null
 
   /**
    * @deprecated Prefer setLanguageIconResolver() before app.mount().
@@ -324,6 +333,8 @@ export const VueRendererMarkdown: Plugin<[options?: MarkstreamVuePluginOptions]>
 
     if (options?.iconTheme)
       setIconTheme(options.iconTheme)
+    if (options && 'languageIconResolver' in options)
+      app.provide(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, options.languageIconResolver ?? null)
     if (options?.getLanguageIcon)
       setLanguageIconResolver(options.getLanguageIcon)
     if (options?.mathOptions)

--- a/src/utils/languageIcon.ts
+++ b/src/utils/languageIcon.ts
@@ -103,7 +103,7 @@ export async function preloadExtendedLanguageIcons() {
 }
 
 export function getLanguageIcon(lang: string): string {
-  // 1. User custom resolver always wins (backward compat)
+  // 1. User custom resolver is process-global (backward compat).
   if (userLanguageIconResolver) {
     const hit = userLanguageIconResolver(lang)
     if (hit != null && hit !== '')

--- a/src/utils/languageIconContext.ts
+++ b/src/utils/languageIconContext.ts
@@ -1,0 +1,4 @@
+import type { InjectionKey } from 'vue'
+import type { LanguageIconResolver } from './languageIcon'
+
+export const MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY: InjectionKey<LanguageIconResolver | null> = Symbol('markstreamLanguageIconResolver')

--- a/src/utils/resolveLanguageIcon.ts
+++ b/src/utils/resolveLanguageIcon.ts
@@ -1,0 +1,21 @@
+import type { LanguageIconResolver } from './languageIcon'
+import { getThemeFallback, resolveFromTheme } from '../icon-themes/registry'
+import { getLanguageIcon, normalizeLanguageIdentifier } from './languageIcon'
+
+export function resolveLanguageIcon(lang: string, appScopedResolver?: LanguageIconResolver | null): string {
+  if (appScopedResolver === undefined)
+    return getLanguageIcon(lang)
+
+  if (appScopedResolver) {
+    const hit = appScopedResolver(lang)
+    if (hit != null && hit !== '')
+      return hit
+  }
+
+  const normalized = normalizeLanguageIdentifier(lang)
+  const themeHit = resolveFromTheme(normalized)
+  if (themeHit)
+    return themeHit
+
+  return getThemeFallback()
+}

--- a/test/public-api/public-api-usage.ts
+++ b/test/public-api/public-api-usage.ts
@@ -113,6 +113,7 @@ const pluginIconTheme = 'material'
 const infographicLoader: InfographicLoader = async () => ({})
 const pluginOptions: MarkstreamVuePluginOptions = {
   components: customComponents,
+  languageIconResolver: pluginLanguageIconResolver,
   getLanguageIcon: pluginLanguageIconResolver,
   iconTheme: pluginIconTheme,
   infographicLoader,

--- a/test/public-api/public-api-usage.ts
+++ b/test/public-api/public-api-usage.ts
@@ -113,6 +113,9 @@ const pluginIconTheme = 'material'
 const infographicLoader: InfographicLoader = async () => ({})
 const pluginOptions: MarkstreamVuePluginOptions = {
   components: customComponents,
+  defaultI18nMap: {
+    'common.copy': 'Copy',
+  },
   languageIconResolver: pluginLanguageIconResolver,
   getLanguageIcon: pluginLanguageIconResolver,
   iconTheme: pluginIconTheme,

--- a/test/ssr-render-to-string.test.ts
+++ b/test/ssr-render-to-string.test.ts
@@ -16,6 +16,7 @@ import { disableKatex, enableKatex, setKatexLoader } from '../src/components/Mat
 import { disableMermaid, enableMermaid } from '../src/components/MermaidBlockNode/mermaid'
 import MarkdownRender from '../src/components/NodeRenderer'
 import { VueRendererMarkdown } from '../src/exports'
+import { setLanguageIconResolver } from '../src/utils/languageIcon'
 import { clearGlobalCustomComponents, removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
 
 const BASIC_SCOPE = 'ssr-render-basic'
@@ -76,6 +77,7 @@ describe('ssr renderToString coverage', () => {
     enableMermaid()
     enableD2()
     disableInfographic()
+    setLanguageIconResolver(null)
   })
 
   it('renders basic markdown, HTML, and custom HTML tags on the server', async () => {
@@ -199,6 +201,63 @@ Footnotes are server-rendered.[^1]
     expect(htmlA).toContain('tenant A')
     expect(htmlB).not.toContain('data-ssr-thinking')
     expect(htmlB).toContain('tenant B')
+  })
+
+  it('keeps plugin language icon resolvers scoped to each SSR app instance', async () => {
+    const node = {
+      type: 'code_block',
+      language: 'ts',
+      code: 'const answer = 42',
+      raw: '```ts\nconst answer = 42\n```',
+      loading: false,
+    }
+    const renderApp = async (tenant: string) => {
+      const app = createSSRApp({
+        render: () => h(MarkdownCodeBlockNode, {
+          node,
+          loading: false,
+          stream: false,
+        }),
+      })
+      app.use(VueRendererMarkdown, {
+        languageIconResolver: lang => `<svg data-ssr-language-icon="${tenant}-${lang}"></svg>`,
+      })
+      return renderToString(app)
+    }
+
+    const htmlA = await renderApp('tenant-a')
+    const htmlB = await renderApp('tenant-b')
+
+    expect(htmlA).toContain('data-ssr-language-icon="tenant-a-typescript"')
+    expect(htmlA).not.toContain('tenant-b-typescript')
+    expect(htmlB).toContain('data-ssr-language-icon="tenant-b-typescript"')
+    expect(htmlB).not.toContain('tenant-a-typescript')
+  })
+
+  it('falls back to theme icons instead of the global resolver on app-scoped resolver misses', async () => {
+    setLanguageIconResolver(lang => `<svg data-ssr-global-language-icon="${lang}"></svg>`)
+
+    const node = {
+      type: 'code_block',
+      language: 'ts',
+      code: 'const answer = 42',
+      raw: '```ts\nconst answer = 42\n```',
+      loading: false,
+    }
+    const app = createSSRApp({
+      render: () => h(MarkdownCodeBlockNode, {
+        node,
+        loading: false,
+        stream: false,
+      }),
+    })
+    app.use(VueRendererMarkdown, {
+      languageIconResolver: () => null,
+    })
+
+    const html = await renderToString(app)
+
+    expect(html).not.toContain('data-ssr-global-language-icon')
   })
 
   it('renders app-scoped custom tags registered with PascalCase keys', async () => {

--- a/test/use-safe-i18n.test.ts
+++ b/test/use-safe-i18n.test.ts
@@ -1,9 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { createSSRApp, defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
+import { renderToString } from 'vue/server-renderer'
 import { useSafeI18n as useVue2SafeI18n } from '../packages/markstream-vue2/src/composables/useSafeI18n'
 import { useSafeI18n } from '../src/composables/useSafeI18n'
+import { VueRendererMarkdown } from '../src/exports'
 
 const TestComponent = defineComponent({
   setup() {
@@ -65,6 +67,54 @@ describe('useSafeI18n', () => {
 
     expect(wrapper.text()).toBe('Copy')
     expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps plugin fallback maps scoped to each app', () => {
+    const first = mount(TestComponent, {
+      global: {
+        plugins: [[VueRendererMarkdown, {
+          defaultI18nMap: {
+            'common.copy': 'Copy A',
+          },
+        }]],
+      },
+    })
+    const second = mount(TestComponent, {
+      global: {
+        plugins: [[VueRendererMarkdown, {
+          defaultI18nMap: {
+            'common.copy': 'Copy B',
+          },
+        }]],
+      },
+    })
+    const globalFallback = mount(TestComponent)
+
+    expect(first.text()).toBe('Copy A')
+    expect(second.text()).toBe('Copy B')
+    expect(globalFallback.text()).toBe('Copy')
+  })
+
+  it('keeps plugin fallback maps scoped during SSR', async () => {
+    const renderApp = async (label: string) => {
+      const app = createSSRApp(TestComponent)
+      app.use(VueRendererMarkdown, {
+        defaultI18nMap: {
+          'common.copy': label,
+        },
+      })
+      return renderToString(app)
+    }
+
+    const first = await renderApp('SSR Copy A')
+    const second = await renderApp('SSR Copy B')
+    const globalFallback = await renderToString(createSSRApp(TestComponent))
+
+    expect(first).toContain('SSR Copy A')
+    expect(first).not.toContain('SSR Copy B')
+    expect(second).toContain('SSR Copy B')
+    expect(second).not.toContain('SSR Copy A')
+    expect(globalFallback).toContain('Copy')
   })
 
   it('still supports an explicitly provided global vue-i18n hook', () => {


### PR DESCRIPTION
## Summary
- add app-scoped languageIconResolver for code block language icons
- add app-scoped defaultI18nMap for fallback UI translations
- keep the existing global setters for compatibility while giving SSR/multi-tenant apps scoped plugin options

## Evidence
- SSR test renders two app instances with different language icon resolvers and asserts no cross-tenant leakage
- SSR/app tests render different defaultI18nMap values per app and assert the global fallback remains unchanged
- public API usage covers the new plugin options without adding new runtime exports

## Verification
- corepack pnpm exec vitest --run test/use-safe-i18n.test.ts test/ssr-render-to-string.test.ts test/markdown-code-block-node.test.ts test/markdown-code-block-node-tooltip.test.ts test/code-block-editor-lock.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- node scripts/check-public-api.mjs --strict
- node scripts/check-public-api-runtime.mjs
- corepack pnpm exec vue-tsc -p tsconfig.public-api.json --noEmit
- corepack pnpm exec vue-tsc -p tsconfig.public-api.package.json --noEmit
- corepack pnpm test -- --run

## Performance
- This PR is not claimed as a measured performance optimization. It is a correctness/isolation change for SSR and multi-app usage.
- The default paths still use the existing global fallback behavior unless an app-scoped plugin option is provided.