### PR TITLE
feat(react): add stable stream-diffs handoff

### DIFF
--- a/packages/markstream-react/README.md
+++ b/packages/markstream-react/README.md
@@ -12,6 +12,8 @@ pnpm add markstream-react
 
 Optional features are peer dependencies. Install only what your Markdown output needs.
 
+Install `stream-diffs` for enhanced File/FileDiff code blocks. While Markdown is streaming or offscreen, React keeps the stable `<pre>` fallback. After the fence closes and the block is visible, it creates one final highlighted surface and swaps only after the first stable frame. The runtime is disposed on unmount or code-block identity change.
+
 ## Quick Start
 
 Import one Markstream CSS file explicitly. The JavaScript entry does not inject styles automatically.

--- a/packages/markstream-react/package.json
+++ b/packages/markstream-react/package.json
@@ -101,6 +101,7 @@
     "mermaid": ">=11",
     "react": ">=18",
     "react-dom": ">=18",
+    "stream-diffs": ">=0.0.1",
     "stream-markdown": ">=0.0.16",
     "stream-monaco": ">=0.0.48"
   },
@@ -115,6 +116,9 @@
       "optional": true
     },
     "mermaid": {
+      "optional": true
+    },
+    "stream-diffs": {
       "optional": true
     },
     "stream-markdown": {

--- a/packages/markstream-react/scripts/rollup.dts.config.mjs
+++ b/packages/markstream-react/scripts/rollup.dts.config.mjs
@@ -33,7 +33,7 @@ const configs = entryNames.map((entryName) => {
       /^node:.*$/,
       /^react(?:\/.*)?$/,
       /^react-dom(?:\/.*)?$/,
-      /^(?:katex|mermaid|stream-monaco|stream-markdown)(?:\/.*)?$/,
+      /^(?:katex|mermaid|stream-diffs|stream-monaco|stream-markdown)(?:\/.*)?$/,
       /^stream-markdown-parser(?:\/.*)?$/,
       /^markstream-core(?:\/.*)?$/,
       /^@antv\/infographic(?:\/.*)?$/,

--- a/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
@@ -77,12 +77,12 @@ function readPositiveNumber(value: unknown): number | undefined {
 
 function readMonacoPadding(value: unknown) {
   if (!value || typeof value !== 'object')
-    return { top: 0, bottom: 0 }
+    return { top: 8, bottom: 8 }
 
   const raw = value as Record<string, unknown>
   return {
-    top: readPositiveNumber(raw.top) ?? 0,
-    bottom: readPositiveNumber(raw.bottom) ?? 0,
+    top: readPositiveNumber(raw.top) ?? 8,
+    bottom: readPositiveNumber(raw.bottom) ?? 8,
   }
 }
 
@@ -259,6 +259,33 @@ function shouldPreferPlainTextFallbackSurface(bg: string, fg: string, isPlainTex
     || (fgLuminance != null && fgLuminance > 190)
 }
 
+function hasRenderedEditorSurface(host: HTMLElement) {
+  const surface = host.querySelector<HTMLElement>('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')
+  if (!surface || !surface.firstElementChild)
+    return false
+  const rect = surface.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+async function waitForEditorVisualReady(host: HTMLElement, isCurrent: () => boolean) {
+  for (let frame = 0; frame < 120; frame += 1) {
+    if (!isCurrent())
+      return false
+    if (hasRenderedEditorSurface(host)) {
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+      return isCurrent() && hasRenderedEditorSurface(host)
+    }
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+  }
+  return false
+}
+
+function getEditorContentSignature(node: CodeBlockNodeProps['node'], language: string) {
+  return node.diff
+    ? `diff\0${language}\0${node.originalCode ?? ''}\0${node.updatedCode ?? node.code ?? ''}`
+    : `single\0${language}\0${node.code ?? ''}`
+}
+
 export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactEvents) {
   const props = { ...DEFAULTS, ...rawProps } as ResolvedProps & CodeBlockNodeReactEvents
   const {
@@ -298,6 +325,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
   const runtimeMonacoOptionsRef = useRef<Record<string, any> | null>(null)
   const structuralSignatureRef = useRef<string | null>(null)
   const editorHeightSyncDisposablesRef = useRef<any[]>([])
+  const editorHeightSyncRafRef = useRef<number | null>(null)
   const diffDomHeightObserverRef = useRef<MutationObserver | null>(null)
   const expandedRef = useRef(false)
 
@@ -313,6 +341,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
   const [collapsed, setCollapsed] = useState(false)
   const [inlinePreviewOpen, setInlinePreviewOpen] = useState(false)
   const [languageIconsRevision, setLanguageIconsRevision] = useState(0)
+  const shouldDelayEditor = loading || !viewportReady
 
   const { t } = useSafeI18n()
 
@@ -402,18 +431,22 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
 
   const scheduleEditorHeightSync = useCallback((nextExpanded: boolean) => {
     applyEditorHeight(nextExpanded)
-    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function')
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
       return
-
-    const first = window.requestAnimationFrame(() => {
+    }
+    if (editorHeightSyncRafRef.current != null)
+      return
+    editorHeightSyncRafRef.current = window.requestAnimationFrame(() => {
+      editorHeightSyncRafRef.current = null
       applyEditorHeight(nextExpanded)
-      window.requestAnimationFrame(() => applyEditorHeight(nextExpanded))
     })
-    window.setTimeout(() => applyEditorHeight(nextExpanded), 180)
-    return () => window.cancelAnimationFrame(first)
   }, [applyEditorHeight])
 
   const clearEditorHeightSyncBindings = useCallback(() => {
+    if (editorHeightSyncRafRef.current != null && typeof window !== 'undefined') {
+      window.cancelAnimationFrame(editorHeightSyncRafRef.current)
+      editorHeightSyncRafRef.current = null
+    }
     for (const disposable of editorHeightSyncDisposablesRef.current) {
       try {
         if (typeof disposable === 'function')
@@ -497,7 +530,6 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     }
     catch {}
     clearEditorHeightSyncBindings()
-    createEditorPromiseRef.current = null
     editorKindRef.current = null
     editorMountElRef.current = null
     setEditorReady(false)
@@ -637,25 +669,25 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
 
   const buildRuntimeMonacoOptions = useCallback(() => {
     const nextOptions = {
-      wordWrap: 'on',
+      wordWrap: 'off',
       wrappingIndent: 'same',
       themes,
       ...(resolvedMonacoOptions || {}),
+      stream: false,
       theme: requestedTheme,
+      disableFileHeader: true,
       ...(node.diff ? { diffAppearance: effectiveDiffAppearance } : {}),
       onThemeChange() {
         syncEditorCssVars()
       },
     } as Record<string, any>
 
-    if (node.diff) {
-      nextOptions.fontSize ??= preFallbackMetrics.fontSize
-      nextOptions.lineHeight ??= preFallbackMetrics.lineHeight
-      nextOptions.padding ??= { top: preFallbackMetrics.paddingTop, bottom: preFallbackMetrics.paddingBottom }
-      nextOptions.tabSize ??= preFallbackMetrics.tabSize
-      if (preFallbackMetrics.fontFamily)
-        nextOptions.fontFamily ??= preFallbackMetrics.fontFamily
-    }
+    nextOptions.fontSize ??= preFallbackMetrics.fontSize
+    nextOptions.lineHeight ??= preFallbackMetrics.lineHeight
+    nextOptions.padding ??= { top: preFallbackMetrics.paddingTop, bottom: preFallbackMetrics.paddingBottom }
+    nextOptions.tabSize ??= preFallbackMetrics.tabSize
+    if (preFallbackMetrics.fontFamily)
+      nextOptions.fontFamily ??= preFallbackMetrics.fontFamily
 
     return nextOptions
   }, [effectiveDiffAppearance, node.diff, preFallbackMetrics, requestedTheme, resolvedMonacoOptions, syncEditorCssVars, themes])
@@ -734,6 +766,11 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
         mounted = false
       }
     }
+    if (shouldDelayEditor) {
+      return () => {
+        mounted = false
+      }
+    }
     if (helpersRef.current) {
       syncRuntimeMonacoOptions()
       return () => {
@@ -774,7 +811,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     return () => {
       mounted = false
     }
-  }, [syncRuntimeMonacoOptions])
+  }, [shouldDelayEditor, syncRuntimeMonacoOptions])
 
   // Vue parity: if language is not provided, detect it from streaming code.
   useEffect(() => {
@@ -797,6 +834,8 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
   }, [codeLanguage, detectedLanguage, node.language])
   const canonicalLanguage = useMemo(() => normalizeLanguageIdentifier(rawLanguage), [rawLanguage])
   const monacoLanguage = useMemo(() => resolveMonacoLanguageId(canonicalLanguage), [canonicalLanguage])
+  const latestMonacoLanguageRef = useRef(monacoLanguage)
+  latestMonacoLanguageRef.current = monacoLanguage
   const isPlainTextLanguage = useMemo(() => monacoLanguage === 'plaintext', [monacoLanguage])
   const languageIcon = useMemo(
     () => getLanguageIcon(canonicalLanguage),
@@ -854,8 +893,6 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
       backgroundColor: `var(--vscode-editor-background, ${resolvedSurfaceIsDark ? '#111827' : '#ffffff'})`,
     }
   }, [node.diff, resolvedSurfaceIsDark])
-
-  const shouldDelayEditor = stream === false && loading
 
   // Vue parity: keep theme in sync without recreating Monaco.
   useEffect(() => {
@@ -926,6 +963,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     syncRuntimeMonacoOptions()
 
     const currentNode = latestNodeRef.current
+    let renderedSignature = getEditorContentSignature(currentNode, monacoLanguage)
     const desiredKind: 'diff' | 'single' = currentNode.diff ? 'diff' : 'single'
     const attachedEl = editorMountElRef.current
     const hasExpectedView = desiredKind === 'diff'
@@ -985,11 +1023,46 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
           catch {}
         }
 
-        bindDiffEditorHeightSync()
-        syncEditorCssVars()
-        if (!expanded && !collapsed)
-          scheduleEditorHeightSync(false)
-        setEditorReady(true)
+        while (editorLifecycleIdRef.current === creationId) {
+          const latestNode = latestNodeRef.current
+          const latestLanguage = latestMonacoLanguageRef.current
+          const latestKind = latestNode.diff ? 'diff' : 'single'
+          if (latestKind !== desiredKind)
+            return
+
+          const latestSignature = getEditorContentSignature(latestNode, latestLanguage)
+          if (latestSignature !== renderedSignature) {
+            if (latestNode.diff && helpers.updateDiff) {
+              await Promise.resolve(helpers.updateDiff(
+                String(latestNode.originalCode ?? ''),
+                String(latestNode.updatedCode ?? latestNode.code ?? ''),
+                latestLanguage,
+              ))
+            }
+            else if (helpers.updateCode) {
+              await Promise.resolve(helpers.updateCode(String(latestNode.code ?? ''), latestLanguage))
+            }
+            renderedSignature = latestSignature
+          }
+
+          bindDiffEditorHeightSync()
+          syncEditorCssVars()
+          if (!expanded && !collapsed)
+            scheduleEditorHeightSync(false)
+          const visualReady = await waitForEditorVisualReady(
+            el,
+            () => editorLifecycleIdRef.current === creationId,
+          )
+          const runtimeReady = typeof helpers.whenVisualReady === 'function'
+            ? await helpers.whenVisualReady()
+            : true
+          if (!visualReady || !runtimeReady || editorLifecycleIdRef.current !== creationId)
+            throw new Error('Editor surface did not paint')
+          if (renderedSignature !== getEditorContentSignature(latestNodeRef.current, latestMonacoLanguageRef.current))
+            continue
+          setEditorReady(true)
+          return
+        }
       }
       catch {
         if (editorLifecycleIdRef.current === creationId)
@@ -1024,6 +1097,10 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     let cancelled = false
     void (async () => {
       resetEditorInstance()
+      try {
+        await createEditorPromiseRef.current
+      }
+      catch {}
       if (cancelled)
         return
       try {
@@ -1059,7 +1136,13 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
       resetEditorInstance()
       return
     }
-    void ensureEditorCreation()
+    void (async () => {
+      try {
+        await createEditorPromiseRef.current
+      }
+      catch {}
+      await ensureEditorCreation()
+    })()
   }, [collapsed, ensureEditorCreation, monacoReady, resetEditorInstance, shouldDelayEditor, useFallback, viewportReady])
 
   useEffect(() => {
@@ -1103,6 +1186,10 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
           }
           catch {}
         }
+        try {
+          await Promise.resolve(ensureEditorCreation())
+        }
+        catch {}
       }
 
       try {
@@ -1238,9 +1325,10 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     return (
       <PreCodeNode
         className="code-fallback-plain m-0"
+        diffHideUnchangedRegions={(resolvedMonacoOptions as any)?.diffHideUnchangedRegions ?? true}
         diffInline={preFallbackDiffInline}
         node={node as any}
-        showLineNumbers={Boolean(node.diff)}
+        showLineNumbers={true}
         style={preFallbackStyle}
       />
     )
@@ -1500,8 +1588,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
                 <div className="code-editor-layer">
                   <div
                     ref={editorHostRef}
-                    className={`code-editor-container${stream ? '' : ' code-height-placeholder'}`}
-                    style={{ visibility: editorReady ? 'visible' : 'hidden' }}
+                    className={`code-editor-container${stream ? '' : ' code-height-placeholder'}${editorReady ? '' : ' is-staging'}`}
                     aria-hidden={!editorReady}
                   />
                   {!editorReady && (
@@ -1510,9 +1597,10 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
                     >
                       <PreCodeNode
                         className="code-fallback-plain m-0"
+                        diffHideUnchangedRegions={(resolvedMonacoOptions as any)?.diffHideUnchangedRegions ?? true}
                         diffInline={preFallbackDiffInline}
                         node={node as any}
-                        showLineNumbers={Boolean(node.diff)}
+                        showLineNumbers={true}
                         style={preFallbackStyle}
                       />
                     </div>

--- a/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
@@ -1,316 +1,44 @@
 import type { PreCodeNodeProps } from '../../types/component-props'
+import { buildDiffPreviewPanes } from 'markstream-core'
 import React, { useMemo } from 'react'
 
-type DiffPreviewLineKind = 'context' | 'removed' | 'added' | 'hunk'
-
-interface DiffPreviewLine {
-  code: string
-  empty: boolean
-  kind: DiffPreviewLineKind
-  key: string
-  number: number | string
-}
-
-interface DiffPreviewPane {
-  className: string
-  key: string
-  lines: DiffPreviewLine[]
-}
-
 function normalizeLanguage(raw: unknown) {
-  const head = String(String(raw ?? '').split(/\s+/g)[0] ?? '')
-    .split(':')[0]
-    .toLowerCase()
-  const safe = head.replace(/[^\w-]/g, '')
-  return safe || 'plaintext'
-}
-
-function splitLines(source: unknown) {
-  return String(source ?? '').split(/\r\n|\n|\r/)
-}
-
-function splitDiffSource(source: unknown) {
-  const code = String(source ?? '')
-  if (!code)
-    return []
-  return code.split(/\r\n|\n|\r/)
-}
-
-function isRemovedDiffLine(line: string) {
-  return line.startsWith('-') && !line.startsWith('---')
-}
-
-function isAddedDiffLine(line: string) {
-  return line.startsWith('+') && !line.startsWith('+++')
-}
-
-function isExplicitDiffLanguage(node: PreCodeNodeProps['node'], normalizedLanguage: string) {
-  if (normalizedLanguage === 'diff')
-    return true
-
-  const firstLine = String((node as any)?.raw ?? '').split(/\r?\n/, 1)[0]?.trim() ?? ''
-  return /^`{3,}\s*diff(?:\s|$)|^~{3,}\s*diff(?:\s|$)/.test(firstLine)
-}
-
-function hasPatchLines(lines: string[], node: PreCodeNodeProps['node'], normalizedLanguage: string) {
-  const hasRemoved = lines.some(line => isRemovedDiffLine(line))
-  const hasAdded = lines.some(line => isAddedDiffLine(line))
-  return (hasRemoved && hasAdded)
-    || (isExplicitDiffLanguage(node, normalizedLanguage) && (hasRemoved || hasAdded))
-}
-
-function hasDiffSourcePair(node: PreCodeNodeProps['node']) {
-  return (node as any)?.originalCode != null || (node as any)?.updatedCode != null
-}
-
-function isBlankDiffLine(code: string) {
-  return String(code ?? '').trim().length === 0
-}
-
-function shouldPreserveSourceBlankDiffKind(lines: string[], index: number) {
-  return !isBlankDiffLine(lines[index]) || index < lines.length - 1
-}
-
-function toDiffLine(
-  code: string,
-  kind: DiffPreviewLineKind,
-  key: string,
-  number: number | string,
-  options: { preserveBlankKind?: boolean } = {},
-): DiffPreviewLine {
-  const empty = String(code ?? '').trim().length === 0
-  return {
-    code,
-    empty,
-    kind: empty && kind !== 'hunk' && !options.preserveBlankKind ? 'context' : kind,
-    key,
-    number,
-  }
-}
-
-function computeSourceLineMatches(original: string[], modified: string[]) {
-  const n = original.length
-  const m = modified.length
-  const maxCells = 1_500_000
-  if ((n + 1) * (m + 1) > maxCells)
-    return null
-
-  const cols = m + 1
-  const scores = new Uint16Array((n + 1) * (m + 1))
-
-  for (let i = n - 1; i >= 0; i--) {
-    for (let j = m - 1; j >= 0; j--) {
-      const current = i * cols + j
-      if (original[i] === modified[j]) {
-        scores[current] = scores[(i + 1) * cols + j + 1] + 1
-      }
-      else {
-        scores[current] = Math.max(scores[(i + 1) * cols + j], scores[i * cols + j + 1])
-      }
-    }
-  }
-
-  const matches: Array<{ originalIndex: number, modifiedIndex: number }> = []
-  let i = 0
-  let j = 0
-  while (i < n && j < m) {
-    if (original[i] === modified[j]) {
-      matches.push({ originalIndex: i, modifiedIndex: j })
-      i++
-      j++
-    }
-    else if (scores[(i + 1) * cols + j] >= scores[i * cols + j + 1]) {
-      i++
-    }
-    else {
-      j++
-    }
-  }
-
-  return matches
-}
-
-function buildInlinePatchPreviewLines(lines: string[]) {
-  let modifiedLine = 1
-  return lines.map((raw, index) => {
-    if (raw.startsWith('@@'))
-      return toDiffLine(raw, 'hunk', `inline-hunk-${index}`, '')
-    if (isRemovedDiffLine(raw)) {
-      const line = toDiffLine(raw.slice(1), 'removed', `inline-removed-${index}`, '', { preserveBlankKind: true })
-      return line
-    }
-    if (isAddedDiffLine(raw))
-      return toDiffLine(raw.slice(1), 'added', `inline-added-${index}`, modifiedLine++, { preserveBlankKind: true })
-
-    const code = raw.startsWith(' ') ? raw.slice(1) : raw
-    return toDiffLine(code, 'context', `inline-context-${index}`, modifiedLine++)
-  })
-}
-
-function buildInlineSourcePreviewLines(originalSource: unknown, modifiedSource: unknown) {
-  const original = splitDiffSource(originalSource)
-  const modified = splitDiffSource(modifiedSource)
-  const matches = computeSourceLineMatches(original, modified)
-
-  if (matches) {
-    const result: DiffPreviewLine[] = []
-    let originalIndex = 0
-    let modifiedIndex = 0
-
-    for (const match of matches) {
-      while (originalIndex < match.originalIndex) {
-        result.push(toDiffLine(original[originalIndex], 'removed', `inline-removed-source-${originalIndex}`, '', {
-          preserveBlankKind: shouldPreserveSourceBlankDiffKind(original, originalIndex),
-        }))
-        originalIndex++
-      }
-      while (modifiedIndex < match.modifiedIndex) {
-        result.push(toDiffLine(modified[modifiedIndex], 'added', `inline-added-source-${modifiedIndex}`, modifiedIndex + 1, {
-          preserveBlankKind: shouldPreserveSourceBlankDiffKind(modified, modifiedIndex),
-        }))
-        modifiedIndex++
-      }
-      result.push(toDiffLine(modified[match.modifiedIndex], 'context', `inline-context-source-${match.originalIndex}-${match.modifiedIndex}`, match.modifiedIndex + 1))
-      originalIndex = match.originalIndex + 1
-      modifiedIndex = match.modifiedIndex + 1
-    }
-
-    while (originalIndex < original.length) {
-      result.push(toDiffLine(original[originalIndex], 'removed', `inline-removed-source-${originalIndex}`, '', {
-        preserveBlankKind: shouldPreserveSourceBlankDiffKind(original, originalIndex),
-      }))
-      originalIndex++
-    }
-    while (modifiedIndex < modified.length) {
-      result.push(toDiffLine(modified[modifiedIndex], 'added', `inline-added-source-${modifiedIndex}`, modifiedIndex + 1, {
-        preserveBlankKind: shouldPreserveSourceBlankDiffKind(modified, modifiedIndex),
-      }))
-      modifiedIndex++
-    }
-
-    return result
-  }
-
-  const result: DiffPreviewLine[] = []
-  let start = 0
-  let originalEnd = original.length - 1
-  let modifiedEnd = modified.length - 1
-
-  while (start <= originalEnd && start <= modifiedEnd && original[start] === modified[start]) {
-    result.push(toDiffLine(modified[start], 'context', `inline-prefix-${start}`, start + 1))
-    start++
-  }
-
-  const suffix: DiffPreviewLine[] = []
-  while (originalEnd >= start && modifiedEnd >= start && original[originalEnd] === modified[modifiedEnd]) {
-    suffix.unshift(toDiffLine(modified[modifiedEnd], 'context', `inline-suffix-${modifiedEnd}`, modifiedEnd + 1))
-    originalEnd--
-    modifiedEnd--
-  }
-
-  for (let index = start; index <= originalEnd; index++) {
-    result.push(toDiffLine(original[index], 'removed', `inline-removed-source-${index}`, '', {
-      preserveBlankKind: shouldPreserveSourceBlankDiffKind(original, index),
-    }))
-  }
-
-  for (let index = start; index <= modifiedEnd; index++) {
-    result.push(toDiffLine(modified[index], 'added', `inline-added-source-${index}`, index + 1, {
-      preserveBlankKind: shouldPreserveSourceBlankDiffKind(modified, index),
-    }))
-  }
-
-  return result.concat(suffix)
-}
-
-function buildDiffPanes(
-  node: PreCodeNodeProps['node'],
-  inline = false,
-  normalizedLanguage = normalizeLanguage((node as any)?.language),
-): DiffPreviewPane[] {
-  const patchLines = splitLines((node as any)?.code)
-  const hasPatchDiffLines = hasPatchLines(patchLines, node, normalizedLanguage)
-
-  if (!hasPatchDiffLines && hasDiffSourcePair(node)) {
-    if (inline) {
-      const lines = buildInlineSourcePreviewLines((node as any)?.originalCode, (node as any)?.updatedCode)
-      return [{ key: 'inline', className: 'markstream-pre__diff-pane--inline', lines }]
-    }
-
-    const original = splitDiffSource((node as any)?.originalCode)
-    const modified = splitDiffSource((node as any)?.updatedCode)
-    return [
-      {
-        key: 'original',
-        className: 'markstream-pre__diff-pane--original',
-        lines: original.map((line, index) => {
-          const kind = modified[index] === line ? 'context' : 'removed'
-          return toDiffLine(line, kind, `original-${index}`, index + 1, {
-            preserveBlankKind: shouldPreserveSourceBlankDiffKind(original, index),
-          })
-        }),
-      },
-      {
-        key: 'modified',
-        className: 'markstream-pre__diff-pane--modified',
-        lines: modified.map((line, index) => {
-          const kind = original[index] === line ? 'context' : 'added'
-          return toDiffLine(line, kind, `modified-${index}`, index + 1, {
-            preserveBlankKind: shouldPreserveSourceBlankDiffKind(modified, index),
-          })
-        }),
-      },
-    ]
-  }
-
-  if (inline) {
-    const lines = buildInlinePatchPreviewLines(patchLines)
-    return [{ key: 'inline', className: 'markstream-pre__diff-pane--inline', lines }]
-  }
-
-  const original: DiffPreviewLine[] = []
-  const modified: DiffPreviewLine[] = []
-  let originalLine = 1
-  let modifiedLine = 1
-
-  for (const [index, raw] of patchLines.entries()) {
-    if (raw.startsWith('@@')) {
-      original.push(toDiffLine(raw, 'hunk', `original-hunk-${index}`, ''))
-      modified.push(toDiffLine(raw, 'hunk', `modified-hunk-${index}`, ''))
-    }
-    else if (isRemovedDiffLine(raw)) {
-      original.push(toDiffLine(raw.slice(1), 'removed', `original-removed-${index}`, originalLine++, { preserveBlankKind: true }))
-    }
-    else if (isAddedDiffLine(raw)) {
-      modified.push(toDiffLine(raw.slice(1), 'added', `modified-added-${index}`, modifiedLine++, { preserveBlankKind: true }))
-    }
-    else {
-      const code = raw.startsWith(' ') ? raw.slice(1) : raw
-      original.push(toDiffLine(code, 'context', `original-context-${index}`, originalLine++))
-      modified.push(toDiffLine(code, 'context', `modified-context-${index}`, modifiedLine++))
-    }
-  }
-
-  return [
-    { key: 'original', className: 'markstream-pre__diff-pane--original', lines: original },
-    { key: 'modified', className: 'markstream-pre__diff-pane--modified', lines: modified },
-  ]
+  const head = String(raw ?? '').split(/\s+/g)[0]?.split(':')[0]?.toLowerCase() ?? ''
+  return head.replace(/[^\w-]/g, '') || 'plaintext'
 }
 
 function getDisplayCode(node: PreCodeNodeProps['node']) {
-  if ((node as any)?.diff === true)
-    return String((node as any)?.code ?? '')
   const value = String((node as any)?.code ?? '')
   return (node as any)?.loading === true ? value : value.replace(/\r\n$|\n$|\r$/, '')
 }
 
-export function PreCodeNode({ node, className, diffInline, showLineNumbers, style }: PreCodeNodeProps) {
+export function PreCodeNode({
+  node,
+  className,
+  diffHideUnchangedRegions,
+  diffInline,
+  showLineNumbers,
+  style,
+}: PreCodeNodeProps) {
   const normalizedLanguage = useMemo(() => normalizeLanguage((node as any)?.language), [node])
   const languageClass = `language-${normalizedLanguage}`
   const ariaLabel = normalizedLanguage ? `Code block: ${normalizedLanguage}` : 'Code block'
   const isDiffPreview = showLineNumbers === true && (node as any)?.diff === true
-  const diffPanes = useMemo(() => isDiffPreview ? buildDiffPanes(node, diffInline === true, normalizedLanguage) : [], [diffInline, isDiffPreview, node, normalizedLanguage])
   const displayCode = useMemo(() => getDisplayCode(node), [node])
+  const lineNumbers = useMemo(() => displayCode.split(/\r\n|\n|\r/).map((_, index) => index + 1).join('\n'), [displayCode])
+  const diffPanes = useMemo(() => isDiffPreview
+    ? buildDiffPreviewPanes({
+        code: (node as any)?.code,
+        hideUnchangedRegions: diffHideUnchangedRegions,
+        inline: diffInline === true,
+        language: (node as any)?.language,
+        loading: (node as any)?.loading === true,
+        originalCode: (node as any)?.originalCode,
+        raw: (node as any)?.raw,
+        updatedCode: (node as any)?.updatedCode,
+      })
+    : [], [diffHideUnchangedRegions, diffInline, isDiffPreview, node])
+  const hasCollapsedRows = diffPanes.some(pane => pane.lines.some(line => line.kind === 'collapsed'))
 
   return (
     <pre
@@ -320,6 +48,7 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
         showLineNumbers ? 'markstream-pre--line-numbers' : '',
         isDiffPreview ? 'markstream-pre--diff-preview' : '',
         isDiffPreview && diffInline ? 'markstream-pre--diff-inline' : '',
+        hasCollapsedRows ? 'markstream-pre--diff-collapsed' : '',
       ].filter(Boolean).join(' ')}
       style={style}
       aria-busy={(node as any)?.loading === true}
@@ -334,20 +63,31 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
             <code translate="no" className="markstream-pre__diff-code">
               {diffPanes.map(pane => (
                 <span key={pane.key} className={['markstream-pre__diff-pane', pane.className].join(' ')}>
-                  {pane.lines.map(line => (
-                    <span key={line.key} className={['markstream-pre__diff-line', `markstream-pre__diff-line--${line.kind}`, line.empty ? 'markstream-pre__diff-line--empty' : ''].filter(Boolean).join(' ')}>
-                      <span className="markstream-pre__diff-rail" aria-hidden="true" />
-                      <span className="markstream-pre__diff-number" aria-hidden="true">{line.number}</span>
-                      <span className="markstream-pre__diff-content">
-                        <span className="markstream-pre__diff-content-inner">{line.code}</span>
+                  <span className="markstream-pre__diff-pane-content">
+                    {pane.lines.map(line => (
+                      <span key={line.key} className={['markstream-pre__diff-line', `markstream-pre__diff-line--${line.kind}`, line.empty ? 'markstream-pre__diff-line--empty' : ''].filter(Boolean).join(' ')}>
+                        <span className="markstream-pre__diff-rail" aria-hidden="true" />
+                        <span className="markstream-pre__diff-number" aria-hidden="true">{line.number}</span>
+                        <span className="markstream-pre__diff-content">
+                          <span className="markstream-pre__diff-content-inner">{line.code}</span>
+                        </span>
                       </span>
-                    </span>
-                  ))}
+                    ))}
+                  </span>
                 </span>
               ))}
             </code>
           )
-        : <code translate="no">{displayCode}</code>}
+        : (
+            <>
+              {showLineNumbers && (
+                <span className="markstream-pre__line-numbers" aria-hidden="true">
+                  <span className="markstream-pre__line-numbers-text">{lineNumbers}</span>
+                </span>
+              )}
+              <code translate="no" className="markstream-pre__code">{displayCode}</code>
+            </>
+          )}
     </pre>
   )
 }

--- a/packages/markstream-react/src/components/CodeBlockNode/monaco.ts
+++ b/packages/markstream-react/src/components/CodeBlockNode/monaco.ts
@@ -3,18 +3,35 @@ import { preload } from '../NodeRenderer/preloadMonaco'
 let mod: any = null
 let importAttempted = false
 
+const runtimeLoaders = [
+  () => import('stream-diffs'),
+  () => import('stream-monaco'),
+]
+
+function normalizeRuntimeModule(imported: any) {
+  if (typeof imported?.useMonaco === 'function')
+    return imported
+  return typeof imported?.default?.useMonaco === 'function' ? imported.default : null
+}
+
 export async function getUseMonaco() {
   if (mod)
     return mod
   if (importAttempted)
     return null
-  try {
-    mod = await import('stream-monaco')
-    await preload(mod)
-    return mod
+  for (const load of runtimeLoaders) {
+    try {
+      const imported = await load()
+      const candidate = normalizeRuntimeModule(imported)
+      if (!candidate)
+        continue
+      await preload(candidate)
+      mod = candidate
+      return mod
+    }
+    catch {}
   }
-  catch {
-    importAttempted = true
-    return null
-  }
+
+  importAttempted = true
+  return null
 }

--- a/packages/markstream-react/src/components/CodeBlockNode/monacoThemeScheduler.ts
+++ b/packages/markstream-react/src/components/CodeBlockNode/monacoThemeScheduler.ts
@@ -1,13 +1,15 @@
 type MonacoTheme = any
 type SetThemeFn = (theme: MonacoTheme, force?: boolean) => Promise<void> | void
 
-let setThemeImpl: SetThemeFn | null = null
-let applying = false
-let inFlight: Promise<void> | null = null
-let inFlightKey: string | null = null
-let pendingTheme: MonacoTheme | null = null
-let pendingKey: string | null = null
-let lastAppliedKey: string | null = null
+interface ThemeQueue {
+  inFlight: Promise<void> | null
+  inFlightKey: string | null
+  pendingTheme: MonacoTheme | null
+  pendingKey: string | null
+  lastAppliedKey: string | null
+}
+
+const queues = new WeakMap<SetThemeFn, ThemeQueue>()
 
 const themeKeyCache = new WeakMap<object, string>()
 let themeKeySeq = 0
@@ -43,45 +45,49 @@ export function scheduleMonacoThemeUpdate(theme: MonacoTheme, setTheme: SetTheme
   if (!key)
     return Promise.resolve()
 
-  if (setThemeImpl !== setTheme)
-    setThemeImpl = setTheme
+  let queue = queues.get(setTheme)
+  if (!queue) {
+    queue = {
+      inFlight: null,
+      inFlightKey: null,
+      pendingTheme: null,
+      pendingKey: null,
+      lastAppliedKey: null,
+    }
+    queues.set(setTheme, queue)
+  }
 
-  if (!applying && lastAppliedKey === key)
+  if (!queue.inFlight && queue.lastAppliedKey === key)
     return Promise.resolve()
 
-  if (inFlight && (pendingKey === key || inFlightKey === key))
-    return inFlight
+  if (queue.inFlight && (queue.pendingKey === key || queue.inFlightKey === key))
+    return queue.inFlight
 
-  pendingTheme = theme
-  pendingKey = key
+  queue.pendingTheme = theme
+  queue.pendingKey = key
 
-  if (inFlight)
-    return inFlight
+  if (queue.inFlight)
+    return queue.inFlight
 
-  applying = true
-  inFlight = (async () => {
-    while (pendingTheme != null && pendingKey != null) {
-      const nextTheme = pendingTheme
-      const nextKey = pendingKey
-      pendingTheme = null
-      pendingKey = null
-      if (lastAppliedKey === nextKey)
+  queue.inFlight = (async () => {
+    while (queue.pendingTheme != null && queue.pendingKey != null) {
+      const nextTheme = queue.pendingTheme
+      const nextKey = queue.pendingKey
+      queue.pendingTheme = null
+      queue.pendingKey = null
+      if (queue.lastAppliedKey === nextKey)
         continue
-      const impl = setThemeImpl
-      if (!impl)
-        break
       try {
-        inFlightKey = nextKey
-        await Promise.resolve(impl(nextTheme))
-        lastAppliedKey = nextKey
+        queue.inFlightKey = nextKey
+        await Promise.resolve(setTheme(nextTheme))
+        queue.lastAppliedKey = nextKey
       }
       catch {}
     }
   })().finally(() => {
-    applying = false
-    inFlight = null
-    inFlightKey = null
+    queue.inFlight = null
+    queue.inFlightKey = null
   })
 
-  return inFlight
+  return queue.inFlight
 }

--- a/packages/markstream-react/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.tsx
+++ b/packages/markstream-react/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.tsx
@@ -546,7 +546,7 @@ export function MarkdownCodeBlockNode(rawProps: MarkdownCodeBlockNodeProps) {
     const rawLang = props.node.language
     const registrationInput = registrationInputRef.current
 
-    if (!viewportReady) {
+    if (props.loading || !viewportReady) {
       renderFallback(code)
       return
     }
@@ -612,7 +612,6 @@ export function MarkdownCodeBlockNode(rawProps: MarkdownCodeBlockNodeProps) {
         langs: currentRegistrationConfig.rendererOptions.langs,
       })
       rendererConfigKeyRef.current = key
-      setRendererReady(true)
     }
 
     if (!rendererRef.current) {
@@ -1033,10 +1032,17 @@ export function MarkdownCodeBlockNode(rawProps: MarkdownCodeBlockNodeProps) {
             overflowX: 'auto',
           }}
         >
-          <div ref={rendererTargetRef} className="code-block-render" />
-          {!rendererReady && fallbackHtml && (
-            <div className="code-fallback-plain" dangerouslySetInnerHTML={{ __html: fallbackHtml }} />
-          )}
+          <div className="code-block-render-layer">
+            <div
+              ref={rendererTargetRef}
+              className={`code-block-render${rendererReady ? '' : ' is-staging'}`}
+              style={{ visibility: rendererReady ? 'visible' : 'hidden' }}
+              aria-hidden={!rendererReady}
+            />
+            {!rendererReady && fallbackHtml && (
+              <div className="code-fallback-plain" dangerouslySetInnerHTML={{ __html: fallbackHtml }} />
+            )}
+          </div>
         </div>
       )}
 

--- a/packages/markstream-react/src/components/NodeRenderer/preloadMonaco.ts
+++ b/packages/markstream-react/src/components/NodeRenderer/preloadMonaco.ts
@@ -1,12 +1,25 @@
 let isPreloaded = false
+let preloadPromise: Promise<void> | null = null
 
 export async function preload(mod: any) {
   if (isPreloaded)
     return
-  isPreloaded = true
-  const existingEnv = (globalThis as any)?.MonacoEnvironment
-  if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function'))
-    return
-  if (mod?.preloadMonacoWorkers)
-    await mod.preloadMonacoWorkers()
+  if (preloadPromise)
+    return preloadPromise
+
+  const pending = (async () => {
+    const existingEnv = (globalThis as any)?.MonacoEnvironment
+    if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function')) {
+      isPreloaded = true
+      return
+    }
+    if (typeof mod?.preloadMonacoWorkers === 'function')
+      await mod.preloadMonacoWorkers()
+    isPreloaded = true
+  })()
+
+  preloadPromise = pending.finally(() => {
+    preloadPromise = null
+  })
+  return preloadPromise
 }

--- a/packages/markstream-react/src/index.css
+++ b/packages/markstream-react/src/index.css
@@ -1246,6 +1246,18 @@
 :where(.markstream-react) .code-editor-layer {
   display: grid;
   min-width: 0;
+  position: relative;
+}
+
+:where(.markstream-react) .code-block-render-layer {
+  display: grid;
+  min-width: 0;
+  position: relative;
+}
+
+:where(.markstream-react) .code-block-render-layer > .code-block-render,
+:where(.markstream-react) .code-block-render-layer > .code-fallback-plain {
+  grid-area: 1 / 1;
 }
 
 :where(.markstream-react) .code-editor-layer > .code-editor-container,
@@ -1253,9 +1265,17 @@
   grid-area: 1 / 1;
 }
 
+:where(.markstream-react) .code-editor-layer > .code-editor-container.is-staging {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 :where(.markstream-react) .code-editor-fallback-surface {
   overflow: auto;
-  padding: 1rem;
+  padding: 0;
 }
 
 :where(.markstream-react) .code-block-container.is-diff .code-editor-fallback-surface {
@@ -1428,6 +1448,12 @@
   min-height: 1px;
 }
 
+:where(.markstream-react) .code-block-render.is-staging {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+}
+
 :where(.markstream-react) .code-block-render pre,
 :where(.markstream-react) .code-block-content .shiki {
   margin: 0;
@@ -1450,6 +1476,9 @@
 :where(.markstream-react) .code-fallback-plain {
   position: relative;
   z-index: 1;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0;
   white-space: pre;
   overflow: auto;
   background: var(--vscode-editor-background, var(--markstream-code-fallback-bg));
@@ -1458,6 +1487,53 @@
   line-height: inherit;
   font-family: inherit;
   font-weight: var(--vscode-editor-font-weight, 400);
+}
+
+:where(.markstream-react) .code-fallback-plain.markstream-pre--line-numbers {
+  --markstream-pre-line-number-width: 2ch;
+  --markstream-pre-line-number-padding-left: 2ch;
+  --markstream-pre-line-number-padding-right: 1ch;
+  --markstream-pre-line-number-separator-width: 2px;
+  --markstream-pre-line-number-box-width: calc(
+    var(--markstream-pre-line-number-padding-left)
+    + var(--markstream-pre-line-number-width)
+    + var(--markstream-pre-line-number-padding-right)
+    + var(--markstream-pre-line-number-separator-width)
+  );
+  --markstream-pre-code-left: calc(var(--markstream-pre-line-number-box-width) + 1ch);
+}
+
+:where(.markstream-react) .code-fallback-plain > .markstream-pre__line-numbers {
+  position: absolute;
+  top: var(--markstream-pre-line-number-top, 8px);
+  left: 0;
+  box-sizing: content-box;
+  width: var(--markstream-pre-line-number-width);
+  min-width: var(--markstream-pre-line-number-width);
+  padding-left: var(--markstream-pre-line-number-padding-left);
+  padding-right: var(--markstream-pre-line-number-padding-right);
+  border-right: var(--markstream-pre-line-number-separator-width) solid var(--markstream-diff-gutter-guide, rgb(148 163 184 / 0.18));
+  color: var(--stream-monaco-line-number, var(--markstream-diff-line-number, #6b7280));
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  text-align: right;
+  pointer-events: none;
+  user-select: none;
+}
+
+:where(.markstream-react) .code-fallback-plain > .markstream-pre__line-numbers > .markstream-pre__line-numbers-text {
+  display: block;
+  white-space: pre;
+}
+
+:where(.markstream-react) .code-fallback-plain:not(.markstream-pre--diff-preview) > .markstream-pre__code {
+  display: block;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
+  padding-left: var(--markstream-pre-code-left);
+  padding-right: 1ch;
 }
 
 :where(.markstream-react) .code-fallback-plain > code {
@@ -1497,10 +1573,17 @@
   );
   --markstream-pre-diff-line-number-width: var(
     --stream-monaco-line-number-width,
-    39px
+    2ch
   );
   --markstream-pre-diff-line-number-padding-left: var(--stream-monaco-line-number-padding-left, 15.6px);
   --markstream-pre-diff-line-number-padding-right: var(--stream-monaco-line-number-padding-right, 7.8px);
+  --markstream-pre-diff-line-number-separator-width: var(--stream-monaco-line-number-separator-width, 2px);
+  --markstream-pre-diff-line-number-box-width: calc(
+    var(--markstream-pre-diff-line-number-padding-left)
+    + var(--markstream-pre-diff-line-number-width)
+    + var(--markstream-pre-diff-line-number-padding-right)
+    + var(--markstream-pre-diff-line-number-separator-width)
+  );
   --markstream-pre-diff-line-number-gap-to-code: var(
     --stream-monaco-original-line-number-gap-to-code,
     var(--stream-monaco-line-number-gap-to-code, var(--markstream-pre-diff-code-gap))
@@ -1516,7 +1599,7 @@
   --markstream-pre-diff-line-number-align: var(--markstream-diff-line-number-align, right);
   --markstream-pre-diff-code-fill-left: calc(
     var(--markstream-pre-diff-line-number-left)
-    + var(--markstream-pre-diff-line-number-width)
+    + var(--markstream-pre-diff-line-number-box-width)
   );
   --markstream-pre-diff-code-left: calc(
     var(--markstream-pre-diff-code-fill-left)
@@ -1556,6 +1639,12 @@
   overflow: hidden;
 }
 
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-pane-content {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}
+
 :where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane {
   overflow-x: auto;
   overflow-y: hidden;
@@ -1586,6 +1675,8 @@
   position: relative;
   display: block;
   box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
   min-height: var(--markstream-pre-diff-line-height, 18px);
   padding-left: var(--markstream-pre-diff-code-left);
   line-height: var(--markstream-pre-diff-line-height, 18px);
@@ -1619,7 +1710,7 @@
   z-index: 1;
   top: 0;
   left: var(--markstream-pre-diff-line-number-left);
-  width: var(--markstream-pre-diff-line-number-width);
+  width: var(--markstream-pre-diff-line-number-box-width);
   height: var(
     --markstream-pre-diff-content-height,
     var(--markstream-pre-diff-line-height, 18px)
@@ -1688,6 +1779,25 @@
 
 :where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--removed > .markstream-pre__diff-rail {
   background: var(--stream-monaco-removed-gutter, var(--markstream-diff-removed-gutter, currentColor));
+}
+
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--spacer > *,
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--spacer::before {
+  visibility: hidden;
+}
+
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--collapsed {
+  min-height: 40px;
+  padding-left: 8px;
+  color: var(--stream-monaco-unchanged-fg, var(--markstream-diff-unchanged-fg));
+  line-height: 40px;
+  background: var(--stream-monaco-unchanged-bg, var(--markstream-diff-unchanged-bg));
+}
+
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--collapsed > .markstream-pre__diff-number,
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--collapsed > .markstream-pre__diff-rail,
+:where(.markstream-react) .code-fallback-plain.markstream-pre--diff-preview .markstream-pre__diff-line--collapsed::before {
+  display: none;
 }
 
 :where(.markstream-react) .code-loading-placeholder {

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -276,6 +276,8 @@ function renderCodeBlock(
       stream={ctx.codeBlockStream}
       monacoOptions={ctx.codeBlockThemes?.monacoOptions}
       themes={ctx.codeBlockThemes?.themes}
+      darkTheme={ctx.codeBlockThemes?.darkTheme}
+      lightTheme={ctx.codeBlockThemes?.lightTheme}
       minWidth={ctx.codeBlockThemes?.minWidth}
       maxWidth={ctx.codeBlockThemes?.maxWidth}
       isDark={ctx.isDark}

--- a/packages/markstream-react/src/types/component-props.ts
+++ b/packages/markstream-react/src/types/component-props.ts
@@ -157,6 +157,7 @@ export interface LinkNodeProps {
 export interface PreCodeNodeProps {
   node: CodeBlockNode
   className?: string
+  diffHideUnchangedRegions?: CodeBlockDiffHideUnchangedRegions
   style?: CSSProperties
   showLineNumbers?: boolean
   diffInline?: boolean

--- a/packages/markstream-react/vite.config.ts
+++ b/packages/markstream-react/vite.config.ts
@@ -98,6 +98,7 @@ export default defineConfig(({ mode }) => {
           'katex',
           'katex/contrib/mhchem',
           'mermaid',
+          'stream-diffs',
           'stream-monaco',
           'stream-markdown',
           'stream-markdown-parser',

--- a/playground-react18/src/shared/TestLab.tsx
+++ b/playground-react18/src/shared/TestLab.tsx
@@ -548,6 +548,7 @@ export function TestLab({ frameworkLabel, onGoHome }: TestLabProps) {
               <div className="preview-surface">
                 <NodeRenderer
                   content={deferredPreview}
+                  final={!isStreaming}
                   typewriter={false}
                   codeBlockStream
                   isDark={isDark}
@@ -555,6 +556,7 @@ export function TestLab({ frameworkLabel, onGoHome }: TestLabProps) {
                   customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
                   codeBlockDarkTheme="vitesse-dark"
                   codeBlockLightTheme="vitesse-light"
+                  renderCodeBlocksAsPre={false}
                 />
               </div>
 

--- a/playground-react19/vite.config.js
+++ b/playground-react19/vite.config.js
@@ -7,6 +7,9 @@ export default defineConfig(({ mode }) => ({
   base: './',
   server: {
     port: 4174,
+    fs: {
+      allow: [path.resolve(__dirname, '..')],
+    },
   },
   worker: {
     format: 'es',
@@ -19,6 +22,8 @@ export default defineConfig(({ mode }) => ({
     ? {
         alias: {
           'markstream-react': path.resolve(__dirname, '../packages/markstream-react/src'),
+          'markstream-core': path.resolve(__dirname, '../packages/markstream-core/src/index.ts'),
+          'markstream-core/': `${path.resolve(__dirname, '../packages/markstream-core/src')}/`,
         },
       }
     : undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       react-dom:
         specifier: '>=18'
         version: 18.3.1(react@18.3.1)
+      stream-diffs:
+        specifier: '>=0.0.1'
+        version: 0.0.1(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.25(typescript@5.9.3))
       stream-markdown:
         specifier: '>=0.0.16'
         version: 0.0.16(react@18.3.1)(shiki@4.3.1)(vue@3.5.25(typescript@5.9.3))
@@ -17252,6 +17255,20 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@pierre/theme': 1.1.0
+      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(shiki@4.3.1)
+      '@shikijs/transformers': 4.3.1
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      shiki: 4.3.1
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
   '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@pierre/theme': 1.1.0
@@ -17267,6 +17284,14 @@ snapshots:
       - '@shikijs/themes'
 
   '@pierre/theme@1.1.0': {}
+
+  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(shiki@4.3.1)':
+    optionalDependencies:
+      '@pierre/theme': 1.1.0
+      '@shikijs/themes': 4.3.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      shiki: 4.3.1
 
   '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
     optionalDependencies:
@@ -27514,6 +27539,16 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
+
+  stream-diffs@0.0.1(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.25(typescript@5.9.3)):
+    dependencies:
+      '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      vue: 3.5.25(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+      - react
+      - react-dom
 
   stream-diffs@0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3)):
     dependencies:

--- a/test/monaco-theme-scheduler.test.ts
+++ b/test/monaco-theme-scheduler.test.ts
@@ -41,4 +41,19 @@ describe('monaco theme scheduler', () => {
 
     await all
   })
+
+  it('tracks each runtime theme setter independently', async () => {
+    vi.resetModules()
+    const { scheduleMonacoThemeUpdate } = await import('../packages/markstream-react/src/components/CodeBlockNode/monacoThemeScheduler')
+    const first = vi.fn(async () => {})
+    const second = vi.fn(async () => {})
+
+    await Promise.all([
+      scheduleMonacoThemeUpdate('vitesse-dark', first),
+      scheduleMonacoThemeUpdate('vitesse-dark', second),
+    ])
+
+    expect(first).toHaveBeenCalledOnce()
+    expect(second).toHaveBeenCalledOnce()
+  })
 })

--- a/test/react-code-block-editor-lock.test.tsx
+++ b/test/react-code-block-editor-lock.test.tsx
@@ -32,8 +32,12 @@ function resetStreamMonacoHelpers() {
   })
 
   helpers.useMonaco.mockReset().mockImplementation(() => helpers)
-  helpers.createEditor.mockReset().mockImplementation(async () => {})
-  helpers.createDiffEditor.mockReset().mockImplementation(async () => {})
+  helpers.createEditor.mockReset().mockImplementation(async (element: HTMLElement) => {
+    appendMockEditorSurface(element, 'monaco-editor')
+  })
+  helpers.createDiffEditor.mockReset().mockImplementation(async (element: HTMLElement) => {
+    appendMockEditorSurface(element, 'monaco-diff-editor')
+  })
   helpers.updateCode.mockReset()
   helpers.updateDiff.mockReset()
   helpers.getEditor.mockReset().mockImplementation(() => null)
@@ -79,7 +83,18 @@ function setElementRect(element: Element, rect: { top: number, bottom: number, h
   })
 }
 
+function appendMockEditorSurface(element: HTMLElement, className: string) {
+  const surface = document.createElement('div')
+  surface.className = className
+  const content = document.createElement('div')
+  content.className = 'view-lines'
+  surface.appendChild(content)
+  setElementRect(surface, { top: 0, bottom: 120, height: 120 })
+  element.appendChild(surface)
+}
+
 afterEach(() => {
+  vi.unstubAllGlobals()
   document.body.innerHTML = ''
   ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = false
 })
@@ -87,7 +102,53 @@ afterEach(() => {
 describe('markstream-react codeBlockNode theme updates', () => {
   beforeEach(() => {
     resetStreamMonacoHelpers()
+    vi.stubGlobal('IntersectionObserver', undefined)
     ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  it('keeps streaming code in pre and creates one final surface after the fence closes', async () => {
+    const helpers = getStreamMonacoHelpers()
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const render = async (code: string, loading: boolean) => {
+      await act(async () => {
+        root.render(React.createElement(CodeBlockNode as any, {
+          node: {
+            type: 'code_block',
+            language: 'typescript',
+            code,
+            raw: `\`\`\`typescript\n${code}\n\`\`\``,
+            loading,
+          },
+          loading,
+          stream: true,
+          showHeader: false,
+        }))
+      })
+      await flushReact()
+    }
+
+    await render('const first = true', true)
+    expect(host.querySelector('pre.code-fallback-plain')?.textContent).toContain('const first = true')
+    expect(helpers.useMonaco).not.toHaveBeenCalled()
+    expect(helpers.createEditor).not.toHaveBeenCalled()
+
+    await render('const final = true', true)
+    expect(host.querySelector('pre.code-fallback-plain')?.textContent).toContain('const final = true')
+    expect(helpers.useMonaco).not.toHaveBeenCalled()
+    expect(helpers.createEditor).not.toHaveBeenCalled()
+
+    await render('const final = true', false)
+    await waitForCallCount(helpers.createEditor, 1)
+    expect(helpers.createEditor).toHaveBeenCalledTimes(1)
+    expect(helpers.createEditor).toHaveBeenCalledWith(expect.any(HTMLElement), 'const final = true', 'typescript')
+    expect(helpers.useMonaco.mock.calls[0]?.[0]?.stream).toBe(false)
+    expect(helpers.useMonaco.mock.calls[0]?.[0]?.disableFileHeader).toBe(true)
+
+    await act(async () => {
+      root.unmount()
+    })
   })
 
   it('updates single-editor themes without recreating the editor when isDark toggles', async () => {
@@ -232,7 +293,7 @@ describe('markstream-react codeBlockNode theme updates', () => {
     })
     expect(options?.fontSize).toBe(12)
     expect(options?.lineHeight).toBe(18)
-    expect(options?.padding).toEqual({ top: 0, bottom: 0 })
+    expect(options?.padding).toEqual({ top: 8, bottom: 8 })
 
     await act(async () => {
       root.unmount()
@@ -271,6 +332,7 @@ describe('markstream-react codeBlockNode theme updates', () => {
       const monacoRoot = document.createElement('div')
       monacoRoot.className = 'monaco-diff-editor'
       setElementRect(monacoRoot, { top: 0, bottom: 500, height: 500 })
+      monacoRoot.appendChild(document.createElement('div'))
       el.appendChild(monacoRoot)
     })
 
@@ -402,6 +464,7 @@ describe('markstream-react codeBlockNode theme updates', () => {
 describe('markstream-react codeBlockNode plain text theme fallback', () => {
   beforeEach(() => {
     resetStreamMonacoHelpers()
+    vi.stubGlobal('IntersectionObserver', undefined)
     ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
   })
 
@@ -426,6 +489,7 @@ describe('markstream-react codeBlockNode plain text theme fallback', () => {
       lines.style.color = 'rgb(17, 24, 39)'
 
       editor.append(background, lines)
+      setElementRect(editor, { top: 0, bottom: 120, height: 120 })
       el.appendChild(editor)
     })
 

--- a/test/react-render-node-heavy-props.test.ts
+++ b/test/react-render-node-heavy-props.test.ts
@@ -146,6 +146,26 @@ describe('markstream-react heavy-node prop forwarding', () => {
     expect(Object.prototype.hasOwnProperty.call(serverElement?.props ?? {}, 'constructor')).toBe(false)
   })
 
+  it('forwards configured themes to the default client code block', () => {
+    const ctx: RenderContext = {
+      ...baseCtx,
+      codeBlockThemes: {
+        darkTheme: 'vitesse-dark',
+        lightTheme: 'vitesse-light',
+      },
+    }
+
+    const element = clientRenderNode({
+      type: 'code_block',
+      language: 'ts',
+      code: 'export const value = 1',
+      raw: '```ts\nexport const value = 1\n```',
+    } as any, 'default-code-theme', ctx) as any
+
+    expect(element?.props?.darkTheme).toBe('vitesse-dark')
+    expect(element?.props?.lightTheme).toBe('vitesse-light')
+  })
+
   it('injects stable preview height estimates for client Mermaid and Infographic custom renderers', () => {
     const longMermaidCode = 'flowchart TD\nA-->B\nB-->C\nC-->D\nD-->E\nE-->F\nF-->G\nG-->H\nH-->I\nI-->J\nJ-->K\nK-->L\n'
     const infographicCode = ['# Release progress', '- Plan: complete', '- Build: active', '- Verify: pending'].join('\n')


### PR DESCRIPTION
## Summary
- keep the React pre fallback while code streams or remains offscreen
- create one final static stream-diffs surface and reveal it after visual readiness
- cancel stale creations and catch up content changes before the atomic handoff
- share the framework-neutral diff preview model and align pre/final layout styles

This PR is stacked on #574 and contains only React-specific changes after that base.

## Verification
- `pnpm --filter markstream-react typecheck`
- 31 React/code-block tests
- `pnpm --filter markstream-react build`
- `pnpm play:react18:build`
- `pnpm play:react19:build`
- React 18 dev playground browser smoke: stream-diffs surface mounted, no console/page errors
- touched-file ESLint
