### PR TITLE
fix(vue): stabilize final code surface handoff

### DIFF
--- a/scripts/e2e-diff-folding.mjs
+++ b/scripts/e2e-diff-folding.mjs
@@ -192,7 +192,12 @@ function resolveChromeLaunchOptions() {
 
 async function waitForHiddenRegions(page, timeout = 20000) {
   await page.waitForFunction(() => {
-    const hiddenTexts = Array.from(document.querySelectorAll('.diff-hidden-lines'))
+    const readyBlocks = Array.from(document.querySelectorAll(
+      '.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"]',
+    ))
+    const hiddenTexts = readyBlocks
+      .flatMap(block => Array.from(block.querySelectorAll('diffs-container')))
+      .flatMap(el => Array.from(el.shadowRoot?.querySelectorAll('[data-separator="line-info"]') ?? []))
       .map(el => (el.textContent ?? '').trim())
       .filter(Boolean)
     return hiddenTexts.some(text => /hidden lines|unchanged|unmodified/i.test(text))
@@ -221,24 +226,30 @@ async function collectResult(page, name, extra = {}) {
       const n = Number.parseFloat(String(value ?? ''))
       return Number.isFinite(n) ? n : null
     }
-    const diffEditors = Array.from(document.querySelectorAll('.monaco-diff-editor'))
-    const hiddenTexts = Array.from(document.querySelectorAll('.diff-hidden-lines'))
+    const diffEditors = Array.from(document.querySelectorAll(
+      '.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"] .stream-diffs-shell',
+    ))
+    const surfaces = diffEditors.map((editorEl) => {
+      const container = editorEl.querySelector('diffs-container')
+      return { editorEl, root: container?.shadowRoot ?? null }
+    })
+    const hiddenTexts = surfaces
+      .flatMap(({ root }) => Array.from(root?.querySelectorAll('[data-separator="line-info"]') ?? []))
       .map(el => (el.textContent ?? '').trim())
       .filter(Boolean)
 
-    const originalVisibleLines = document.querySelectorAll('.editor.original .view-line').length
-    const modifiedVisibleLines = document.querySelectorAll('.editor.modified .view-line').length
-    const bodyText = document.body.textContent ?? ''
-    const diffEditorMetrics = diffEditors.map((editorEl, index) => {
+    const bodyText = `${document.body.textContent ?? ''} ${surfaces.map(({ root }) => root?.textContent ?? '').join(' ')}`
+    const diffEditorMetrics = surfaces.map(({ editorEl, root }, index) => {
       const editorRect = editorEl.getBoundingClientRect()
       const host = editorEl.closest('.code-editor-container')
       const hostStyle = host instanceof HTMLElement ? window.getComputedStyle(host) : null
-      const editorHiddenTexts = Array.from(editorEl.querySelectorAll('.diff-hidden-lines'))
+      const editorStyle = window.getComputedStyle(editorEl)
+      const pre = root?.querySelector('pre')
+      const preStyle = pre ? window.getComputedStyle(pre) : null
+      const editorHiddenTexts = Array.from(root?.querySelectorAll('[data-separator="line-info"]') ?? [])
         .map(el => (el.textContent ?? '').trim())
         .filter(Boolean)
-      const foldButtonCandidates = Array.from(
-        editorEl.querySelectorAll('.markstream-inline-fold-proxy, .diff-hidden-lines a'),
-      )
+      const foldButtonCandidates = Array.from(root?.querySelectorAll('[data-expand-button]') ?? [])
       const foldButton
         = foldButtonCandidates.find(candidate => isVisibleButton(candidate))
           ?? foldButtonCandidates[0]
@@ -250,8 +261,8 @@ async function collectResult(page, name, extra = {}) {
 
       return {
         index,
-        isSideBySide: editorEl.classList.contains('side-by-side'),
-        foldButtonKind: foldButton?.classList.contains('markstream-inline-fold-proxy') ? 'proxy' : (foldButton ? 'native' : null),
+        isSideBySide: preStyle?.display === 'grid',
+        foldButtonKind: foldButton ? 'stream-diffs' : null,
         hiddenRegionTexts: editorHiddenTexts,
         hostHeightPx,
         hostInlineHeight: host instanceof HTMLElement ? host.style.height : '',
@@ -260,6 +271,10 @@ async function collectResult(page, name, extra = {}) {
         hostOverflow,
         hostOverflowY: hostStyle?.overflowY ?? null,
         editorHeightPx: roundPx(editorEl.getBoundingClientRect().height),
+        editorScrollHeightPx: roundPx(editorEl.scrollHeight),
+        editorClientHeightPx: roundPx(editorEl.clientHeight),
+        editorOverflowY: editorStyle.overflowY,
+        editorScrollable: editorEl.scrollHeight > editorEl.clientHeight + 1,
         foldButtonRect: foldButtonRect
           ? {
               x: roundPx(foldButtonRect.x),
@@ -281,8 +296,8 @@ async function collectResult(page, name, extra = {}) {
       }
     })
     const foldedMetrics = diffEditorMetrics.filter(metric => metric.hiddenRegionTexts.length > 0)
-    const inlineMetrics = foldedMetrics.filter(metric => metric.isSideBySide === false)
     const foldedHostShrinks = foldedMetrics.length > 0 && foldedMetrics.every(metric => metric.hostShrunkAfterFolding === true)
+    const inlineMetrics = foldedMetrics.filter(metric => metric.isSideBySide === false)
     const inlineFoldButtonVisible = inlineMetrics.length > 0 && inlineMetrics.every(metric => metric.foldButtonVisible === true)
 
     return {
@@ -293,8 +308,7 @@ async function collectResult(page, name, extra = {}) {
       hiddenRegionTexts: hiddenTexts,
       hasHiddenRegionText: hiddenTexts.some(text => /hidden lines|unchanged|unmodified/i.test(text)),
       bodyContainsHiddenLinesText: /hidden lines|unchanged|unmodified/i.test(bodyText),
-      originalVisibleLines,
-      modifiedVisibleLines,
+      visibleLines: surfaces.reduce((sum, { root }) => sum + (root?.querySelectorAll('[data-line]').length ?? 0), 0),
       foldedHostShrinks,
       inlineFoldButtonVisible,
       diffEditorMetrics,
@@ -309,7 +323,7 @@ async function runControlledScenario(context, baseUrl) {
   const url = `${baseUrl}/test#data=raw:${encodeURIComponent(markdown)}`
 
   await page.goto(url, { waitUntil: 'networkidle' })
-  await page.waitForSelector('.monaco-diff-editor', { timeout: 20000 })
+  await page.waitForSelector('.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"] .stream-diffs-shell', { timeout: 30000 })
   await waitForHiddenRegions(page)
   await page.waitForTimeout(500)
 
@@ -327,10 +341,10 @@ async function runControlledScenario(context, baseUrl) {
 async function runHomeScenario(context, baseUrl) {
   const page = await context.newPage()
   const url = `${baseUrl}/`
-  const diffEditor = page.locator('.monaco-diff-editor').last()
+  const diffEditor = page.locator('.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"] .stream-diffs-shell')
 
   await page.goto(url, { waitUntil: 'networkidle' })
-  await page.waitForSelector('.monaco-diff-editor', { timeout: 30000 })
+  await diffEditor.waitFor({ state: 'visible', timeout: 30000 })
   await diffEditor.scrollIntoViewIfNeeded()
   await page.waitForTimeout(500)
   await waitForHiddenRegions(page, 30000)
@@ -344,26 +358,39 @@ async function runHomeScenario(context, baseUrl) {
 async function runHomeInlineScenario(context, baseUrl) {
   const page = await context.newPage()
   const url = `${baseUrl}/`
-  const diffEditor = page.locator('.monaco-diff-editor').last()
+  const diffEditor = page.locator('.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"] .stream-diffs-shell')
 
   await page.setViewportSize({ width: 430, height: 900 })
   await page.goto(url, { waitUntil: 'networkidle' })
-  await page.waitForSelector('.monaco-diff-editor', { timeout: 30000 })
+  await diffEditor.waitFor({ state: 'visible', timeout: 30000 })
   await diffEditor.scrollIntoViewIfNeeded()
   await waitForHiddenRegions(page, 30000)
   await page.waitForTimeout(800)
 
   const initial = await collectResult(page, 'index-route-inline', { url })
-  const foldButton = page.locator('.markstream-inline-fold-proxy:visible, .diff-hidden-lines a:visible').first()
+  const foldButton = diffEditor.locator('[data-expand-button]').first()
   await foldButton.click()
-  await page.waitForFunction(() => document.querySelectorAll('.diff-hidden-lines').length === 0, { timeout: 10000 })
-  const afterExpandHiddenRegionCount = await page.locator('.diff-hidden-lines').count()
+  await page.waitForFunction(({ previousLines, previousTexts }) => {
+    const roots = Array.from(document.querySelectorAll(
+      '.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"][data-markstream-code-block-state="settled"] diffs-container',
+    ))
+      .map(el => el.shadowRoot)
+      .filter(Boolean)
+    const currentLines = roots.reduce((sum, root) => sum + root.querySelectorAll('[data-line]').length, 0)
+    const currentTexts = roots
+      .flatMap(root => Array.from(root.querySelectorAll('[data-separator="line-info"]')))
+      .map(el => (el.textContent ?? '').trim())
+    return currentLines > previousLines || JSON.stringify(currentTexts) !== JSON.stringify(previousTexts)
+  }, { previousLines: initial.visibleLines, previousTexts: initial.hiddenRegionTexts }, { timeout: 10000 })
+  const afterExpand = await collectResult(page, 'index-route-inline-expanded', { url })
+  const afterExpandHiddenRegionCount = afterExpand.hiddenRegionCount
 
   await page.close()
   return {
     ...initial,
     afterExpandHiddenRegionCount,
-    afterExpandFoldCleared: afterExpandHiddenRegionCount === 0,
+    afterExpandFoldCleared: afterExpand.visibleLines > initial.visibleLines
+      || JSON.stringify(afterExpand.hiddenRegionTexts) !== JSON.stringify(initial.hiddenRegionTexts),
   }
 }
 

--- a/scripts/e2e-diff-theme-switch.mjs
+++ b/scripts/e2e-diff-theme-switch.mjs
@@ -96,47 +96,36 @@ function colorLuminance(color) {
 
 async function snapshot(page) {
   return page.evaluate(() => {
-    function visibleTextElements(selector) {
-      return Array.from(document.querySelectorAll(selector))
-        .filter((node) => {
-          if (!(node instanceof HTMLElement))
-            return false
-          const text = node.textContent?.trim() ?? ''
-          if (!text)
-            return false
-          const style = window.getComputedStyle(node)
-          return style.display !== 'none'
-            && style.visibility !== 'hidden'
-            && Number.parseFloat(style.opacity || '1') > 0.05
-        })
-        .map(node => node.textContent.trim())
-    }
-
     const container = document.querySelector('.code-block-container')
     const header = document.querySelector('.code-block-header')
     const preview = document.querySelector('[data-testid="diff-theme-preview"]')
-    const diffRoot = document.querySelector('.stream-monaco-diff-root')
-    const editorBackground = diffRoot?.querySelector('.monaco-editor .monaco-editor-background')
+    const diffRoot = document.querySelector('.stream-diffs-shell')
+    const diffs = diffRoot?.querySelector('diffs-container')
+    const shadow = diffs?.shadowRoot
+    const editorBackground = shadow?.querySelector('pre')
 
     const containerStyle = container instanceof HTMLElement ? window.getComputedStyle(container) : null
     const headerStyle = header instanceof HTMLElement ? window.getComputedStyle(header) : null
     const previewStyle = preview instanceof HTMLElement ? window.getComputedStyle(preview) : null
     const editorStyle = editorBackground instanceof HTMLElement ? window.getComputedStyle(editorBackground) : null
 
-    const visibleNativeCompactTexts = visibleTextElements('.diff-hidden-lines-compact .text')
-    const visibleNativeCenterTexts = Array.from(document.querySelectorAll('.diff-hidden-lines .center'))
+    const visibleUnmodifiedTexts = Array.from(shadow?.querySelectorAll('[data-unmodified-lines]') ?? [])
       .filter((node) => {
         if (!(node instanceof HTMLElement))
           return false
-        if (node.classList.contains('stream-monaco-clickable'))
-          return false
         const style = window.getComputedStyle(node)
+        const rect = node.getBoundingClientRect()
         return style.display !== 'none'
           && style.visibility !== 'hidden'
           && Number.parseFloat(style.opacity || '1') > 0.05
+          && rect.width > 0
+          && rect.height > 0
       })
       .map(node => (node instanceof HTMLElement ? node.textContent.trim() : ''))
       .filter(Boolean)
+    const fallback = container?.querySelector('pre.code-pre-fallback')
+    const fallbackStyle = fallback instanceof HTMLElement ? window.getComputedStyle(fallback) : null
+    const fallbackRect = fallback instanceof HTMLElement ? fallback.getBoundingClientRect() : null
 
     return {
       pageMode: document.documentElement.dataset.themeMode || '',
@@ -146,10 +135,13 @@ async function snapshot(page) {
       editorBg: editorStyle?.backgroundColor || '',
       rootClasses: diffRoot instanceof HTMLElement ? Array.from(diffRoot.classList) : [],
       isDarkClass: container instanceof HTMLElement ? container.classList.contains('is-dark') : false,
-      metadataLabels: Array.from(document.querySelectorAll('.stream-monaco-unchanged-metadata-label')).map(node => node.textContent?.trim() || ''),
-      visibleNativeCompactTexts,
-      visibleNativeCenterTexts,
-      visibleHiddenLinesInBody: /hidden lines/i.test(document.body.textContent || ''),
+      metadataLabels: visibleUnmodifiedTexts,
+      fallbackVisible: !!(fallbackRect
+        && fallbackRect.width > 0
+        && fallbackRect.height > 0
+        && fallbackStyle?.display !== 'none'
+        && fallbackStyle?.visibility !== 'hidden'),
+      visibleHiddenLinesInDiff: visibleUnmodifiedTexts.some(text => /hidden lines/i.test(text)),
     }
   })
 }
@@ -208,9 +200,10 @@ async function main() {
     await page.goto(`http://${host}:${port}/diff-theme-regression`, {
       waitUntil: 'networkidle',
     })
-    await page.waitForSelector('.monaco-diff-editor', { timeout: 30000 })
+    await page.waitForSelector('.code-block-container.is-diff[data-markstream-enhanced="true"][data-markstream-enhancement-state="ready"] .stream-diffs-shell', { timeout: 30000 })
     await page.waitForFunction(() => {
-      return Array.from(document.querySelectorAll('.stream-monaco-unchanged-metadata-label'))
+      const diffs = document.querySelector('.code-block-container.is-diff[data-markstream-enhanced="true"] diffs-container')
+      return Array.from(diffs?.shadowRoot?.querySelectorAll('[data-unmodified-lines]') ?? [])
         .some((node) => {
           if (!(node instanceof HTMLElement))
             return false
@@ -237,9 +230,7 @@ async function main() {
 
     const frames = [...toLight.frames, ...toDark.frames]
     const anyHiddenFlash = frames.some(frame =>
-      frame.visibleHiddenLinesInBody
-      || frame.visibleNativeCompactTexts.length > 0
-      || frame.visibleNativeCenterTexts.some(text => /hidden lines/i.test(text)),
+      frame.visibleHiddenLinesInDiff || frame.fallbackVisible,
     )
 
     const ok = (initialLum != null && initialLum < 90)
@@ -247,8 +238,8 @@ async function main() {
       && (darkLum != null && darkLum < 90)
       && initial.containerBg !== toLight.final.containerBg
       && toLight.final.containerBg !== toDark.final.containerBg
-      && toLight.final.rootClasses.includes('stream-monaco-diff-appearance-light')
-      && toDark.final.rootClasses.includes('stream-monaco-diff-appearance-dark')
+      && toLight.final.isDarkClass === false
+      && toDark.final.isDarkClass === true
       && !anyHiddenFlash
       && pageErrors.length === 0
       && consoleErrors.length === 0

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -600,7 +600,7 @@ function resolvePreFallbackDiffCollapse() {
   const minimumLineCount = Math.max(1, Math.floor(options.minimumLineCount ?? 4))
   return {
     contextLineCount,
-    collapsedContextThreshold: contextLineCount + minimumLineCount - 1,
+    collapsedContextThreshold: minimumLineCount - 1,
   }
 }
 function isHostScrollManagedCodeBlockElement(el?: HTMLElement | null) {
@@ -3728,7 +3728,7 @@ async function runEditorCreation(el: HTMLElement) {
       ? await waitForDiffEditorVisualReady({ requireHighlight: true })
       : await waitForSingleEditorVisualReady()
     : runtimeVisualReady
-  if (isUnmounted)
+  if (isUnmounted || desiredEditorKind.value !== creationKind || codeEditor.value !== el)
     return
   if (!diffVisualReady) {
     markEditorCreationFailed()
@@ -4520,7 +4520,11 @@ watch(
               syncDiffScrollFromFallback()
               syncInlineFoldProxies()
               refreshDiffStats()
-              const visualReady = await waitForDiffEditorVisualReady({ requireHighlight: true })
+              const localVisualReady = await waitForDiffEditorVisualReady({ requireHighlight: true })
+              const runtimeVisualReady = whenRuntimeVisualReady
+                ? await whenRuntimeVisualReady()
+                : true
+              const visualReady = localVisualReady && runtimeVisualReady
               if (!isUnmounted && visualReady && !editorDisplayReady.value)
                 await revealEditorDisplay()
               scheduleEditorHeightSync()

--- a/src/components/CodeBlockNode/monaco.ts
+++ b/src/components/CodeBlockNode/monaco.ts
@@ -76,6 +76,11 @@ export interface MonacoModule {
 let mod: MonacoModule | null = null
 let loadingPromise: Promise<MonacoModule | null> | null = null
 
+const runtimeLoaders = [
+  () => import('stream-diffs'),
+  () => import('stream-monaco'),
+]
+
 function normalizeMonacoModule(value: unknown): MonacoModule | null {
   const moduleValue = value as MonacoModule | undefined
   if (typeof moduleValue?.useMonaco === 'function')
@@ -96,14 +101,16 @@ export async function getUseMonaco(): Promise<MonacoModule | null> {
 
   loadingPromise = (async () => {
     if (!mod) {
-      try {
-        mod = normalizeMonacoModule(await import('stream-diffs'))
-        if (!mod)
-          return null
+      for (const load of runtimeLoaders) {
+        try {
+          mod = normalizeMonacoModule(await load())
+          if (mod)
+            break
+        }
+        catch {}
       }
-      catch {
+      if (!mod)
         return null
-      }
     }
 
     try {

--- a/test/optional-monaco.test.ts
+++ b/test/optional-monaco.test.ts
@@ -27,7 +27,7 @@ describe('optional stream-diffs dependency', () => {
     expect(result1).toBe(result2)
   })
 
-  it('treats an empty optional-peer stub as unavailable', async () => {
+  it('falls back to stream-monaco when stream-diffs is an empty optional-peer stub', async () => {
     vi.resetModules()
     vi.doMock('stream-diffs', () => ({
       default: {},
@@ -35,6 +35,8 @@ describe('optional stream-diffs dependency', () => {
 
     const { getUseMonaco } = await import('../src/components/CodeBlockNode/monaco')
 
-    await expect(getUseMonaco()).resolves.toBeNull()
+    await expect(getUseMonaco()).resolves.toMatchObject({
+      useMonaco: expect.any(Function),
+    })
   })
 })


### PR DESCRIPTION
## Summary
- reject stale Vue 3 editor creations before revealing their surface
- wait for the current runtime visual commit before removing the pre fallback
- align unchanged-region folding thresholds with the final Diffs surface
- fall back to stream-monaco when the optional stream-diffs runtime is unavailable

## Verification
- `pnpm typecheck`
- 50 targeted code-block tests
- `pnpm test:e2e:diff-folding`
- `pnpm test:e2e:diff-theme-switch`
- touched-file ESLint
