### PR TITLE
fix: avoid flashing raw inline math while streaming

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -965,6 +965,27 @@ export function parseInlineTokens(
     return String(token.markup ?? '').startsWith(escapedPrefix)
   }
 
+  function stripTrailingLoadingParenMathOpener(token: MarkdownToken) {
+    if (!currentTextNode || token.loading !== true || token.markup !== '\\(\\)')
+      return
+
+    const previousToken = tokens[i - 1]
+    if (!previousToken || previousToken.type !== 'text' || !hasEscapedMarkup(previousToken, '\\('))
+      return
+
+    if (!currentTextNode.content.endsWith('('))
+      return
+
+    currentTextNode.content = currentTextNode.content.slice(0, -1)
+    if (currentTextNode.raw.endsWith('('))
+      currentTextNode.raw = currentTextNode.raw.slice(0, -1)
+
+    if (!currentTextNode.content && result[result.length - 1] === currentTextNode) {
+      result.pop()
+      currentTextNode = null
+    }
+  }
+
   function isMarkdownLinkBeforeLinkifiedUrl(content: string) {
     if (!content.endsWith(']('))
       return false
@@ -1204,6 +1225,7 @@ export function parseInlineTokens(
       }
 
       case 'math_inline': {
+        stripTrailingLoadingParenMathOpener(token)
         resetCurrentTextNode()
         // 可能遇到 math_inline text math_inline 的特殊情况，需要合并成一个
         if (!token.content && token.markup === '$' && tokens[i + 1]?.type === 'text' && tokens[i + 2]?.type === 'math_inline') {

--- a/packages/markdown-parser/test/inline-math-streaming-prefix.test.ts
+++ b/packages/markdown-parser/test/inline-math-streaming-prefix.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+function collectByType(nodes: any, type: string, out: any[] = []) {
+  if (!nodes)
+    return out
+  if (Array.isArray(nodes)) {
+    nodes.forEach(node => collectByType(node, type, out))
+    return out
+  }
+  if (nodes.type === type)
+    out.push(nodes)
+  if (Array.isArray(nodes.children))
+    nodes.children.forEach((child: any) => collectByType(child, type, out))
+  if (Array.isArray(nodes.items))
+    nodes.items.forEach((item: any) => collectByType(item, type, out))
+  return out
+}
+
+describe('inline math streaming prefix', () => {
+  it('does not leave the escaped opener as text before loading paren math after a softbreak', () => {
+    const md = getMarkdown('inline-math-streaming-prefix')
+    const input = '如果考虑多个向量，正文补空间的概念可以扩展。\n\\(W = \\operatorname{span}\\{\\boldsy'
+    const nodes = parseMarkdownToStructure(input, md, { final: false }) as any[]
+    const text = collectByType(nodes, 'text').map((node: any) => node.content).join('')
+    const math = collectByType(nodes, 'math_inline')
+
+    expect(text).toBe('如果考虑多个向量，正文补空间的概念可以扩展。\n')
+    expect(math).toHaveLength(1)
+    expect(math[0]).toMatchObject({
+      type: 'math_inline',
+      content: 'W = \\operatorname{span}\\{\\boldsy',
+      loading: true,
+      markup: '\\(\\)',
+    })
+  })
+})

--- a/packages/markdown-parser/test/inline-math-streaming-prefix.test.ts
+++ b/packages/markdown-parser/test/inline-math-streaming-prefix.test.ts
@@ -34,4 +34,21 @@ describe('inline math streaming prefix', () => {
       markup: '\\(\\)',
     })
   })
+
+  it('keeps an adjacent escaped literal paren before loading paren math', () => {
+    const md = getMarkdown('inline-math-streaming-adjacent-literal')
+    const input = String.raw`literal \(\(x`
+    const nodes = parseMarkdownToStructure(input, md, { final: false }) as any[]
+    const text = collectByType(nodes, 'text').map((node: any) => node.content).join('')
+    const math = collectByType(nodes, 'math_inline')
+
+    expect(text).toBe('literal (')
+    expect(math).toHaveLength(1)
+    expect(math[0]).toMatchObject({
+      type: 'math_inline',
+      content: 'x',
+      loading: true,
+      markup: '\\(\\)',
+    })
+  })
 })

--- a/packages/markstream-vue2/src/components/MathInlineNode/MathInlineNode.vue
+++ b/packages/markstream-vue2/src/components/MathInlineNode/MathInlineNode.vue
@@ -77,8 +77,10 @@ async function renderMath() {
     return
 
   if (!props.node.content) {
-    applyRawFallback()
-    hasRenderedOnce = true
+    renderedHtml.value = ''
+    fallbackText.value = props.node.loading ? '' : props.node.raw
+    renderingLoading.value = !!props.node.loading
+    hasRenderedOnce = !props.node.loading
     return
   }
 

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -189,7 +189,7 @@ async function renderMath() {
 }
 
 watch(
-  () => props.node.content,
+  () => [props.node.content, props.node.loading, props.node.raw, props.node.markup],
   () => {
     renderMath()
   },

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -26,8 +26,8 @@ function resolveInitialState() {
   if (!katex) {
     return {
       html: '',
-      text: props.node.raw,
-      loading: false,
+      text: props.node.loading ? '' : props.node.raw,
+      loading: props.node.loading,
     }
   }
 
@@ -44,8 +44,8 @@ function resolveInitialState() {
   catch {
     return {
       html: '',
-      text: props.node.raw,
-      loading: false,
+      text: props.node.loading ? '' : props.node.raw,
+      loading: props.node.loading,
     }
   }
 }

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -17,8 +17,8 @@ function resolveInitialState() {
   if (!props.node.content) {
     return {
       html: '',
-      text: props.node.raw,
-      loading: false,
+      text: props.node.loading ? '' : props.node.raw,
+      loading: props.node.loading,
     }
   }
 
@@ -89,10 +89,10 @@ async function renderMath() {
 
   if (!props.node.content) {
     clearRenderPending()
-    renderingLoading.value = false
     renderedHtml.value = ''
-    renderedText.value = props.node.raw
-    hasRenderedOnce = true
+    renderedText.value = props.node.loading ? '' : props.node.raw
+    renderingLoading.value = props.node.loading
+    hasRenderedOnce = !props.node.loading
     return
   }
 

--- a/test/math-inline-loading-state.test.ts
+++ b/test/math-inline-loading-state.test.ts
@@ -47,4 +47,28 @@ describe('mathInlineNode pending state', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps loading inline math in loading mode instead of flashing raw fallback', async () => {
+    const wrapper = mount(MathInlineNode as any, {
+      props: {
+        node: {
+          type: 'math_inline',
+          content: 'W = \\operatorname{span}\\{\\boldsy',
+          raw: '\\(W = \\operatorname{span}\\{\\boldsy\\)',
+          markup: '\\(\\)',
+          loading: true,
+        },
+      },
+    })
+
+    await flushAll()
+
+    expect(mocks.renderKaTeXWithBackpressure).toHaveBeenCalled()
+    expect(wrapper.attributes('data-markstream-mode')).toBe('loading')
+    expect(wrapper.attributes('data-markstream-pending')).toBe('true')
+    expect(wrapper.find('.math-inline--fallback').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('\\operatorname')
+
+    wrapper.unmount()
+  })
 })

--- a/test/math-inline-loading-state.test.ts
+++ b/test/math-inline-loading-state.test.ts
@@ -71,4 +71,45 @@ describe('mathInlineNode pending state', () => {
 
     wrapper.unmount()
   })
+
+  it('re-renders when loading changes without a content change', async () => {
+    const disabledError: any = new Error('KaTeX disabled')
+    disabledError.code = 'KATEX_DISABLED'
+    mocks.renderKaTeXWithBackpressure
+      .mockImplementationOnce(() => new Promise<string>(() => {}))
+      .mockRejectedValueOnce(disabledError)
+
+    const wrapper = mount(MathInlineNode as any, {
+      props: {
+        node: {
+          type: 'math_inline',
+          content: 'x',
+          raw: '\\(x\\)',
+          markup: '\\(\\)',
+          loading: true,
+        },
+      },
+    })
+
+    await flushAll()
+
+    expect(wrapper.attributes('data-markstream-mode')).toBe('loading')
+
+    await wrapper.setProps({
+      node: {
+        type: 'math_inline',
+        content: 'x',
+        raw: '\\(x\\)',
+        markup: '\\(\\)',
+        loading: false,
+      },
+    })
+    await flushAll()
+
+    expect(mocks.renderKaTeXWithBackpressure).toHaveBeenCalledTimes(2)
+    expect(wrapper.attributes('data-markstream-mode')).toBe('fallback')
+    expect(wrapper.text()).toContain('\\(x\\)')
+
+    wrapper.unmount()
+  })
 })

--- a/test/math-inline-loading-state.test.ts
+++ b/test/math-inline-loading-state.test.ts
@@ -72,6 +72,61 @@ describe('mathInlineNode pending state', () => {
     wrapper.unmount()
   })
 
+  it('keeps empty loading paren math in loading mode', async () => {
+    const wrapper = mount(MathInlineNode as any, {
+      props: {
+        node: {
+          type: 'math_inline',
+          content: '',
+          raw: '\\(\\)',
+          markup: '\\(\\)',
+          loading: true,
+        },
+      },
+    })
+
+    await flushAll()
+
+    expect(mocks.renderKaTeXWithBackpressure).not.toHaveBeenCalled()
+    expect(wrapper.attributes('data-markstream-mode')).toBe('loading')
+    expect(wrapper.find('.math-inline--fallback').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('\\(\\)')
+
+    wrapper.unmount()
+  })
+
+  it('shows raw fallback when empty loading paren math settles without content', async () => {
+    const wrapper = mount(MathInlineNode as any, {
+      props: {
+        node: {
+          type: 'math_inline',
+          content: '',
+          raw: '\\(\\)',
+          markup: '\\(\\)',
+          loading: true,
+        },
+      },
+    })
+
+    await flushAll()
+
+    await wrapper.setProps({
+      node: {
+        type: 'math_inline',
+        content: '',
+        raw: '\\(\\)',
+        markup: '\\(\\)',
+        loading: false,
+      },
+    })
+    await flushAll()
+
+    expect(wrapper.attributes('data-markstream-mode')).toBe('fallback')
+    expect(wrapper.text()).toContain('\\(\\)')
+
+    wrapper.unmount()
+  })
+
   it('re-renders when loading changes without a content change', async () => {
     const disabledError: any = new Error('KaTeX disabled')
     disabledError.code = 'KATEX_DISABLED'

--- a/test/vue2-math-inline-loading-state.test.ts
+++ b/test/vue2-math-inline-loading-state.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('markstream-vue2 MathInlineNode loading state', () => {
+  it('keeps empty loading inline math in loading mode instead of raw fallback', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'packages/markstream-vue2/src/components/MathInlineNode/MathInlineNode.vue'),
+      'utf8',
+    )
+
+    expect(source).toContain('fallbackText.value = props.node.loading ? \'\' : props.node.raw')
+    expect(source).toContain('renderingLoading.value = !!props.node.loading')
+    expect(source).toContain('hasRenderedOnce = !props.node.loading')
+    expect(source).not.toContain(`if (!props.node.content) {
+    applyRawFallback()
+    hasRenderedOnce = true
+    return
+  }`)
+  })
+})


### PR DESCRIPTION
## Summary
- remove the stray escaped `\(` opener from text before loading inline paren math after a softbreak
- keep loading inline math in loading mode instead of rendering raw fallback before KaTeX settles
- add parser and Vue regression coverage for the streaming inline math prefix case

## Tests
- `pnpm exec vitest --run packages/markdown-parser/test/inline-math-streaming-prefix.test.ts test/math-inline-loading-state.test.ts`
- `pnpm exec vitest --run test/math-inline-edgecases.test.ts test/math-inline-escaped-parens-duplicate.test.ts packages/markdown-parser/test/escaped-punctuation-math-adjacent.test.ts`
- `pnpm exec vitest --run packages/markdown-parser/test/strong-math-inline-regression.test.ts packages/markdown-parser/test/list-inline-streaming-regression.test.ts packages/markdown-parser/test/math-block-same-line-boundary.test.ts`
- `pnpm exec vitest --run test/math-inline-loading-state.test.ts test/math-inline-busy-fallback.test.ts test/math-block-loading-state.test.ts`
- `pnpm -C packages/markdown-parser typecheck`
- `pnpm exec eslint packages/markdown-parser/src/parser/inline-parsers/index.ts packages/markdown-parser/test/inline-math-streaming-prefix.test.ts src/components/MathInlineNode/MathInlineNode.vue test/math-inline-loading-state.test.ts`