### PR TITLE
docs: add FAQ metadata to use-case landing pages

### DIFF
--- a/docs/use-cases/long-ai-responses.md
+++ b/docs/use-cases/long-ai-responses.md
@@ -1,6 +1,20 @@
 ---
 title: Long AI responses — Markdown rendering and virtualization
 description: Use Markstream's virtualized rendering for long AI responses (50 KB+). Bounded live nodes, viewport-aware heavy blocks, and predictable memory usage.
+keywords:
+  - long AI response renderer
+  - virtualized Markdown renderer
+  - large Markdown document rendering
+  - long context LLM Markdown
+  - viewport-aware Markdown
+  - bounded live nodes
+faq:
+  - question: When does a long AI answer need Markdown virtualization?
+    answer: Enable virtualization when responses regularly exceed tens of kilobytes, contain many blocks, or cause scroll and layout work to become visible.
+  - question: Is virtual-scroll required for a single long message?
+    answer: Usually no. Use node-level virtualization first; virtual-scroll is for outer timeline virtualizers that coordinate many messages.
+  - question: Do offscreen Mermaid or Monaco blocks still render immediately?
+    answer: Not when viewport-priority and defer-until-visible paths are enabled. Heavy blocks can stay idle until they approach the viewport.
 ---
 # Long AI responses
 

--- a/docs/use-cases/mobile-webview.md
+++ b/docs/use-cases/mobile-webview.md
@@ -1,3 +1,22 @@
+---
+title: Mobile WebView Markdown rendering for AI apps
+description: Use Markstream in iOS WKWebView and Android WebView surfaces with px CSS, mobile-friendly code blocks, virtualization, and worker-aware heavy block rendering.
+keywords:
+  - mobile WebView Markdown renderer
+  - iOS WKWebView Markdown
+  - Android WebView Markdown
+  - AI chat WebView Markdown
+  - px CSS Markdown renderer
+  - mobile streaming Markdown
+faq:
+  - question: Why should mobile WebViews use index.px.css?
+    answer: px CSS keeps Markstream internal sizing stable when the host app or operating system changes the root font size.
+  - question: Should mobile chat surfaces use Monaco code blocks?
+    answer: Usually no. Use pre or lightweight highlighting on mobile WebViews unless the user explicitly needs an editor.
+  - question: When should virtualization be enabled on mobile?
+    answer: Enable it earlier than desktop, especially when AI responses exceed about 10 KB or include multiple code, diagram, or math blocks.
+---
+
 # Mobile WebView Markdown Rendering
 
 Render streaming Markdown in mobile app WebViews with proper font scaling and performance.

--- a/docs/use-cases/sse-websocket.md
+++ b/docs/use-cases/sse-websocket.md
@@ -1,6 +1,20 @@
 ---
 title: SSE and WebSocket Markdown streaming — use Markstream for real-time AI output
 description: Render Markdown from SSE and WebSocket streams in Vue, React, Svelte, and Angular. Patterns for token-by-token rendering, batched updates, and graceful incomplete states.
+keywords:
+  - SSE Markdown renderer
+  - WebSocket Markdown renderer
+  - real-time AI Markdown
+  - streaming Markdown transport
+  - token stream batching
+  - incomplete Markdown rendering
+faq:
+  - question: Should an SSE or WebSocket app update Markdown on every token?
+    answer: No. Buffer tiny chunks and commit at animation-frame or small batch cadence so the renderer parses fewer intermediate states.
+  - question: Does Markstream require SSE specifically?
+    answer: No. Markstream receives Markdown content or nodes, so the same rendering path works for SSE, WebSocket, fetch streams, or custom transports.
+  - question: What should happen when the server sends the final chunk?
+    answer: Mark the message as final so incomplete fences, tables, math, and other streaming mid-states can settle into their final rendering.
 ---
 # SSE and WebSocket Markdown streaming
 

--- a/docs/use-cases/streaming-mermaid-katex.md
+++ b/docs/use-cases/streaming-mermaid-katex.md
@@ -1,6 +1,20 @@
 ---
 title: Streaming Mermaid and KaTeX in AI-generated Markdown
 description: Use Markstream to render progressive Mermaid diagrams and KaTeX math during AI streaming. Diagrams render incrementally, math defers until expressions are complete.
+keywords:
+  - streaming Mermaid renderer
+  - streaming KaTeX Markdown
+  - AI generated Mermaid
+  - progressive diagram rendering
+  - worker Mermaid rendering
+  - worker KaTeX rendering
+faq:
+  - question: Can Mermaid diagrams render before the full code fence closes?
+    answer: Yes. Markstream can progressively parse renderable Mermaid prefixes so users see useful diagram output before the final chunk arrives.
+  - question: Why does KaTeX sometimes wait during streaming?
+    answer: Partial math often is not valid KaTeX yet, so Markstream defers rendering until the inline or block expression is complete.
+  - question: Do Mermaid and KaTeX peers have to be installed together?
+    answer: No. Install only the optional peers your AI output needs, and configure workers only for the heavy blocks you enable.
 ---
 # Streaming Mermaid and KaTeX
 

--- a/docs/zh/use-cases/mobile-webview.md
+++ b/docs/zh/use-cases/mobile-webview.md
@@ -1,6 +1,19 @@
 ---
 title: 移动端 WebView AI Markdown 渲染
 description: 在 iOS WKWebView 和 Android WebView 中使用 Markstream 渲染 AI Markdown、处理字体缩放、长回答、Mermaid 和代码块性能。
+keywords:
+  - 移动端 WebView Markdown
+  - iOS WKWebView Markdown
+  - Android WebView Markdown
+  - AI 聊天 WebView Markdown
+  - px CSS Markdown 渲染
+faq:
+  - question: 移动端 WebView 为什么建议使用 index.px.css？
+    answer: px CSS 能避免宿主 App 或系统字体缩放改变根字号后，Markstream 内部尺寸被 rem 连带放大或缩小。
+  - question: 移动端聊天界面应该默认启用 Monaco 吗？
+    answer: 通常不建议。移动端优先使用 pre 或轻量高亮，只有明确需要编辑器能力时再启用 Monaco。
+  - question: 移动端什么时候需要开启虚拟化？
+    answer: 当 AI 回复超过约 10 KB，或者包含多个代码块、图表、数学公式时，就应该比桌面端更早启用虚拟化。
 ---
 
 # 移动端 WebView AI Markdown 渲染

--- a/docs/zh/use-cases/sse-websocket.md
+++ b/docs/zh/use-cases/sse-websocket.md
@@ -1,6 +1,19 @@
 ---
 title: SSE 与 WebSocket Markdown 流式渲染
 description: 使用 Markstream 渲染来自 Server-Sent Events 和 WebSocket 的 Markdown 流，覆盖 AI 输出、批处理、未闭合语法和长内容性能。
+keywords:
+  - SSE Markdown 渲染器
+  - WebSocket Markdown 渲染器
+  - 实时 AI Markdown
+  - token 流批处理
+  - 未闭合 Markdown 渲染
+faq:
+  - question: SSE 或 WebSocket 应该每个 token 都触发一次 Markdown 渲染吗？
+    answer: 不建议。先把小 chunk 缓冲到一帧或一小批，再提交给渲染器，可以减少解析和 DOM 更新次数。
+  - question: Markstream 只支持 SSE 吗？
+    answer: 不是。Markstream 接收 Markdown content 或 nodes，因此 SSE、WebSocket、fetch stream 或自定义传输都能走同一套渲染路径。
+  - question: 服务端发送最终 chunk 时需要做什么？
+    answer: 把消息标记为 final，让未闭合代码块、表格、数学公式等流式中间态稳定成最终渲染。
 ---
 
 # SSE 与 WebSocket Markdown 流式渲染

--- a/scripts/check-docs-seo-output.mjs
+++ b/scripts/check-docs-seo-output.mjs
@@ -31,6 +31,8 @@ const primaryLandingPaths = [
   '/use-cases/ai-chat-streaming',
   '/use-cases/sse-websocket',
   '/use-cases/mobile-webview',
+  '/use-cases/streaming-mermaid-katex',
+  '/use-cases/long-ai-responses',
   '/zh',
   '/zh/frameworks',
   '/zh/frameworks/vue',


### PR DESCRIPTION
## Summary
- add FAQ frontmatter and keyword metadata to focused use-case landing pages
- add missing frontmatter for the English Mobile WebView use-case page
- extend docs SEO output checks to cover Streaming Mermaid/KaTeX and Long AI Responses as primary landing pages

## Verification
- `corepack pnpm lint`
- `corepack pnpm docs:seo:check`
- `git diff --check`

Docs-only SEO structured-data work. No runtime or performance-path changes.