### PR TITLE
refactor: extract height estimation probes

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     FootnoteReferenceNode: typeof import('./src/components/FootnoteReferenceNode/FootnoteReferenceNode.vue')['default']
     HardBreakNode: typeof import('./src/components/HardBreakNode/HardBreakNode.vue')['default']
     HeadingNode: typeof import('./src/components/HeadingNode/HeadingNode.vue')['default']
+    HeightEstimationProbes: typeof import('./src/components/NodeRenderer/HeightEstimationProbes.vue')['default']
     HighlightNode: typeof import('./src/components/HighlightNode/HighlightNode.vue')['default']
     HtmlBlockNode: typeof import('./src/components/HtmlBlockNode/HtmlBlockNode.vue')['default']
     HtmlInlineNode: typeof import('./src/components/HtmlInlineNode/HtmlInlineNode.vue')['default']

--- a/src/components/NodeRenderer/HeightEstimationProbes.vue
+++ b/src/components/NodeRenderer/HeightEstimationProbes.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import type { ParsedNode } from 'stream-markdown-parser'
+import HeadingNode from '../../components/HeadingNode'
+import ListItemNode from '../../components/ListItemNode'
+import ListNode from '../../components/ListNode'
+import ParagraphNode from '../../components/ParagraphNode'
+
+defineOptions({ name: 'HeightEstimationProbes' })
+
+const props = defineProps<{
+  width: number
+  flowRoot: boolean
+  paragraphNode: ParsedNode | null
+  listItemNode: ParsedNode | null
+  listNode: ParsedNode | null
+  headingNodes: Record<number, ParsedNode | null> | null
+  setParagraphWrapper: (el: HTMLElement | null) => void
+  setListItemWrapper: (el: HTMLElement | null) => void
+  setListWrapper: (el: HTMLElement | null) => void
+  setHeadingWrapper: (level: number, el: HTMLElement | null) => void
+}>()
+
+function getHeadingNode(level: number) {
+  return props.headingNodes?.[level] ?? null
+}
+</script>
+
+<template>
+  <div
+    class="height-estimation-probes"
+    :style="{ width: `${width}px` }"
+    aria-hidden="true"
+  >
+    <div
+      :ref="el => setParagraphWrapper(el as HTMLElement | null)"
+      class="node-content"
+      :class="{ 'node-content-flow-root': flowRoot }"
+      data-probe="paragraph"
+    >
+      <ParagraphNode
+        :node="paragraphNode as any"
+        index-key="probe-paragraph"
+      />
+    </div>
+    <div
+      :ref="el => setListItemWrapper(el as HTMLElement | null)"
+      class="node-content"
+      :class="{ 'node-content-flow-root': flowRoot }"
+      data-probe="list-item"
+    >
+      <ul class="m-0 p-0">
+        <ListItemNode
+          :node="listItemNode as any"
+          index-key="probe-list-item"
+        />
+      </ul>
+    </div>
+    <div
+      :ref="el => setListWrapper(el as HTMLElement | null)"
+      class="node-content"
+      :class="{ 'node-content-flow-root': flowRoot }"
+      data-probe="list"
+    >
+      <ListNode
+        :node="listNode as any"
+        index-key="probe-list"
+      />
+    </div>
+    <div
+      v-for="level in 6"
+      :key="`probe-heading-${level}`"
+      :ref="el => setHeadingWrapper(level, el as HTMLElement | null)"
+      class="node-content"
+      :class="{ 'node-content-flow-root': flowRoot }"
+      :data-probe="`heading-${level}`"
+    >
+      <HeadingNode
+        :node="getHeadingNode(level) as any"
+        :index-key="`probe-heading-${level}`"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.height-estimation-probes {
+  position: absolute;
+  left: -100000px;
+  top: 0;
+  visibility: hidden;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.node-content {
+  width: 100%;
+}
+
+.node-content-flow-root {
+  display: flow-root;
+}
+</style>

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -84,6 +84,7 @@ import { useScrollRestore } from './composables/useScrollRestore'
 import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
 import { useViewportRoot } from './composables/useViewportRoot'
 import FallbackComponent from './FallbackComponent.vue'
+import HeightEstimationProbes from './HeightEstimationProbes.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
 import { MermaidBlockNodeLoading } from './MermaidBlockNodeLoading'
 
@@ -1149,8 +1150,16 @@ function ensureExperimentProbeNodes() {
   headingProbeNodes.value = headings
 }
 
-function getHeadingProbeNode(level: number) {
-  return headingProbeNodes.value?.[level] ?? null
+function setParagraphProbeWrapper(el: HTMLElement | null) {
+  paragraphProbeWrapperRef.value = el
+}
+
+function setListItemProbeWrapper(el: HTMLElement | null) {
+  listItemProbeWrapperRef.value = el
+}
+
+function setListProbeWrapper(el: HTMLElement | null) {
+  listProbeWrapperRef.value = el
 }
 
 const {
@@ -6100,45 +6109,19 @@ onBeforeUnmount(() => {
     @mouseout="handleContainerMouseout"
   >
     <template v-if="heightEstimationDomActive || virtualizationEnabled">
-      <div
+      <HeightEstimationProbes
         v-if="heightEstimationDomActive"
-        class="height-estimation-probes"
-        :style="{ width: `${experimentProbeWidth}px` }"
-        aria-hidden="true"
-      >
-        <div ref="paragraphProbeWrapperRef" class="node-content" data-probe="paragraph">
-          <ParagraphNode
-            :node="paragraphProbeNode as any"
-            index-key="probe-paragraph"
-          />
-        </div>
-        <div ref="listItemProbeWrapperRef" class="node-content" data-probe="list-item">
-          <ul class="m-0 p-0">
-            <ListItemNode
-              :node="listItemProbeNode as any"
-              index-key="probe-list-item"
-            />
-          </ul>
-        </div>
-        <div ref="listProbeWrapperRef" class="node-content" data-probe="list">
-          <ListNode
-            :node="listProbeNode as any"
-            index-key="probe-list"
-          />
-        </div>
-        <div
-          v-for="level in 6"
-          :key="`probe-heading-${level}`"
-          :ref="el => setHeadingProbeWrapper(level, el as HTMLElement | null)"
-          class="node-content"
-          :data-probe="`heading-${level}`"
-        >
-          <HeadingNode
-            :node="getHeadingProbeNode(level) as any"
-            :index-key="`probe-heading-${level}`"
-          />
-        </div>
-      </div>
+        :width="experimentProbeWidth"
+        :flow-root="virtualizationEnabled || virtualScrollDomEnabled"
+        :paragraph-node="paragraphProbeNode"
+        :list-item-node="listItemProbeNode"
+        :list-node="listProbeNode"
+        :heading-nodes="headingProbeNodes"
+        :set-paragraph-wrapper="setParagraphProbeWrapper"
+        :set-list-item-wrapper="setListItemProbeWrapper"
+        :set-list-wrapper="setListProbeWrapper"
+        :set-heading-wrapper="setHeadingProbeWrapper"
+      />
       <div
         v-if="virtualizationEnabled"
         class="node-spacer"
@@ -6298,16 +6281,6 @@ onBeforeUnmount(() => {
      already limits DOM cost, so keep it visible to avoid a blank first paint. */
   content-visibility: visible;
   contain-intrinsic-size: auto;
-}
-
-.height-estimation-probes {
-  position: absolute;
-  left: -100000px;
-  top: 0;
-  visibility: hidden;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: -1;
 }
 
 .node-slot {

--- a/test/node-renderer-virtual-scroll.test.ts
+++ b/test/node-renderer-virtual-scroll.test.ts
@@ -268,6 +268,7 @@ describe('node renderer virtual-scroll coordination', () => {
     const probe = wrapper.element.querySelector('.height-estimation-probes') as HTMLElement | null
     expect(probe).toBeTruthy()
     expect(probe?.style.width).toBe('280px')
+    expect(probe?.querySelector('[data-probe="paragraph"]')?.classList.contains('node-content-flow-root')).toBe(true)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary
- Extract hidden height estimation probe DOM from `NodeRenderer.vue` into `HeightEstimationProbes.vue`
- Preserve virtualized / virtual-scroll coordinated probe wrapper `flow-root` behavior after the scoped-style boundary moved
- Add a regression assertion for virtual-scroll probe flow-root wiring

## Performance note
This is a behavior-preserving NodeRenderer split. It does not claim a measured speedup; the goal is to reduce `NodeRenderer.vue` template ownership without changing height estimation or virtual-scroll behavior.

## Verification
- `corepack pnpm exec vitest --run test/node-renderer-virtual-scroll.test.ts test/height-estimation-experiment.test.ts test/node-renderer-height-stability.test.ts test/node-renderer-measurement-performance.test.ts`
- `corepack pnpm lint`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm test -- --run`
- `corepack pnpm build`
- `git diff --check`

## Review
- Two read-only subagents reviewed this split. Both initially caught the scoped CSS `flow-root` regression after moving probe wrappers into a child component.
- The PR now passes `virtualizationEnabled || virtualScrollDomEnabled` into the probe component and applies `node-content-flow-root` to all probe wrappers; both subagents re-reviewed and confirmed the issue is resolved.