### PR TITLE
fix: avoid detached code block tooltip anchor

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -6,7 +6,7 @@ import type { MonacoDiffEditorViewLike, MonacoDisposableLike, MonacoEditorViewLi
 import { computed, getCurrentInstance, inject, nextTick, onBeforeUnmount, onUnmounted, ref, shallowRef, useAttrs, watch } from 'vue'
 import { useSafeI18n } from '../../composables/useSafeI18n'
 // Tooltip is provided as a singleton via composable to avoid many DOM nodes
-import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
+import { hideTooltip } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { languageIconsRevision, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../../utils'
 import { MARKSTREAM_LANGUAGE_ICON_RESOLVER_KEY } from '../../utils/languageIconContext'
@@ -179,7 +179,6 @@ const { t } = useSafeI18n()
 const codeEditor = ref<HTMLElement | null>(null)
 const container = ref<HTMLElement | null>(null)
 const copyText = ref(false)
-// local tooltip logic removed; use shared `showTooltipForAnchor` / `hideTooltip`
 
 const codeLanguage = ref(resolveStreamingCodeLanguage(props.node.language, props.node.code, isCodeBlockLoading()))
 const monacoLanguage = computed(() => resolveMonacoLanguageId(codeLanguage.value))
@@ -3538,23 +3537,8 @@ watch(tooltipsEnabled, (enabled) => {
     hideTooltip()
 })
 
-function resolveTooltipTarget(e: Event) {
-  const btn = (e.currentTarget || e.target) as HTMLButtonElement | null
-  if (!btn || btn.disabled)
-    return null
-  return btn
-}
-
-function toggleExpand(e?: Event) {
+function toggleExpand() {
   isExpanded.value = !isExpanded.value
-
-  if (e && tooltipsEnabled.value) {
-    const target = resolveTooltipTarget(e)
-    if (target) {
-      const txt = isExpanded.value ? (t('common.collapse') || 'Collapse') : (t('common.expand') || 'Expand')
-      showTooltipForAnchor(target, txt, 'top', false, undefined, props.isDark)
-    }
-  }
 
   const editor = isDiff.value
     ? getDiffEditorView()

--- a/src/components/CodeBlockNode/CodeBlockShell.vue
+++ b/src/components/CodeBlockNode/CodeBlockShell.vue
@@ -61,7 +61,7 @@ const emit = defineEmits<{
   (e: 'resetFont'): void
   (e: 'increaseFont'): void
   (e: 'copy'): void
-  (e: 'toggleExpand', event: MouseEvent): void
+  (e: 'toggleExpand'): void
   (e: 'preview'): void
 }>()
 const moreMenuOpen = ref(false)
@@ -217,7 +217,7 @@ const fontIncreaseDisabled = computed(() =>
               </template>
 
               <!-- Expand -->
-              <button v-if="props.showExpandButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="closeMoreMenu(); emit('toggleExpand', $event)">
+              <button v-if="props.showExpandButton" type="button" role="menuitem" class="flex items-center gap-2 w-full py-1.5 px-2 rounded text-xs text-[var(--code-action-fg)] cursor-pointer whitespace-nowrap hover:bg-[var(--code-action-hover-bg)] hover:text-[var(--code-action-hover-fg)] transition-colors" @click="closeMoreMenu(); emit('toggleExpand')">
                 <svg v-if="isExpanded" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m14 10l7-7m-1 7h-6V4M3 21l7-7m-6 0h6v6" /></svg>
                 <svg v-else xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" viewBox="0 0 24 24" class="action-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 3h6v6m0-6l-7 7M3 21l7-7m-1 7H3v-6" /></svg>
                 <span>{{ isExpanded ? (t('common.collapse') || 'Collapse') : (t('common.expand') || 'Expand') }}</span>

--- a/test/code-block-shell-tooltip.test.ts
+++ b/test/code-block-shell-tooltip.test.ts
@@ -53,4 +53,30 @@ describe('codeBlockShell overflow menu tooltip', () => {
 
     wrapper.unmount()
   })
+
+  it('does not expose a removed expand menu item as a tooltip anchor', async () => {
+    const wrapper = mount(CodeBlockShell, {
+      attachTo: document.body,
+      props: {
+        showCollapseButton: false,
+        showCopyButton: false,
+        showExpandButton: true,
+        showFontSizeButtons: false,
+        isPreviewable: false,
+      },
+    })
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    await nextTick()
+
+    const expandButton = wrapper.get('button[role="menuitem"]')
+    const expandElement = expandButton.element as HTMLElement
+    await expandButton.trigger('click')
+    await nextTick()
+
+    expect(expandElement.isConnected).toBe(false)
+    expect(wrapper.emitted('toggleExpand')).toEqual([[]])
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary

- stop forwarding the expand menu item's `MouseEvent` after the overflow menu closes
- remove the CodeBlockNode click-feedback tooltip path that could anchor to the removed menu item
- add regression coverage for the detached expand menu item contract

Follow-up to #556.

## Tests

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --run` (294 files, 2434 tests)
