### PR TITLE
fix: stabilize code block visual handoff

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CodeBlockDiffHideUnchangedRegions, CodeBlockDiffHideUnchangedRegionsOptions, CodeBlockMonacoTheme, CodeBlockNodeProps, CodeBlockPreviewPayload } from '../../types/component-props'
+import type { CodeBlockMonacoTheme, CodeBlockNodeProps, CodeBlockPreviewPayload } from '../../types/component-props'
 import type { MonacoDiffEditorViewLike, MonacoDisposableLike, MonacoEditorViewLike, MonacoNamespaceLike, MonacoRuntimeOptions } from './monaco'
 // Avoid static import of `stream-monaco` for types so the runtime bundle
 // doesn't get a reference. Define minimal local types we need here.
@@ -15,6 +15,13 @@ import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { resolveLanguageIcon } from '../../utils/resolveLanguageIcon'
 import { safeCancelRaf, safeRaf } from '../../utils/safeRaf'
 import PreCodeNode from '../PreCodeNode'
+import {
+  defaultDiffHideUnchangedRegions,
+  isDiffCodeBlock,
+  resolveCodeBlockHeader,
+  resolveDiffHideUnchangedRegionsOption,
+  resolveDiffInlineLayout,
+} from './codeBlockHeader'
 import CodeBlockShell from './CodeBlockShell.vue'
 import HtmlPreviewFrame from './HtmlPreviewFrame.vue'
 import {
@@ -25,6 +32,7 @@ const props = withDefaults(
   defineProps<CodeBlockNodeProps & {
     estimatedHeightPx?: number
     estimatedContentHeightPx?: number
+    estimatedDiffInline?: boolean
   }>(),
   {
     isShowPreview: true,
@@ -325,6 +333,7 @@ let getDiffEditorView: () => MonacoDiffEditorViewLike | null = () => ({ getModel
 let cleanupEditor: () => void = () => {}
 let safeClean = () => {}
 let refreshDiffPresentation: () => Promise<unknown> | unknown = () => {}
+let whenRuntimeVisualReady: (() => Promise<boolean> | boolean) | null = null
 let createEditorPromise: Promise<void> | null = null
 let editorRuntimeCreationPromise: Promise<void> | null = null
 let monacoRuntimePromise: Promise<void> | null = null
@@ -335,43 +344,14 @@ let pendingDiffResultErrorFilterCleanup: (() => void) | null = null
 const editorHeightSyncDisposables: MonacoDisposableLike[] = []
 const inlineFoldProxyCleanups: Array<() => void> = []
 let runtimeMonacoOptions: MonacoRuntimeOptions | null = null
-function isDiffFenceInfo(value: unknown) {
-  const firstToken = String(value ?? '').trim().split(/\s+/, 1)[0] ?? ''
-  return firstToken === 'diff'
-}
-
-const isDiff = computed(() => {
-  return props.node.diff === true
-    || isDiffFenceInfo(props.node.language)
-    || isDiffFenceInfo(parseCodeFenceInfo(String(props.node.raw ?? '')))
-})
+const isDiff = computed(() => isDiffCodeBlock(props.node))
 const diffStats = ref({ removed: 0, added: 0 })
 const diffStatsAriaLabel = computed(() => `-${diffStats.value.removed} +${diffStats.value.added}`)
-const defaultDiffHideUnchangedRegions = Object.freeze({
-  enabled: true,
-  contextLineCount: 2,
-  minimumLineCount: 4,
-  revealLineCount: 5,
-})
 const disabledDiffHideUnchangedRegions = Object.freeze({
   ...defaultDiffHideUnchangedRegions,
   enabled: false,
   revealLineCount: 0,
 })
-function resolveDiffHideUnchangedRegionsOption(value: unknown): CodeBlockDiffHideUnchangedRegions {
-  if (typeof value === 'boolean')
-    return value
-  if (value && typeof value === 'object') {
-    const raw = value as Record<string, unknown>
-    return {
-      ...defaultDiffHideUnchangedRegions,
-      ...raw,
-      enabled: raw.enabled ?? true,
-    } as CodeBlockDiffHideUnchangedRegionsOptions
-  }
-  return { ...defaultDiffHideUnchangedRegions }
-}
-
 function resolveDiffWordWrapOption(raw: Record<string, unknown>) {
   if (raw.diffWordWrap !== undefined)
     return raw.diffWordWrap
@@ -380,20 +360,10 @@ function resolveDiffWordWrapOption(raw: Record<string, unknown>) {
 }
 
 function shouldUseInlineDiffLayout(options: Record<string, unknown>) {
-  if (options.renderSideBySide === false)
-    return true
-
-  if (options.useInlineViewWhenSpaceIsLimited !== true)
-    return false
-
-  const rawBreakpoint = options.renderSideBySideInlineBreakpoint
-  const breakpoint = typeof rawBreakpoint === 'number' && Number.isFinite(rawBreakpoint)
-    ? rawBreakpoint
-    : 900
   const width = container.value?.getBoundingClientRect?.().width
     || container.value?.clientWidth
     || (typeof window === 'undefined' ? 0 : window.innerWidth)
-  return width > 0 && width <= breakpoint
+  return resolveDiffInlineLayout(options, width)
 }
 
 function resolveDiffScrollbar(raw: Record<string, unknown>) {
@@ -735,6 +705,7 @@ async function ensureMonacoRuntime() {
       safeClean = helpers.safeClean || helpers.cleanupEditor || safeClean
       refreshDiffPresentation = helpers.refreshDiffPresentation || refreshDiffPresentation
       setTheme = helpers.setTheme || setTheme
+      whenRuntimeVisualReady = helpers.whenVisualReady || null
       monacoReady.value = true
     }
     catch (err) {
@@ -813,12 +784,13 @@ const preFallbackTabSize = computed(() => {
 })
 const preFallbackVerticalPadding = computed(() => {
   const padding = props.monacoOptions?.padding
-  const top = typeof padding?.top === 'number' && Number.isFinite(padding.top) && padding.top > 0
+  const defaultPadding = isDiff.value ? 0 : 8
+  const top = typeof padding?.top === 'number' && Number.isFinite(padding.top) && padding.top >= 0
     ? padding.top
-    : 0
-  const bottom = typeof padding?.bottom === 'number' && Number.isFinite(padding.bottom) && padding.bottom > 0
+    : defaultPadding
+  const bottom = typeof padding?.bottom === 'number' && Number.isFinite(padding.bottom) && padding.bottom >= 0
     ? padding.bottom
-    : 0
+    : defaultPadding
   return { top, bottom }
 })
 // Keep computed height tight to content. Extra padding caused visible bottom gap.
@@ -1046,11 +1018,11 @@ const codeEditorContainerStyle = computed(() => {
   // While the diff fallback pre is visible, the hidden Monaco host must not
   // participate in layout. The fallback pre owns the row height.
   if (isDiff.value && showPreWhileMonacoLoads.value)
-    return undefined
+    return {}
 
   const reserved = reservedEditorContentHeight.value
   if (!shouldReserveEstimatedEditorHeight.value || reserved == null)
-    return undefined
+    return {}
   return {
     minHeight: `${reserved}px`,
   }
@@ -1792,7 +1764,7 @@ function computeContentHeight(): number | null {
       if (h > 0) {
         if (!isDiff.value)
           plainEditorContentMeasured.value = true
-        return Math.ceil(h + PIXEL_EPSILON)
+        return Math.ceil(h)
       }
     }
     // generic fallback
@@ -3448,51 +3420,13 @@ const displayLanguage = computed(() => {
   return languageMap[lang] || lang.charAt(0).toUpperCase() + lang.slice(1)
 })
 
-function parseCodeFenceInfo(raw: string) {
-  const firstLine = String(raw ?? '').split(/\r?\n/, 1)[0]?.trim() ?? ''
-  if (firstLine.length < 3)
-    return ''
-  const marker = firstLine[0]
-  if ((marker !== '`' && marker !== '~') || firstLine[1] !== marker || firstLine[2] !== marker)
-    return ''
-
-  let index = 3
-  while (firstLine[index] === marker)
-    index += 1
-
-  return firstLine.slice(index).trim()
-}
-
-function extractCodeBlockFileLabel(raw: string) {
-  const info = parseCodeFenceInfo(raw)
-  if (!info)
-    return ''
-
-  const tokens = info.split(/\s+/).filter(Boolean)
-  if (!tokens.length)
-    return ''
-
-  const candidates = tokens[0] === 'diff' ? tokens.slice(1) : tokens
-  for (const token of candidates) {
-    const value = token.includes(':')
-      ? token.slice(token.indexOf(':') + 1)
-      : token
-    if (!value)
-      continue
-    if (/[./\\-]/.test(value))
-      return value
-  }
-
-  return ''
-}
-
-const codeFileLabel = computed(() => extractCodeBlockFileLabel(String(props.node.raw ?? '')))
-const headerTitle = computed(() => codeFileLabel.value || displayLanguage.value)
-const headerCaption = computed(() => {
-  if (!codeFileLabel.value)
-    return ''
-  return isDiff.value ? `Diff / ${displayLanguage.value}` : displayLanguage.value
-})
+const codeBlockHeader = computed(() => resolveCodeBlockHeader(
+  String(props.node.raw ?? ''),
+  displayLanguage.value,
+  isDiff.value,
+))
+const headerTitle = computed(() => codeBlockHeader.value.title)
+const headerCaption = computed(() => codeBlockHeader.value.caption)
 
 // Computed property for language icon
 const languageIcon = computed(() => {
@@ -3771,10 +3705,32 @@ async function runEditorCreation(el: HTMLElement) {
   refreshDiffStats()
   scheduleEditorHeightSync()
   await nextTick()
-  // Geometry, diff decorations, and syntax tokens must be ready before handoff.
-  const diffVisualReady = creationKind === 'diff'
-    ? await waitForDiffEditorVisualReady({ requireHighlight: true })
-    : await waitForSingleEditorVisualReady()
+  // stream-diffs owns its asynchronous highlight commit. Keep the fallback
+  // visible until that runtime confirms the first visual frame is complete.
+  let runtimeVisualReady: boolean | null = null
+  if (whenRuntimeVisualReady) {
+    let pendingVisualReady = whenRuntimeVisualReady()
+    for (;;) {
+      const visualReady = await pendingVisualReady
+      if (isUnmounted)
+        break
+      if (visualReady) {
+        await nextTick()
+        await waitForAnimationFrame()
+      }
+      const currentVisualReady = whenRuntimeVisualReady()
+      if (currentVisualReady === pendingVisualReady) {
+        runtimeVisualReady = visualReady
+        break
+      }
+      pendingVisualReady = currentVisualReady
+    }
+  }
+  const diffVisualReady = runtimeVisualReady == null
+    ? creationKind === 'diff'
+      ? await waitForDiffEditorVisualReady({ requireHighlight: true })
+      : await waitForSingleEditorVisualReady()
+    : runtimeVisualReady
   if (isUnmounted)
     return
   if (!diffVisualReady) {

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -333,7 +333,7 @@ let getDiffEditorView: () => MonacoDiffEditorViewLike | null = () => ({ getModel
 let cleanupEditor: () => void = () => {}
 let safeClean = () => {}
 let refreshDiffPresentation: () => Promise<unknown> | unknown = () => {}
-let whenRuntimeVisualReady: (() => Promise<boolean> | boolean) | null = null
+let whenRuntimeVisualReady: (() => Promise<boolean>) | null = null
 let createEditorPromise: Promise<void> | null = null
 let editorRuntimeCreationPromise: Promise<void> | null = null
 let monacoRuntimePromise: Promise<void> | null = null
@@ -1050,11 +1050,13 @@ function syncDiffScrollFromFallback() {
 
 async function revealEditorDisplay() {
   if (!isDiff.value) {
+    if (whenRuntimeVisualReady && !await whenRuntimeVisualReady())
+      return false
     editorDisplayReady.value = true
     await nextTick()
     syncEditorHostHeight(false)
     layoutEditorToHost()
-    return
+    return true
   }
 
   // The editor is fully prepared while hidden. Flip the two layers in one Vue
@@ -1071,6 +1073,11 @@ async function revealEditorDisplay() {
   layoutEditorToHost(true)
   await waitForAnimationFrame()
   layoutEditorToHost(true)
+  if (whenRuntimeVisualReady && !await whenRuntimeVisualReady())
+    return false
+  syncFallbackFontMetricsFromEditor()
+  syncDiffRevealHostHeight()
+  layoutEditorToHost(true)
   editorDisplayReady.value = true
   await nextTick()
   syncDiffRevealHostHeight()
@@ -1078,6 +1085,7 @@ async function revealEditorDisplay() {
   syncFallbackFontMetricsFromEditor()
   syncInlineFoldProxies()
   scheduleEditorHeightSync()
+  return true
 }
 
 function syncDiffRevealHostHeight() {
@@ -1774,7 +1782,7 @@ function computeContentHeight(): number | null {
       lineCount = model.getLineCount()
     }
     const lh = getLineHeightSafe(editor)
-    return Math.ceil(lineCount * (lh + LINE_EXTRA_PER_LINE) + CONTENT_PADDING + PIXEL_EPSILON)
+    return Math.ceil(lineCount * (lh + LINE_EXTRA_PER_LINE) + CONTENT_PADDING)
   }
   catch {
     return null
@@ -3709,21 +3717,10 @@ async function runEditorCreation(el: HTMLElement) {
   // visible until that runtime confirms the first visual frame is complete.
   let runtimeVisualReady: boolean | null = null
   if (whenRuntimeVisualReady) {
-    let pendingVisualReady = whenRuntimeVisualReady()
-    for (;;) {
-      const visualReady = await pendingVisualReady
-      if (isUnmounted)
-        break
-      if (visualReady) {
-        await nextTick()
-        await waitForAnimationFrame()
-      }
-      const currentVisualReady = whenRuntimeVisualReady()
-      if (currentVisualReady === pendingVisualReady) {
-        runtimeVisualReady = visualReady
-        break
-      }
-      pendingVisualReady = currentVisualReady
+    runtimeVisualReady = await whenRuntimeVisualReady()
+    if (runtimeVisualReady) {
+      await nextTick()
+      await waitForAnimationFrame()
     }
   }
   const diffVisualReady = runtimeVisualReady == null
@@ -3739,7 +3736,8 @@ async function runEditorCreation(el: HTMLElement) {
   }
   syncFallbackFontMetricsFromEditor()
   syncDiffRevealHostHeight()
-  await revealEditorDisplay()
+  if (!await revealEditorDisplay())
+    markEditorCreationFailed()
 }
 
 function ensureEditorCreation(el: HTMLElement, options: { allowStaleContentRetry?: boolean } = {}) {

--- a/src/components/CodeBlockNode/codeBlockHeader.ts
+++ b/src/components/CodeBlockNode/codeBlockHeader.ts
@@ -1,0 +1,90 @@
+import type { CodeBlockDiffHideUnchangedRegions, CodeBlockDiffHideUnchangedRegionsOptions } from '../../types/component-props'
+
+export const defaultDiffHideUnchangedRegions = Object.freeze({
+  enabled: true,
+  contextLineCount: 2,
+  minimumLineCount: 4,
+  revealLineCount: 5,
+})
+
+export function resolveDiffHideUnchangedRegionsOption(value: unknown): CodeBlockDiffHideUnchangedRegions {
+  if (typeof value === 'boolean')
+    return value
+  if (value && typeof value === 'object') {
+    const raw = value as Record<string, unknown>
+    return {
+      ...defaultDiffHideUnchangedRegions,
+      ...raw,
+      enabled: raw.enabled ?? true,
+    } as CodeBlockDiffHideUnchangedRegionsOptions
+  }
+  return { ...defaultDiffHideUnchangedRegions }
+}
+
+export function resolveDiffInlineLayout(options: Record<string, unknown>, width: number) {
+  if (options.renderSideBySide === false)
+    return true
+  if (options.useInlineViewWhenSpaceIsLimited !== true)
+    return false
+
+  const rawBreakpoint = options.renderSideBySideInlineBreakpoint
+  const breakpoint = typeof rawBreakpoint === 'number' && Number.isFinite(rawBreakpoint)
+    ? rawBreakpoint
+    : 900
+  return width > 0 && width <= breakpoint
+}
+
+export function parseCodeFenceInfo(raw: string) {
+  const firstLine = String(raw ?? '').split(/\r?\n/, 1)[0]?.trim() ?? ''
+  if (firstLine.length < 3)
+    return ''
+  const marker = firstLine[0]
+  if ((marker !== '`' && marker !== '~') || firstLine[1] !== marker || firstLine[2] !== marker)
+    return ''
+
+  let index = 3
+  while (firstLine[index] === marker)
+    index += 1
+
+  return firstLine.slice(index).trim()
+}
+
+export function isDiffFenceInfo(value: unknown) {
+  const firstToken = String(value ?? '').trim().split(/\s+/, 1)[0] ?? ''
+  return firstToken === 'diff'
+}
+
+export function isDiffCodeBlock(node: { diff?: boolean, language?: unknown, raw?: unknown }) {
+  return node.diff === true
+    || isDiffFenceInfo(node.language)
+    || isDiffFenceInfo(parseCodeFenceInfo(String(node.raw ?? '')))
+}
+
+export function extractCodeBlockFileLabel(raw: string) {
+  const info = parseCodeFenceInfo(raw)
+  if (!info)
+    return ''
+
+  const tokens = info.split(/\s+/).filter(Boolean)
+  if (!tokens.length)
+    return ''
+
+  const candidates = tokens[0] === 'diff' ? tokens.slice(1) : tokens
+  for (const token of candidates) {
+    const value = token.includes(':')
+      ? token.slice(token.indexOf(':') + 1)
+      : token
+    if (value && /[./\\-]/.test(value))
+      return value
+  }
+
+  return ''
+}
+
+export function resolveCodeBlockHeader(raw: string, displayLanguage: string, isDiff: boolean) {
+  const fileLabel = extractCodeBlockFileLabel(raw)
+  return {
+    title: fileLabel || displayLanguage,
+    caption: fileLabel ? (isDiff ? `Diff / ${displayLanguage}` : displayLanguage) : '',
+  }
+}

--- a/src/components/CodeBlockNode/monaco.ts
+++ b/src/components/CodeBlockNode/monaco.ts
@@ -64,7 +64,7 @@ export interface MonacoHelpers {
   safeClean?: () => void
   refreshDiffPresentation?: () => Promise<unknown> | unknown
   setTheme?: (theme: CodeBlockMonacoTheme | undefined) => Promise<void> | void
-  whenVisualReady?: () => Promise<boolean> | boolean
+  whenVisualReady?: () => Promise<boolean>
 }
 
 export interface MonacoModule {

--- a/src/components/CodeBlockNode/monaco.ts
+++ b/src/components/CodeBlockNode/monaco.ts
@@ -64,6 +64,7 @@ export interface MonacoHelpers {
   safeClean?: () => void
   refreshDiffPresentation?: () => Promise<unknown> | unknown
   setTheme?: (theme: CodeBlockMonacoTheme | undefined) => Promise<void> | void
+  whenVisualReady?: () => Promise<boolean> | boolean
 }
 
 export interface MonacoModule {

--- a/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
+++ b/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
@@ -1419,6 +1419,10 @@ function reconcileRecordSize(
     const restoredFloor = getRestoredItemHeightFloor(record.key, itemSizeSource)
     const growsPastRestoredFloor = restoredFloor > 0
       && next > restoredFloor + ITEM_SIZE_RECONCILE_DEADBAND_PX
+      && (
+        !getMarkstreamTimelineItemFinal(getRecordLiveItem(record), record.index, props)
+        || options.allowRestoredFloorShrink === true
+      )
     const readyToReleaseRestoredFloor = record.markdown
       && restoredFloor > 0
       && (options.allowRestoredFloorShrink === true || growsPastRestoredFloor)

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1674,6 +1674,7 @@ function estimateNodeHeight(node: ParsedNode, index: number, width: number) {
         rendererKind,
         monacoOptions: rendererProps.codeBlockMonacoOptions,
         showHeader: resolveCodeBlockShowHeader(),
+        width,
       })
     }
   }
@@ -5460,6 +5461,7 @@ const renderedItems = computed(() => {
           ...bindings,
           estimatedHeightPx: estimatedHeight.height,
           estimatedContentHeightPx: estimatedHeight.contentHeight,
+          estimatedDiffInline: estimatedHeight.diffInline,
         }
       }
     }

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -162,6 +162,9 @@ export const CodeBlockNodeLoading = defineComponent({
       const monacoOptions = props.monacoOptions
       const diffInline = isDiff && (props.estimatedDiffInline
         ?? resolveDiffInlineLayout(monacoOptions ?? {}, typeof window === 'undefined' ? 0 : window.innerWidth))
+      const diffAppearance = monacoOptions?.diffAppearance
+      const isSurfaceDark = diffAppearance === 'dark'
+        || (diffAppearance !== 'light' && props.isDark === true)
       const fontSize = typeof monacoOptions?.fontSize === 'number' && Number.isFinite(monacoOptions.fontSize) && monacoOptions.fontSize > 0
         ? monacoOptions.fontSize
         : 12
@@ -186,6 +189,7 @@ export const CodeBlockNodeLoading = defineComponent({
         'paddingTop': `${paddingTop}px`,
         'paddingBottom': `${paddingBottom}px`,
         '--markstream-pre-line-number-top': `${paddingTop}px`,
+        ...(isDiff ? { '--markstream-pre-diff-line-height': `${lineHeight}px` } : {}),
         ...(fontFamily ? { '--markstream-code-font-family': fontFamily } : {}),
       }
       const actionPlaceholder = () => h('button', {
@@ -199,10 +203,39 @@ export const CodeBlockNodeLoading = defineComponent({
       const showOverflowPlaceholder = (props.showFontSizeButtons !== false && props.enableFontSizeControl !== false)
         || props.showExpandButton !== false
         || (isPreviewable && props.showPreviewButton !== false)
-
+      const formatSize = (value: unknown) => {
+        if (value == null)
+          return undefined
+        return typeof value === 'number' ? `${value}px` : String(value)
+      }
+      const containerStyle = {
+        '--markstream-code-layout-character-width': '1ch',
+        ...(formatSize(props.minWidth) ? { minWidth: formatSize(props.minWidth) } : {}),
+        ...(formatSize(props.maxWidth) ? { maxWidth: formatSize(props.maxWidth) } : {}),
+        ...(!isDiff
+          ? {
+              color: 'var(--vscode-editor-foreground, var(--markstream-code-fallback-fg))',
+              backgroundColor: 'var(--vscode-editor-background, var(--markstream-code-fallback-bg))',
+              borderColor: 'var(--markstream-code-border-color)',
+            }
+          : {}),
+      }
       return h('div', {
         ...attrs,
-        'class': ['code-block-container', 'rounded-lg', 'border', { 'is-diff': isDiff }, attrs.class],
+        'class': [
+          'code-block-container',
+          'rounded-lg',
+          'border',
+          {
+            'dark': props.isDark === true,
+            'is-rendering': props.loading !== false,
+            'is-dark': isSurfaceDark,
+            'is-diff': isDiff,
+            'is-plain-text': language === '' || language === 'plaintext' || language === 'text',
+          },
+          attrs.class,
+        ],
+        'style': [containerStyle, attrs.style],
         'data-markstream-code-block': '1',
         'data-markstream-enhanced': 'false',
         'data-markstream-code-block-state': props.loading ? 'streaming' : 'settled',
@@ -239,7 +272,10 @@ export const CodeBlockNodeLoading = defineComponent({
                   : null,
               ]),
             ]),
-        h('div', { class: 'code-block-shell-content' }, [
+        h('div', {
+          class: 'code-block-shell-content',
+          style: props.stream !== false || props.loading === false ? undefined : { display: 'none' },
+        }, [
           h(PreCodeNode, {
             'node': props.node,
             'loading': props.loading,
@@ -254,6 +290,17 @@ export const CodeBlockNodeLoading = defineComponent({
             'data-markstream-code-loading': '1',
           }),
         ]),
+        h('div', {
+          class: 'code-loading-placeholder',
+          style: props.stream === false && props.loading !== false ? undefined : { display: 'none' },
+        }, [
+          h('div', { class: 'loading-skeleton' }, [
+            h('div', { class: 'skeleton-line' }),
+            h('div', { class: 'skeleton-line' }),
+            h('div', { class: 'skeleton-line short' }),
+          ]),
+        ]),
+        h('span', { 'class': 'sr-only', 'aria-live': 'polite', 'role': 'status' }),
       ])
     }
   },

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -6,6 +6,13 @@ import type {
 } from '../../types/component-props'
 import { defineAsyncComponent, defineComponent, getCurrentInstance, h, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions } from '../../composables/viewportPriority'
+import { languageMap, normalizeLanguageIdentifier } from '../../utils'
+import {
+  isDiffCodeBlock,
+  resolveCodeBlockHeader,
+  resolveDiffHideUnchangedRegionsOption,
+  resolveDiffInlineLayout,
+} from '../CodeBlockNode/codeBlockHeader'
 import { getKatex } from '../MathInlineNode/katex'
 import PreCodeNode from '../PreCodeNode'
 import TextNode from '../TextNode'
@@ -106,23 +113,149 @@ export function withViewportDeferredLoading(name: string, component: Component, 
 export const CodeBlockNodeLoading = defineComponent({
   name: 'CodeBlockNodeLoading',
   inheritAttrs: false,
-  setup(_props, { attrs }) {
-    const props = attrs as CodeBlockFallbackProps & {
+  props: [
+    'node',
+    'isDark',
+    'loading',
+    'stream',
+    'theme',
+    'darkTheme',
+    'lightTheme',
+    'isShowPreview',
+    'monacoOptions',
+    'enableFontSizeControl',
+    'minWidth',
+    'maxWidth',
+    'themes',
+    'showHeader',
+    'showCopyButton',
+    'showExpandButton',
+    'showPreviewButton',
+    'showCollapseButton',
+    'showFontSizeButtons',
+    'showTooltips',
+    'htmlPreviewAllowScripts',
+    'htmlPreviewSandbox',
+    'customId',
+    'estimatedHeightPx',
+    'estimatedContentHeightPx',
+    'estimatedDiffInline',
+  ],
+  emits: ['previewCode', 'copy'],
+  setup(rawProps, { attrs }) {
+    const props = rawProps as CodeBlockFallbackProps & {
       estimatedHeightPx?: number
       estimatedContentHeightPx?: number
+      estimatedDiffInline?: boolean
     }
 
-    return () => h(PreCodeNode, {
-      ...attrs,
-      'node': props.node,
-      'showLineNumbers': true,
-      'reservedHeightPx': props.estimatedHeightPx ?? props.estimatedContentHeightPx,
-      'class': ['code-pre-fallback', attrs.class],
-      'data-markstream-code-block': '1',
-      'data-markstream-enhanced': 'false',
-      'data-markstream-code-block-state': props.loading ? 'streaming' : 'settled',
-      'data-markstream-code-loading': '1',
-    })
+    return () => {
+      const language = normalizeLanguageIdentifier(String(props.node?.language ?? ''))
+      const displayLanguage = languageMap[language]
+        || (language ? language.charAt(0).toUpperCase() + language.slice(1) : languageMap[''])
+      const isDiff = isDiffCodeBlock(props.node)
+      const header = resolveCodeBlockHeader(
+        String(props.node?.raw ?? ''),
+        displayLanguage,
+        isDiff,
+      )
+      const monacoOptions = props.monacoOptions
+      const diffInline = isDiff && (props.estimatedDiffInline
+        ?? resolveDiffInlineLayout(monacoOptions ?? {}, typeof window === 'undefined' ? 0 : window.innerWidth))
+      const fontSize = typeof monacoOptions?.fontSize === 'number' && Number.isFinite(monacoOptions.fontSize) && monacoOptions.fontSize > 0
+        ? monacoOptions.fontSize
+        : 12
+      const lineHeight = typeof monacoOptions?.lineHeight === 'number' && Number.isFinite(monacoOptions.lineHeight) && monacoOptions.lineHeight > 0
+        ? monacoOptions.lineHeight
+        : fontSize === 12 ? 18 : Math.max(12, Math.round(fontSize * 1.5))
+      const tabSize = typeof monacoOptions?.tabSize === 'number' && Number.isFinite(monacoOptions.tabSize) && monacoOptions.tabSize > 0
+        ? monacoOptions.tabSize
+        : 4
+      const defaultPadding = isDiff ? 0 : 8
+      const paddingTop = typeof monacoOptions?.padding?.top === 'number' && Number.isFinite(monacoOptions.padding.top) && monacoOptions.padding.top >= 0
+        ? monacoOptions.padding.top
+        : defaultPadding
+      const paddingBottom = typeof monacoOptions?.padding?.bottom === 'number' && Number.isFinite(monacoOptions.padding.bottom) && monacoOptions.padding.bottom >= 0
+        ? monacoOptions.padding.bottom
+        : defaultPadding
+      const fontFamily = typeof monacoOptions?.fontFamily === 'string' ? monacoOptions.fontFamily.trim() : ''
+      const preStyle = {
+        'fontSize': `${fontSize}px`,
+        'lineHeight': `${lineHeight}px`,
+        'tabSize': tabSize,
+        'paddingTop': `${paddingTop}px`,
+        'paddingBottom': `${paddingBottom}px`,
+        '--markstream-pre-line-number-top': `${paddingTop}px`,
+        ...(fontFamily ? { '--markstream-code-font-family': fontFamily } : {}),
+      }
+      const actionPlaceholder = () => h('button', {
+        'class': 'code-action-btn inline-flex items-center justify-center p-[var(--ms-action-btn-padding)] rounded leading-none shrink-0',
+        'aria-hidden': 'true',
+        'disabled': true,
+        'tabindex': -1,
+        'type': 'button',
+      }, [h('svg', { class: 'action-icon' })])
+      const isPreviewable = props.isShowPreview !== false && (language === 'html' || language === 'svg')
+      const showOverflowPlaceholder = (props.showFontSizeButtons !== false && props.enableFontSizeControl !== false)
+        || props.showExpandButton !== false
+        || (isPreviewable && props.showPreviewButton !== false)
+
+      return h('div', {
+        ...attrs,
+        'class': ['code-block-container', 'rounded-lg', 'border', { 'is-diff': isDiff }, attrs.class],
+        'data-markstream-code-block': '1',
+        'data-markstream-enhanced': 'false',
+        'data-markstream-code-block-state': props.loading ? 'streaming' : 'settled',
+        'data-markstream-code-loading': '1',
+      }, [
+        props.showHeader === false
+          ? null
+          : h('div', {
+              class: 'code-block-header flex justify-between items-center border-b px-[var(--ms-inset-panel-x)] py-[var(--ms-inset-panel-y)] border-[var(--code-border)] bg-[var(--code-header-bg)] text-[var(--code-fg)]',
+            }, [
+              h('div', { class: 'code-header-main' }, [
+                h('span', { class: 'icon-slot h-4 w-4 flex-shrink-0' }),
+                h('div', { class: 'code-header-copy' }, [
+                  h('div', { class: 'code-header-title' }, header.title),
+                  header.caption
+                    ? h('div', { class: 'code-header-caption' }, header.caption)
+                    : null,
+                ]),
+              ]),
+              h('div', {
+                class: 'flex items-center gap-0.5',
+                style: { visibility: 'hidden' },
+              }, [
+                isDiff
+                  ? h('div', { 'class': 'code-diff-stats', 'aria-hidden': 'true' }, [
+                      h('span', { class: 'code-diff-stat removed' }, '-0'),
+                      h('span', { class: 'code-diff-stat added' }, '+0'),
+                    ])
+                  : null,
+                props.showCopyButton === false ? null : actionPlaceholder(),
+                props.showCollapseButton === false ? null : actionPlaceholder(),
+                showOverflowPlaceholder
+                  ? h('div', { class: 'relative' }, [actionPlaceholder()])
+                  : null,
+              ]),
+            ]),
+        h('div', { class: 'code-block-shell-content' }, [
+          h(PreCodeNode, {
+            'node': props.node,
+            'loading': props.loading,
+            'showLineNumbers': true,
+            'reservedHeightPx': isDiff ? undefined : props.estimatedContentHeightPx,
+            'diffInline': diffInline,
+            'diffHideUnchangedRegions': isDiff
+              ? resolveDiffHideUnchangedRegionsOption(monacoOptions?.diffHideUnchangedRegions)
+              : undefined,
+            'class': 'code-pre-fallback',
+            'style': preStyle,
+            'data-markstream-code-loading': '1',
+          }),
+        ]),
+      ])
+    }
   },
 })
 

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -872,8 +872,8 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
   padding: var(--markstream-code-padding-y, 8px) var(--markstream-code-padding-x, 12px);
   padding-left: var(--markstream-code-padding-left);
   overflow: auto;
-  border: 1px solid var(--code-border);
-  border-radius: var(--ms-radius);
+  border: 0;
+  border-radius: 0;
   background: var(--code-bg);
   color: var(--code-fg);
   font-family: var(

--- a/src/internal/heightEstimationExperiment.ts
+++ b/src/internal/heightEstimationExperiment.ts
@@ -2,6 +2,7 @@ import type { PreparedText } from '@chenglou/pretext'
 import type { ParsedNode } from 'stream-markdown-parser'
 import { layout, prepare } from '@chenglou/pretext'
 import { shallowRef } from 'vue'
+import { resolveDiffInlineLayout } from '../components/CodeBlockNode/codeBlockHeader'
 
 type WhiteSpaceMode = 'normal' | 'pre-wrap'
 type EstimateKind = 'simple-text' | 'code-block'
@@ -75,12 +76,14 @@ export interface EstimatedNodeHeight {
   height: number
   contentHeight?: number
   rendererKind?: CodeRendererKind
+  diffInline?: boolean
 }
 
 export interface CodeBlockEstimateOptions {
   rendererKind: CodeRendererKind
   monacoOptions?: Record<string, any> | null | undefined
   showHeader?: boolean
+  width?: number
 }
 
 const GLOBAL_STORE_KEY = '__MARKSTREAM_VUE_HEIGHT_ESTIMATION_EXPERIMENT__'
@@ -91,6 +94,7 @@ const CODE_BLOCK_DEFAULT_CAP = 500
 const MARKDOWN_CODE_LINE_HEIGHT = 21
 const MARKDOWN_CODE_VERTICAL_PADDING = 32
 const PRE_CODE_LINE_HEIGHT = 28
+const DIFF_METADATA_PREFIXES = ['diff ', 'index ', '--- ', '+++ ', '@@ ']
 
 interface PreparedCacheEntry {
   prepared: PreparedText
@@ -351,31 +355,74 @@ function getDisplayCode(source: unknown, loading?: boolean) {
   return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
 }
 
-function getCodeBlockVisibleLineCount(node: ParsedNode) {
-  if ((node as any).diff) {
+function getSplitDiffLineCount(node: ParsedNode) {
+  const originalCode = (node as any).originalCode
+  const updatedCode = (node as any).updatedCode
+  if (originalCode != null || updatedCode != null) {
     return Math.max(
-      countCodeLines(String((node as any).originalCode ?? '')),
-      countCodeLines(String((node as any).updatedCode ?? '')),
-      countCodeLines(String((node as any).code ?? '')),
+      countCodeLines(getDisplayCode(originalCode)),
+      countCodeLines(getDisplayCode(updatedCode)),
     )
+  }
+
+  const lines = getDisplayCode((node as any).code).split(/\r?\n/)
+  let originalLines = 0
+  let updatedLines = 0
+  for (const line of lines) {
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      updatedLines++
+    }
+    else if (line.startsWith('-') && !line.startsWith('---')) {
+      originalLines++
+    }
+    else {
+      originalLines++
+      updatedLines++
+    }
+  }
+  return Math.max(1, originalLines, updatedLines)
+}
+
+function getInlineDiffLineCount(node: ParsedNode) {
+  const raw = getDisplayCode((node as any).raw)
+  if (raw) {
+    const lines = raw.split(/\r?\n/)
+    if ((node as any).originalCode != null || (node as any).updatedCode != null) {
+      return Math.max(1, lines.filter(line =>
+        !DIFF_METADATA_PREFIXES.some(prefix => line.startsWith(prefix)),
+      ).length)
+    }
+    return Math.max(1, lines.length)
+  }
+  return countCodeLines(getDisplayCode((node as any).originalCode))
+    + countCodeLines(getDisplayCode((node as any).updatedCode))
+}
+
+function getCodeBlockVisibleLineCount(
+  node: ParsedNode,
+  monacoOptions?: Record<string, any> | null,
+  width = 0,
+) {
+  if ((node as any).diff) {
+    if (!resolveDiffInlineLayout(monacoOptions ?? {}, width))
+      return getSplitDiffLineCount(node)
+    return getInlineDiffLineCount(node)
   }
   return countCodeLines(getDisplayCode((node as any).code, (node as any).loading === true))
 }
 
-function resolveMonacoLineHeight(monacoOptions: Record<string, any> | null | undefined, isDiff: boolean) {
+function resolveMonacoLineHeight(monacoOptions: Record<string, any> | null | undefined) {
   const fontSize = typeof monacoOptions?.fontSize === 'number' && monacoOptions.fontSize > 0
     ? monacoOptions.fontSize
-    : (isDiff ? 13 : 12)
+    : 12
   if (typeof monacoOptions?.lineHeight === 'number' && monacoOptions.lineHeight > 0)
     return monacoOptions.lineHeight
-  return isDiff ? 30 : Math.round(fontSize * 1.5)
+  return Math.round(fontSize * 1.5)
 }
 
 function resolveMonacoVerticalPadding(monacoOptions: Record<string, any> | null | undefined, isDiff: boolean) {
-  if (!isDiff)
-    return 0
-  const top = typeof monacoOptions?.padding?.top === 'number' ? monacoOptions.padding.top : 10
-  const bottom = typeof monacoOptions?.padding?.bottom === 'number' ? monacoOptions.padding.bottom : 22
+  const top = typeof monacoOptions?.padding?.top === 'number' ? monacoOptions.padding.top : (isDiff ? 0 : 8)
+  const bottom = typeof monacoOptions?.padding?.bottom === 'number' ? monacoOptions.padding.bottom : (isDiff ? 0 : 8)
   return Math.max(0, top) + Math.max(0, bottom)
 }
 
@@ -388,26 +435,26 @@ export function estimateCodeBlockHeight(
 
   const rendererKind = options.rendererKind
   const showHeader = rendererKind !== 'pre' && options.showHeader !== false
-  const lineCount = getCodeBlockVisibleLineCount(node)
   const isDiff = Boolean((node as any).diff)
   let contentHeight = 0
   let cap = CODE_BLOCK_DEFAULT_CAP
 
   if (rendererKind === 'monaco') {
     const monacoOptions = options.monacoOptions ?? {}
-    const lineHeight = resolveMonacoLineHeight(monacoOptions, isDiff)
+    const lineCount = getCodeBlockVisibleLineCount(node, monacoOptions, options.width)
+    const lineHeight = resolveMonacoLineHeight(monacoOptions)
     const verticalPadding = resolveMonacoVerticalPadding(monacoOptions, isDiff)
     cap = typeof monacoOptions.MAX_HEIGHT === 'number' && monacoOptions.MAX_HEIGHT > 0
       ? monacoOptions.MAX_HEIGHT
       : CODE_BLOCK_DEFAULT_CAP
-    contentHeight = isDiff
-      ? Math.round(lineCount * lineHeight + verticalPadding)
-      : Math.round(lineCount * lineHeight)
+    contentHeight = Math.round(lineCount * lineHeight + verticalPadding)
   }
   else if (rendererKind === 'markdown') {
+    const lineCount = getCodeBlockVisibleLineCount(node)
     contentHeight = Math.round(lineCount * MARKDOWN_CODE_LINE_HEIGHT + MARKDOWN_CODE_VERTICAL_PADDING)
   }
   else {
+    const lineCount = getCodeBlockVisibleLineCount(node)
     contentHeight = Math.round(lineCount * PRE_CODE_LINE_HEIGHT)
     cap = Number.POSITIVE_INFINITY
   }
@@ -418,6 +465,9 @@ export function estimateCodeBlockHeight(
     height: Math.round(visibleContentHeight + (showHeader ? CODE_BLOCK_HEADER_HEIGHT : 0)),
     contentHeight: visibleContentHeight,
     rendererKind,
+    ...(isDiff && rendererKind === 'monaco'
+      ? { diffInline: resolveDiffInlineLayout(options.monacoOptions ?? {}, options.width ?? 0) }
+      : {}),
   }
 }
 

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -86,6 +86,7 @@ function resetHelpers() {
   runtime.safeClean.mockReset()
   runtime.refreshDiffPresentation.mockReset()
   runtime.setTheme.mockReset()
+  runtime.whenVisualReady = undefined
 }
 
 async function flush() {
@@ -188,6 +189,187 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
     expect(runtime.createEditor).toHaveBeenCalledTimes(1)
     expect(runtime.updateCode).toHaveBeenCalledWith('const updated = true', 'typescript')
+    wrapper.unmount()
+  })
+
+  it('keeps the fallback until stream-diffs commits its first visual frame', async () => {
+    const runtime = helpers()
+    let resolveVisualReady!: (ready: boolean) => void
+    const visualReady = new Promise<boolean>((resolve) => {
+      resolveVisualReady = resolve
+    })
+    runtime.whenVisualReady = vi.fn(() => visualReady)
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.createEditor).toHaveBeenCalledTimes(1))
+    expect(wrapper.find('diffs-container').exists()).toBe(true)
+    expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(true)
+    expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-enhanced')).toBe('false')
+
+    resolveVisualReady(true)
+    await vi.waitFor(() => {
+      expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
+      expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-enhanced')).toBe('true')
+    })
+    wrapper.unmount()
+  })
+
+  it('waits for the current visual revision when the first render is superseded', async () => {
+    const runtime = helpers()
+    let resolveFirst!: (ready: boolean) => void
+    let resolveCurrent!: (ready: boolean) => void
+    const firstReady = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    const currentReady = new Promise<boolean>((resolve) => {
+      resolveCurrent = resolve
+    })
+    runtime.whenVisualReady = vi.fn()
+      .mockReturnValueOnce(firstReady)
+      .mockReturnValue(currentReady)
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(1))
+
+    resolveFirst(false)
+    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(2))
+    expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(true)
+
+    resolveCurrent(true)
+    await vi.waitFor(() => {
+      expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
+      expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-enhanced')).toBe('true')
+    })
+    wrapper.unmount()
+  })
+
+  it('rechecks the visual revision after the reveal frame', async () => {
+    const runtime = helpers()
+    let resolveFirst!: (ready: boolean) => void
+    let resolveCurrent!: (ready: boolean) => void
+    const firstReady = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    const currentReady = new Promise<boolean>((resolve) => {
+      resolveCurrent = resolve
+    })
+    runtime.whenVisualReady = vi.fn()
+      .mockReturnValueOnce(firstReady)
+      .mockReturnValue(currentReady)
+
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(1))
+
+    resolveFirst(true)
+    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(2))
+    expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(true)
+
+    resolveCurrent(true)
+    await vi.waitFor(() => {
+      expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
+      expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-enhanced')).toBe('true')
+    })
+    wrapper.unmount()
+  })
+
+  it('preserves runtime-owned font styles when the reserved height is released', async () => {
+    const runtime = helpers()
+    runtime.getEditorView.mockReturnValue({
+      getModel: () => ({ getValue: () => '', getLineCount: () => 1 }),
+      getOption: () => 14,
+      updateOptions: vi.fn(),
+      layout: vi.fn(),
+      getContentHeight: () => 36,
+    })
+    let resolveVisualReady!: (ready: boolean) => void
+    const visualReady = new Promise<boolean>((resolve) => {
+      resolveVisualReady = resolve
+    })
+    runtime.whenVisualReady = vi.fn(() => visualReady)
+    runtime.createEditor.mockImplementation(async (container: HTMLElement) => {
+      container.style.fontSize = '13px'
+      container.style.lineHeight = '20px'
+      container.style.fontFamily = 'monospace'
+      installFinalDiffsDom(container)
+    })
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+        estimatedHeightPx: 36,
+        estimatedContentHeightPx: 36,
+        monacoOptions: { fontSize: 13, lineHeight: 20 },
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.createEditor).toHaveBeenCalledTimes(1))
+
+    resolveVisualReady(true)
+    await vi.waitFor(() => expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false))
+
+    const editorHost = wrapper.get('.code-editor-container').element as HTMLElement
+    expect(editorHost.style.fontSize).toBe('13px')
+    expect(editorHost.style.lineHeight).toBe('20px')
+    expect(editorHost.style.fontFamily).toBe('monospace')
+    expect(editorHost.style.height).toBe('36px')
+    wrapper.unmount()
+  })
+
+  it('keeps the final editor height equal to its measured content height', async () => {
+    const runtime = helpers()
+    let resolveVisualReady!: (ready: boolean) => void
+    const visualReady = new Promise<boolean>((resolve) => {
+      resolveVisualReady = resolve
+    })
+    runtime.whenVisualReady = vi.fn(() => visualReady)
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.createEditor).toHaveBeenCalledTimes(1))
+    resolveVisualReady(true)
+    await vi.waitFor(() => expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false))
+
+    expect((wrapper.get('.code-editor-container').element as HTMLElement).style.height).toBe('18px')
     wrapper.unmount()
   })
 

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -223,7 +223,7 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
-  it('waits for the current visual revision when the first render is superseded', async () => {
+  it('rechecks visual readiness immediately before removing the fallback', async () => {
     const runtime = helpers()
     let resolveFirst!: (ready: boolean) => void
     let resolveCurrent!: (ready: boolean) => void
@@ -236,45 +236,6 @@ describe('codeBlockNode final Diffs gate', () => {
     runtime.whenVisualReady = vi.fn()
       .mockReturnValueOnce(firstReady)
       .mockReturnValue(currentReady)
-    const wrapper = mount(DeferredCodeBlockNode, {
-      props: {
-        node: makeNode('const ready = true', false),
-        loading: false,
-        stream: true,
-        showHeader: false,
-      },
-    })
-
-    await flush()
-    observers.at(-1)?.emit()
-    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(1))
-
-    resolveFirst(false)
-    await vi.waitFor(() => expect(runtime.whenVisualReady).toHaveBeenCalledTimes(2))
-    expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(true)
-
-    resolveCurrent(true)
-    await vi.waitFor(() => {
-      expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
-      expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-enhanced')).toBe('true')
-    })
-    wrapper.unmount()
-  })
-
-  it('rechecks the visual revision after the reveal frame', async () => {
-    const runtime = helpers()
-    let resolveFirst!: (ready: boolean) => void
-    let resolveCurrent!: (ready: boolean) => void
-    const firstReady = new Promise<boolean>((resolve) => {
-      resolveFirst = resolve
-    })
-    const currentReady = new Promise<boolean>((resolve) => {
-      resolveCurrent = resolve
-    })
-    runtime.whenVisualReady = vi.fn()
-      .mockReturnValueOnce(firstReady)
-      .mockReturnValue(currentReady)
-
     const wrapper = mount(DeferredCodeBlockNode, {
       props: {
         node: makeNode('const ready = true', false),
@@ -370,6 +331,32 @@ describe('codeBlockNode final Diffs gate', () => {
     await vi.waitFor(() => expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false))
 
     expect((wrapper.get('.code-editor-container').element as HTMLElement).style.height).toBe('18px')
+    wrapper.unmount()
+  })
+
+  it('does not add an extra pixel in the generic editor height fallback', async () => {
+    const runtime = helpers()
+    runtime.getEditorView.mockReturnValue({
+      getModel: () => ({ getValue: () => '', getLineCount: () => 1 }),
+      getOption: () => 18,
+      updateOptions: vi.fn(),
+      layout: vi.fn(),
+    })
+    runtime.whenVisualReady = vi.fn(() => Promise.resolve(true))
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false))
+
+    expect((wrapper.get('.code-editor-container').element as HTMLElement).style.height).toBe('19px')
     wrapper.unmount()
   })
 

--- a/test/diff-code-block-fallback-height.test.ts
+++ b/test/diff-code-block-fallback-height.test.ts
@@ -131,6 +131,37 @@ describe('diff CodeBlockNode fallback height stability', () => {
     wrapper.unmount()
   })
 
+  it('keeps the default diff fallback padding aligned with the final surface', async () => {
+    const helpers = getStreamMonacoHelpers()
+    helpers.createDiffEditor.mockImplementation(() => new Promise<void>(() => {}))
+
+    const wrapper = mount(CodeBlockNode, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'diff',
+          code: '',
+          raw: '',
+          diff: true,
+          originalCode: 'const a = 1',
+          updatedCode: 'const a = 2',
+        },
+        loading: false,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flushPendingMicrotasks()
+
+    const pre = wrapper.get('pre.code-pre-fallback').element as HTMLElement
+    expect(pre.style.paddingTop).toBe('0px')
+    expect(pre.style.paddingBottom).toBe('0px')
+    expect(helpers.useMonaco.mock.calls[0]?.[0]?.padding).toEqual({ top: 0, bottom: 0 })
+
+    wrapper.unmount()
+  })
+
   it('does not reserve the full source height for a folded diff fallback', async () => {
     const helpers = getStreamMonacoHelpers()
     helpers.createDiffEditor.mockImplementation(() => new Promise<void>(() => {}))

--- a/test/height-estimation-experiment.test.ts
+++ b/test/height-estimation-experiment.test.ts
@@ -145,7 +145,7 @@ describe('height estimation experiment internals', () => {
     expect(loadingWithTerminalNewline?.contentHeight).toBe(withBlankLine?.contentHeight)
   })
 
-  it('estimates ordinary monaco code blocks from visible line height only', () => {
+  it('includes the native surface padding in ordinary monaco code block estimates', () => {
     const code = Array.from({ length: 24 }, (_, index) => `line ${index + 1}`).join('\n')
     const estimated = estimateCodeBlockHeight(
       {
@@ -164,8 +164,104 @@ describe('height estimation experiment internals', () => {
       },
     )
 
-    expect(estimated?.contentHeight).toBe(432)
-    expect(estimated?.height).toBe(432)
+    expect(estimated?.contentHeight).toBe(448)
+    expect(estimated?.height).toBe(448)
+  })
+
+  it('estimates split and inline diff rows independently', () => {
+    const node = {
+      type: 'code_block',
+      language: 'diff',
+      code: 'same\nnew\ntail',
+      raw: [
+        'diff --git a/value.ts b/value.ts',
+        'index 1234567..7654321 100644',
+        '--- a/value.ts',
+        '+++ b/value.ts',
+        '@@ -1,3 +1,3 @@',
+        ' same',
+        '-old',
+        '+new',
+        ' tail',
+        '',
+      ].join('\n'),
+      diff: true,
+      originalCode: 'same\nold\ntail\n',
+      updatedCode: 'same\nnew\ntail\n',
+    } as any
+    const split = estimateCodeBlockHeight(
+      node,
+      {
+        rendererKind: 'monaco',
+        monacoOptions: {
+          lineHeight: 18,
+          padding: { top: 0, bottom: 0 },
+        },
+        showHeader: false,
+      },
+    )
+    const inline = estimateCodeBlockHeight(
+      node,
+      {
+        rendererKind: 'monaco',
+        monacoOptions: {
+          lineHeight: 18,
+          padding: { top: 0, bottom: 0 },
+          renderSideBySide: false,
+        },
+        showHeader: false,
+      },
+    )
+
+    expect(split?.contentHeight).toBe(54)
+    expect(inline?.contentHeight).toBe(72)
+  })
+
+  it('uses the responsive inline layout below the configured breakpoint', () => {
+    const node = {
+      type: 'code_block',
+      language: 'diff',
+      code: 'new',
+      raw: '-old\n+new\n',
+      diff: true,
+      originalCode: 'old\n',
+      updatedCode: 'new\n',
+    } as any
+    const options = {
+      rendererKind: 'monaco' as const,
+      monacoOptions: {
+        lineHeight: 18,
+        padding: { top: 0, bottom: 0 },
+        useInlineViewWhenSpaceIsLimited: true,
+        renderSideBySideInlineBreakpoint: 600,
+      },
+      showHeader: false,
+    }
+
+    expect(estimateCodeBlockHeight(node, { ...options, width: 500 })?.contentHeight).toBe(36)
+    expect(estimateCodeBlockHeight(node, { ...options, width: 700 })?.contentHeight).toBe(18)
+  })
+
+  it('estimates split patch rows without source pairs', () => {
+    const estimated = estimateCodeBlockHeight(
+      {
+        type: 'code_block',
+        language: 'diff',
+        code: '-old\n+new',
+        raw: '-old\n+new\n',
+        diff: true,
+      } as any,
+      {
+        rendererKind: 'monaco',
+        monacoOptions: {
+          lineHeight: 18,
+          padding: { top: 0, bottom: 0 },
+        },
+        showHeader: false,
+      },
+    )
+
+    expect(estimated?.contentHeight).toBe(18)
   })
 
   it('caps monaco estimate by max height', () => {

--- a/test/node-renderer-heavy-node-props.test.ts
+++ b/test/node-renderer-heavy-node-props.test.ts
@@ -424,10 +424,11 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
       },
     })
 
-    for (let attempt = 0; attempt < 10 && !wrapper.find('.code-block-container').exists(); attempt++)
-      await flushAll()
+    await vi.waitFor(() => {
+      expect(wrapper.find('.code-block-container[data-has-monaco-options]').exists()).toBe(true)
+    })
 
-    const shiki = wrapper.get('.code-block-container')
+    const shiki = wrapper.get('.code-block-container[data-has-monaco-options]')
     expect(wrapper.find('[data-markstream-code-block="1"]').exists()).toBe(false)
     expect(shiki.attributes('data-has-monaco-options')).toBe('false')
   })
@@ -448,8 +449,9 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
       },
     })
 
-    for (let attempt = 0; attempt < 10 && !wrapper.find('.code-block-container').exists(); attempt++)
-      await flushAll()
+    await vi.waitFor(() => {
+      expect(wrapper.find('.code-block-container[data-langs]').exists()).toBe(true)
+    })
 
     expect(wrapper.get('.code-block-container').attributes('data-langs')).toBe('["typescript"]')
 
@@ -487,8 +489,9 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
       },
     })
 
-    for (let attempt = 0; attempt < 10 && !wrapper.find('.code-block-container').exists(); attempt++)
-      await flushAll()
+    await vi.waitFor(() => {
+      expect(wrapper.find('.answer-box .code-block-container[data-langs]').exists()).toBe(true)
+    })
 
     expect(wrapper.get('.answer-box .code-block-container').attributes('data-langs')).toBe('["typescript"]')
   })
@@ -516,8 +519,9 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
       },
     })
 
-    for (let attempt = 0; attempt < 10 && !wrapper.find('li .code-block-container').exists(); attempt++)
-      await flushAll()
+    await vi.waitFor(() => {
+      expect(wrapper.find('li .code-block-container[data-langs]').exists()).toBe(true)
+    })
 
     const nestedCodeBlock = wrapper.get('li .code-block-container')
     expect(nestedCodeBlock.attributes('data-langs')).toBe('["tsx"]')

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -6,7 +6,7 @@ import { nextTick } from 'vue'
 import PreCodeNode from '../src/components/PreCodeNode'
 
 describe('pre code node diff preview', () => {
-  it('styles async code block loading fallback as a code surface', () => {
+  it('styles async code block loading content inside the bordered shell', () => {
     const source = readFileSync('src/components/PreCodeNode/PreCodeNode.vue', 'utf8')
     const selector = '.markstream-vue pre.code-pre-fallback[data-markstream-code-loading=\'1\']'
     const start = source.indexOf(selector)
@@ -16,7 +16,8 @@ describe('pre code node diff preview', () => {
 
     expect(rule).toContain('background: var(--code-bg)')
     expect(rule).toContain('color: var(--code-fg)')
-    expect(rule).toContain('border: 1px solid var(--code-border)')
+    expect(rule).toContain('border: 0')
+    expect(rule).toContain('border-radius: 0')
     expect(rule).toContain('font-family: var(')
   })
 

--- a/test/virtual-timeline-restore-readiness.test.ts
+++ b/test/virtual-timeline-restore-readiness.test.ts
@@ -1747,6 +1747,45 @@ describe('virtual timeline restore visual readiness', () => {
     diff.unmount()
   })
 
+  it('keeps async loading container state aligned with the final shell', async () => {
+    const { CodeBlockNodeLoading } = await import('../src/components/NodeRenderer/asyncComponent')
+    const wrapper = mount(CodeBlockNodeLoading as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'diff',
+          code: '-const before = true\n+const ready = true',
+          raw: '```diff\n-const before = true\n+const ready = true\n```',
+          diff: true,
+          originalCode: 'const before = true',
+          updatedCode: 'const ready = true',
+          loading: true,
+        },
+        loading: true,
+        stream: false,
+        isDark: true,
+        minWidth: 120,
+        maxWidth: '80%',
+        monacoOptions: { lineHeight: 20 },
+      },
+    })
+
+    const root = wrapper.get('.code-block-container')
+    expect(root.classes()).toContain('dark')
+    expect(root.classes()).toContain('is-dark')
+    expect(root.classes()).toContain('is-rendering')
+    expect(root.attributes('style')).toContain('min-width: 120px')
+    expect(root.attributes('style')).toContain('max-width: 80%')
+    expect(wrapper.get('pre.code-pre-fallback').attributes('style')).toContain('--markstream-pre-diff-line-height: 20px')
+    expect(wrapper.get('.code-block-shell-content').attributes('style')).toContain('display: none')
+    expect(wrapper.get('.code-loading-placeholder').attributes('style') ?? '').not.toContain('display: none')
+
+    await wrapper.setProps({ loading: false })
+    expect(wrapper.get('.code-block-shell-content').attributes('style') ?? '').not.toContain('display: none')
+    expect(wrapper.get('.code-loading-placeholder').attributes('style')).toContain('display: none')
+    wrapper.unmount()
+  })
+
   it('keeps configured item overscan mounted during restore', async () => {
     const itemHeight = 88
 

--- a/test/virtual-timeline-restore-readiness.test.ts
+++ b/test/virtual-timeline-restore-readiness.test.ts
@@ -1645,26 +1645,106 @@ describe('virtual timeline restore visual readiness', () => {
 
     const wrapper = mount(CodeBlockNodeLoading as any, {
       attrs: {
-        node: {
+        'node': {
           type: 'code_block',
           language: 'ts',
           code: 'const x = 1',
-          raw: '```ts\nconst x = 1\n```',
+          raw: '```ts src/example.ts\nconst x = 1\n```',
           loading: true,
         },
-        estimatedHeightPx: 240,
-        estimatedContentHeightPx: 123.2,
+        'estimatedHeightPx': 240,
+        'estimatedContentHeightPx': 123.2,
+        'monacoOptions': {
+          fontSize: 13,
+          lineHeight: 20,
+          fontFamily: 'Test Mono',
+          tabSize: 3,
+          padding: { top: 5, bottom: 7 },
+        },
+        'style': { width: '73%' },
+        'data-root-probe': 'outer',
       },
     })
 
     const pre = wrapper.get('pre.code-pre-fallback')
+    const root = wrapper.get('.code-block-container')
     expect(pre.attributes('data-markstream-code-loading')).toBe('1')
-    expect(pre.attributes('style')).not.toMatch(/(?:^|;\s*)height: 240px/)
-    expect(pre.attributes('style')).not.toMatch(/(?:^|;\s*)min-height: 240px/)
-    expect(pre.attributes('style')).toContain('max-height: 240px')
+    expect(root.attributes('data-markstream-code-loading')).toBe('1')
+    expect(root.attributes('data-root-probe')).toBe('outer')
+    expect(root.attributes('style')).toContain('width: 73%')
+    expect(pre.attributes('data-root-probe')).toBeUndefined()
+    expect(pre.attributes('style')).not.toMatch(/(?:^|;\s*)height: 123px/)
+    expect(pre.attributes('style')).not.toMatch(/(?:^|;\s*)min-height: 123px/)
+    expect(pre.attributes('style')).toContain('max-height: 124px')
     expect(pre.attributes('style')).toContain('overflow: auto')
+    expect((pre.element as HTMLElement).style.fontSize).toBe('13px')
+    expect((pre.element as HTMLElement).style.lineHeight).toBe('20px')
+    expect((pre.element as HTMLElement).style.fontFamily).toBe('')
+    expect((pre.element as HTMLElement).style.getPropertyValue('--markstream-code-font-family')).toBe('Test Mono')
+    expect((pre.element as HTMLElement).style.tabSize).toBe('3')
+    expect((pre.element as HTMLElement).style.paddingTop).toBe('5px')
+    expect((pre.element as HTMLElement).style.paddingBottom).toBe('7px')
+    expect(wrapper.get('.code-header-title').text()).toBe('src/example.ts')
+    expect(wrapper.get('.code-header-caption').text()).toBe('Typescript')
+    expect(wrapper.get('.icon-slot').exists()).toBe(true)
+    expect(wrapper.get('.code-block-container').classes()).toContain('border')
+    expect(pre.classes()).not.toContain('border')
 
     wrapper.unmount()
+  })
+
+  it('reserves preview-only and diff-only header chrome while loading', async () => {
+    const { CodeBlockNodeLoading } = await import('../src/components/NodeRenderer/asyncComponent')
+    const disabledActions = {
+      showCopyButton: false,
+      showCollapseButton: false,
+      showFontSizeButtons: false,
+      enableFontSizeControl: false,
+      showExpandButton: false,
+    }
+
+    const preview = mount(CodeBlockNodeLoading as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'html',
+          code: '<p>preview</p>',
+          raw: '```html\n<p>preview</p>\n```',
+          loading: true,
+        },
+        ...disabledActions,
+        isShowPreview: true,
+        showPreviewButton: true,
+      },
+    })
+    expect(preview.findAll('.code-action-btn')).toHaveLength(1)
+    preview.unmount()
+
+    const diff = mount(CodeBlockNodeLoading as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'diff',
+          code: '',
+          raw: '```diff\n-old\n+new\n```',
+          diff: true,
+          originalCode: 'old',
+          updatedCode: 'new',
+          loading: true,
+        },
+        estimatedContentHeightPx: 36,
+        ...disabledActions,
+        showPreviewButton: false,
+      },
+    })
+    expect(diff.findAll('.code-action-btn')).toHaveLength(0)
+    expect(diff.findAll('.code-diff-stat')).toHaveLength(2)
+    expect(diff.get('.code-block-container').classes()).toContain('is-diff')
+    expect(diff.get('pre.code-pre-fallback').attributes('style')).not.toContain('36px')
+    expect(diff.get('pre.code-pre-fallback').classes()).not.toContain('markstream-pre--diff-inline')
+    await diff.setProps({ monacoOptions: { renderSideBySide: false } })
+    expect(diff.get('pre.code-pre-fallback').classes()).toContain('markstream-pre--diff-inline')
+    diff.unmount()
   })
 
   it('keeps configured item overscan mounted during restore', async () => {

--- a/test/virtual-timeline.test.ts
+++ b/test/virtual-timeline.test.ts
@@ -1507,6 +1507,22 @@ describe('virtual timeline API', () => {
     await waitForTimelineRestoreSettled(root)
 
     const markdownProps = slotProps.find(props => props.kind === 'assistant-markdown').markdownProps
+    markdownProps.onHeightChange({
+      ...createMetrics(1400, 'thread-a:a1:1'),
+      stable: false,
+      confidence: 'mixed',
+      nodeCount: 90,
+      liveRange: { start: 0, end: 50 },
+      renderedCount: 66,
+      measuredCount: 50,
+      estimatedCount: 29,
+    })
+
+    await flushAnimationFrame()
+    await nextTick()
+
+    expect((wrapper.vm as any).getItemSize('a1')).toBe(1060)
+
     markdownProps.onHeightChange(createMetrics(1400, 'thread-a:a1:1'))
 
     await flushAnimationFrame()


### PR DESCRIPTION
## Summary

- Keep async code-block loading shells geometrically aligned with final headers, actions, borders, typography, padding, and diff layout.
- Align split, inline, and responsive diff height estimates with parser and rendered row semantics, including Git unified-diff metadata handling.
- Wait for the optional stream-diffs visual-ready revision before revealing the enhanced surface, while preserving the existing geometry fallback.
- Release restored virtual-timeline height floors only after trusted stable metrics, while still allowing live content growth.

## Compatibility

stream-diffs 0.0.1 continues to use the geometry fallback. Exact runtime-owned visual handoff activates automatically with a future stream-diffs release that exposes whenVisualReady.

## Verification

- Fresh independent source/minimality, API/delivery, and height/E2E reviews: PASS
- lint and typecheck
- 302 test files, 2530 tests
- parser, core, package, playground, React, SSR, and Vue 2 builds/smokes
- virtual-scroll E2E: scrollTopRange 0, itemHeightRange 0, itemHeightDelta 0
- minimal install and optional-peer packed-package smoke
- size budget, public API, package exports, and subpath isolation
- linked readiness runtime diagnostic: diff block height range 0, item height range 0, scroll range 0