### PR TITLE
fix(parser): preserve CJK emphasis delimiters

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -30,6 +30,8 @@ const ESCAPABLE_PUNCTUATION = new Set(['\\', '(', ')', '[', ']', '`', '$', '|', 
 const WHITESPACE_RE = /\s/u
 const ASCII_PUNCTUATION_RE = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/
 const UNICODE_PUNCTUATION_RE = /\p{P}/u
+const CJK_OPENING_PUNCTUATION_RE = /^[《「『【〔〖〘〚〈（［｛“‘﹁﹃﹙﹛﹝]$/u
+const CJK_CLOSING_PUNCTUATION_RE = /^[》」』】〕〗〙〛〉）］｝”’﹂﹄﹚﹜﹞]$/u
 
 // Helper: detect likely URLs/hrefs (autolinks). Extracted so the
 // detection logic is easy to tweak and test.
@@ -152,6 +154,20 @@ function isPunctuationChar(ch?: string) {
   return !!ch && (ASCII_PUNCTUATION_RE.test(ch) || UNICODE_PUNCTUATION_RE.test(ch))
 }
 
+function isCjkOpeningPunctuation(ch?: string, previous?: string) {
+  return !!ch
+    && !!previous
+    && /^\p{Script=Han}$/u.test(previous)
+    && CJK_OPENING_PUNCTUATION_RE.test(ch)
+}
+
+function isCjkClosingPunctuation(ch?: string, next?: string) {
+  return !!ch
+    && !!next
+    && /^\p{Script=Han}$/u.test(next)
+    && CJK_CLOSING_PUNCTUATION_RE.test(ch)
+}
+
 function isEmphasisOpenDelimiter(content: string, index: number) {
   const prev = index > 0 ? content[index - 1] : undefined
   const next = content[index + 1]
@@ -159,7 +175,7 @@ function isEmphasisOpenDelimiter(content: string, index: number) {
   if (!next || isWhitespaceChar(next))
     return false
 
-  return !(isPunctuationChar(next) && !!prev && !isWhitespaceChar(prev) && !isPunctuationChar(prev))
+  return !(isPunctuationChar(next) && !isCjkOpeningPunctuation(next, prev) && !!prev && !isWhitespaceChar(prev) && !isPunctuationChar(prev))
 }
 
 function isEmphasisCloseDelimiter(content: string, index: number) {
@@ -169,7 +185,7 @@ function isEmphasisCloseDelimiter(content: string, index: number) {
   if (!prev || isWhitespaceChar(prev))
     return false
 
-  return !(isPunctuationChar(prev) && !!next && !isWhitespaceChar(next) && !isPunctuationChar(next))
+  return !(isPunctuationChar(prev) && !isCjkClosingPunctuation(prev, next) && !!next && !isWhitespaceChar(next) && !isPunctuationChar(next))
 }
 
 function findNextUnescapedEmphasisClose(
@@ -205,7 +221,7 @@ function isStrongOpenDelimiter(content: string, index: number) {
   if (!next || isWhitespaceChar(next))
     return false
 
-  return !(isPunctuationChar(next) && !!prev && !isWhitespaceChar(prev) && !isPunctuationChar(prev))
+  return !(isPunctuationChar(next) && !isCjkOpeningPunctuation(next, prev) && !!prev && !isWhitespaceChar(prev) && !isPunctuationChar(prev))
 }
 
 function isStrongCloseDelimiter(content: string, index: number) {
@@ -215,7 +231,7 @@ function isStrongCloseDelimiter(content: string, index: number) {
   if (!prev || isWhitespaceChar(prev))
     return false
 
-  return !(isPunctuationChar(prev) && !!next && !isWhitespaceChar(next) && !isPunctuationChar(next))
+  return !(isPunctuationChar(prev) && !isCjkClosingPunctuation(prev, next) && !!next && !isWhitespaceChar(next) && !isPunctuationChar(next))
 }
 
 function findNextStrongClose(content: string, startContentIndex = 0) {

--- a/packages/markdown-parser/test/issue-561-chinese-strong.test.ts
+++ b/packages/markdown-parser/test/issue-561-chinese-strong.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+function collectText(value: any): string {
+  if (!value || typeof value !== 'object')
+    return ''
+  if (value.type === 'text')
+    return String(value.content ?? '')
+  if (Array.isArray(value))
+    return value.map(collectText).join('')
+  return collectText(value.children)
+}
+
+describe('issue 561: strong text after CJK text', () => {
+  it.each([true, false])('preserves all text when final=%s', (final) => {
+    const markdown = '了**《中华人民共和国大气污染防治法》第四十八条**：'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown(`issue-561-${final}`), { final }) as any[]
+    const children = nodes[0].children
+
+    expect(children).toHaveLength(3)
+    expect(children[0]).toMatchObject({ type: 'text', content: '了' })
+    expect(children[1]).toMatchObject({
+      type: 'strong',
+      raw: '**《中华人民共和国大气污染防治法》第四十八条**',
+    })
+    expect(children[1].children[0]).toMatchObject({
+      type: 'text',
+      content: '《中华人民共和国大气污染防治法》第四十八条',
+    })
+    expect(children[2]).toMatchObject({ type: 'text', content: '：' })
+  })
+
+  it.each([true, false])('preserves Han text immediately after the closing marker when final=%s', (final) => {
+    const markdown = '了**《法》**后'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown(`issue-561-trailing-han-${final}`), { final })
+
+    expect(collectText(nodes)).toBe('了《法》后')
+    expect(nodes[0].children.filter((child: any) => child.type === 'strong')).toHaveLength(1)
+  })
+
+  it.each([
+    ['了**「法」**：', '了「法」：'],
+    ['了**『法』**：', '了『法』：'],
+    ['了**【法】**：', '了【法】：'],
+    ['了**（法）**：', '了（法）：'],
+    ['了**“法”**：', '了“法”：'],
+  ])('preserves text for opening punctuation variant %s', (markdown, expected) => {
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-561-opening-punctuation'), { final: true })
+
+    expect(collectText(nodes)).toBe(expected)
+    expect(nodes[0].children.filter((child: any) => child.type === 'strong')).toHaveLength(1)
+  })
+
+  it('preserves a strong label when the affected text is inside a link', () => {
+    const markdown = '了[**《法》**](https://example.com)：'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-561-link'), { final: true })
+
+    expect(collectText(nodes)).toBe('了《法》：')
+    expect(nodes[0].children.find((child: any) => child.type === 'link')?.children[0]).toMatchObject({
+      type: 'strong',
+      raw: '**《法》**',
+    })
+  })
+
+  it('keeps adjacent emphasis content intact as a related inline edge case', () => {
+    const markdown = '了*《法》*：'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-561-emphasis'), { final: true })
+
+    expect(collectText(nodes)).toBe('了《法》：')
+    expect(nodes[0].children).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'emphasis', raw: '*《法》*' }),
+    ]))
+  })
+})


### PR DESCRIPTION
## Summary

- preserve strong/emphasis content when CJK opening or closing punctuation is adjacent to delimiters
- add regression coverage for issue #561, punctuation variants, trailing Han text, and link/emphasis contexts

Fixes #561

## Validation

- `pnpm test --run`
- `pnpm typecheck`
- targeted ESLint

The parser change is intentionally limited to CJK delimiter classification to avoid broad token-recovery changes and related regressions.