### PR TITLE
fix: preserve diagram previews across streaming failures

### DIFF
--- a/src/components/InfographicBlockNode/InfographicBlockNode.vue
+++ b/src/components/InfographicBlockNode/InfographicBlockNode.vue
@@ -433,6 +433,7 @@ async function renderInfographic(force = false) {
   if (!force && signature === lastCompletedRenderSignature && hasPreview.value)
     return
 
+  const final = props.loading === false
   const generation = ++renderGeneration
   renderInFlight = true
   markLifecyclePending()
@@ -505,7 +506,7 @@ async function renderInfographic(force = false) {
   catch (error) {
     if (!isCurrentRender(generation))
       return
-    if (props.loading === false) {
+    if (final) {
       console.error('Failed to render infographic:', error)
       hasPreview.value = false
       hasRenderError.value = true

--- a/src/components/InfographicBlockNode/InfographicBlockNode.vue
+++ b/src/components/InfographicBlockNode/InfographicBlockNode.vue
@@ -506,7 +506,7 @@ async function renderInfographic(force = false) {
   catch (error) {
     if (!isCurrentRender(generation))
       return
-    if (final) {
+    if (final && props.loading === false && signature === renderSignature.value) {
       console.error('Failed to render infographic:', error)
       hasPreview.value = false
       hasRenderError.value = true

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -325,10 +325,12 @@ const isRendering = ref(false)
 const renderQueue = ref<Promise<boolean> | null>(null)
 interface MermaidRenderRequest {
   codeWithTheme: string
+  final: boolean
   signature: string
   theme: 'light' | 'dark'
 }
 let activeRenderSignature = ''
+let activeRenderIsFinal = false
 let lastCompletedRenderSignature = ''
 const lastContentLength = ref(0)
 const isContentGenerating = ref(false)
@@ -579,7 +581,7 @@ function withTimeoutSignal<T>(
   })
 }
 
-// Unified error renderer (only used when props.loading === false)
+// Unified error renderer (only used for final render requests)
 function renderErrorToContainer(error: unknown) {
   if (typeof document === 'undefined')
     return
@@ -1401,9 +1403,11 @@ async function switchMode(target: 'source' | 'preview') {
 function createMermaidRenderRequest(
   code = baseFixedCode.value,
   theme: 'light' | 'dark' = props.isDark ? 'dark' : 'light',
+  final = props.loading === false,
 ): MermaidRenderRequest {
   return {
     codeWithTheme: getCodeWithTheme(theme, code),
+    final,
     signature: `${theme}\u0000${code}`,
     theme,
   }
@@ -1420,14 +1424,20 @@ async function initMermaid(request = createMermaidRenderRequest()) {
     return false
   if (isRendering.value) {
     const activeQueue = renderQueue.value
+    const activeIsFinal = activeRenderIsFinal
     const activeSignature = activeRenderSignature
     if (!activeQueue)
       return false
     const rendered = await activeQueue
     if (!isActiveGeneration(generation) || !isCurrentRenderRequest(request))
       return false
-    if (activeSignature === request.signature)
-      return rendered && lastCompletedRenderSignature === request.signature
+    if (activeSignature === request.signature) {
+      if (rendered && lastCompletedRenderSignature === request.signature)
+        return true
+      if (request.final && !activeIsFinal)
+        return initMermaid(request)
+      return false
+    }
     return initMermaid(request)
   }
 
@@ -1444,6 +1454,7 @@ async function initMermaid(request = createMermaidRenderRequest()) {
     return false
 
   isRendering.value = true
+  activeRenderIsFinal = request.final
   activeRenderSignature = request.signature
   markLifecyclePending()
 
@@ -1477,7 +1488,7 @@ async function initMermaid(request = createMermaidRenderRequest()) {
 
       if (!mermaidContent.value)
         return false
-      const rendered = renderSvgToTarget(mermaidContent.value, res?.svg, { keepPreviousOnFailure: props.loading !== false })
+      const rendered = renderSvgToTarget(mermaidContent.value, res?.svg, { keepPreviousOnFailure: !request.final })
       if (!rendered) {
         if (isThemeRendering.value)
           isThemeRendering.value = false
@@ -1525,14 +1536,15 @@ async function initMermaid(request = createMermaidRenderRequest()) {
       else {
         consecutiveRenderTimeouts = 0
         clearRenderRetryTimer()
-        if (props.loading === false)
+        if (request.final)
           console.error('Failed to render mermaid diagram:', error)
-        if (props.loading === false)
+        if (request.final)
           renderErrorToContainer(error)
       }
       return false
     }
     finally {
+      activeRenderIsFinal = false
       activeRenderSignature = ''
       isRendering.value = false
       renderQueue.value = null

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -1434,7 +1434,7 @@ async function initMermaid(request = createMermaidRenderRequest()) {
     if (activeSignature === request.signature) {
       if (rendered && lastCompletedRenderSignature === request.signature)
         return true
-      if (request.final && !activeIsFinal)
+      if (request.final && props.loading === false && !activeIsFinal)
         return initMermaid(request)
       return false
     }
@@ -1488,7 +1488,9 @@ async function initMermaid(request = createMermaidRenderRequest()) {
 
       if (!mermaidContent.value)
         return false
-      const rendered = renderSvgToTarget(mermaidContent.value, res?.svg, { keepPreviousOnFailure: !request.final })
+      const rendered = renderSvgToTarget(mermaidContent.value, res?.svg, {
+        keepPreviousOnFailure: !request.final || props.loading !== false,
+      })
       if (!rendered) {
         if (isThemeRendering.value)
           isThemeRendering.value = false
@@ -1536,9 +1538,9 @@ async function initMermaid(request = createMermaidRenderRequest()) {
       else {
         consecutiveRenderTimeouts = 0
         clearRenderRetryTimer()
-        if (request.final)
+        if (request.final && props.loading === false)
           console.error('Failed to render mermaid diagram:', error)
-        if (request.final)
+        if (request.final && props.loading === false)
           renderErrorToContainer(error)
       }
       return false

--- a/test/infographic-streaming-error.test.ts
+++ b/test/infographic-streaming-error.test.ts
@@ -95,6 +95,65 @@ describe('infographicBlockNode streaming errors', () => {
     wrapper.unmount()
   })
 
+  it('does not report an in-flight streaming failure after loading settles', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    let resolveLoader: ((value: unknown) => void) | null = null
+    const loaderPromise = new Promise<unknown>((resolve) => {
+      resolveLoader = resolve
+    })
+    let renderCount = 0
+
+    class StreamingRaceInfographic {
+      private container: HTMLElement
+      private errorHandler?: (error: unknown) => void
+
+      constructor(options: { container: HTMLElement }) {
+        this.container = options.container
+      }
+
+      on(event: string, handler: (error: unknown) => void) {
+        if (event === 'error')
+          this.errorHandler = handler
+      }
+
+      render() {
+        renderCount++
+        if (renderCount === 1) {
+          this.errorHandler?.(new Error('Incomplete streaming options'))
+          return
+        }
+        this.container.innerHTML = '<svg data-infographic="final"></svg>'
+      }
+
+      destroy() {}
+    }
+
+    setInfographicLoader(() => loaderPromise)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(InfographicBlockNode as any, {
+      props: {
+        node: createNode('infographic list-row-simple-horizontal-arrow'),
+        loading: true,
+      },
+    })
+
+    await flushAll()
+    expect(renderCount).toBe(0)
+
+    await wrapper.setProps({ loading: false })
+    await flushAll()
+    resolveLoader?.(StreamingRaceInfographic)
+    await flushAll()
+
+    expect(renderCount).toBe(2)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Failed to render infographic')
+    expect(wrapper.find('svg[data-infographic="final"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
   it('keeps lifecycle pending across a queued rerender', async () => {
     vi.stubGlobal('IntersectionObserver', undefined as any)
 

--- a/test/infographic-streaming-error.test.ts
+++ b/test/infographic-streaming-error.test.ts
@@ -154,6 +154,101 @@ describe('infographicBlockNode streaming errors', () => {
     wrapper.unmount()
   })
 
+  it('keeps the previous preview when a final render fails after streaming restarts', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+    setInfographicLoader(() => HeightChangingInfographic)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(InfographicBlockNode as any, {
+      props: {
+        node: createNode('infographic list-row-simple-horizontal-arrow'),
+        loading: true,
+      },
+    })
+    await flushAll()
+
+    expect(wrapper.find('svg[data-infographic="1"]').exists()).toBe(true)
+
+    let resolveLoader: ((value: unknown) => void) | null = null
+    const loaderPromise = new Promise<unknown>((resolve) => {
+      resolveLoader = resolve
+    })
+    setInfographicLoader(() => loaderPromise)
+    await wrapper.setProps({
+      node: createNode('infographic list-row-simple-horizontal-arrow next'),
+      loading: false,
+    })
+    await flushAll()
+
+    await wrapper.setProps({ loading: true })
+    await flushAll()
+    resolveLoader?.(ErrorInfographic)
+    await flushAll()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Failed to render infographic')
+    expect(wrapper.find('svg[data-infographic="1"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('does not report a stale final failure after the source changes', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    let resolveLoader: ((value: unknown) => void) | null = null
+    const loaderPromise = new Promise<unknown>((resolve) => {
+      resolveLoader = resolve
+    })
+    let renderCount = 0
+
+    class SourceRaceInfographic {
+      private container: HTMLElement
+      private errorHandler?: (error: unknown) => void
+
+      constructor(options: { container: HTMLElement }) {
+        this.container = options.container
+      }
+
+      on(event: string, handler: (error: unknown) => void) {
+        if (event === 'error')
+          this.errorHandler = handler
+      }
+
+      render() {
+        renderCount++
+        if (renderCount === 1) {
+          this.errorHandler?.(new Error('Stale final source'))
+          return
+        }
+        this.container.innerHTML = '<svg data-infographic="latest"></svg>'
+      }
+
+      destroy() {}
+    }
+
+    setInfographicLoader(() => loaderPromise)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mount(InfographicBlockNode as any, {
+      props: {
+        node: createNode('first'),
+        loading: false,
+      },
+    })
+
+    await flushAll()
+    await wrapper.setProps({ node: createNode('second') })
+    await flushAll()
+    resolveLoader?.(SourceRaceInfographic)
+    await flushAll()
+
+    expect(renderCount).toBe(2)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Failed to render infographic')
+    expect(wrapper.find('svg[data-infographic="latest"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
   it('keeps lifecycle pending across a queued rerender', async () => {
     vi.stubGlobal('IntersectionObserver', undefined as any)
 

--- a/test/mermaid-streaming-preview-regression.test.ts
+++ b/test/mermaid-streaming-preview-regression.test.ts
@@ -537,6 +537,92 @@ describe('mermaid streaming preview regression', () => {
     wrapper.unmount()
   })
 
+  it('keeps the previous preview when a streaming render fails after loading settles', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    let rejectStreamingRender!: (reason?: unknown) => void
+    let resolveFinalRender!: (value: { svg: string }) => void
+    const streamingRender = new Promise<{ svg: string }>((_resolve, reject) => {
+      rejectStreamingRender = reject
+    })
+    const finalRender = new Promise<{ svg: string }>((resolve) => {
+      resolveFinalRender = resolve
+    })
+    let latestRenderCount = 0
+    const canParseOffthread = vi.fn(async () => true)
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render: vi.fn((_id: string, code: string) => {
+        if (!code.includes('B-->C')) {
+          return Promise.resolve({
+            svg: '<svg data-rendered="previous" viewBox="0 0 10 10"><text>A</text></svg>',
+          })
+        }
+        latestRenderCount++
+        return latestRenderCount === 1 ? streamingRender : finalRender
+      }),
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread,
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: createNode('graph LR\nA-->B\n'),
+        loading: true,
+        previewPollDelayMs: 10000,
+      },
+    })
+
+    ;(wrapper.vm as any).userToggledShowSource = true
+    await settleStreamingRender()
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).viewportReady = true
+    ;(wrapper.vm as any).showSource = false
+    await settleStreamingRender()
+
+    expect(wrapper.find('svg[data-rendered="previous"]').exists()).toBe(true)
+
+    await wrapper.setProps({
+      node: createNode('graph LR\nA-->B\nB-->C\n'),
+    })
+    await vi.advanceTimersByTimeAsync(400)
+    await settleStreamingRender()
+
+    expect(fakeMermaid.render).toHaveBeenCalledTimes(2)
+
+    await wrapper.setProps({ loading: false })
+    await settleStreamingRender()
+    rejectStreamingRender(new Error('Incomplete streaming diagram'))
+    await settleStreamingRender(10)
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(fakeMermaid.render).toHaveBeenCalledTimes(3)
+    expect(wrapper.find('svg[data-rendered="previous"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('Failed to render diagram')
+
+    resolveFinalRender({
+      svg: '<svg data-rendered="final" viewBox="0 0 10 10"><text>B</text></svg>',
+    })
+    await settleStreamingRender(10)
+    await vi.advanceTimersByTimeAsync(40)
+    await settleStreamingRender()
+
+    expect(wrapper.find('svg[data-rendered="final"]').exists()).toBe(true)
+    expect(wrapper.find('svg[data-rendered="previous"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('keeps retrying a transient worker busy result beyond 150ms without using the main thread parser', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('IntersectionObserver', undefined as any)

--- a/test/mermaid-streaming-preview-regression.test.ts
+++ b/test/mermaid-streaming-preview-regression.test.ts
@@ -623,6 +623,74 @@ describe('mermaid streaming preview regression', () => {
     wrapper.unmount()
   })
 
+  it('keeps the previous preview when a final render fails after streaming restarts', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    let rejectFinalRender!: (reason?: unknown) => void
+    const finalRender = new Promise<{ svg: string }>((_resolve, reject) => {
+      rejectFinalRender = reject
+    })
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render: vi.fn((_id: string, code: string) => {
+        if (code.includes('B-->C'))
+          return finalRender
+        return Promise.resolve({
+          svg: '<svg data-rendered="previous" viewBox="0 0 10 10"><text>A</text></svg>',
+        })
+      }),
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread: vi.fn(async () => true),
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: createNode('graph LR\nA-->B\n'),
+        loading: true,
+        renderDebounceMs: 10000,
+      },
+    })
+
+    ;(wrapper.vm as any).userToggledShowSource = true
+    await settleStreamingRender()
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).viewportReady = true
+    ;(wrapper.vm as any).showSource = false
+    await settleStreamingRender()
+
+    expect(wrapper.find('svg[data-rendered="previous"]').exists()).toBe(true)
+
+    await wrapper.setProps({
+      node: createNode('graph LR\nA-->B\nB-->C\n'),
+    })
+    await settleStreamingRender()
+    await wrapper.setProps({ loading: false })
+    await settleStreamingRender()
+
+    expect(fakeMermaid.render).toHaveBeenCalledTimes(2)
+
+    await wrapper.setProps({ loading: true })
+    rejectFinalRender(new Error('Stale final render failure'))
+    await settleStreamingRender(10)
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(fakeMermaid.render).toHaveBeenCalledTimes(2)
+    expect(wrapper.find('svg[data-rendered="previous"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('Failed to render diagram')
+    wrapper.unmount()
+  })
+
   it('keeps retrying a transient worker busy result beyond 150ms without using the main thread parser', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('IntersectionObserver', undefined as any)


### PR DESCRIPTION
## Summary

- classify Mermaid and Infographic failures using the render state captured when each request starts
- keep the last successful preview when an in-flight streaming render fails after loading settles
- rerun Mermaid as a true final render before surfacing an error
- add regression coverage for Mermaid and Infographic render races

## Testing

- pnpm lint
- pnpm typecheck
- pnpm test (302 test files, 2511 tests)
- pnpm -C packages/markdown-parser build && pnpm build