### PR TITLE
fix: clear code block menu tooltip on close

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockShell.vue
+++ b/src/components/CodeBlockNode/CodeBlockShell.vue
@@ -69,10 +69,16 @@ const moreMenuRef = ref<HTMLElement | null>(null)
 const moreBtnRef = ref<HTMLElement | null>(null)
 
 function toggleMoreMenu() {
+  hideTooltip(true)
   moreMenuOpen.value = !moreMenuOpen.value
   if (moreMenuOpen.value) {
     document.addEventListener('click', closeMoreMenuOutside, { once: true, capture: true })
   }
+}
+
+function closeMoreMenu() {
+  hideTooltip(true)
+  moreMenuOpen.value = false
 }
 
 function closeMoreMenuOutside(e: Event) {
@@ -81,7 +87,7 @@ function closeMoreMenuOutside(e: Event) {
     document.addEventListener('click', closeMoreMenuOutside, { once: true, capture: true })
   }
   else {
-    moreMenuOpen.value = false
+    closeMoreMenu()
   }
 }
 
@@ -196,29 +202,29 @@ const fontIncreaseDisabled = computed(() =>
             <div v-if="moreMenuOpen" ref="moreMenuRef" class="code-more-menu min-w-[10rem] p-1 bg-[hsl(var(--ms-popover))] text-[hsl(var(--ms-popover-foreground))] border border-[var(--code-border)] shadow-[var(--ms-shadow-popover)]" role="menu">
               <!-- Font size controls -->
               <template v-if="props.showFontSizeButtons && props.enableFontSizeControl">
-                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontDecreaseDisabled" @click="emit('decreaseFont')">
+                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontDecreaseDisabled" @click="hideTooltip(true); emit('decreaseFont')">
                   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" /></svg>
                   <span>{{ t('common.fontSmaller') || 'Font size −' }}</span>
                 </button>
-                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontResetDisabled" @click="emit('resetFont')">
+                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontResetDisabled" @click="hideTooltip(true); emit('resetFont')">
                   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9a9.75 9.75 0 0 0-6.74 2.74L3 8" /><path d="M3 3v5h5" /></g></svg>
                   <span>{{ t('common.fontReset') || 'Font size reset' }}</span>
                 </button>
-                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontIncreaseDisabled" @click="emit('increaseFont')">
+                <button type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors" :disabled="fontIncreaseDisabled" @click="hideTooltip(true); emit('increaseFont')">
                   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14m-7-7v14" /></svg>
                   <span>{{ t('common.fontLarger') || 'Font size +' }}</span>
                 </button>
               </template>
 
               <!-- Expand -->
-              <button v-if="props.showExpandButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="emit('toggleExpand', $event); moreMenuOpen = false">
+              <button v-if="props.showExpandButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="closeMoreMenu(); emit('toggleExpand', $event)">
                 <svg v-if="isExpanded" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m14 10l7-7m-1 7h-6V4M3 21l7-7m-6 0h6v6" /></svg>
                 <svg v-else xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 3h6v6m0-6l-7 7M3 21l7-7m-1 7H3v-6" /></svg>
                 <span>{{ isExpanded ? (t('common.collapse') || 'Collapse') : (t('common.expand') || 'Expand') }}</span>
               </button>
 
               <!-- Preview -->
-              <button v-if="isPreviewable && props.showPreviewButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="emit('preview'); moreMenuOpen = false">
+              <button v-if="isPreviewable && props.showPreviewButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="closeMoreMenu(); emit('preview')">
                 <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M2.062 12.348a1 1 0 0 1 0-.696a10.75 10.75 0 0 1 19.876 0a1 1 0 0 1 0 .696a10.75 10.75 0 0 1-19.876 0" /><circle cx="12" cy="12" r="3" /></g></svg>
                 <span>{{ t('common.preview') || 'Preview' }}</span>
               </button>

--- a/test/code-block-shell-tooltip.test.ts
+++ b/test/code-block-shell-tooltip.test.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import CodeBlockShell from '../src/components/CodeBlockNode/CodeBlockShell.vue'
+import { hideTooltip } from '../src/composables/useSingletonTooltip'
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitTooltipShow() {
+  await wait(100)
+  await vi.dynamicImportSettled()
+  await nextTick()
+}
+
+describe('codeBlockShell overflow menu tooltip', () => {
+  afterEach(async () => {
+    hideTooltip(true)
+    await nextTick()
+  })
+
+  it('clears the singleton tooltip when a menu item closes the overflow menu', async () => {
+    const wrapper = mount(CodeBlockShell, {
+      attachTo: document.body,
+      props: {
+        showCollapseButton: false,
+        showCopyButton: false,
+        showExpandButton: false,
+        showFontSizeButtons: false,
+        isPreviewable: true,
+      },
+    })
+
+    const moreButton = wrapper.get('button[aria-haspopup="true"]')
+
+    await moreButton.trigger('mouseenter')
+    await waitTooltipShow()
+    expect(moreButton.attributes('aria-describedby')).toBeDefined()
+
+    await moreButton.trigger('click')
+    await nextTick()
+
+    const previewButton = wrapper.findAll('button[role="menuitem"]').find(button => button.text().includes('Preview'))
+    expect(previewButton).toBeTruthy()
+
+    await previewButton!.trigger('click')
+    await nextTick()
+
+    expect(wrapper.emitted('preview')).toHaveLength(1)
+    expect(moreButton.attributes('aria-describedby')).toBeUndefined()
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- clear the singleton tooltip when the code block overflow menu opens or closes
- clear tooltip state before overflow menu item actions run
- add a regression test for clicking an overflow menu item after the More tooltip appears

Fixes #556

## Verification
- pnpm lint
- pnpm typecheck
- pnpm exec vitest --run --testTimeout=10000