### PR TITLE
refactor: extract renderer mode defaults

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -13,7 +13,6 @@ import type {
   MarkstreamVirtualPhase,
   MarkstreamVirtualReason,
   MarkstreamVirtualState,
-  NodeRendererCodeRenderer,
   NodeRendererDomMode,
   NodeRendererMode,
   NodeRendererProps,
@@ -90,6 +89,7 @@ import FallbackComponent from './FallbackComponent.vue'
 import HeightEstimationProbes from './HeightEstimationProbes.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
 import { MermaidBlockNodeLoading } from './MermaidBlockNodeLoading'
+import { normalizeRendererMode, RENDERER_MODE_DEFAULTS, resolveNodeRendererCodeRenderer } from './rendererModeDefaults'
 
 type RuntimeCodeBlockNode = ParsedNode & {
   type: 'code_block'
@@ -161,97 +161,17 @@ function resolveRendererProp<K extends keyof NodeRendererProps>(key: K): NodeRen
 
 const isDevEnv = isDevEnvironment()
 
-const RENDERER_MODE_DEFAULTS: Record<NodeRendererMode, Pick<
-  NodeRendererProps,
-  | 'showTooltips'
-  | 'fade'
-  | 'batchRendering'
-  | 'initialRenderBatchSize'
-  | 'renderBatchSize'
-  | 'renderBatchDelay'
-  | 'renderBatchBudgetMs'
-  | 'renderBatchIdleTimeoutMs'
-  | 'deferNodesUntilVisible'
-  | 'maxLiveNodes'
-  | 'liveNodeBuffer'
-  | 'nodeVirtual'
->> = {
-  docs: {
-    showTooltips: true,
-    fade: true,
-    batchRendering: true,
-    initialRenderBatchSize: 40,
-    renderBatchSize: 80,
-    renderBatchDelay: 16,
-    renderBatchBudgetMs: 6,
-    renderBatchIdleTimeoutMs: 120,
-    deferNodesUntilVisible: true,
-    maxLiveNodes: 220,
-    liveNodeBuffer: 60,
-    nodeVirtual: 'auto',
-  },
-  chat: {
-    showTooltips: false,
-    fade: false,
-    batchRendering: true,
-    initialRenderBatchSize: 16,
-    renderBatchSize: 16,
-    renderBatchDelay: 8,
-    renderBatchBudgetMs: 4,
-    renderBatchIdleTimeoutMs: 120,
-    deferNodesUntilVisible: true,
-    maxLiveNodes: 0,
-    liveNodeBuffer: 0,
-    nodeVirtual: 'auto',
-  },
-  minimal: {
-    showTooltips: false,
-    fade: false,
-    batchRendering: true,
-    initialRenderBatchSize: 16,
-    renderBatchSize: 16,
-    renderBatchDelay: 8,
-    renderBatchBudgetMs: 4,
-    renderBatchIdleTimeoutMs: 120,
-    deferNodesUntilVisible: true,
-    maxLiveNodes: 0,
-    liveNodeBuffer: 0,
-    nodeVirtual: 'auto',
-  },
-}
-
-function normalizeRendererMode(value: unknown): NodeRendererMode {
-  return value === 'chat' || value === 'minimal' || value === 'docs'
-    ? value
-    : 'docs'
-}
-
 function normalizeRendererDomMode(value: unknown): NodeRendererDomMode {
   return value === 'minimal' ? 'minimal' : 'full'
 }
 
 const resolvedMode = computed<NodeRendererMode>(() => normalizeRendererMode(resolveRendererProp('mode')))
 const resolvedDomMode = computed<NodeRendererDomMode>(() => normalizeRendererDomMode(resolveRendererProp('domMode')))
-const resolvedCodeRenderer = computed<NodeRendererCodeRenderer>(() => {
-  const renderCodeBlocksAsPre = resolveRendererProp('renderCodeBlocksAsPre')
-  const codeRenderer = resolveRendererProp('codeRenderer')
-
-  if (renderCodeBlocksAsPre === true)
-    return 'pre'
-
-  if (
-    codeRenderer === 'pre'
-    || codeRenderer === 'shiki'
-    || codeRenderer === 'monaco'
-  ) {
-    return codeRenderer
-  }
-
-  if (renderCodeBlocksAsPre === false)
-    return 'monaco'
-
-  return resolvedMode.value === 'docs' ? 'monaco' : 'pre'
-})
+const resolvedCodeRenderer = computed(() => resolveNodeRendererCodeRenderer({
+  mode: resolvedMode.value,
+  codeRenderer: resolveRendererProp('codeRenderer'),
+  renderCodeBlocksAsPre: resolveRendererProp('renderCodeBlocksAsPre'),
+}))
 const resolvedModeDefaults = computed(() => RENDERER_MODE_DEFAULTS[resolvedMode.value])
 const resolvedShowTooltipsProp = computed(() => resolveRendererProp('showTooltips') ?? resolvedModeDefaults.value.showTooltips)
 const resolvedFade = computed(() => resolveRendererProp('fade') ?? resolvedModeDefaults.value.fade)

--- a/src/components/NodeRenderer/rendererModeDefaults.ts
+++ b/src/components/NodeRenderer/rendererModeDefaults.ts
@@ -1,0 +1,94 @@
+import type {
+  NodeRendererCodeRenderer,
+  NodeRendererMode,
+  NodeRendererProps,
+} from '../../types/node-renderer-props'
+
+export type RendererModeDefaults = Pick<
+  NodeRendererProps,
+  | 'showTooltips'
+  | 'fade'
+  | 'batchRendering'
+  | 'initialRenderBatchSize'
+  | 'renderBatchSize'
+  | 'renderBatchDelay'
+  | 'renderBatchBudgetMs'
+  | 'renderBatchIdleTimeoutMs'
+  | 'deferNodesUntilVisible'
+  | 'maxLiveNodes'
+  | 'liveNodeBuffer'
+  | 'nodeVirtual'
+>
+
+export const RENDERER_MODE_DEFAULTS: Record<NodeRendererMode, RendererModeDefaults> = {
+  docs: {
+    showTooltips: true,
+    fade: true,
+    batchRendering: true,
+    initialRenderBatchSize: 40,
+    renderBatchSize: 80,
+    renderBatchDelay: 16,
+    renderBatchBudgetMs: 6,
+    renderBatchIdleTimeoutMs: 120,
+    deferNodesUntilVisible: true,
+    maxLiveNodes: 220,
+    liveNodeBuffer: 60,
+    nodeVirtual: 'auto',
+  },
+  chat: {
+    showTooltips: false,
+    fade: false,
+    batchRendering: true,
+    initialRenderBatchSize: 16,
+    renderBatchSize: 16,
+    renderBatchDelay: 8,
+    renderBatchBudgetMs: 4,
+    renderBatchIdleTimeoutMs: 120,
+    deferNodesUntilVisible: true,
+    maxLiveNodes: 0,
+    liveNodeBuffer: 0,
+    nodeVirtual: 'auto',
+  },
+  minimal: {
+    showTooltips: false,
+    fade: false,
+    batchRendering: true,
+    initialRenderBatchSize: 16,
+    renderBatchSize: 16,
+    renderBatchDelay: 8,
+    renderBatchBudgetMs: 4,
+    renderBatchIdleTimeoutMs: 120,
+    deferNodesUntilVisible: true,
+    maxLiveNodes: 0,
+    liveNodeBuffer: 0,
+    nodeVirtual: 'auto',
+  },
+}
+
+export function normalizeRendererMode(value: unknown): NodeRendererMode {
+  return value === 'chat' || value === 'minimal' || value === 'docs'
+    ? value
+    : 'docs'
+}
+
+export function resolveNodeRendererCodeRenderer(options: {
+  mode: NodeRendererMode
+  codeRenderer: NodeRendererProps['codeRenderer']
+  renderCodeBlocksAsPre: NodeRendererProps['renderCodeBlocksAsPre']
+}): NodeRendererCodeRenderer {
+  if (options.renderCodeBlocksAsPre === true)
+    return 'pre'
+
+  if (
+    options.codeRenderer === 'pre'
+    || options.codeRenderer === 'shiki'
+    || options.codeRenderer === 'monaco'
+  ) {
+    return options.codeRenderer
+  }
+
+  if (options.renderCodeBlocksAsPre === false)
+    return 'monaco'
+
+  return options.mode === 'docs' ? 'monaco' : 'pre'
+}

--- a/test/node-renderer-mode-defaults.test.ts
+++ b/test/node-renderer-mode-defaults.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeRendererMode,
+  RENDERER_MODE_DEFAULTS,
+  resolveNodeRendererCodeRenderer,
+} from '../src/components/NodeRenderer/rendererModeDefaults'
+
+describe('rendererModeDefaults', () => {
+  it('normalizes unknown modes to docs', () => {
+    expect(normalizeRendererMode('docs')).toBe('docs')
+    expect(normalizeRendererMode('chat')).toBe('chat')
+    expect(normalizeRendererMode('minimal')).toBe('minimal')
+    expect(normalizeRendererMode('unknown')).toBe('docs')
+    expect(normalizeRendererMode(undefined)).toBe('docs')
+  })
+
+  it('keeps docs and chat/minimal defaults distinct', () => {
+    expect(RENDERER_MODE_DEFAULTS.docs).toMatchObject({
+      showTooltips: true,
+      fade: true,
+      initialRenderBatchSize: 40,
+      renderBatchSize: 80,
+      maxLiveNodes: 220,
+    })
+    expect(RENDERER_MODE_DEFAULTS.chat).toMatchObject({
+      showTooltips: false,
+      fade: false,
+      initialRenderBatchSize: 16,
+      renderBatchSize: 16,
+      maxLiveNodes: 0,
+    })
+    expect(RENDERER_MODE_DEFAULTS.minimal).toMatchObject(RENDERER_MODE_DEFAULTS.chat)
+  })
+
+  it('resolves code renderer defaults and legacy pre flag precedence', () => {
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'docs',
+      codeRenderer: undefined,
+      renderCodeBlocksAsPre: undefined,
+    })).toBe('monaco')
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'chat',
+      codeRenderer: undefined,
+      renderCodeBlocksAsPre: undefined,
+    })).toBe('pre')
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'docs',
+      codeRenderer: 'shiki',
+      renderCodeBlocksAsPre: undefined,
+    })).toBe('shiki')
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'chat',
+      codeRenderer: 'shiki',
+      renderCodeBlocksAsPre: false,
+    })).toBe('shiki')
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'docs',
+      codeRenderer: 'monaco',
+      renderCodeBlocksAsPre: true,
+    })).toBe('pre')
+    expect(resolveNodeRendererCodeRenderer({
+      mode: 'chat',
+      codeRenderer: undefined,
+      renderCodeBlocksAsPre: false,
+    })).toBe('monaco')
+  })
+})


### PR DESCRIPTION
## Summary
- Move NodeRenderer mode defaults, mode normalization, and code renderer resolution into `rendererModeDefaults.ts`
- Keep `NodeRenderer.vue` responsible only for computed wiring around those helpers
- Add focused unit coverage for mode fallback, docs/chat/minimal defaults, and legacy `renderCodeBlocksAsPre` precedence

## Performance note
This is a behavior-preserving NodeRenderer split, not a measured performance optimization. It reduces SFC ownership without changing render, scroll, or typewriter behavior.

## Verification
- `corepack pnpm exec vitest --run test/node-renderer-mode-defaults.test.ts test/node-renderer-smooth-streaming.test.ts test/node-renderer-batch-scheduler.test.ts`
- `corepack pnpm exec vitest --run test/node-renderer-mode-defaults.test.ts test/node-renderer-heavy-node-props.test.ts test/node-renderer-virtual-scroll.test.ts`
- `corepack pnpm exec vue-tsc --noEmit --pretty false`
- `corepack pnpm lint`
- `corepack pnpm test -- --run`
- `corepack pnpm build`
- `git diff --check`

## Review
- Two read-only subagents reviewed the split. Both found no blocking issues.
- One noted likely future merge work with #532/#533 because those PRs also touch mode/typewriter setup near the extracted area; this PR intentionally keeps the extracted helper internal and does not re-export it as public API.