### PR TITLE
feat: add app-scoped language icon resolver

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -8,7 +8,8 @@ import { useSafeI18n } from '../../composables/useSafeI18n'
 // Tooltip is provided as a singleton via composable to avoid many DOM nodes
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
-import { getLanguageIcon, languageIconsRevision, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../../utils'
+import { languageIconsRevision, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../../utils'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, resolveLanguageIcon } from '../../utils/languageIconResolver'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { safeCancelRaf, safeRaf } from '../../utils/safeRaf'
@@ -53,6 +54,7 @@ const emits = defineEmits<{
 
 const attrs = useAttrs()
 const lifecycle = inject(MARKSTREAM_NODE_LIFECYCLE_KEY, null)
+const languageIconResolver = inject(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, null)
 const hostScrollManaged = inject<{ value: boolean } | null>('markstreamHostScrollManaged', null)
 const lifecycleIndexKey = computed(() => {
   return resolveLifecycleIndexKey(props, attrs)
@@ -2699,7 +2701,7 @@ const headerCaption = computed(() => {
 // Computed property for language icon
 const languageIcon = computed(() => {
   void languageIconsRevision.value
-  return getLanguageIcon(codeLanguage.value || '')
+  return resolveLanguageIcon(codeLanguage.value || '', languageIconResolver)
 })
 
 // Compute inline style for container to respect optional min/max width

--- a/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
+++ b/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
@@ -7,17 +7,17 @@ import {
   normalizeShikiLanguage,
   registerHighlightOnce,
 } from 'markstream-core'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { isDevEnvironment } from '../../utils/devEnv'
 import {
-  getLanguageIcon,
   languageIconsRevision,
   languageMap,
   normalizeLanguageIdentifier,
 } from '../../utils/languageIcon'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, resolveLanguageIcon } from '../../utils/languageIconResolver'
 import CodeBlockShell from '../CodeBlockNode/CodeBlockShell.vue'
 
 interface MarkdownCodeBlockNodeProps extends ShikiCodeBlockProps {
@@ -80,6 +80,7 @@ const emits = defineEmits<{
   (e: 'copy', code: string): void
 }>()
 const { t } = useSafeI18n()
+const languageIconResolver = inject(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, null)
 
 const codeLanguage = ref<string>(resolveStreamingCodeLanguage(props.node.language, props.node.code, isCodeBlockLoading()))
 const copyText = ref(false)
@@ -164,7 +165,7 @@ const displayLanguage = computed(() => {
 const languageIcon = computed(() => {
   void languageIconsRevision.value
   const lang = codeLanguage.value.trim().toLowerCase()
-  return getLanguageIcon(lang.split(':')[0])
+  return resolveLanguageIcon(lang.split(':')[0], languageIconResolver)
 })
 
 // Check if the language is previewable (HTML or SVG)

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -56,6 +56,7 @@ import { setDefaultI18nMap } from './composables/useSafeI18n'
 import { useSmoothMarkdownStream } from './composables/useSmoothMarkdownStream'
 import { setIconTheme } from './icon-themes'
 import { setLanguageIconResolver } from './utils/languageIcon'
+import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY } from './utils/languageIconResolver'
 import { clearGlobalCustomComponents, createCustomComponentsRef, getCustomNodeComponents, MARKSTREAM_CUSTOM_COMPONENTS_KEY, removeCustomComponents, setCustomComponents } from './utils/nodeComponents'
 
 function definePublicAsyncComponent<TProps extends object>(
@@ -170,6 +171,11 @@ export interface MarkstreamVuePluginOptions {
    * App-scoped custom components.
    */
   components?: Partial<MarkstreamCustomComponents>
+
+  /**
+   * App-scoped code language icon resolver. Prefer this in SSR/multi-tenant apps.
+   */
+  languageIconResolver?: LanguageIconResolver
 
   /**
    * @deprecated Prefer setLanguageIconResolver() before app.mount().
@@ -330,6 +336,9 @@ export const VueRendererMarkdown: Plugin<[options?: MarkstreamVuePluginOptions]>
       setDefaultMathOptions(options.mathOptions)
     if (options && 'infographicLoader' in options)
       setInfographicLoader(options.infographicLoader ?? null)
+
+    if (options?.languageIconResolver)
+      app.provide(MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY, options.languageIconResolver)
 
     if (options?.components)
       app.provide(MARKSTREAM_CUSTOM_COMPONENTS_KEY, createCustomComponentsRef(options.components))

--- a/src/utils/languageIconResolver.ts
+++ b/src/utils/languageIconResolver.ts
@@ -1,0 +1,15 @@
+import type { InjectionKey } from 'vue'
+import type { LanguageIconResolver } from './languageIcon'
+import { getLanguageIcon } from './languageIcon'
+
+export const MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY: InjectionKey<LanguageIconResolver> = Symbol('markstreamLanguageIconResolver')
+
+export function resolveLanguageIcon(lang: string, appResolver?: LanguageIconResolver | null): string {
+  if (appResolver) {
+    const hit = appResolver(lang)
+    if (hit != null && hit !== '')
+      return hit
+  }
+
+  return getLanguageIcon(lang)
+}

--- a/test/app-scoped-language-icons.test.ts
+++ b/test/app-scoped-language-icons.test.ts
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CodeBlockNode from '../src/components/CodeBlockNode/CodeBlockNode.vue'
+import MarkdownCodeBlockNode from '../src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue'
+import { setLanguageIconResolver, VueRendererMarkdown } from '../src/exports'
+
+function makeNode(language: string) {
+  return {
+    type: 'code_block' as const,
+    language,
+    code: 'console.log(1)',
+    raw: `\`\`\`${language}\nconsole.log(1)\n\`\`\``,
+  }
+}
+
+describe('app-scoped language icons', () => {
+  afterEach(() => {
+    setLanguageIconResolver(null)
+    vi.restoreAllMocks()
+  })
+
+  it('uses app-scoped language icon resolvers without mutating global resolver state', () => {
+    const globalResolver = vi.fn(() => '<svg data-icon="global"></svg>')
+    setLanguageIconResolver(globalResolver)
+
+    const first = mount(MarkdownCodeBlockNode, {
+      props: {
+        loading: false,
+        node: makeNode('js'),
+      },
+      global: {
+        plugins: [[VueRendererMarkdown, {
+          languageIconResolver: () => '<svg data-icon="first"></svg>',
+        }]],
+      },
+    })
+
+    const second = mount(MarkdownCodeBlockNode, {
+      props: {
+        loading: false,
+        node: makeNode('js'),
+      },
+      global: {
+        plugins: [[VueRendererMarkdown, {
+          languageIconResolver: () => '<svg data-icon="second"></svg>',
+        }]],
+      },
+    })
+
+    expect(first.get('.icon-slot').html()).toContain('data-icon="first"')
+    expect(second.get('.icon-slot').html()).toContain('data-icon="second"')
+    expect(first.get('.icon-slot').html()).not.toContain('data-icon="second"')
+    expect(second.get('.icon-slot').html()).not.toContain('data-icon="first"')
+    expect(globalResolver).not.toHaveBeenCalled()
+
+    first.unmount()
+    second.unmount()
+  })
+
+  it('uses app-scoped language icon resolver in CodeBlockNode', () => {
+    const wrapper = mount(CodeBlockNode, {
+      props: {
+        loading: false,
+        node: makeNode('ts'),
+        stream: false,
+      },
+      global: {
+        plugins: [[VueRendererMarkdown, {
+          languageIconResolver: () => '<svg data-icon="code-block"></svg>',
+        }]],
+      },
+    })
+
+    expect(wrapper.get('.icon-slot').html()).toContain('data-icon="code-block"')
+
+    wrapper.unmount()
+  })
+})

--- a/test/public-api/public-api-usage.ts
+++ b/test/public-api/public-api-usage.ts
@@ -113,6 +113,7 @@ const pluginIconTheme = 'material'
 const infographicLoader: InfographicLoader = async () => ({})
 const pluginOptions: MarkstreamVuePluginOptions = {
   components: customComponents,
+  languageIconResolver: pluginLanguageIconResolver,
   getLanguageIcon: pluginLanguageIconResolver,
   iconTheme: pluginIconTheme,
   infographicLoader,


### PR DESCRIPTION
## Summary
- add app-scoped languageIconResolver to VueRendererMarkdown plugin options
- resolve CodeBlockNode and MarkdownCodeBlockNode icons from app scope first, then fall back to the existing global/theme resolver
- keep the injection key and resolver helper internal so the public value export surface does not grow

## Evidence
- test/app-scoped-language-icons.test.ts mounts two app instances with different resolvers while a global resolver is set, and asserts no cross-app/global leakage
- CodeBlockNode is covered separately for the same app-scoped resolver path

## Verification
- corepack pnpm build
- corepack pnpm exec vitest --run test/app-scoped-language-icons.test.ts test/markdown-code-block-node.test.ts test/markdown-code-block-node-tooltip.test.ts test/code-block-editor-lock.test.ts
- node scripts/check-public-api.mjs --strict
- node scripts/check-public-api-runtime.mjs
- corepack pnpm exec vue-tsc -p tsconfig.public-api.json --noEmit
- corepack pnpm exec vue-tsc -p tsconfig.public-api.package.json --noEmit
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm test -- --run

## Performance
- This PR is not claimed as a measured performance optimization. It is a correctness/isolation change for SSR and multi-app usage.
- The existing no-option path still falls back to the previous getLanguageIcon implementation. The extra work is one setup-time inject and one small helper call in the existing computed icon path.