### PR TITLE
refactor: extract NodeRenderer height model

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -17,6 +17,7 @@ import type {
   NodeRendererMode,
   NodeRendererProps,
 } from '../../types/node-renderer-props'
+import type { VirtualHeightSummary } from './composables/useHeightModel'
 import { getHighlightRegistrationKey, normalizeShikiLanguage } from 'markstream-core'
 import { computed, defineAsyncComponent, getCurrentInstance, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch } from 'vue'
 import AdmonitionNode from '../../components/AdmonitionNode'
@@ -74,6 +75,7 @@ import { useBatchRenderingScheduler } from './composables/useBatchRenderingSched
 import { useBatchRenderingState } from './composables/useBatchRenderingState'
 import { useFocusSyncScheduler } from './composables/useFocusSyncScheduler'
 import { useHeightMeasurements } from './composables/useHeightMeasurements'
+import { getHeightCacheWidthBucket, UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET, useHeightModel } from './composables/useHeightModel'
 import { useLiveRangeState } from './composables/useLiveRangeState'
 import { useMarkdownParsing } from './composables/useMarkdownParsing'
 import { useNodeVisibilityState } from './composables/useNodeVisibilityState'
@@ -331,8 +333,6 @@ const MAX_DEFERRED_NODE_COUNT = 900
 const MAX_VIEWPORT_OBSERVER_TARGETS = 640
 const VIEWPORT_PRIORITY_RECOVERY_COUNT = 200
 const CONTENT_STREAMING_TAIL_IDLE_MS = 1200
-const HEIGHT_CACHE_WIDTH_BUCKET_PX = 32
-const UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET = -1
 const BOTTOM_ANCHOR_CAPTURE_MAX_DISTANCE_PX = 160
 const BOTTOM_ANCHOR_SCROLL_ROOT_MAX_DISTANCE_PX = 64
 const BOTTOM_ANCHOR_RELEASE_THRESHOLD_PX = 32
@@ -847,6 +847,33 @@ function consumeVirtualBottomProgrammaticScrollGuard(box: { scrollTop: number })
 
   return guarded
 }
+
+let heightModel: ReturnType<typeof useHeightModel>
+
+function markFallbackHeightPrefixDirty() {
+  heightModel.markFallbackHeightPrefixDirty()
+}
+
+function getFallbackNodeHeight(index: number) {
+  return heightModel.getFallbackNodeHeight(index)
+}
+
+function estimateHeightRange(start: number, end: number) {
+  return heightModel.estimateHeightRange(start, end)
+}
+
+function estimateIndexForOffset(offsetPx: number) {
+  return heightModel.estimateIndexForOffset(offsetPx)
+}
+
+function estimateIndexForOffsetFromEnd(offsetPx: number) {
+  return heightModel.estimateIndexForOffsetFromEnd(offsetPx)
+}
+
+function getEstimatedNodeHeightCount() {
+  return heightModel.getEstimatedNodeHeightCount()
+}
+
 const {
   activeRestoreAnchor,
   getRelativeScrollTopWithinContainer,
@@ -1027,13 +1054,6 @@ const pendingAsyncNodeCount = computed(() => {
   return total
 })
 let heightMeasurementRaf: number | null = null
-let fallbackHeightPrefixDirty = true
-let fallbackHeightPrefixCache: number[] = [0]
-let fallbackHeightPrefixCacheKey = ''
-
-function markFallbackHeightPrefixDirty() {
-  fallbackHeightPrefixDirty = true
-}
 
 const desiredRenderedCount = computed(() => {
   if (!virtualizationEnabled.value)
@@ -1492,212 +1512,38 @@ const estimatedNodeHeights = computed(() => {
   })
 })
 
-function getFallbackNodeHeight(index: number) {
-  const measured = nodeHeights[index]
-  if (Number.isFinite(measured) && measured > 0)
-    return measured
+heightModel = useHeightModel({
+  parsedNodes,
+  nodeHeights,
+  heightStats,
+  heightTreeSize,
+  heightSumTree,
+  heightKnownTree,
+  averageNodeHeight,
+  heightEstimationActive,
+  estimatedNodeHeights,
+  getContainerWidth: getMeasuredContainerWidth,
+  getPrefixCacheKeyParts: () => {
+    const width = experimentContainerWidth.value || readLayout('getFallbackHeightPrefix.clientWidth', () => containerRef.value?.clientWidth || 0)
+    const widthBucket = getHeightCacheWidthBucket(width)
+    const measurementKey = props.virtualScroll?.measurementKey == null
+      ? ''
+      : String(props.virtualScroll.measurementKey)
 
-  const estimated = estimatedNodeHeights.value[index]?.height
-  if (Number.isFinite(estimated) && estimated > 0)
-    return estimated
-
-  return Math.max(
-    averageNodeHeight.value,
-    getStaticNodeHeightFallback(index),
-  )
-}
-
-function getStaticNodeHeightFallback(index: number) {
-  const node = parsedNodes.value[index] as any
-  if (!node || typeof node !== 'object')
-    return 32
-
-  const type = String(node.type ?? '')
-  const width = getMeasuredContainerWidth() || 640
-
-  switch (type) {
-    case 'heading':
-      return 44
-
-    case 'paragraph':
-      return estimateTextFallbackHeight(
-        String(node.raw ?? node.content ?? ''),
-        width,
-        34,
-      )
-
-    case 'list': {
-      const items = Array.isArray(node.items) ? node.items.length : 1
-      return Math.max(48, items * 30 + 12)
-    }
-
-    case 'list_item':
-      return estimateTextFallbackHeight(
-        String(node.raw ?? node.content ?? ''),
-        width,
-        34,
-      )
-
-    case 'blockquote':
-      return estimateTextFallbackHeight(
-        String(node.raw ?? node.content ?? ''),
-        width,
-        56,
-      )
-
-    case 'table': {
-      const rowCount = Array.isArray(node.rows)
-        ? node.rows.length
-        : Array.isArray(node.children)
-          ? node.children.length
-          : 3
-      return Math.max(120, rowCount * 38 + 48)
-    }
-
-    case 'code_block':
-      return estimateTextFallbackHeight(
-        String(node.code ?? node.raw ?? ''),
-        width,
-        96,
-        20,
-      )
-
-    case 'math_block':
-      return 72
-
-    case 'image':
-      return 220
-
-    case 'admonition':
-    case 'vmr_container':
-    case 'html_block':
-      return estimateTextFallbackHeight(
-        String(node.raw ?? node.content ?? ''),
-        width,
-        96,
-      )
-
-    case 'thematic_break':
-      return 24
-
-    default:
-      return estimateTextFallbackHeight(
-        String(node.raw ?? node.content ?? ''),
-        width,
-        40,
-      )
-  }
-}
-
-function estimateTextFallbackHeight(
-  text: string,
-  width: number,
-  minHeight: number,
-  lineHeight = 22,
-) {
-  const source = String(text ?? '')
-  if (!source)
-    return minHeight
-
-  const charsPerLine = Math.max(18, Math.floor(Math.max(320, width) / 8))
-  const hardLines = source.split(/\r?\n/).length
-  const softLines = Math.ceil(source.length / charsPerLine)
-  const lines = Math.max(1, hardLines, softLines)
-
-  return Math.max(minHeight, Math.ceil(lines * lineHeight + 12))
-}
-
-function getHeightCacheWidthBucket(width: unknown) {
-  const numeric = Number(width)
-  if (!Number.isFinite(numeric) || numeric <= 0)
-    return UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET
-
-  return Math.round(numeric / HEIGHT_CACHE_WIDTH_BUCKET_PX)
-}
-
-function getFallbackHeightPrefix() {
-  const total = parsedNodes.value.length
-  const width = experimentContainerWidth.value || readLayout('getFallbackHeightPrefix.clientWidth', () => containerRef.value?.clientWidth || 0)
-  const widthBucket = getHeightCacheWidthBucket(width)
-  const measurementKey = props.virtualScroll?.measurementKey == null
-    ? ''
-    : String(props.virtualScroll.measurementKey)
-  const key = [
-    total,
-    heightStats.count,
-    Math.round(heightStats.total),
-    Math.round(averageNodeHeight.value * 100),
-    measurementKey,
-    widthBucket,
-    heightEstimationActive.value ? 1 : 0,
-    heightEstimationExperimentRevision.value,
-    streamRenderVersion.value,
-  ].join(':')
-
-  if (!fallbackHeightPrefixDirty && fallbackHeightPrefixCacheKey === key)
-    return fallbackHeightPrefixCache
-
-  const prefix = new Array<number>(total + 1)
-  prefix[0] = 0
-
-  for (let i = 0; i < total; i++) {
-    prefix[i + 1] = prefix[i] + (
-      heightEstimationActive.value
-        ? getFallbackNodeHeight(i)
-        : (nodeHeights[i] ?? averageNodeHeight.value)
-    )
-  }
-
-  fallbackHeightPrefixCache = prefix
-  fallbackHeightPrefixCacheKey = key
-  fallbackHeightPrefixDirty = false
-
-  return prefix
-}
-
-function estimateHeightRangeFromPrefix(start: number, end: number) {
-  const total = parsedNodes.value.length
-  const boundedStart = clamp(Math.trunc(start), 0, total)
-  const boundedEnd = clamp(Math.trunc(end), boundedStart, total)
-  if (boundedStart >= boundedEnd)
-    return 0
-
-  const prefix = getFallbackHeightPrefix()
-  return (prefix[boundedEnd] ?? 0) - (prefix[boundedStart] ?? 0)
-}
-
-function estimateIndexForOffsetFromPrefix(offsetPx: number) {
-  const nodes = parsedNodes.value
-  const total = nodes.length
-  if (total <= 0)
-    return 0
-  if (offsetPx <= 0)
-    return 0
-
-  const prefix = getFallbackHeightPrefix()
-  const totalHeight = prefix[total] ?? 0
-  if (offsetPx >= totalHeight)
-    return total - 1
-
-  let low = 0
-  let high = total - 1
-  let answer = total - 1
-
-  while (low <= high) {
-    const mid = (low + high) >> 1
-    const midEnd = prefix[mid + 1] ?? 0
-
-    if (midEnd >= offsetPx) {
-      answer = mid
-      high = mid - 1
-    }
-    else {
-      low = mid + 1
-    }
-  }
-
-  return answer
-}
+    return [
+      parsedNodes.value.length,
+      heightStats.count,
+      Math.round(heightStats.total),
+      Math.round(averageNodeHeight.value * 100),
+      measurementKey,
+      widthBucket,
+      heightEstimationActive.value ? 1 : 0,
+      heightEstimationExperimentRevision.value,
+      streamRenderVersion.value,
+    ]
+  },
+  fenwickRangeSum,
+})
 
 watch(
   () => parsedNodes.value.length,
@@ -1714,32 +1560,6 @@ watch(
   },
   { immediate: true },
 )
-
-function estimateHeightRange(start: number, end: number) {
-  if (start >= end)
-    return 0
-  if (heightEstimationActive.value) {
-    return estimateHeightRangeFromPrefix(start, end)
-  }
-  if (heightTreeSize.value !== parsedNodes.value.length) {
-    let total = 0
-    for (let i = start; i < end; i++)
-      total += nodeHeights[i] ?? averageNodeHeight.value
-    return total
-  }
-  const sumTree = heightSumTree.value
-  const countTree = heightKnownTree.value
-  if (!sumTree.length || !countTree.length) {
-    let total = 0
-    for (let i = start; i < end; i++)
-      total += nodeHeights[i] ?? averageNodeHeight.value
-    return total
-  }
-  const sumKnown = fenwickRangeSum(sumTree, start, end)
-  const countKnown = fenwickRangeSum(countTree, start, end)
-  const unknownCount = (end - start) - countKnown
-  return sumKnown + unknownCount * averageNodeHeight.value
-}
 
 const visibleNodes = computed(() => {
   // Use the full `parsedNodes` list to build the visible window so that
@@ -1775,49 +1595,12 @@ const bottomSpacerHeight = computed(() => {
   return estimateHeightRange(end, total)
 })
 
-interface VirtualHeightSummary {
-  totalNodes: number
-  measuredCount: number
-  estimatedCount: number
-  averageNodeHeight: number
-  topSpacerHeight: number
-  bottomSpacerHeight: number
-  estimatedTotalHeight: number
-  width: number
-}
-
-function getEstimatedNodeHeightCount() {
-  if (!heightEstimationActive.value)
-    return 0
-
-  let count = 0
-  const estimates = estimatedNodeHeights.value
-  for (let i = 0; i < estimates.length; i++) {
-    if (!estimates[i])
-      continue
-
-    const measuredHeight = nodeHeights[i]
-    if (Number.isFinite(measuredHeight) && measuredHeight > 0)
-      continue
-
-    count++
-  }
-  return count
-}
-
 function buildVirtualHeightSummary(): VirtualHeightSummary {
-  const totalNodes = parsedNodes.value.length
-
-  return {
-    totalNodes,
-    measuredCount: heightStats.count,
-    estimatedCount: getEstimatedNodeHeightCount(),
-    averageNodeHeight: averageNodeHeight.value,
+  return heightModel.buildVirtualHeightSummary({
     topSpacerHeight: topSpacerHeight.value,
     bottomSpacerHeight: bottomSpacerHeight.value,
-    estimatedTotalHeight: estimateHeightRange(0, totalNodes),
     width: getCurrentVirtualWidth(),
-  }
+  })
 }
 
 function buildExperimentReport() {
@@ -3998,76 +3781,6 @@ defineExpose<MarkstreamRendererHandle>({
   settle,
   scrollToNode,
 })
-
-function estimateIndexForOffset(offsetPx: number) {
-  if (offsetPx <= 0)
-    return 0
-  const nodes = parsedNodes.value
-  if (heightEstimationActive.value) {
-    return estimateIndexForOffsetFromPrefix(offsetPx)
-  }
-  if (heightTreeSize.value === nodes.length && heightSumTree.value.length && heightKnownTree.value.length) {
-    const avg = averageNodeHeight.value
-    const sumTree = heightSumTree.value
-    const countTree = heightKnownTree.value
-    const prefix = (endExclusive: number) => {
-      if (endExclusive <= 0)
-        return 0
-      const sumKnown = fenwickRangeSum(sumTree, 0, endExclusive)
-      const countKnown = fenwickRangeSum(countTree, 0, endExclusive)
-      return sumKnown + (endExclusive - countKnown) * avg
-    }
-    let low = 0
-    let high = nodes.length - 1
-    let ans = nodes.length - 1
-    while (low <= high) {
-      const mid = (low + high) >> 1
-      const height = prefix(mid + 1)
-      if (height >= offsetPx) {
-        ans = mid
-        high = mid - 1
-      }
-      else {
-        low = mid + 1
-      }
-    }
-    return ans
-  }
-  let remaining = offsetPx
-  for (let i = 0; i < nodes.length; i++) {
-    const height = nodeHeights[i] ?? averageNodeHeight.value
-    if (remaining <= height)
-      return i
-    remaining -= height
-  }
-  return Math.max(0, nodes.length - 1)
-}
-
-function estimateIndexForOffsetFromEnd(offsetPx: number) {
-  const nodes = parsedNodes.value
-  if (!nodes.length)
-    return 0
-  if (offsetPx <= 0)
-    return Math.max(0, nodes.length - 1)
-  if (heightEstimationActive.value) {
-    const prefix = getFallbackHeightPrefix()
-    const totalHeight = prefix[nodes.length] ?? 0
-    return estimateIndexForOffsetFromPrefix(Math.max(0, totalHeight - offsetPx))
-  }
-  if (heightTreeSize.value === nodes.length) {
-    const totalHeight = estimateHeightRange(0, nodes.length)
-    const target = Math.max(0, totalHeight - offsetPx)
-    return estimateIndexForOffset(target)
-  }
-  let remaining = offsetPx
-  for (let i = nodes.length - 1; i >= 0; i--) {
-    const height = nodeHeights[i] ?? averageNodeHeight.value
-    if (remaining <= height)
-      return i
-    remaining -= height
-  }
-  return 0
-}
 
 function bumpNodeSlotVersion() {
   nodeSlotVersion.value += 1

--- a/src/components/NodeRenderer/composables/useHeightModel.ts
+++ b/src/components/NodeRenderer/composables/useHeightModel.ts
@@ -1,0 +1,398 @@
+import type { ParsedNode } from 'stream-markdown-parser'
+import type { ComputedRef, Ref } from 'vue'
+import type { EstimatedNodeHeight } from '../../../internal/heightEstimationExperiment'
+
+const HEIGHT_CACHE_WIDTH_BUCKET_PX = 32
+
+export const UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET = -1
+
+export interface VirtualHeightSummary {
+  totalNodes: number
+  measuredCount: number
+  estimatedCount: number
+  averageNodeHeight: number
+  topSpacerHeight: number
+  bottomSpacerHeight: number
+  estimatedTotalHeight: number
+  width: number
+}
+
+export interface HeightModelOptions {
+  parsedNodes: ComputedRef<ParsedNode[]>
+  nodeHeights: Record<number, number>
+  heightStats: {
+    total: number
+    count: number
+  }
+  heightTreeSize: Ref<number>
+  heightSumTree: Ref<number[]>
+  heightKnownTree: Ref<number[]>
+  averageNodeHeight: ComputedRef<number>
+  heightEstimationActive: ComputedRef<boolean>
+  estimatedNodeHeights: ComputedRef<readonly (EstimatedNodeHeight | null)[]>
+  getContainerWidth: () => number
+  getPrefixCacheKeyParts: () => readonly unknown[]
+  fenwickRangeSum: (tree: number[], start: number, end: number) => number
+}
+
+export interface BuildVirtualHeightSummaryOptions {
+  topSpacerHeight: number
+  bottomSpacerHeight: number
+  width?: number
+}
+
+type HeightFallbackNode = ParsedNode & {
+  content?: string
+  rows?: unknown[]
+  children?: unknown[]
+  items?: unknown[]
+}
+
+export function getHeightCacheWidthBucket(width: unknown) {
+  const numeric = Number(width)
+  if (!Number.isFinite(numeric) || numeric <= 0)
+    return UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET
+
+  return Math.round(numeric / HEIGHT_CACHE_WIDTH_BUCKET_PX)
+}
+
+export function estimateTextFallbackHeight(
+  text: string,
+  width: number,
+  minHeight: number,
+  lineHeight = 22,
+) {
+  const source = String(text ?? '')
+  if (!source)
+    return minHeight
+
+  const charsPerLine = Math.max(18, Math.floor(Math.max(320, width) / 8))
+  const hardLines = source.split(/\r?\n/).length
+  const softLines = Math.ceil(source.length / charsPerLine)
+  const lines = Math.max(1, hardLines, softLines)
+
+  return Math.max(minHeight, Math.ceil(lines * lineHeight + 12))
+}
+
+export function estimateStaticNodeHeightFallback(node: ParsedNode | undefined, width: number) {
+  if (!node || typeof node !== 'object')
+    return 32
+
+  const fallbackNode = node as HeightFallbackNode
+  const type = String(fallbackNode.type ?? '')
+  const fallbackWidth = Number.isFinite(width) && width > 0 ? width : 640
+
+  switch (type) {
+    case 'heading':
+      return 44
+
+    case 'paragraph':
+      return estimateTextFallbackHeight(
+        String(fallbackNode.raw ?? fallbackNode.content ?? ''),
+        fallbackWidth,
+        34,
+      )
+
+    case 'list': {
+      const items = Array.isArray(fallbackNode.items) ? fallbackNode.items.length : 1
+      return Math.max(48, items * 30 + 12)
+    }
+
+    case 'list_item':
+      return estimateTextFallbackHeight(
+        String(fallbackNode.raw ?? fallbackNode.content ?? ''),
+        fallbackWidth,
+        34,
+      )
+
+    case 'blockquote':
+      return estimateTextFallbackHeight(
+        String(fallbackNode.raw ?? fallbackNode.content ?? ''),
+        fallbackWidth,
+        56,
+      )
+
+    case 'table': {
+      const rowCount = Array.isArray(fallbackNode.rows)
+        ? fallbackNode.rows.length
+        : Array.isArray(fallbackNode.children)
+          ? fallbackNode.children.length
+          : 3
+      return Math.max(120, rowCount * 38 + 48)
+    }
+
+    case 'code_block':
+      return estimateTextFallbackHeight(
+        String(fallbackNode.code ?? fallbackNode.raw ?? ''),
+        fallbackWidth,
+        96,
+        20,
+      )
+
+    case 'math_block':
+      return 72
+
+    case 'image':
+      return 220
+
+    case 'admonition':
+    case 'vmr_container':
+    case 'html_block':
+      return estimateTextFallbackHeight(
+        String(fallbackNode.raw ?? fallbackNode.content ?? ''),
+        fallbackWidth,
+        96,
+      )
+
+    case 'thematic_break':
+      return 24
+
+    default:
+      return estimateTextFallbackHeight(
+        String(fallbackNode.raw ?? fallbackNode.content ?? ''),
+        fallbackWidth,
+        40,
+      )
+  }
+}
+
+export function useHeightModel(options: HeightModelOptions) {
+  let fallbackHeightPrefixDirty = true
+  let fallbackHeightPrefixCache: number[] = [0]
+  let fallbackHeightPrefixCacheKey = ''
+
+  function markFallbackHeightPrefixDirty() {
+    fallbackHeightPrefixDirty = true
+  }
+
+  function getFallbackNodeHeight(index: number) {
+    const measured = options.nodeHeights[index]
+    if (Number.isFinite(measured) && measured > 0)
+      return measured
+
+    const estimated = options.estimatedNodeHeights.value[index]?.height
+    if (Number.isFinite(estimated) && estimated > 0)
+      return estimated
+
+    return Math.max(
+      options.averageNodeHeight.value,
+      estimateStaticNodeHeightFallback(
+        options.parsedNodes.value[index],
+        options.getContainerWidth() || 640,
+      ),
+    )
+  }
+
+  function getFallbackHeightPrefix() {
+    const total = options.parsedNodes.value.length
+    const key = options.getPrefixCacheKeyParts().join(':')
+
+    if (!fallbackHeightPrefixDirty && fallbackHeightPrefixCacheKey === key)
+      return fallbackHeightPrefixCache
+
+    const prefix = new Array<number>(total + 1)
+    prefix[0] = 0
+
+    for (let i = 0; i < total; i++) {
+      prefix[i + 1] = prefix[i] + (
+        options.heightEstimationActive.value
+          ? getFallbackNodeHeight(i)
+          : (options.nodeHeights[i] ?? options.averageNodeHeight.value)
+      )
+    }
+
+    fallbackHeightPrefixCache = prefix
+    fallbackHeightPrefixCacheKey = key
+    fallbackHeightPrefixDirty = false
+
+    return prefix
+  }
+
+  function estimateHeightRangeFromPrefix(start: number, end: number) {
+    const total = options.parsedNodes.value.length
+    const boundedStart = clamp(Math.trunc(start), 0, total)
+    const boundedEnd = clamp(Math.trunc(end), boundedStart, total)
+    if (boundedStart >= boundedEnd)
+      return 0
+
+    const prefix = getFallbackHeightPrefix()
+    return (prefix[boundedEnd] ?? 0) - (prefix[boundedStart] ?? 0)
+  }
+
+  function estimateIndexForOffsetFromPrefix(offsetPx: number) {
+    const nodes = options.parsedNodes.value
+    const total = nodes.length
+    if (total <= 0)
+      return 0
+    if (offsetPx <= 0)
+      return 0
+
+    const prefix = getFallbackHeightPrefix()
+    const totalHeight = prefix[total] ?? 0
+    if (offsetPx >= totalHeight)
+      return total - 1
+
+    let low = 0
+    let high = total - 1
+    let answer = total - 1
+
+    while (low <= high) {
+      const mid = (low + high) >> 1
+      const midEnd = prefix[mid + 1] ?? 0
+
+      if (midEnd >= offsetPx) {
+        answer = mid
+        high = mid - 1
+      }
+      else {
+        low = mid + 1
+      }
+    }
+
+    return answer
+  }
+
+  function estimateHeightRange(start: number, end: number) {
+    if (start >= end)
+      return 0
+    if (options.heightEstimationActive.value) {
+      return estimateHeightRangeFromPrefix(start, end)
+    }
+    if (options.heightTreeSize.value !== options.parsedNodes.value.length) {
+      let total = 0
+      for (let i = start; i < end; i++)
+        total += options.nodeHeights[i] ?? options.averageNodeHeight.value
+      return total
+    }
+    const sumTree = options.heightSumTree.value
+    const countTree = options.heightKnownTree.value
+    if (!sumTree.length || !countTree.length) {
+      let total = 0
+      for (let i = start; i < end; i++)
+        total += options.nodeHeights[i] ?? options.averageNodeHeight.value
+      return total
+    }
+    const sumKnown = options.fenwickRangeSum(sumTree, start, end)
+    const countKnown = options.fenwickRangeSum(countTree, start, end)
+    const unknownCount = (end - start) - countKnown
+    return sumKnown + unknownCount * options.averageNodeHeight.value
+  }
+
+  function estimateIndexForOffset(offsetPx: number) {
+    if (offsetPx <= 0)
+      return 0
+    const nodes = options.parsedNodes.value
+    if (options.heightEstimationActive.value) {
+      return estimateIndexForOffsetFromPrefix(offsetPx)
+    }
+    if (options.heightTreeSize.value === nodes.length && options.heightSumTree.value.length && options.heightKnownTree.value.length) {
+      const avg = options.averageNodeHeight.value
+      const sumTree = options.heightSumTree.value
+      const countTree = options.heightKnownTree.value
+      const prefix = (endExclusive: number) => {
+        if (endExclusive <= 0)
+          return 0
+        const sumKnown = options.fenwickRangeSum(sumTree, 0, endExclusive)
+        const countKnown = options.fenwickRangeSum(countTree, 0, endExclusive)
+        return sumKnown + (endExclusive - countKnown) * avg
+      }
+      let low = 0
+      let high = nodes.length - 1
+      let ans = nodes.length - 1
+      while (low <= high) {
+        const mid = (low + high) >> 1
+        const height = prefix(mid + 1)
+        if (height >= offsetPx) {
+          ans = mid
+          high = mid - 1
+        }
+        else {
+          low = mid + 1
+        }
+      }
+      return ans
+    }
+    let remaining = offsetPx
+    for (let i = 0; i < nodes.length; i++) {
+      const height = options.nodeHeights[i] ?? options.averageNodeHeight.value
+      if (remaining <= height)
+        return i
+      remaining -= height
+    }
+    return Math.max(0, nodes.length - 1)
+  }
+
+  function estimateIndexForOffsetFromEnd(offsetPx: number) {
+    const nodes = options.parsedNodes.value
+    if (!nodes.length)
+      return 0
+    if (offsetPx <= 0)
+      return Math.max(0, nodes.length - 1)
+    if (options.heightEstimationActive.value) {
+      const prefix = getFallbackHeightPrefix()
+      const totalHeight = prefix[nodes.length] ?? 0
+      return estimateIndexForOffsetFromPrefix(Math.max(0, totalHeight - offsetPx))
+    }
+    if (options.heightTreeSize.value === nodes.length) {
+      const totalHeight = estimateHeightRange(0, nodes.length)
+      const target = Math.max(0, totalHeight - offsetPx)
+      return estimateIndexForOffset(target)
+    }
+    let remaining = offsetPx
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const height = options.nodeHeights[i] ?? options.averageNodeHeight.value
+      if (remaining <= height)
+        return i
+      remaining -= height
+    }
+    return 0
+  }
+
+  function getEstimatedNodeHeightCount() {
+    if (!options.heightEstimationActive.value)
+      return 0
+
+    let count = 0
+    const estimates = options.estimatedNodeHeights.value
+    for (let i = 0; i < estimates.length; i++) {
+      if (!estimates[i])
+        continue
+
+      const measuredHeight = options.nodeHeights[i]
+      if (Number.isFinite(measuredHeight) && measuredHeight > 0)
+        continue
+
+      count++
+    }
+    return count
+  }
+
+  function buildVirtualHeightSummary(summaryOptions: BuildVirtualHeightSummaryOptions): VirtualHeightSummary {
+    const totalNodes = options.parsedNodes.value.length
+
+    return {
+      totalNodes,
+      measuredCount: options.heightStats.count,
+      estimatedCount: getEstimatedNodeHeightCount(),
+      averageNodeHeight: options.averageNodeHeight.value,
+      topSpacerHeight: summaryOptions.topSpacerHeight,
+      bottomSpacerHeight: summaryOptions.bottomSpacerHeight,
+      estimatedTotalHeight: estimateHeightRange(0, totalNodes),
+      width: summaryOptions.width ?? options.getContainerWidth(),
+    }
+  }
+
+  return {
+    markFallbackHeightPrefixDirty,
+    getFallbackNodeHeight,
+    estimateHeightRange,
+    estimateIndexForOffset,
+    estimateIndexForOffsetFromEnd,
+    getEstimatedNodeHeightCount,
+    buildVirtualHeightSummary,
+  }
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}

--- a/test/node-renderer-height-model.test.ts
+++ b/test/node-renderer-height-model.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment node
+ */
+
+import type { ParsedNode } from 'stream-markdown-parser'
+import type { EstimatedNodeHeight } from '../src/internal/heightEstimationExperiment'
+import { describe, expect, it } from 'vitest'
+import { computed, ref } from 'vue'
+import { useHeightMeasurements } from '../src/components/NodeRenderer/composables/useHeightMeasurements'
+import {
+  estimateStaticNodeHeightFallback,
+  estimateTextFallbackHeight,
+  getHeightCacheWidthBucket,
+  UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET,
+  useHeightModel,
+} from '../src/components/NodeRenderer/composables/useHeightModel'
+
+function paragraph(raw: string): ParsedNode {
+  return {
+    type: 'paragraph',
+    raw,
+    children: [],
+  } as ParsedNode
+}
+
+function createModel(options: {
+  nodes: ParsedNode[]
+  active?: boolean
+  estimates?: Array<EstimatedNodeHeight | null>
+  width?: number
+}) {
+  const nodes = ref(options.nodes)
+  const active = ref(options.active ?? false)
+  const estimates = ref<Array<EstimatedNodeHeight | null>>(options.estimates ?? [])
+  const width = ref(options.width ?? 640)
+  const measurements = useHeightMeasurements()
+  const model = useHeightModel({
+    parsedNodes: computed(() => nodes.value),
+    nodeHeights: measurements.nodeHeights,
+    heightStats: measurements.heightStats,
+    heightTreeSize: measurements.heightTreeSize,
+    heightSumTree: measurements.heightSumTree,
+    heightKnownTree: measurements.heightKnownTree,
+    averageNodeHeight: measurements.averageNodeHeight,
+    heightEstimationActive: computed(() => active.value),
+    estimatedNodeHeights: computed(() => estimates.value),
+    getContainerWidth: () => width.value,
+    getPrefixCacheKeyParts: () => [
+      nodes.value.length,
+      measurements.heightStats.count,
+      Math.round(measurements.heightStats.total),
+      Math.round(measurements.averageNodeHeight.value * 100),
+      getHeightCacheWidthBucket(width.value),
+      active.value ? 1 : 0,
+    ],
+    fenwickRangeSum: measurements.fenwickRangeSum,
+  })
+
+  return {
+    active,
+    estimates,
+    measurements,
+    model,
+    nodes,
+    width,
+  }
+}
+
+describe('useHeightModel', () => {
+  it('keeps text and static fallback estimates deterministic', () => {
+    expect(estimateTextFallbackHeight('', 640, 34)).toBe(34)
+    expect(estimateTextFallbackHeight('x'.repeat(200), 320, 34)).toBeGreaterThan(
+      estimateTextFallbackHeight('x'.repeat(200), 960, 34),
+    )
+    expect(estimateStaticNodeHeightFallback({
+      type: 'list',
+      raw: '- a\n- b\n- c',
+      ordered: false,
+      items: [paragraph('a'), paragraph('b'), paragraph('c')],
+    } as ParsedNode, 640)).toBe(102)
+    expect(estimateStaticNodeHeightFallback(undefined, 640)).toBe(32)
+  })
+
+  it('uses measured Fenwick trees for range and offset lookup when estimation is inactive', () => {
+    const { measurements, model } = createModel({
+      nodes: [
+        paragraph('a'),
+        paragraph('b'),
+        paragraph('c'),
+        paragraph('d'),
+      ],
+    })
+
+    measurements.recordNodeHeight(0, 10)
+    measurements.recordNodeHeight(2, 30)
+    measurements.rebuildHeightTrees(4)
+
+    expect(measurements.averageNodeHeight.value).toBe(20)
+    expect(model.estimateHeightRange(0, 4)).toBe(80)
+    expect(model.estimateHeightRange(1, 3)).toBe(50)
+    expect(model.estimateIndexForOffset(1)).toBe(0)
+    expect(model.estimateIndexForOffset(11)).toBe(1)
+    expect(model.estimateIndexForOffset(60)).toBe(2)
+    expect(model.estimateIndexForOffsetFromEnd(25)).toBe(2)
+  })
+
+  it('prefers active node estimates but keeps measured heights authoritative', () => {
+    const { measurements, model } = createModel({
+      active: true,
+      nodes: [
+        paragraph('first'),
+        paragraph('second'),
+        paragraph('third'),
+      ],
+      estimates: [
+        { kind: 'simple-text', height: 50 },
+        null,
+        { kind: 'simple-text', height: 70 },
+      ],
+    })
+
+    measurements.recordNodeHeight(2, 20)
+
+    expect(model.getFallbackNodeHeight(0)).toBe(50)
+    expect(model.getFallbackNodeHeight(1)).toBe(34)
+    expect(model.getFallbackNodeHeight(2)).toBe(20)
+    expect(model.estimateHeightRange(0, 3)).toBe(104)
+    expect(model.estimateIndexForOffset(84)).toBe(1)
+    expect(model.estimateIndexForOffsetFromEnd(21)).toBe(1)
+    expect(model.buildVirtualHeightSummary({
+      topSpacerHeight: 50,
+      bottomSpacerHeight: 20,
+      width: 640,
+    })).toMatchObject({
+      totalNodes: 3,
+      measuredCount: 1,
+      estimatedCount: 1,
+      topSpacerHeight: 50,
+      bottomSpacerHeight: 20,
+      estimatedTotalHeight: 104,
+      width: 640,
+    })
+  })
+
+  it('invalidates active fallback prefixes when cache key parts change', () => {
+    const { model, width } = createModel({
+      active: true,
+      nodes: [paragraph('x'.repeat(200))],
+      width: 320,
+    })
+
+    const narrowHeight = model.estimateHeightRange(0, 1)
+
+    width.value = 960
+
+    expect(model.estimateHeightRange(0, 1)).toBeLessThan(narrowHeight)
+  })
+
+  it('maps width buckets consistently', () => {
+    expect(getHeightCacheWidthBucket(0)).toBe(UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET)
+    expect(getHeightCacheWidthBucket(Number.NaN)).toBe(UNKNOWN_HEIGHT_CACHE_WIDTH_BUCKET)
+    expect(getHeightCacheWidthBucket(64)).toBe(2)
+    expect(getHeightCacheWidthBucket(80)).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- Move NodeRenderer height fallback, prefix cache, range estimate, offset-to-index lookup, and virtual height summary logic into `useHeightModel`
- Keep `useHeightMeasurements` focused on measured heights and Fenwick tree state
- Add focused unit tests for static fallback estimates, measured Fenwick ranges, active estimates, prefix invalidation, and width buckets

## Performance note
This is a behavior-preserving maintainability refactor, not a measured performance optimization. It preserves the existing Fenwick path and prefix-cache behavior; I did not claim a speedup because there is no benchmark delta attached to this PR.

## Verification
- `corepack pnpm exec vitest --run test/node-renderer-height-model.test.ts test/node-renderer-height-measurements.test.ts`
- `corepack pnpm exec vitest --run test/node-renderer-height-model.test.ts test/node-renderer-height-measurements.test.ts test/node-renderer-height-stability.test.ts test/node-renderer-scroll-restore.test.ts test/node-renderer-scroll-listener.test.ts test/node-renderer-virtual-scroll.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm lint`
- `corepack pnpm test -- --run`
- `corepack pnpm build`

## Review
- Two read-only subagents reviewed the diff for behavior/performance risk and scope/overengineering. Both found no blocking issues; both noted the local setup-order proxy in `NodeRenderer.vue` is acceptable because `useScrollRestore` stores callbacks and does not call them synchronously.