### PR TITLE
fix(parser): restore streaming block predictions

### DIFF
--- a/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
@@ -150,7 +150,7 @@ function parseVmrContainer(
   }
 
   const hasCloseToken = j < tokens.length && tokens[j].type === 'vmr_container_close'
-  const closed = hasCloseToken || !!options?.final
+  const closed = (hasCloseToken && openToken.meta?.unclosed !== true) || !!options?.final
 
   // Build raw content
   let raw = `::: ${name}`

--- a/packages/markdown-parser/src/plugins/containers.ts
+++ b/packages/markdown-parser/src/plugins/containers.ts
@@ -354,8 +354,11 @@ export function applyContainers(md: MarkdownIt) {
         s.tokens.push(...(innerTokens as unknown as MarkdownToken[]))
       }
 
-      if (found)
-        s.push('vmr_container_close', 'div', -1)
+      const tokenClose = s.push('vmr_container_close', 'div', -1)
+      if (!found) {
+        tokenClose.hidden = true
+        tokenClose.map = [endLine, endLine]
+      }
 
       s.line = found ? (nextLine + 1) : nextLine
       return true

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -1499,6 +1499,21 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
       // 这里其实不应该只匹配 startWith的情况因为很可能前面还有 text
       if (lineText.startsWith(open)) {
         if (open.includes('[')) {
+          const sameLineContent = open === '\\[' ? lineText.slice(open.length) : ''
+          if (
+            open === '\\['
+            && allowLoading
+            && !strict
+            && findUnescapedDelimiter(sameLineContent, close) === -1
+            && !/^\s*!\[/.test(sameLineContent)
+            && !sameLineContent.includes('`')
+            && isMathLike(sameLineContent)
+          ) {
+            matched = true
+            openDelim = open
+            closeDelim = close
+            break
+          }
           if (mathOpts?.strictDelimiters) {
             if (lineText.replace('\\', '') === '[') {
               if (startLine + 1 < endLine) {

--- a/packages/markdown-parser/test/math-block-streaming-close.test.ts
+++ b/packages/markdown-parser/test/math-block-streaming-close.test.ts
@@ -22,6 +22,36 @@ function collect(nodes: any, type: string): any[] {
 }
 
 describe('math block streaming close handling', () => {
+  it('promotes same-line explicit bracket math before the closing delimiter arrives', () => {
+    const md = getMarkdown('math-block-streaming-same-line-open')
+    const chunks = [
+      '- **自然对数**（在 x = 0 附近）：\n\n\\[',
+      '\\ln(1+x)',
+      ' = x - \\frac{x^2}{2}',
+      '\\]',
+    ]
+    let markdown = ''
+
+    for (const [index, chunk] of chunks.entries()) {
+      markdown += chunk
+      const nodes = parseMarkdownToStructure(markdown, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any) as any[]
+      const mathBlocks = collect(nodes, 'math_block')
+
+      if (index === 0) {
+        expect(mathBlocks).toHaveLength(0)
+        continue
+      }
+
+      expect(mathBlocks).toHaveLength(1)
+      expect(mathBlocks[0].content).toBe(markdown.slice(markdown.indexOf('\\[') + 2, markdown.endsWith('\\]') ? -2 : undefined))
+      expect(mathBlocks[0].loading).toBe(index < chunks.length - 1)
+    }
+  })
+
   it('does not keep a standalone plain ] close line inside \\[ math content', () => {
     const md = getMarkdown('math-block-streaming-plain-close')
     const markdown = String.raw`- **矩阵：**

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -178,6 +178,45 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes).toBeGreaterThan(0)
   })
 
+  it.each([
+    ['unordered list', '- item', 'list'],
+    ['ordered list', '1. item', 'list'],
+    ['table header', '| A | B |\n', 'table'],
+  ])('keeps an early %s prediction equivalent to a cold parse', (_, tail, expectedType) => {
+    const md = getMarkdown(`stream-parser-early-${expectedType}`)
+    const coldMd = getMarkdown(`stream-parser-early-${expectedType}-cold`)
+    const base = buildLargeAppendFriendlyDoc(40)
+    let source = base
+
+    parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+
+    for (const char of tail) {
+      source += char
+      const streamed = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any)
+      const cold = parseMarkdownToStructure(source, coldMd, {
+        final: false,
+        streamParse: false,
+      })
+
+      expect(streamed).toEqual(cold)
+    }
+
+    const nodes = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    expect(nodes.at(-1)?.type).toBe(expectedType)
+  })
+
   it('reprocesses the previous last group when content becomes mixed', () => {
     const md = getMarkdown('stream-parser-mixed-last-group-overlap')
     const base = 'alpha\n\nbeta\n\n'

--- a/packages/markdown-parser/test/vmr-container-fence.test.ts
+++ b/packages/markdown-parser/test/vmr-container-fence.test.ts
@@ -201,6 +201,34 @@ describe('vmr_container fallback', () => {
     expect(nodes[0]?.loading).toBe(false)
   })
 
+  it('keeps an unclosed container current across streaming appends', () => {
+    const md = getMarkdown('vmr_container_loading_progressive')
+    const chunks = ['::: viewcode:stream\n', 'con', 'tent\n', ':', ':', ':']
+    let markdown = ''
+
+    for (const [index, chunk] of chunks.entries()) {
+      markdown += chunk
+      const nodes = parseMarkdownToStructure(markdown, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any) as any[]
+      const container = nodes[0]
+
+      expect(container?.type).toBe('vmr_container')
+      expect(container?.loading).toBe(index < chunks.length - 1)
+      if (index >= 1)
+        expect(container?.raw).toContain(index === 1 ? 'con' : 'content')
+    }
+
+    const nodes = parseMarkdownToStructure(markdown, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any) as any[]
+    expect(nodes[0]?.children?.[0]?.raw).toBe('content')
+  })
+
   it('forces loading=false when final=true even if closing ::: is missing', () => {
     const md = getMarkdown('vmr_container_loading_final')
     const markdown = [


### PR DESCRIPTION
## Summary

- promote same-line unclosed `\[` input to a loading math block once its content is clearly math-like
- keep unclosed fallback `:::` containers balanced so incremental AST reuse reparses their evolving content
- add streaming regressions for bracket math, containers, unordered/ordered lists, and table headers

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run` (302 files / 2520 tests)
- `pnpm test:api`
- `pnpm docs:build:ci`
- `pnpm benchmark:1.0` with release-gate thresholds
- CI build, SSR, E2E, package smoke, and size checks

Pre-PR workflow dispatches: [CI](https://github.com/Simon-He95/markstream-vue/actions/runs/29479874557) · [1.0 Benchmark](https://github.com/Simon-He95/markstream-vue/actions/runs/29479874110)