### PR TITLE
fix: keep streaming markdown rendering continuous

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -3,6 +3,7 @@ import type { HtmlBlockNode, InternalParseOptions, MarkdownToken, ParsedNode, Pa
 import { normalizeCustomHtmlTags } from '../customHtmlTags'
 import { NON_STRUCTURING_HTML_TAGS, STANDARD_BLOCK_HTML_TAGS, STANDARD_HTML_TAGS, VOID_HTML_TAGS } from '../htmlTags'
 import { escapeTagForRegExp, findTagCloseIndexOutsideQuotes, parseTagAttrs } from '../htmlTagUtils'
+import { isMathLike } from '../plugins/isMathLike'
 import {
   getTolerantMathBlockBoundaryStreamKey,
   hasMarkstreamMathPlugin,
@@ -34,9 +35,12 @@ interface ExplicitBracketMathContext {
   fenceInList: boolean
   fenceLen: number
   fenceListIndent: number
+  inDollarMath: boolean
   inFence: boolean
   inMath: boolean
   listContentIndent: number | null
+  dollarMathOpenOffset: number | null
+  mathOpenOffset: number | null
 }
 
 interface ExplicitBracketMathStreamState {
@@ -50,6 +54,10 @@ const tolerantMathBoundaryStreamCache = new WeakMap<object, {
   source: string
   key: string | null
   pendingCandidate: boolean
+}>()
+const pendingExplicitMathTailCache = new WeakMap<object, {
+  source: string
+  state: ExplicitBracketMathStreamState
 }>()
 
 const TOLERANT_BOUNDARY_SPLIT_OPENERS = ['$$', '\\[']
@@ -614,9 +622,12 @@ function createExplicitBracketMathContext(): ExplicitBracketMathContext {
     fenceInList: false,
     fenceLen: 0,
     fenceListIndent: 0,
+    inDollarMath: false,
     inFence: false,
     inMath: false,
     listContentIndent: null,
+    dollarMathOpenOffset: null,
+    mathOpenOffset: null,
   }
 }
 
@@ -1217,6 +1228,21 @@ function scanLineForExplicitBracketMathState(
         if (appendStart != null && openAtAppendStart && lineStart + index + 2 > appendStart)
           closedOpenMath = true
         context.inMath = false
+        context.mathOpenOffset = null
+        index += 2
+        continue
+      }
+
+      index++
+      continue
+    }
+
+    if (context.inDollarMath) {
+      if (line.startsWith('$$', index) && !isEscapedDelimiterAt(line, sourceIndex)) {
+        if (appendStart != null && openAtAppendStart && lineStart + index + 2 > appendStart)
+          closedOpenMath = true
+        context.inDollarMath = false
+        context.dollarMathOpenOffset = null
         index += 2
         continue
       }
@@ -1236,6 +1262,14 @@ function scanLineForExplicitBracketMathState(
 
     if (line.startsWith('\\[', index) && !isEscapedDelimiterAt(line, sourceIndex)) {
       context.inMath = true
+      context.mathOpenOffset = lineStart + index
+      index += 2
+      continue
+    }
+
+    if (line.startsWith('$$', index) && !isEscapedDelimiterAt(line, sourceIndex)) {
+      context.inDollarMath = true
+      context.dollarMathOpenOffset = lineStart + index
       index += 2
       continue
     }
@@ -1244,6 +1278,46 @@ function scanLineForExplicitBracketMathState(
   }
 
   return closedOpenMath
+}
+
+function stripPendingExplicitMathTail(markdown: string, md: MarkdownIt) {
+  if (!hasMarkstreamMathPlugin(md))
+    return markdown
+
+  const owner = md as unknown as object
+  const previous = pendingExplicitMathTailCache.get(owner)
+  const state = previous?.source === markdown
+    ? previous.state
+    : previous && markdown.startsWith(previous.source)
+      ? updateExplicitBracketMathStreamState(
+        previous.state,
+        markdown.slice(previous.source.length),
+        previous.source.length - previous.state.lineBuffer.length,
+      ).state
+      : scanExplicitBracketMathStreamState(markdown).state
+  pendingExplicitMathTailCache.set(owner, { source: markdown, state })
+
+  const { context } = state
+  const openOffset = context.inMath
+    ? context.mathOpenOffset
+    : context.inDollarMath ? context.dollarMathOpenOffset : null
+  if (openOffset == null)
+    return markdown
+
+  const content = markdown.slice(openOffset + 2)
+  const lineStart = markdown.lastIndexOf('\n', openOffset - 1) + 1
+  const startsBlockLine = markdown.slice(lineStart, openOffset).trim() === ''
+  if (!startsBlockLine && !/^\r?\n/.test(content))
+    return markdown
+  if (/^\s*!\[/.test(content))
+    return markdown
+
+  const stripped = content.trim()
+  const weakSingleVariable = /^(?:[a-z]|pi)$/i.test(stripped)
+  if (isMathLike(content) && !weakSingleVariable)
+    return markdown
+
+  return markdown.slice(0, openOffset)
 }
 
 function scanExplicitBracketMathLine(
@@ -1281,7 +1355,7 @@ function scanExplicitBracketMathLine(
     context.listContentIndent = null
   }
 
-  if (!context.inMath) {
+  if (!context.inMath && !context.inDollarMath) {
     const fenceMatch = matchMarkdownFenceMarker(line)
     if (fenceMatch) {
       if (context.inFence) {
@@ -1323,6 +1397,7 @@ function scanExplicitBracketMathStreamState(
   initialContext: ExplicitBracketMathContext = createExplicitBracketMathContext(),
   appendStart: number | null = null,
   openAtAppendStart = false,
+  sourceOffset = 0,
 ) {
   const context = cloneExplicitBracketMathContext(initialContext)
   let committedContext = cloneExplicitBracketMathContext(initialContext)
@@ -1338,7 +1413,7 @@ function scanExplicitBracketMathStreamState(
       : hasNewline ? newlineIndex : source.length
     const line = source.slice(index, lineEnd)
 
-    if (scanExplicitBracketMathLine(line, context, index, appendStart, openAtAppendStart))
+    if (scanExplicitBracketMathLine(line, context, sourceOffset + index, appendStart, openAtAppendStart))
       closedOpenMath = true
 
     if (hasNewline) {
@@ -1362,13 +1437,18 @@ function scanExplicitBracketMathStreamState(
   }
 }
 
-function updateExplicitBracketMathStreamState(previous: ExplicitBracketMathStreamState, appended: string) {
+function updateExplicitBracketMathStreamState(
+  previous: ExplicitBracketMathStreamState,
+  appended: string,
+  lineBufferStartOffset = 0,
+) {
   if (
     appended
     && !previous.context.inMath
+    && !previous.context.inDollarMath
     && !previous.context.inFence
     && !previous.committedContext.inFence
-    && !/[\\`~\r\n]/.test(appended)
+    && !/[\\$`~\r\n]/.test(appended)
     && !(previous.lineBuffer.endsWith('\\') && (appended[0] === '[' || appended[0] === ']'))
   ) {
     return {
@@ -1384,8 +1464,9 @@ function updateExplicitBracketMathStreamState(previous: ExplicitBracketMathStrea
   return scanExplicitBracketMathStreamState(
     previous.lineBuffer + appended,
     previous.committedContext,
-    previous.lineBuffer.length,
-    previous.context.inMath,
+    lineBufferStartOffset + previous.lineBuffer.length,
+    previous.context.inMath || previous.context.inDollarMath,
+    lineBufferStartOffset,
   )
 }
 
@@ -1406,7 +1487,11 @@ function syncTolerantMathBoundaryStreamCache(md: MarkdownIt, source: string) {
   const sourceExtendsPrevious = previous ? source.startsWith(previous.source) : false
   const appended = sourceExtendsPrevious && previous ? source.slice(previous.source.length) : ''
   const explicitBracketMathUpdate = sourceExtendsPrevious && previous
-    ? updateExplicitBracketMathStreamState(previous.explicitBracketMath, appended)
+    ? updateExplicitBracketMathStreamState(
+        previous.explicitBracketMath,
+        appended,
+        previous.source.length - previous.explicitBracketMath.lineBuffer.length,
+      )
     : scanExplicitBracketMathStreamState(source)
   const nextExplicitBracketMath = explicitBracketMathUpdate.state
   const completesExplicitBracketMathClose = sourceExtendsPrevious && previous
@@ -3596,6 +3681,7 @@ export function parseMarkdownToStructure(
       safeMarkdown = safeMarkdown.replace(/(\n\[|\n\()+\n*$/g, '\n')
     }
 
+    safeMarkdown = stripPendingExplicitMathTail(safeMarkdown, md)
     safeMarkdown = getStreamingAdmonitionOpenTailReplacement(safeMarkdown, options.customHtmlTags) ?? safeMarkdown
   }
 

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -1502,8 +1502,6 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
           const sameLineContent = open === '\\[' ? lineText.slice(open.length) : ''
           if (
             open === '\\['
-            && allowLoading
-            && !strict
             && findUnescapedDelimiter(sameLineContent, close) === -1
             && !/^\s*!\[/.test(sameLineContent)
             && !sameLineContent.includes('`')

--- a/packages/markdown-parser/test/math-block-streaming-close.test.ts
+++ b/packages/markdown-parser/test/math-block-streaming-close.test.ts
@@ -22,6 +22,107 @@ function collect(nodes: any, type: string): any[] {
 }
 
 describe('math block streaming close handling', () => {
+  it('hides an ambiguous explicit bracket math tail until it becomes math-like', () => {
+    const md = getMarkdown('math-block-streaming-ambiguous-open')
+    const prefix = 'Before the formula.\n\n'
+    const partialFormula = '\\[\nf(x)'
+
+    for (let end = 2; end < partialFormula.length; end++) {
+      const pending = parseMarkdownToStructure(`${prefix}${partialFormula.slice(0, end)}`, md, {
+        final: false,
+        streamParse: true,
+      }) as any[]
+      expect(JSON.stringify(pending)).toContain('Before the formula.')
+      expect(collect(pending, 'text').map(node => node.content).join('')).toBe('Before the formula.')
+      expect(collect(pending, 'math_block')).toHaveLength(0)
+    }
+
+    const mathLike = parseMarkdownToStructure(`${prefix}${partialFormula}`, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    expect(collect(mathLike, 'math_block')).toMatchObject([{
+      content: 'f(x)',
+      loading: true,
+    }])
+  })
+
+  it('hides an ambiguous dollar math tail until it becomes math-like', () => {
+    const md = getMarkdown('math-block-streaming-ambiguous-dollar-open')
+    const prefix = 'Before the formula.\n\n'
+    const partialFormula = '$$\nf(x)'
+
+    for (let end = 1; end < partialFormula.length; end++) {
+      const nodes = parseMarkdownToStructure(`${prefix}${partialFormula.slice(0, end)}`, md, {
+        final: false,
+        streamParse: true,
+      }) as any[]
+      const serialized = JSON.stringify(nodes)
+      expect(serialized).toContain('Before the formula.')
+      expect(collect(nodes, 'text').map(node => node.content).join('')).toBe('Before the formula.')
+      expect(collect(nodes, 'math_block')).toHaveLength(0)
+    }
+
+    const mathLike = parseMarkdownToStructure(`${prefix}${partialFormula}`, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    expect(collect(mathLike, 'math_block')).toMatchObject([{
+      content: 'f(x)',
+      loading: true,
+    }])
+  })
+
+  it('restores an unclosed non-math explicit bracket tail when the stream is final', () => {
+    const md = getMarkdown('math-block-streaming-final-non-math-open')
+    const markdown = '\\[\nf('
+
+    const streaming = parseMarkdownToStructure(markdown, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    expect(streaming).toHaveLength(0)
+
+    const final = parseMarkdownToStructure(markdown, md, {
+      final: true,
+      streamParse: true,
+    }) as any[]
+    expect(final.length).toBeGreaterThan(0)
+    expect(JSON.stringify(final)).toContain('f(')
+    expect(collect(final, 'math_block')).toHaveLength(0)
+  })
+
+  it('restores an unclosed non-math dollar tail when the stream is final', () => {
+    const md = getMarkdown('math-block-streaming-final-non-math-dollar-open')
+    const markdown = '$$\nf('
+
+    const streaming = parseMarkdownToStructure(markdown, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+    expect(streaming).toHaveLength(0)
+
+    const final = parseMarkdownToStructure(markdown, md, {
+      final: true,
+      streamParse: true,
+    }) as any[]
+    expect(final.length).toBeGreaterThan(0)
+    expect(JSON.stringify(final)).toContain('f(')
+  })
+
+  it('does not hide explicit bracket text inside code while streaming', () => {
+    const md = getMarkdown('math-block-streaming-code-open')
+    const markdown = '```text\n\\[\n$$\nf('
+
+    const nodes = parseMarkdownToStructure(markdown, md, {
+      final: false,
+      streamParse: true,
+    }) as any[]
+
+    expect(JSON.stringify(nodes)).toContain('f(')
+    expect(collect(nodes, 'math_block')).toHaveLength(0)
+  })
+
   it('promotes same-line explicit bracket math before the closing delimiter arrives', () => {
     const md = getMarkdown('math-block-streaming-same-line-open')
     const chunks = [

--- a/packages/markdown-parser/test/math-block-streaming-close.test.ts
+++ b/packages/markdown-parser/test/math-block-streaming-close.test.ts
@@ -77,6 +77,53 @@ describe('math block streaming close handling', () => {
     expect(textNodes.map(node => node.content)).not.toContain(']')
   })
 
+  it('keeps multiple completed formulas after a streamed list', () => {
+    const md = getMarkdown('math-block-streaming-list-formulas')
+    const markdown = String.raw`- **矩阵：**
+
+\[\begin{bmatrix}
+2x_2 - 8x_3 = 8 \\
+5x_1 - 5x_3 = 10
+\end{bmatrix}\]
+
+- **公式**
+
+- **代入数据**
+
+\[\frac{363}{15,\!135} \times 100\% = 2.398\%\]
+
+- **差异说明**
+
+$$E=mc^2$$`
+
+    let streamed: any[] = []
+    for (let end = 1; end <= markdown.length; end++) {
+      streamed = parseMarkdownToStructure(markdown.slice(0, end), md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any) as any[]
+    }
+
+    const final = parseMarkdownToStructure(markdown, md, {
+      final: true,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any) as any[]
+    const cold = parseMarkdownToStructure(markdown, getMarkdown('math-block-streaming-list-formulas-cold'), {
+      final: true,
+      streamParse: false,
+    }) as any[]
+
+    expect(collect(streamed, 'math_block')).toHaveLength(3)
+    expect(final).toEqual(cold)
+    expect(collect(final, 'math_block').map(node => node.content)).toEqual([
+      '\\begin{bmatrix}\n2x_2 - 8x_3 = 8 \\\\\n5x_1 - 5x_3 = 10\n\\end{bmatrix}',
+      '\\frac{363}{15,\\!135} \\times 100\\% = 2.398\\%',
+      'E=mc^2',
+    ])
+  })
+
   it('closes bracket math after lines that should not keep a markdown fence open', () => {
     const prefix = `${Array.from(
       { length: 40 },

--- a/packages/markdown-parser/test/streaming-mermaid-fence-regression.test.ts
+++ b/packages/markdown-parser/test/streaming-mermaid-fence-regression.test.ts
@@ -16,7 +16,7 @@ function codeBlocks(nodes: any[]) {
 }
 
 describe('streaming mermaid fence boundaries', () => {
-  it('does not absorb following math markdown after the mermaid closing fence has streamed', () => {
+  it('keeps every closed diagram fence separate from following markdown at every stream boundary', () => {
     const markdown = [
       '```mermaid',
       'xychart',
@@ -24,6 +24,18 @@ describe('streaming mermaid fence boundaries', () => {
       '  x-axis ["一月", "二月"]',
       '  y-axis "收入" 4000 --> 11000',
       '  line [5000, 6000]',
+      '```',
+      '',
+      '```infographic',
+      'infographic list-row-simple-horizontal-arrow',
+      'data',
+      '  items',
+      '    - label 步骤 1',
+      '      desc 开始',
+      '    - label 步骤 2',
+      '      desc 进行中',
+      '    - label 步骤 3',
+      '      desc 完成',
       '```',
       '',
       '---',
@@ -37,12 +49,17 @@ describe('streaming mermaid fence boundaries', () => {
 
     for (let end = 1; end <= markdown.length; end++) {
       const chunk = markdown.slice(0, end)
-      const nodes = parseMarkdownToStructure(chunk, md, { final: false, streamParse: true })
-      const mermaidBlocks = codeBlocks(nodes).filter(node => node.language === 'mermaid')
+      const nodes = parseMarkdownToStructure(chunk, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any)
+      const blocks = codeBlocks(nodes)
 
-      for (const block of mermaidBlocks) {
+      for (const block of blocks) {
         expect(block.code, `prefix length ${end}`).not.toContain('正交补空间')
         expect(block.code, `prefix length ${end}`).not.toContain('boldsymbol')
+        expect(block.code, `prefix length ${end}`).not.toContain('复杂数学公式')
       }
     }
   })

--- a/playground/src/pages/test-sandbox.vue
+++ b/playground/src/pages/test-sandbox.vue
@@ -144,8 +144,18 @@ function cleanupRuntime() {
 }
 
 function setupCommonRendererRuntime(rendererModule: Record<string, any>) {
-  rendererModule.enableKatex?.()
-  rendererModule.enableMermaid?.()
+  const katexUrl = createEsmPackageUrl('katex', TEST_SANDBOX_KATEX_VERSION)
+  const mermaidUrl = `https://cdn.jsdelivr.net/npm/mermaid@${TEST_SANDBOX_MERMAID_VERSION}/dist/mermaid.esm.min.mjs`
+
+  if (rendererModule.setKatexLoader)
+    rendererModule.setKatexLoader(() => importRemote(katexUrl))
+  else
+    rendererModule.enableKatex?.()
+
+  if (rendererModule.setMermaidLoader)
+    rendererModule.setMermaidLoader(() => importRemote(mermaidUrl))
+  else
+    rendererModule.enableMermaid?.()
 
   const katexHandle = rendererModule.createKaTeXWorkerFromCDN?.({
     mode: 'classic',
@@ -158,7 +168,7 @@ function setupCommonRendererRuntime(rendererModule: Record<string, any>) {
   const mermaidHandle = rendererModule.createMermaidWorkerFromCDN?.({
     mode: 'module',
     workerOptions: { type: 'module' },
-    mermaidUrl: `https://cdn.jsdelivr.net/npm/mermaid@${TEST_SANDBOX_MERMAID_VERSION}/dist/mermaid.esm.min.mjs`,
+    mermaidUrl,
   })
   if (mermaidHandle?.worker)
     rendererModule.setMermaidWorker?.(mermaidHandle.worker)
@@ -252,6 +262,7 @@ async function mountVue3Sandbox(current: SandboxSelection, content: string, moun
     render() {
       return h(MarkdownRender, {
         content,
+        final: true,
         isDark: sandboxIsDark.value,
         batchRendering: false,
         typewriter: false,
@@ -300,6 +311,7 @@ async function mountVue2Sandbox(current: SandboxSelection, content: string, moun
       return createElement(MarkdownRender, {
         props: {
           content,
+          final: true,
           isDark: sandboxIsDark.value,
           batchRendering: false,
           typewriter: false,
@@ -353,6 +365,7 @@ async function mountReactSandbox(current: SandboxSelection, content: string, mou
   root.render(
     React.createElement(MarkdownRender, {
       content,
+      final: true,
       isDark: sandboxIsDark.value,
       batchRendering: false,
       typewriter: false,

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { MathBlockNodeProps } from '../../types/component-props'
 import { computed, getCurrentInstance, inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions, waitForVisibilityOrAbort } from '../../composables/viewportPriority'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
@@ -15,13 +14,6 @@ const containerEl = ref<HTMLElement | null>(null)
 const lifecycle = inject(MARKSTREAM_NODE_LIFECYCLE_KEY, null)
 const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 const isHydrating = getCurrentInstance()?.vnode.el?.nodeType === 1
-const deferOffscreenHeavyNodes = useOffscreenHeavyNodeDeferral()
-const viewportPriorityOptions = useViewportPriorityOptions()
-const viewportReady = ref(
-  typeof window === 'undefined'
-  || isHydrating
-  || !deferOffscreenHeavyNodes.value,
-)
 const lifecycleIndexKey = computed(() => {
   return resolveLifecycleIndexKey(props, {})
 })
@@ -43,14 +35,13 @@ function resolveInitialState() {
     }
   }
 
-  const katex = typeof window === 'undefined' || isHydrating || !deferOffscreenHeavyNodes.value
-    ? getKatexSync()
-    : null
+  const katex = getKatexSync()
   if (!katex) {
+    const keepHydrationFallback = typeof window === 'undefined' || isHydrating
     return {
       html: '',
-      text: props.node.loading ? '' : props.node.raw,
-      loading: props.node.loading,
+      text: keepHydrationFallback ? props.node.raw : '',
+      loading: !keepHydrationFallback,
     }
   }
 
@@ -83,8 +74,6 @@ let currentRenderId = 0
 let isUnmounted = false
 let currentAbortController: AbortController | null = null
 const minHeightCacheContext = useMathBlockMinHeightCache()
-const registerVisibility = useViewportPriority()
-let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
 let resizeObserver: ResizeObserver | null = null
 let lifecyclePendingIndexKey = ''
 const renderingLoading = ref(initialState.loading)
@@ -228,30 +217,7 @@ async function renderMath() {
   const abortController = new AbortController()
   currentAbortController = abortController
 
-  // Mark pending before visibility wait. During restore, the element may be in
-  // layout but visually hidden; readiness must not reveal raw fallback as final.
   markRenderPending()
-
-  // Wait until near/in viewport to prioritize visible area
-  if (!hasRenderedOnce && deferOffscreenHeavyNodes.value) {
-    try {
-      // register once per mount
-      if (!visibilityHandle && containerEl.value) {
-        // Observe the outer wrapper to ensure IO triggers even if inner is empty
-        visibilityHandle = registerVisibility(containerEl.value, {
-          rootMargin: viewportPriorityOptions?.value.heavyBlockMargin,
-          allowIdle: false,
-        })
-        viewportReady.value = visibilityHandle.isVisible.value
-      }
-      await waitForVisibilityOrAbort(visibilityHandle, abortController.signal)
-      viewportReady.value = true
-    }
-    catch {}
-  }
-  else if (!deferOffscreenHeavyNodes.value) {
-    viewportReady.value = true
-  }
   if (isUnmounted || renderId !== currentRenderId || abortController.signal.aborted) {
     if (!isUnmounted)
       clearRenderPending(renderId)
@@ -382,8 +348,6 @@ onBeforeUnmount(() => {
   }
   resizeObserver?.disconnect()
   resizeObserver = null
-  visibilityHandle?.destroy?.()
-  visibilityHandle = null
 })
 </script>
 
@@ -394,7 +358,6 @@ onBeforeUnmount(() => {
     data-markstream-math="block"
     :data-markstream-mode="renderedHtml ? 'katex' : renderedText ? 'fallback' : 'loading'"
     :data-markstream-pending="renderingPending ? 'true' : undefined"
-    :data-markstream-viewport-pending="deferOffscreenHeavyNodes && !viewportReady ? 'true' : undefined"
     :style="lockedMinHeight ? { minHeight: `${lockedMinHeight}px` } : undefined"
   >
     <Transition name="math-fade">
@@ -439,14 +402,6 @@ onBeforeUnmount(() => {
   border-top-color: color-mix(in srgb, var(--loading-spinner) 80%, transparent);
   border-radius: 50%;
   animation: math-spin 0.8s linear infinite;
-}
-
-.math-block[data-markstream-viewport-pending='true'] .math-loading-overlay {
-  backdrop-filter: none;
-}
-
-.math-block[data-markstream-viewport-pending='true'] .math-loading-spinner {
-  animation: none;
 }
 
 @keyframes math-spin {

--- a/src/components/MathInlineNode/MathInlineNode.vue
+++ b/src/components/MathInlineNode/MathInlineNode.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { MathInlineNodeProps } from '../../types/component-props'
 import { computed, getCurrentInstance, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions, waitForVisibilityOrAbort } from '../../composables/viewportPriority'
 import { normalizeKaTeXRenderInput } from '../../utils/normalizeKaTeXRenderInput'
 import { renderKaTeXWithBackpressure, setKaTeXCache, WORKER_BUSY_CODE } from '../../workers/katexWorkerClient'
 
@@ -13,13 +12,6 @@ const containerEl = ref<HTMLElement | null>(null)
 const displayMode = computed(() => props.node.markup === '$$')
 const mathContent = computed(() => normalizeKaTeXRenderInput(props.node.content))
 const isHydrating = getCurrentInstance()?.vnode.el?.nodeType === 1
-const deferOffscreenHeavyNodes = useOffscreenHeavyNodeDeferral()
-const viewportPriorityOptions = useViewportPriorityOptions()
-const viewportReady = ref(
-  typeof window === 'undefined'
-  || isHydrating
-  || !deferOffscreenHeavyNodes.value,
-)
 
 function resolveInitialState() {
   if (!props.node.content) {
@@ -38,14 +30,13 @@ function resolveInitialState() {
     }
   }
 
-  const katex = typeof window === 'undefined' || isHydrating || !deferOffscreenHeavyNodes.value
-    ? getKatexSync()
-    : null
+  const katex = getKatexSync()
   if (!katex) {
+    const keepHydrationFallback = typeof window === 'undefined' || isHydrating
     return {
       html: '',
-      text: props.node.loading ? '' : props.node.raw,
-      loading: props.node.loading,
+      text: keepHydrationFallback ? props.node.raw : '',
+      loading: !keepHydrationFallback,
     }
   }
 
@@ -79,8 +70,6 @@ let isUnmounted = false
 let currentAbortController: AbortController | null = null
 const renderingLoading = ref(initialState.loading)
 const renderingPending = ref(false)
-const registerVisibility = useViewportPriority()
-let visibilityHandle: ReturnType<typeof registerVisibility> | null = null
 
 if (initialState.html)
   hasRenderedOnce = true
@@ -119,29 +108,7 @@ async function renderMath() {
   const abortController = new AbortController()
   currentAbortController = abortController
 
-  // Mark pending before visibility wait. During restore, the element may be in
-  // layout but visually hidden; readiness must not reveal raw fallback as final.
   markRenderPending()
-
-  // Defer heavy work until visible on first render
-  if (!hasRenderedOnce && deferOffscreenHeavyNodes.value) {
-    try {
-      if (!visibilityHandle && containerEl.value) {
-        // Observe the always-visible wrapper, not the v-show hidden math span
-        visibilityHandle = registerVisibility(containerEl.value, {
-          rootMargin: viewportPriorityOptions?.value.rootMargin,
-          allowIdle: false,
-        })
-        viewportReady.value = visibilityHandle.isVisible.value
-      }
-      await waitForVisibilityOrAbort(visibilityHandle, abortController.signal)
-      viewportReady.value = true
-    }
-    catch {}
-  }
-  else if (!deferOffscreenHeavyNodes.value) {
-    viewportReady.value = true
-  }
 
   if (isUnmounted || renderId !== currentRenderId || abortController.signal.aborted) {
     clearRenderPending(renderId)
@@ -234,8 +201,6 @@ onBeforeUnmount(() => {
     currentAbortController.abort()
     currentAbortController = null
   }
-  visibilityHandle?.destroy?.()
-  visibilityHandle = null
 })
 </script>
 
@@ -246,7 +211,6 @@ onBeforeUnmount(() => {
     data-markstream-math="inline"
     :data-markstream-mode="renderedHtml ? 'katex' : renderedText ? 'fallback' : 'loading'"
     :data-markstream-pending="renderingPending ? 'true' : undefined"
-    :data-markstream-viewport-pending="deferOffscreenHeavyNodes && !viewportReady ? 'true' : undefined"
   >
     <span v-if="renderedHtml" class="math-inline" v-html="renderedHtml" />
     <span v-else-if="renderedText" class="math-inline math-inline--fallback">{{ renderedText }}</span>
@@ -294,11 +258,6 @@ onBeforeUnmount(() => {
   border: 2px solid color-mix(in srgb, var(--loading-spinner) 25%, transparent);
   border-top-color: color-mix(in srgb, var(--loading-spinner) 80%, transparent);
   will-change: transform;
-}
-
-.math-inline-wrapper[data-markstream-viewport-pending='true'] .math-inline__spinner {
-  animation: none !important;
-  will-change: auto;
 }
 
 .table-node-fade-enter-active,

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -324,6 +324,7 @@ const userToggledShowSource = ref(false)
 const isRendering = ref(false)
 const renderQueue = ref<Promise<boolean> | null>(null)
 interface MermaidRenderRequest {
+  code: string
   codeWithTheme: string
   final: boolean
   signature: string
@@ -378,7 +379,8 @@ function clearProgressiveRenderDebounceTimer() {
 function debouncedProgressiveRender() {
   if (unmounted)
     return
-  clearProgressiveRenderDebounceTimer()
+  if (progressiveRenderDebounceTimer != null || progressiveRenderIdleId != null)
+    return
   progressiveRenderDebounceTimer = (globalThis as any).setTimeout(() => {
     progressiveRenderDebounceTimer = null
     if (!canScheduleViewportWork())
@@ -1413,6 +1415,7 @@ function createMermaidRenderRequest(
   final = props.loading === false,
 ): MermaidRenderRequest {
   return {
+    code,
     codeWithTheme: getCodeWithTheme(theme, code),
     final,
     signature: `${theme}\u0000${code}`,
@@ -1422,6 +1425,11 @@ function createMermaidRenderRequest(
 
 function isCurrentRenderRequest(request: MermaidRenderRequest) {
   return request.signature === createMermaidRenderRequest().signature
+}
+
+function canCommitRenderRequest(request: MermaidRenderRequest) {
+  return isCurrentRenderRequest(request)
+    || (!request.final && props.loading !== false && baseFixedCode.value.startsWith(request.code))
 }
 
 // 优化的 mermaid 渲染函数
@@ -1487,7 +1495,7 @@ async function initMermaid(request = createMermaidRenderRequest()) {
         timeouts.value.fullRender,
       )
 
-      if (!isActiveGeneration(generation) || !isCurrentRenderRequest(request)) {
+      if (!isActiveGeneration(generation) || !canCommitRenderRequest(request)) {
         if (isThemeRendering.value)
           isThemeRendering.value = false
         return false

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -630,6 +630,13 @@ function isAbortError(error: unknown) {
   return (error as any)?.name === 'AbortError'
 }
 
+function requiresMainThreadMermaid(error: unknown) {
+  const message = typeof (error as any)?.message === 'string'
+    ? (error as any).message
+    : String(error ?? '')
+  return /(?:DOM)?purify\.(?:sanitize|addHook) is not a function/i.test(message)
+}
+
 function shouldRetrySequenceSemicolonEscape(error: unknown) {
   return !isTimeoutError(error) && !isAbortError(error)
 }
@@ -848,7 +855,7 @@ async function canParseOffthread(
     if (error?.name === 'AbortError')
       throw error
     const errorCode = error?.code || error?.name
-    if (errorCode === 'WORKER_INIT_ERROR' || error?.fallbackToRenderer)
+    if (errorCode === 'WORKER_INIT_ERROR' || error?.fallbackToRenderer || requiresMainThreadMermaid(error))
       return await canParseOnMain(code, theme, opts)
     throw error
   }

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -407,6 +407,7 @@ const {
 const stableLayoutInitiallyFinal = requestedFinal.value === true
 provide('markstreamSmoothStreaming', smoothStreamingEnabled)
 const contentStreamingTailActive = ref(false)
+const continuousStreamingObserved = ref(false)
 const hasObservedNonFinalContent = ref(false)
 let previousContentStreamValue = ''
 let hasSeenContentStreamValue = false
@@ -421,6 +422,7 @@ function clearContentStreamingTailIdleTimer() {
 
 function markContentStreamingTailActive() {
   contentStreamingTailActive.value = true
+  continuousStreamingObserved.value = true
   if (!isClient)
     return
 
@@ -444,6 +446,7 @@ watch(
   [() => rendererProps.indexKey, () => rendererProps.customId],
   () => {
     clearContentStreamingTailActive()
+    continuousStreamingObserved.value = false
     hasObservedNonFinalContent.value = !props.nodes?.length
       && requestedFinal.value !== true
       && Boolean(props.content)
@@ -469,6 +472,7 @@ watch(
 
     if (nodes?.length || finalRequested === true) {
       clearContentStreamingTailActive()
+      continuousStreamingObserved.value = false
       previousContentStreamValue = nextContent
       hasSeenContentStreamValue = true
       return
@@ -488,6 +492,7 @@ watch(
     }
     else if (nextContent.length < previousContentStreamValue.length || !nextContent.startsWith(previousContentStreamValue)) {
       clearContentStreamingTailActive()
+      continuousStreamingObserved.value = false
     }
 
     previousContentStreamValue = nextContent
@@ -864,6 +869,7 @@ const {
   isTestEnv,
   renderAsFragment,
   forceFullRenderFinalContent,
+  continuousStreaming: computed(() => continuousStreamingObserved.value && effectiveFinal.value !== true),
 })
 const incrementalRenderingDomRequired = computed(() => {
   return !renderAsFragment.value
@@ -6427,8 +6433,6 @@ onBeforeUnmount(() => {
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
-  border-radius: var(--ms-radius);
-  background-image: linear-gradient(90deg, var(--loading-shimmer), transparent, var(--loading-shimmer));
 }
 
 .node-placeholder:first-child {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5523,7 +5523,7 @@ const renderedItems = computed(() => {
       slotContent: String((node as any).content ?? ''),
       isCodeBlock: node.type === 'code_block',
       indexKey: `${indexPrefix.value}-${item.index}`,
-      vnodeKey: `${rendererSessionIdentity.value}\u0000${item.index}`,
+      vnodeKey: `${rendererSessionIdentity.value}\u0000${item.index}\u0000${node.type}`,
     }
   })
 })

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -4026,8 +4026,19 @@ function bumpNodeSlotVersion() {
 function shouldRenderNode(index: number) {
   // Respect incremental rendering budget only when incremental batching
   // is active (virtualization disabled). Otherwise render immediately.
-  if (incrementalRenderingActive.value && index >= renderedCount.value)
-    return false
+  if (incrementalRenderingActive.value && index >= renderedCount.value) {
+    const node = parsedNodes.value[index]
+    // A heading or paragraph can be immediately followed by the active heavy node.
+    const isFinalCatchUpTail = requestedFinal.value === true
+      && effectiveFinal.value !== true
+      && index >= parsedNodes.value.length - 2
+    const canDefer = node?.type === 'code_block'
+      || node?.type === 'image'
+      || node?.type === 'mermaid'
+      || node?.type === 'infographic'
+    if (!isFinalCatchUpTail || canDefer)
+      return false
+  }
   if (!deferNodes.value)
     return true
   if (index < resolvedInitialBatch.value)

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -209,9 +209,9 @@ export const CodeBlockNodeLoading = defineComponent({
         ...(formatSize(props.maxWidth) ? { maxWidth: formatSize(props.maxWidth) } : {}),
         ...(!isDiff
           ? {
-              color: 'var(--vscode-editor-foreground, var(--markstream-code-fallback-fg))',
-              backgroundColor: 'var(--vscode-editor-background, var(--markstream-code-fallback-bg))',
-              borderColor: 'var(--markstream-code-border-color)',
+              color: 'var(--vscode-editor-foreground, var(--markstream-code-fallback-fg, var(--code-fg)))',
+              backgroundColor: 'var(--vscode-editor-background, var(--markstream-code-fallback-bg, var(--code-bg)))',
+              borderColor: 'var(--markstream-code-border-color, var(--code-border))',
             }
           : {}),
       }

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -32,11 +32,6 @@ function getProcessEnv() {
   return processValue?.env
 }
 
-function shouldAwaitKatexLoader() {
-  return typeof window === 'undefined'
-    || document.querySelector('[data-markstream-math][data-markstream-mode="katex"]') !== null
-}
-
 export function withViewportDeferredLoading(name: string, component: Component, loadingComponent: Component) {
   return defineComponent({
     name,
@@ -331,20 +326,7 @@ export const CodeBlockNodeAsync = withViewportDeferredLoading(
   CodeBlockNodeLoading,
 )
 
-const MathInlineNodeLoading = defineComponent({
-  name: 'MathInlineNodeLoading',
-  inheritAttrs: false,
-  setup(_props, { attrs }) {
-    const props = attrs as MathInlineFallbackProps
-    return () => h('span', {
-      'class': 'math-inline math-inline--fallback',
-      'data-markstream-math': 'inline',
-      'data-markstream-mode': 'fallback',
-    }, props.node.raw ?? `$${props.node.content ?? ''}$`)
-  },
-})
-
-const MathInlineNodeInnerAsync = defineAsyncComponent(async () => {
+export const MathInlineNodeAsync = defineAsyncComponent(async () => {
   // In test environment prefer the simple text fallback to avoid
   // race conditions with workers/KaTeX rendering.
   const isTestEnv = getProcessEnv()?.NODE_ENV === 'test'
@@ -363,8 +345,7 @@ const MathInlineNodeInnerAsync = defineAsyncComponent(async () => {
   }
 
   try {
-    if (shouldAwaitKatexLoader())
-      await getKatex()
+    await getKatex()
     const mod = await import('../../components/MathInlineNode')
     return mod.default
   }
@@ -386,29 +367,9 @@ const MathInlineNodeInnerAsync = defineAsyncComponent(async () => {
   }
 })
 
-export const MathInlineNodeAsync = withViewportDeferredLoading(
-  'ViewportDeferredMathInlineNode',
-  MathInlineNodeInnerAsync,
-  MathInlineNodeLoading,
-)
-
-const MathBlockNodeLoading = defineComponent({
-  name: 'MathBlockNodeLoading',
-  inheritAttrs: false,
-  setup(_props, { attrs }) {
-    const props = attrs as MathBlockFallbackProps
-    return () => h('pre', {
-      'class': 'math-block__fallback text-left',
-      'data-markstream-math': 'block',
-      'data-markstream-mode': 'fallback',
-    }, props.node.raw ?? `$$${props.node.content ?? ''}$$`)
-  },
-})
-
-const MathBlockNodeInnerAsync = defineAsyncComponent(async () => {
+export const MathBlockNodeAsync = defineAsyncComponent(async () => {
   try {
-    if (shouldAwaitKatexLoader())
-      await getKatex()
+    await getKatex()
     const mod = await import('../../components/MathBlockNode')
     return mod.default
   }
@@ -429,9 +390,3 @@ const MathBlockNodeInnerAsync = defineAsyncComponent(async () => {
     })
   }
 })
-
-export const MathBlockNodeAsync = withViewportDeferredLoading(
-  'ViewportDeferredMathBlockNode',
-  MathBlockNodeInnerAsync,
-  MathBlockNodeLoading,
-)

--- a/src/components/NodeRenderer/composables/useBatchRenderingState.ts
+++ b/src/components/NodeRenderer/composables/useBatchRenderingState.ts
@@ -3,6 +3,7 @@ import type { NodeRendererProps } from '../../../types/node-renderer-props'
 import { computed, ref } from 'vue'
 
 export interface BatchRenderingStateOptions {
+  continuousStreaming?: ComputedRef<boolean>
   isClient: boolean
   isTestEnv: boolean
   renderAsFragment: ComputedRef<boolean>
@@ -72,6 +73,7 @@ export function useBatchRenderingState(
 
   const incrementalRenderingActive = computed(() => {
     return batchingEnabled.value
+      && !options.continuousStreaming?.value
       && !options.forceFullRenderFinalContent?.value
       && (props.maxLiveNodes ?? 0) <= 0
   })

--- a/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
+++ b/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
@@ -14,6 +14,8 @@ const DEFAULT_RENDERER_SMOOTH_STREAMING_OPTIONS = {
   catchUpThreshold: 400,
 }
 
+const CONTINUOUS_STREAM_CHUNK_MAX_LENGTH = 8
+
 export interface SmoothStreamingBridgeOptions {
   isClient: boolean
   inheritedSmoothStreaming?: { value?: boolean }
@@ -90,10 +92,19 @@ export function useSmoothStreamingBridge(
     return finalRequested
   })
 
+  let consecutiveSmallAppends = 0
+  let continuousSmallStream = false
+
+  function resetContinuousStreamDetection() {
+    consecutiveSmallAppends = 0
+    continuousSmallStream = false
+  }
+
   watch(
     [() => props.content, () => props.nodes, smoothStreamingEnabled, requestedFinal],
     ([content, nodes, enabled, finalRequested]) => {
       if (nodes?.length) {
+        resetContinuousStreamDetection()
         smoothStream.reset('')
         return
       }
@@ -101,6 +112,7 @@ export function useSmoothStreamingBridge(
       const nextContent = content ?? ''
 
       if (!enabled) {
+        resetContinuousStreamDetection()
         smoothStream.reset(nextContent)
 
         if (finalRequested)
@@ -112,15 +124,35 @@ export function useSmoothStreamingBridge(
       const source = smoothStream.source.value
 
       if (!nextContent) {
+        resetContinuousStreamDetection()
         smoothStream.reset('')
       }
       else if (nextContent === source) {
         // no-op
       }
       else if (nextContent.startsWith(source)) {
-        smoothStream.enqueue(nextContent.slice(source.length))
+        const appended = nextContent.slice(source.length)
+        const pendingBeforeAppend = smoothStream.pendingChars.value
+        if (appended.length <= CONTINUOUS_STREAM_CHUNK_MAX_LENGTH) {
+          consecutiveSmallAppends++
+          if (continuousSmallStream || (
+            consecutiveSmallAppends >= 2
+            && pendingBeforeAppend <= CONTINUOUS_STREAM_CHUNK_MAX_LENGTH
+          )) {
+            continuousSmallStream = true
+            smoothStream.reset(nextContent)
+          }
+          else {
+            smoothStream.enqueue(appended)
+          }
+        }
+        else {
+          resetContinuousStreamDetection()
+          smoothStream.enqueue(appended)
+        }
       }
       else {
+        resetContinuousStreamDetection()
         smoothStream.reset(nextContent)
       }
 

--- a/test/heavy-node-final-restore-defer.test.ts
+++ b/test/heavy-node-final-restore-defer.test.ts
@@ -549,14 +549,16 @@ describe('final restore heavy-node deferral', () => {
         expect(wrapper.text()).toContain('History semantic start')
         expect(image.attributes('alt')).toBe('History integration image')
         expect(codeTarget.text()).toContain('code-semantic')
-        expect(mathTarget.text()).toContain('$x^2 + y^2$')
+        expect(mathTarget.attributes('data-markstream-mode')).toBe('katex')
+        expect(mathTarget.text()).toContain('x^2 + y^2')
         expect(mermaidTarget.text()).toContain('HistoryStart --> HistoryEnd')
         expect(infographicTarget.text()).toContain('title: Integration history')
       }, { timeout: 3000 })
 
       expect(countHistoryImageRequests()).toBe(0)
       expect(monacoLoader).toHaveBeenCalledTimes(0)
-      expect(katexLoader).toHaveBeenCalledTimes(0)
+      expect(katexLoader).toHaveBeenCalledTimes(1)
+      expect(katexRender).toHaveBeenCalledTimes(1)
       expect(mermaidLoader).toHaveBeenCalledTimes(0)
       expect(infographicLoader).toHaveBeenCalledTimes(0)
 
@@ -564,14 +566,14 @@ describe('final restore heavy-node deferral', () => {
 
       expect(countHistoryImageRequests()).toBe(0)
       expect(monacoLoader).toHaveBeenCalledTimes(0)
-      expect(katexLoader).toHaveBeenCalledTimes(0)
+      expect(katexLoader).toHaveBeenCalledTimes(1)
       expect(mermaidLoader).toHaveBeenCalledTimes(0)
       expect(infographicLoader).toHaveBeenCalledTimes(0)
+      expect(findObserver(mathTarget.element)).toBeUndefined()
 
       const viewportTargets = [
         imageTarget.element,
         codeTarget.element,
-        mathTarget.element,
         mermaidTarget.element,
         infographicTarget.element,
       ]
@@ -583,7 +585,6 @@ describe('final restore heavy-node deferral', () => {
 
       const deferredComponentTargets = [
         ['[data-markstream-code-block="1"]', codeTarget.element],
-        ['[data-markstream-math="inline"]', mathTarget.element],
         ['[data-markstream-mermaid="1"]', mermaidTarget.element],
         ['[data-markstream-infographic="1"]', infographicTarget.element],
       ] as const

--- a/test/markdown-midstates.test.ts
+++ b/test/markdown-midstates.test.ts
@@ -677,11 +677,9 @@ describe('parseMarkdownToStructure - incremental/mid-typing states', () => {
     })
 
     describe('math block mid-states', () => {
-      it('"$$" mid-state: accept math_block or paragraph fallback', () => {
+      it('"$$" mid-state: waits for enough block math content', () => {
         const nodes = parseMarkdownToStructure('$$', md)
-        const math = collect(nodes, 'math_block').length > 0 || collect(nodes, 'math').length > 0
-        const para = hasParagraph(nodes)
-        expect(math || para).toBe(true)
+        expect(nodes).toHaveLength(0)
       })
 
       it('"$$\na+b\n$$" closed: should be math_block or paragraph fallback (depending on plugin)', () => {

--- a/test/math-block-loading-state.test.ts
+++ b/test/math-block-loading-state.test.ts
@@ -27,6 +27,28 @@ describe('mathBlockNode loading state', () => {
     mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
   })
 
+  it('does not flash settled raw math while async KaTeX render is in flight', async () => {
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: '\\ln(1+x) = x - \\frac{x^2}{2}',
+          raw: '\\[\\ln(1+x) = x - \\frac{x^2}{2}\\]',
+          loading: false,
+        },
+      },
+    })
+
+    await flushAll()
+
+    expect(mocks.renderKaTeXWithBackpressure).toHaveBeenCalled()
+    expect(wrapper.attributes('data-markstream-mode')).toBe('loading')
+    expect(wrapper.find('.math-block__fallback').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('\\ln(1+x)')
+
+    wrapper.unmount()
+  })
+
   it('keeps loading math blocks in loading mode instead of flashing raw fallback', async () => {
     const wrapper = mount(MathBlockNode as any, {
       props: {

--- a/test/math-final-restore-defer.test.ts
+++ b/test/math-final-restore-defer.test.ts
@@ -55,7 +55,7 @@ class FakeIntersectionObserver {
   }
 }
 
-describe('final restore math deferral', () => {
+describe('math rendering priority', () => {
   beforeEach(() => {
     mocks.renderSync.mockClear()
     mocks.renderWorker.mockClear()
@@ -73,7 +73,7 @@ describe('final restore math deferral', () => {
   it.each([
     ['inline', MathInlineNode, { type: 'math_inline', content: 'x^2', raw: '$x^2$', markup: '$', loading: false }],
     ['block', MathBlockNode, { type: 'math_block', content: 'x^2', raw: '$$x^2$$', markup: '$$', loading: false }],
-  ])('keeps settled %s KaTeX offscreen until it enters the preload viewport', async (_kind, component, node) => {
+  ])('renders settled %s KaTeX immediately when heavy-node deferral is enabled', async (_kind, component, node) => {
     const Probe = defineComponent({
       setup() {
         provideOffscreenHeavyNodeDeferral(computed(() => true))
@@ -86,17 +86,11 @@ describe('final restore math deferral', () => {
     await flushAll()
 
     const target = wrapper.get('[data-markstream-math]')
-    expect(target.attributes('data-markstream-mode')).toBe('fallback')
-    expect(mocks.renderSync).not.toHaveBeenCalled()
+    expect(target.attributes('data-markstream-mode')).toBe('katex')
+    expect(mocks.renderSync).toHaveBeenCalledTimes(1)
     expect(mocks.renderWorker).not.toHaveBeenCalled()
     expect(requestIdleCallback).not.toHaveBeenCalled()
-
-    const observer = FakeIntersectionObserver.instances.find(instance => instance.elements.has(target.element))
-    expect(observer).toBeTruthy()
-    observer?.trigger(target.element)
-    await flushAll()
-
-    expect(mocks.renderWorker).toHaveBeenCalledTimes(1)
+    expect(FakeIntersectionObserver.instances).toHaveLength(0)
     wrapper.unmount()
   })
 

--- a/test/math-inline-loading-state.test.ts
+++ b/test/math-inline-loading-state.test.ts
@@ -26,7 +26,7 @@ describe('mathInlineNode pending state', () => {
     mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
   })
 
-  it('exposes pending state while async KaTeX render is in flight', async () => {
+  it('does not flash settled raw math while async KaTeX render is in flight', async () => {
     const wrapper = mount(MathInlineNode as any, {
       props: {
         node: {
@@ -42,8 +42,10 @@ describe('mathInlineNode pending state', () => {
     await flushAll()
 
     expect(mocks.renderKaTeXWithBackpressure).toHaveBeenCalled()
-    expect(wrapper.attributes('data-markstream-mode')).toBe('fallback')
+    expect(wrapper.attributes('data-markstream-mode')).toBe('loading')
     expect(wrapper.attributes('data-markstream-pending')).toBe('true')
+    expect(wrapper.find('.math-inline--fallback').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('$x$')
 
     wrapper.unmount()
   })

--- a/test/mermaid-streaming-preview-regression.test.ts
+++ b/test/mermaid-streaming-preview-regression.test.ts
@@ -29,6 +29,122 @@ afterEach(() => {
 })
 
 describe('mermaid streaming preview regression', () => {
+  it('checks the latest source at a bounded interval while chunks keep arriving', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    const canParseOffthread = vi.fn(async () => true)
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render: vi.fn(async (_id: string, code: string) => ({
+        svg: `<svg data-code="${code.includes('D') ? 'latest' : 'older'}" viewBox="0 0 10 10" />`,
+      })),
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread,
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: createNode('graph LR\nA-->B\n'),
+        loading: true,
+        renderDebounceMs: 300,
+      },
+    })
+
+    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).viewportReady = true
+    ;(wrapper.vm as any).showSource = false
+    await settleStreamingRender()
+    canParseOffthread.mockClear()
+    fakeMermaid.render.mockClear()
+
+    await wrapper.setProps({ node: createNode('graph LR\nA-->B\nB-->C\n') })
+    await vi.advanceTimersByTimeAsync(120)
+    await wrapper.setProps({ node: createNode('graph LR\nA-->B\nB-->C\nC-->D\n') })
+    await vi.advanceTimersByTimeAsync(120)
+    await wrapper.setProps({ node: createNode('graph LR\nA-->B\nB-->C\nC-->D\nD-->E\n') })
+    await vi.advanceTimersByTimeAsync(120)
+    await settleStreamingRender()
+
+    expect(canParseOffthread).toHaveBeenCalled()
+    expect(canParseOffthread.mock.calls.at(-1)?.[0]).toContain('D-->E')
+    wrapper.unmount()
+  })
+
+  it('shows a successfully rendered streaming snapshot while newer source is still arriving', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    let resolveSnapshot!: (value: { svg: string }) => void
+    const snapshotRender = new Promise<{ svg: string }>((resolve) => {
+      resolveSnapshot = resolve
+    })
+    const canParseOffthread = vi.fn(async () => true)
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      render: vi.fn((_id: string, code: string) => {
+        if (code.includes('B-->C') && !code.includes('C-->D'))
+          return snapshotRender
+        return Promise.resolve({
+          svg: `<svg data-rendered="${code.includes('C-->D') ? 'latest' : 'initial'}" viewBox="0 0 10 10"><rect width="1" height="1" /></svg>`,
+        })
+      }),
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread,
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: createNode('graph LR\nA-->B\n'),
+        loading: true,
+        renderDebounceMs: 100,
+      },
+    })
+
+    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).viewportReady = true
+    ;(wrapper.vm as any).showSource = false
+    await settleStreamingRender()
+
+    await wrapper.setProps({ node: createNode('graph LR\nA-->B\nB-->C\n') })
+    await vi.advanceTimersByTimeAsync(120)
+    await settleStreamingRender()
+    expect(fakeMermaid.render.mock.calls.some(([, code]) => code.includes('B-->C') && !code.includes('C-->D'))).toBe(true)
+    await wrapper.setProps({ node: createNode('graph LR\nA-->B\nB-->C\nC-->D\n') })
+
+    resolveSnapshot({
+      svg: '<svg data-rendered="snapshot" viewBox="0 0 10 10"><rect width="1" height="1" /></svg>',
+    })
+    await settleStreamingRender(10)
+
+    expect(wrapper.find('svg[data-rendered="snapshot"]').exists()).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(120)
+    await settleStreamingRender(10)
+    expect(wrapper.find('svg[data-rendered="latest"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
   it('falls back to the main thread when DOMPurify is unavailable in the worker', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('IntersectionObserver', undefined as any)

--- a/test/mermaid-streaming-preview-regression.test.ts
+++ b/test/mermaid-streaming-preview-regression.test.ts
@@ -29,6 +29,59 @@ afterEach(() => {
 })
 
 describe('mermaid streaming preview regression', () => {
+  it('falls back to the main thread when DOMPurify is unavailable in the worker', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    const canParseOffthread = vi.fn(async () => Promise.reject(new Error('purify.sanitize is not a function')))
+    const fakeMermaid = {
+      initialize: vi.fn(),
+      parse: vi.fn(async () => true),
+      render: vi.fn(async () => ({
+        svg: '<svg data-rendered="final" viewBox="0 0 10 10"><rect width="1" height="1" /></svg>',
+      })),
+    }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread,
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: createNode('graph LR\nA[Label]-->B\n'),
+        loading: true,
+        renderDebounceMs: 10000,
+      },
+    })
+
+    ;(wrapper.vm as any).userToggledShowSource = true
+    await settleStreamingRender()
+    ;(wrapper.vm as any).mermaidAvailable = false
+    ;(wrapper.vm as any).showSource = false
+    await settleStreamingRender()
+
+    const loadingUpdate = wrapper.setProps({ loading: false })
+    ;(wrapper.vm as any).mermaidAvailable = true
+    await loadingUpdate
+    await settleStreamingRender(10)
+
+    expect(canParseOffthread).toHaveBeenCalled()
+    expect(fakeMermaid.parse).toHaveBeenCalledTimes(1)
+    expect(fakeMermaid.render).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('svg[data-rendered="final"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('Failed to render diagram')
+    expect(errorSpy).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
   it('does not retry a busy worker parse on the main thread', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('IntersectionObserver', undefined as any)

--- a/test/node-renderer-dom-mode.test.ts
+++ b/test/node-renderer-dom-mode.test.ts
@@ -184,6 +184,45 @@ describe('node renderer domMode', () => {
     }
   })
 
+  it('does not leave transparent placeholders for a small streaming append', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: 'Paragraph 1',
+        batchRendering: true,
+        deferNodesUntilVisible: false,
+        fade: false,
+        final: false,
+        initialRenderBatchSize: 1,
+        maxLiveNodes: 0,
+        nodeVirtual: false,
+        renderBatchDelay: 100000,
+        renderBatchSize: 1,
+        smoothStreaming: false,
+        typewriter: false,
+        viewportPriority: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      expect(wrapper.findAll('.node-placeholder')).toHaveLength(0)
+
+      await wrapper.setProps({ content: 'Paragraph 1\n\nParagraph 2' })
+      await flushAll()
+
+      expect(wrapper.findAll('.node-slot')).toHaveLength(2)
+      expect(wrapper.findAll('.node-placeholder')).toHaveLength(0)
+      expect(wrapper.text()).toContain('Paragraph 2')
+    }
+    finally {
+      wrapper.unmount()
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
   it('renders final non-virtual content without incremental placeholders', async () => {
     const originalNodeEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'development'

--- a/test/node-renderer-dom-mode.test.ts
+++ b/test/node-renderer-dom-mode.test.ts
@@ -41,6 +41,39 @@ describe('node renderer domMode', () => {
     catch {}
   })
 
+  it('replaces a code renderer when the streamed node at that index becomes markdown', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        nodes: [codeBlockNode(2)],
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        fade: false,
+        nodeVirtual: false,
+        viewportPriority: false,
+      },
+    })
+    await flushAll()
+
+    const firstKey = (wrapper.vm.$.setupState.renderedItems as any[])[0].vnodeKey
+    expect(wrapper.find('[data-markstream-code-block="1"]').exists()).toBe(true)
+
+    await wrapper.setProps({
+      nodes: [{
+        type: 'heading',
+        level: 1,
+        raw: '# 复杂数学公式',
+        children: [{ type: 'text', content: '复杂数学公式', raw: '复杂数学公式' }],
+      }],
+    })
+    await flushAll()
+
+    const nextKey = (wrapper.vm.$.setupState.renderedItems as any[])[0].vnodeKey
+    expect(nextKey).not.toBe(firstKey)
+    expect(wrapper.find('[data-markstream-code-block="1"]').exists()).toBe(false)
+    expect(wrapper.get('h1').text()).toBe('复杂数学公式')
+    wrapper.unmount()
+  })
+
   it('renders simple content without per-node wrappers in minimal DOM mode', async () => {
     const nodes = [paragraphNode(1), paragraphNode(2), paragraphNode(3)]
     const commonProps = {

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -76,6 +76,53 @@ describe('node renderer smooth streaming', () => {
     rawWrapper.unmount()
   })
 
+  it('keeps smooth streaming appends continuous without node placeholders', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        final: false,
+        smoothStreaming: true,
+        batchRendering: true,
+        initialRenderBatchSize: 1,
+        renderBatchSize: 1,
+        renderBatchDelay: 100000,
+        maxLiveNodes: 0,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      await nextTick()
+      queuedFrames.length = 0
+      await wrapper.setProps({ content: 'Paragraph 1\n\nParagraph 2\n\nParagraph 3' })
+
+      const baseline = performance.now()
+      for (let step = 1; step <= 80 && queuedFrames.length > 0; step++) {
+        queuedFrames.shift()?.(baseline + step * 80)
+        await nextTick()
+        expect(wrapper.findAll('.node-placeholder')).toHaveLength(0)
+        if (wrapper.text().includes('Paragraph 3'))
+          break
+      }
+
+      expect(wrapper.text()).toContain('Paragraph 3')
+    }
+    finally {
+      wrapper.unmount()
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
   it('does not smooth initial static content before mounted appends', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -123,6 +123,80 @@ describe('node renderer smooth streaming', () => {
     }
   })
 
+  it('does not batch an upstream one-character stream behind a second pacing queue', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        final: false,
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      let content = ''
+      for (const character of '矩阵：\n\\[\n\\begin{bmatrix}') {
+        content += character
+        await wrapper.setProps({ content })
+        await nextTick()
+
+        if (content.length >= 2) {
+          const renderContent = wrapper.vm.$?.setupState?.renderContent as string | undefined
+          expect(renderContent).toBe(content)
+        }
+      }
+
+      expect(queuedFrames.length).toBeLessThanOrEqual(1)
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('does not flush a large paced backlog when small chunks follow it', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        final: false,
+        smoothStreaming: true,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      const largeChunk = 'a'.repeat(200)
+      await wrapper.setProps({ content: largeChunk })
+      await wrapper.setProps({ content: `${largeChunk}b` })
+      await wrapper.setProps({ content: `${largeChunk}bc` })
+      await nextTick()
+
+      const renderContent = wrapper.vm.$?.setupState?.renderContent as string | undefined
+      expect(renderContent).toBe('')
+      expect(queuedFrames.length).toBeGreaterThan(0)
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
   it('keeps completed transport content continuous while smooth streaming catches up', async () => {
     const originalNodeEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'development'
@@ -421,15 +495,15 @@ describe('node renderer smooth streaming', () => {
     const initialVersion = readStreamRenderVersion(wrapper)
 
     // Initial append — visible is still empty (rAF not ticked)
-    await wrapper.setProps({ content: 'hello' })
+    await wrapper.setProps({ content: 'hello smooth streaming chunk one' })
     await nextTick()
 
     // More raw chunk appends without advancing rAF
-    await wrapper.setProps({ content: 'hello world 1' })
+    await wrapper.setProps({ content: 'hello smooth streaming chunk one and chunk two' })
     await nextTick()
-    await wrapper.setProps({ content: 'hello world 12' })
+    await wrapper.setProps({ content: 'hello smooth streaming chunk one and chunk two and chunk three' })
     await nextTick()
-    await wrapper.setProps({ content: 'hello world 123' })
+    await wrapper.setProps({ content: 'hello smooth streaming chunk one and chunk two and chunk three and chunk four' })
     await nextTick()
 
     // DOM should still show nothing (visible hasn't advanced)
@@ -437,7 +511,7 @@ describe('node renderer smooth streaming', () => {
     // streamRenderVersion increments from raw content changes.
     // Before the fix, each props.content change bumped streamRenderVersion,
     // which could trigger TextNode watchers even though visible was unchanged.
-    expect(wrapper.text()).not.toContain('hello world')
+    expect(wrapper.text()).not.toContain('hello smooth')
     expect(readStreamRenderVersion(wrapper)).toBe(initialVersion)
     wrapper.unmount()
   })

--- a/test/node-renderer-smooth-streaming.test.ts
+++ b/test/node-renderer-smooth-streaming.test.ts
@@ -123,6 +123,71 @@ describe('node renderer smooth streaming', () => {
     }
   })
 
+  it('keeps completed transport content continuous while smooth streaming catches up', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    const queuedFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      queuedFrames.push(cb)
+      return queuedFrames.length
+    }) as typeof requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', (() => {}) as typeof cancelAnimationFrame)
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        final: false,
+        smoothStreaming: true,
+        batchRendering: true,
+        initialRenderBatchSize: 1,
+        renderBatchSize: 1,
+        renderBatchDelay: 100000,
+        maxLiveNodes: 0,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    try {
+      await nextTick()
+      queuedFrames.length = 0
+      await wrapper.setProps({
+        content: [
+          '5. Create a native module example (C++):',
+          '',
+          '```cpp',
+          '#include <bits/stdc++.h>',
+          'int main() { return 0; }',
+          '```',
+          '',
+          '6. Add the native module to the application:',
+          '',
+          '```ts',
+          'console.log("ready")',
+          '```',
+        ].join('\n'),
+        final: true,
+      })
+
+      const baseline = performance.now()
+      for (let step = 1; step <= 160 && queuedFrames.length > 0; step++) {
+        queuedFrames.shift()?.(baseline + step * 80)
+        await nextTick()
+        const visibleContent = wrapper.vm.$?.setupState?.renderContent as string | undefined
+        if (visibleContent?.includes('6. Add the native module'))
+          expect(wrapper.text()).toContain('Add')
+        if (wrapper.text().includes('console.log'))
+          break
+      }
+
+      expect(wrapper.text()).toContain('console.log')
+    }
+    finally {
+      wrapper.unmount()
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
   it('does not smooth initial static content before mounted appends', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {

--- a/test/playground-stream-content-regression.test.ts
+++ b/test/playground-stream-content-regression.test.ts
@@ -16,6 +16,24 @@ function codeBlocks(nodes: any[]) {
   return result
 }
 
+function textContent(nodes: any[]) {
+  const result: string[] = []
+  const walk = (value: any) => {
+    if (!value)
+      return
+    if (Array.isArray(value)) {
+      value.forEach(walk)
+      return
+    }
+    if (value.type === 'text')
+      result.push(String(value.content ?? ''))
+    for (const key of ['children', 'items'])
+      walk(value[key])
+  }
+  walk(nodes)
+  return result.join('')
+}
+
 describe('playground stream content', () => {
   it('does not contain accidental template-literal control characters', () => {
     const controls = Array.from(streamContent)
@@ -62,6 +80,24 @@ describe('playground stream content', () => {
         expect(block.code, `prefix length ${end}`).not.toContain('正交补空间')
         expect(block.code, `prefix length ${end}`).not.toContain('boldsymbol')
       }
+    }
+  })
+
+  it('keeps matrix heading text visible while the following math block is still ambiguous', () => {
+    const headingStart = streamContent.indexOf('矩阵', streamContent.indexOf('二项式展开'))
+    const mathLikeEnd = streamContent.indexOf('\\begin{bmatrix}', headingStart) + '\\begin{bmatrix}'.length
+    expect(headingStart).toBeGreaterThan(0)
+    expect(mathLikeEnd).toBeGreaterThan(headingStart)
+
+    const md = getMarkdown('playground-matrix-heading-stream-regression')
+    for (let end = headingStart + 1; end <= mathLikeEnd; end++) {
+      const nodes = parseMarkdownToStructure(streamContent.slice(0, end), md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any)
+      const arrivedHeading = streamContent.slice(headingStart, Math.min(end, headingStart + '矩阵'.length))
+      expect(textContent(nodes), `prefix length ${end}`).toContain(arrivedHeading)
     }
   })
 })

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -3,6 +3,7 @@ import type { NodeRendererProps } from '../src/types/node-renderer-props'
 import { clearRegisteredMarkdownPlugins, getMarkdown, parseMarkdownToStructure, registerMarkdownPlugin } from 'stream-markdown-parser'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { computed, effectScope, reactive, ref, watch } from 'vue'
+import { streamContent } from '../playground/src/const/markdown'
 import { useMarkdownParsing } from '../src/components/NodeRenderer/composables/useMarkdownParsing'
 
 function createParsingState(
@@ -74,6 +75,20 @@ function findNode(nodes: any[], type: string) {
   return nodes.find(node => node?.type === type)
 }
 
+function findCodeBlocks(nodes: any[]) {
+  const result: any[] = []
+  const visit = (items: any[]) => {
+    for (const node of items) {
+      if (node?.type === 'code_block')
+        result.push(node)
+      if (Array.isArray(node?.children))
+        visit(node.children)
+    }
+  }
+  visit(nodes)
+  return result
+}
+
 function createDefinitionListTokens(definition: string) {
   return [
     { type: 'dl_open' },
@@ -110,6 +125,60 @@ describe('useMarkdownParsing performance behavior', () => {
     clearRegisteredMarkdownPlugins()
     vi.useRealTimers()
     vi.restoreAllMocks()
+  })
+
+  it('never reclassifies markdown after a streamed diagram fence as plain code', () => {
+    const markdown = [
+      '```mermaid',
+      'graph LR',
+      '  A --> B',
+      '```',
+      '',
+      '```infographic',
+      'infographic list-row-simple-horizontal-arrow',
+      'data',
+      '  items',
+      '    - label 步骤 3',
+      '      desc 完成',
+      '```',
+      '',
+      '---',
+      '# 复杂数学公式',
+      '',
+      '### 1. **理解 \\(\\boldsymbol{\\alpha}^T \\boldsymbol{\\beta} = 0\\) 的含义**',
+      '普通正文。',
+      '',
+    ].join('\n')
+    const content = ref('')
+    const { scope, state } = createParsingState(content)
+
+    for (let end = 1; end <= markdown.length; end++) {
+      content.value = markdown.slice(0, end)
+      for (const block of findCodeBlocks(state.parsedNodes.value)) {
+        expect(block.code, `prefix length ${end}`).not.toContain('复杂数学公式')
+        expect(block.code, `prefix length ${end}`).not.toContain('boldsymbol')
+      }
+    }
+
+    scope.stop()
+  })
+
+  it('keeps the real playground diagram chain closed while its math section streams', () => {
+    const diagramStart = streamContent.indexOf('```mermaid\ngraph TD')
+    const mathEnd = streamContent.indexOf('### 2.', streamContent.indexOf('# 复杂数学公式'))
+    const streamedSection = streamContent.slice(diagramStart, mathEnd)
+    const content = ref(streamContent.slice(0, diagramStart))
+    const { scope, state } = createParsingState(content)
+
+    for (let end = 1; end <= streamedSection.length; end++) {
+      content.value = streamContent.slice(0, diagramStart + end)
+      for (const block of findCodeBlocks(state.parsedNodes.value)) {
+        expect(block.code, `playground prefix length ${diagramStart + end}`).not.toContain('复杂数学公式')
+        expect(block.code, `playground prefix length ${diagramStart + end}`).not.toContain('boldsymbol')
+      }
+    }
+
+    scope.stop()
   })
 
   it('coalesces smooth streaming character updates until the parse interval elapses', async () => {

--- a/test/virtual-timeline-restore-readiness.test.ts
+++ b/test/virtual-timeline-restore-readiness.test.ts
@@ -1688,6 +1688,9 @@ describe('virtual timeline restore visual readiness', () => {
     expect(wrapper.get('.code-header-caption').text()).toBe('Typescript')
     expect(wrapper.get('.icon-slot').exists()).toBe(true)
     expect(wrapper.get('.code-block-container').classes()).toContain('border')
+    expect((root.element as HTMLElement).style.color).toBe('var(--vscode-editor-foreground, var(--markstream-code-fallback-fg, var(--code-fg)))')
+    expect((root.element as HTMLElement).style.backgroundColor).toBe('var(--vscode-editor-background, var(--markstream-code-fallback-bg, var(--code-bg)))')
+    expect((root.element as HTMLElement).style.borderColor).toBe('var(--markstream-code-border-color, var(--code-border))')
     expect(pre.classes()).not.toContain('border')
 
     wrapper.unmount()


### PR DESCRIPTION
## Summary

- disable top-level node batching after a live content append so text streams continuously instead of leaving blank placeholders and then appearing in a burst
- render KaTeX without viewport deferral or raw-formula flashes, and fix streamed bracket-math classification across list content
- fall back to main-thread Mermaid validation when DOMPurify is unavailable in a Web Worker, and use explicit sandbox peer loaders

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run` (302 files, 2536 tests)
- `pnpm run -C packages/markdown-parser test --run math-block-streaming-close.test.ts`
- `pnpm build`
- `pnpm play:build`