### PR TITLE
fix: remove diff preview line background radius

### DIFF
--- a/packages/markstream-react/src/index.css
+++ b/packages/markstream-react/src/index.css
@@ -1583,6 +1583,7 @@
   height: var(--markstream-pre-diff-line-height, 18px);
   z-index: 0;
   pointer-events: none;
+  border-radius: 0;
   background: transparent;
 }
 

--- a/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
+++ b/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
@@ -473,6 +473,7 @@ const diffPreviewPanes = computed(() => isDiffPreview.value ? buildDiffPanes(isI
   height: var(--markstream-pre-diff-line-height, 18px);
   z-index: 0;
   pointer-events: none;
+  border-radius: 0;
   background: transparent;
 }
 

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -765,6 +765,7 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
   );
   z-index: 0;
   pointer-events: none;
+  border-radius: 0;
   background: transparent;
 }
 

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -123,6 +123,18 @@ describe('pre code node diff preview', () => {
     expect(source).toContain('width: var(--markstream-pre-diff-gutter-marker-width, 4px);')
   })
 
+  it('keeps diff fallback line fills square', () => {
+    const source = readFileSync(
+      'src/components/PreCodeNode/PreCodeNode.vue',
+      'utf8',
+    )
+
+    expect(source).toContain('.markstream-pre__diff-line::before')
+    expect(source).toContain('border-radius: 0;')
+    expect(source).toContain('.markstream-pre__diff-line--added::before')
+    expect(source).toContain('.markstream-pre__diff-line--removed::before')
+  })
+
   it('lets side-by-side diff fallback panes scroll horizontally when wrap is disabled', () => {
     const source = readFileSync(
       'src/components/PreCodeNode/PreCodeNode.vue',

--- a/test/pre-code-node-family-sync.test.tsx
+++ b/test/pre-code-node-family-sync.test.tsx
@@ -132,6 +132,7 @@ describe('pre code node family sync', () => {
       expect(source).toContain('--markstream-pre-diff-gutter-marker-width: var(--stream-monaco-gutter-marker-width, 4px);')
       expect(source).toContain('left: var(--markstream-pre-diff-scrollable-left);')
       expect(source).toContain('width: var(--markstream-pre-diff-gutter-marker-width, 4px);')
+      expect(source).toContain('border-radius: 0;')
       expect(source).not.toContain('markstream-pre__diff-line--added:not(.markstream-pre__diff-line--empty)')
       expect(source).not.toContain('markstream-pre__diff-line--removed:not(.markstream-pre__diff-line--empty)')
     }


### PR DESCRIPTION
## Summary
- make diff preview line background overlays square across Vue, Vue 2, and React styles
- cover the radius reset in PreCode diff preview tests

## Tests
- pnpm exec vitest --run test/pre-code-node-diff-preview.test.ts test/pre-code-node-family-sync.test.tsx --testTimeout=30000
- pnpm lint
- git diff --check HEAD~1..HEAD