### PR TITLE
chore: upgrade pretext to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     }
   },
   "dependencies": {
-    "@chenglou/pretext": "^0.0.5",
+    "@chenglou/pretext": "^0.0.8",
     "@floating-ui/dom": "^1.7.6",
     "markstream-core": "workspace:*",
     "stream-markdown-parser": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3
       '@chenglou/pretext':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.8
+        version: 0.0.8
       '@floating-ui/dom':
         specifier: ^1.7.6
         version: 1.7.6
@@ -1896,8 +1896,8 @@ packages:
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
 
-  '@chenglou/pretext@0.0.5':
-    resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
+  '@chenglou/pretext@0.0.8':
+    resolution: {integrity: sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
@@ -15247,7 +15247,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
-  '@chenglou/pretext@0.0.5': {}
+  '@chenglou/pretext@0.0.8': {}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade `@chenglou/pretext` from `^0.0.5` to `^0.0.8`.
- Update the lockfile entry for `@chenglou/pretext` to `0.0.8`.

## Validation
- `pnpm typecheck` passed.
- `pnpm build` completed with exit code 0. Note: the existing `vite:dts` step still prints `stream-markdown-parser` type-resolution diagnostics during the build.
- `pnpm test:e2e:height-estimation-experiment` was attempted locally but the standard script failed before assertions because the page API was not mounted when `page.evaluate` ran.
- `pnpm test:perf:height-estimation-experiment` reproduced the same local harness issue: `Missing __heightEstimationExperiment API`.
