### PR TITLE
fix: stabilize completed markdown layout

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -343,11 +343,13 @@ provide('markstreamCustomMarkdownIt', computed(() => rendererProps.customMarkdow
 const {
   smoothStreamingEnabled,
   renderContent,
+  requestedFinal,
   effectiveFinal,
 } = useSmoothStreamingBridge(rendererProps, {
   isClient,
   inheritedSmoothStreaming,
 })
+const stableLayoutInitiallyFinal = requestedFinal.value === true
 provide('markstreamSmoothStreaming', smoothStreamingEnabled)
 const contentStreamingTailActive = ref(false)
 let previousContentStreamValue = ''
@@ -958,6 +960,7 @@ const incrementalRenderingConfigured = computed(() => {
 })
 const stableLayoutDomEnabled = computed(() => {
   return !renderAsFragment.value
+    && stableLayoutInitiallyFinal
     && effectiveFinal.value === true
     && !virtualizationEnabled.value
     && !virtualScrollRequested.value

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -950,6 +950,21 @@ function importHeightCache(
 const deferNodes = computed(() => {
   return deferNodesDomRequired.value && viewportPriorityEnabled.value
 })
+const incrementalRenderingConfigured = computed(() => {
+  return !renderAsFragment.value
+    && rendererProps.batchRendering !== false
+    && resolvedBatchSize.value > 0
+    && (rendererProps.maxLiveNodes ?? 0) <= 0
+})
+const stableLayoutDomEnabled = computed(() => {
+  return !renderAsFragment.value
+    && effectiveFinal.value === true
+    && !virtualizationEnabled.value
+    && !virtualScrollRequested.value
+    && !heightExperimentDomRequired.value
+    && !deferNodes.value
+    && !incrementalRenderingConfigured.value
+})
 const shouldObserveSlots = computed(() => !!registerNodeVisibility && (deferNodes.value || virtualizationEnabled.value))
 const scrollListenerEnabled = computed(() => virtualizationEnabled.value || virtualScrollEnabled.value)
 const {
@@ -5813,6 +5828,7 @@ onBeforeUnmount(() => {
       { dark: rendererProps.isDark },
       { virtualized: virtualizationEnabled },
       { 'virtual-scroll-coordinated': virtualScrollDomEnabled },
+      { 'stable-layout': stableLayoutDomEnabled },
       { 'typewriter-simple-cursor': showTypewriterCursor && resolvedTypewriterCursorMode === 'simple' },
     ]"
     :data-custom-id="rendererProps.customId"
@@ -6013,6 +6029,11 @@ onBeforeUnmount(() => {
      already limits DOM cost, so keep it visible to avoid a blank first paint. */
   content-visibility: visible;
   contain-intrinsic-size: auto;
+}
+
+.markdown-renderer.stable-layout {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
 }
 
 .node-slot {

--- a/test/node-renderer-final-transition-dom.test.ts
+++ b/test/node-renderer-final-transition-dom.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, onBeforeUnmount, onMounted } from 'vue'
@@ -107,5 +108,62 @@ describe('node renderer final transition DOM stability', () => {
     expect(wrapper.get('.paragraph-probe').element).toBe(initialElement)
 
     wrapper.unmount()
+  })
+
+  it('disables the root intrinsic placeholder for completed stable renders only', async () => {
+    const content = Array.from({ length: 80 }, (_, index) => `Paragraph ${index + 1}`).join('\n\n')
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        final: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: Number.MAX_SAFE_INTEGER,
+        nodeVirtual: false,
+      },
+    })
+    await flushAll()
+
+    const root = wrapper.get('.markdown-renderer')
+    expect(root.classes()).toContain('stable-layout')
+    expect(root.classes()).not.toContain('virtualized')
+    expect(root.classes()).not.toContain('virtual-scroll-coordinated')
+    wrapper.unmount()
+
+    const streamingWrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        final: false,
+        smoothStreaming: false,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: Number.MAX_SAFE_INTEGER,
+        nodeVirtual: false,
+      },
+    })
+    await flushAll()
+
+    expect(streamingWrapper.get('.markdown-renderer').classes()).not.toContain('stable-layout')
+    streamingWrapper.unmount()
+
+    const batchedWrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        final: true,
+        mode: 'chat',
+        smoothStreaming: false,
+      },
+    })
+    await flushAll()
+
+    expect(batchedWrapper.get('.markdown-renderer').classes()).not.toContain('stable-layout')
+    batchedWrapper.unmount()
+
+    const source = readFileSync('src/components/NodeRenderer/NodeRenderer.vue', 'utf8')
+    expect(source).toContain(`.markdown-renderer.stable-layout {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
+}`)
   })
 })


### PR DESCRIPTION
## Why

A downstream DeepChat historical-session repro showed a repeatable scroll/layout jump while slowly scrolling upward from the bottom of a completed chat. There was no active streaming, images were already loaded, and application scroll code was not writing `scrollTop` at the moment of the jump.

The actual change happened inside the completed markdown subtree. Runtime inspection showed the root renderer still had:

```css
.markstream-vue.markdown-renderer {
  content-visibility: auto;
  contain-intrinsic-size: auto 800px auto 600px;
}
```

While that completed markdown was offscreen, Chromium used the intrinsic placeholder height. When the block approached the viewport, Chromium resolved the real layout height. In the repro, the outer chat row changed from `2697px` to `2141px`, and the scroll container changed from `4554px` to `3998px`, producing the visible jump.

```text
Before: offscreen completed markdown still uses intrinsic placeholder

[chat scroll container]
  scrollHeight = 4554
  ┌─────────────────────────────────────────┐
  │ assistant message row                   │  row height = 2697
  │                                         │
  │  .markstream-vue.markdown-renderer      │
  │    content-visibility: auto             │
  │    intrinsic placeholder: 600px         │
  │                                         │
  │  image / later content already loaded   │
  └─────────────────────────────────────────┘
                 ▲
                 │ slowly scroll upward
                 │
                 └─ browser resolves real markdown layout
                    row height 2697 -> 2141
                    scrollHeight 4554 -> 3998
                    viewport jumps

After: stable completed markdown does not use the root placeholder

[chat scroll container]
  scrollHeight = stable
  ┌─────────────────────────────────────────┐
  │ assistant message row                   │
  │                                         │
  │  .markstream-vue.markdown-renderer      │
  │    content-visibility: visible          │
  │    contain-intrinsic-size: none         │
  │                                         │
  └─────────────────────────────────────────┘
```

## What changed

- Add a `stable-layout` class to the root markdown renderer when the render is final and the internal virtualization/deferred/incremental paths are not active.
- For that stable root, disable the root `content-visibility` intrinsic placeholder.
- Leave streaming, virtual-scroll coordination, node virtualization, deferred rendering, and incremental batch rendering behavior unchanged.
- Add a regression test for the completed stable-render path and for the streaming/batched paths that must not receive the stable class.

## Testing

```bash
./node_modules/.bin/vitest --run test/node-renderer-final-transition-dom.test.ts test/node-renderer-defer-nodes.test.ts test/node-renderer-batch-scheduler.test.ts
./node_modules/.bin/eslint src/components/NodeRenderer/NodeRenderer.vue test/node-renderer-final-transition-dom.test.ts
./node_modules/.bin/vue-tsc --noEmit
git diff --check
```