### PR TITLE
feat(vue2): add stable stream-diffs handoff

### DIFF
--- a/packages/markstream-vue2/README.md
+++ b/packages/markstream-vue2/README.md
@@ -149,7 +149,8 @@ new Vue({
 
 - For simple chat streaming, passing `content` is the fastest way to integrate.
 - For high-frequency SSE / token streaming, long conversations, or very large code/table/math blocks, prefer parsing outside the renderer and pass `nodes` instead of reparsing the whole `content` string every chunk.
-- Keep `viewport-priority` enabled unless you explicitly want eager rendering. Mermaid / Monaco / D2 blocks now stay idle while offscreen and resume when they approach the viewport.
+- Install `stream-diffs` for enhanced File/FileDiff code blocks. Code stays in the stable `<pre>` while its fence is incomplete or offscreen; Vue 2 creates one final highlighted surface after completion and visibility, then swaps after the first stable frame.
+- Keep `viewport-priority` enabled unless you explicitly want eager rendering. Mermaid, Diffs, and D2 blocks stay idle while offscreen and resume when they approach the viewport.
 
 ```vue
 <template>

--- a/packages/markstream-vue2/package.json
+++ b/packages/markstream-vue2/package.json
@@ -115,6 +115,7 @@
     "@vue/composition-api": ">=1.7.2",
     "katex": ">=0.16.22",
     "mermaid": ">=11",
+    "stream-diffs": ">=0.0.1",
     "stream-markdown": ">=0.0.16",
     "stream-monaco": ">=0.0.48",
     "vue": ">=2.6.14 <3",
@@ -134,6 +135,9 @@
       "optional": true
     },
     "mermaid": {
+      "optional": true
+    },
+    "stream-diffs": {
       "optional": true
     },
     "stream-markdown": {

--- a/packages/markstream-vue2/scripts/rollup.dts.config.mjs
+++ b/packages/markstream-vue2/scripts/rollup.dts.config.mjs
@@ -38,6 +38,7 @@ export default [
       }),
     ],
     external: [
+      /^stream-diffs(?:\/.*)?$/,
       /^stream-markdown-parser(?:\/.*)?$/,
       /^markstream-core(?:\/.*)?$/,
       /^vue-demi(?:\/.*)?$/,

--- a/packages/markstream-vue2/src/components/AdmonitionNode/AdmonitionNode.vue
+++ b/packages/markstream-vue2/src/components/AdmonitionNode/AdmonitionNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, ref } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { computed, markRaw, ref, version } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -54,11 +54,7 @@ function toggleCollapse() {
 
 // 为无障碍生成 ID（用于 aria-labelledby）
 const headerId = `admonition-${Math.random().toString(36).slice(2, 9)}`
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 </script>
 
 <template>

--- a/packages/markstream-vue2/src/components/BlockquoteNode/BlockquoteNode.vue
+++ b/packages/markstream-vue2/src/components/BlockquoteNode/BlockquoteNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { markRaw, version } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -28,11 +28,7 @@ defineEmits<{
   copy: [text: string]
 }>()
 
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 </script>
 
 <template>

--- a/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -103,18 +103,20 @@ function withPassiveOptions(options?: boolean | AddEventListenerOptions): AddEve
   return { passive: true }
 }
 
-const instance = getCurrentInstance() as any
-const hasPreviewListener = computed(() => {
-  const proxy = instance?.proxy as any
-  const listeners = proxy?.$listeners ?? {}
-  if (listeners.previewCode || listeners['preview-code'])
-    return true
-  const vnodeListeners = proxy?.$vnode?.data?.on ?? proxy?.$vnode?.componentOptions?.listeners ?? {}
-  if (vnodeListeners.previewCode || vnodeListeners['preview-code'])
-    return true
-  const props = (proxy?.$vnode as any)?.props ?? instance?.vnode?.props
-  return !!(props && (props.onPreviewCode || props.onPreviewcode))
-})
+const hasPreviewListener = (() => {
+  const instance = getCurrentInstance() as any
+  return computed(() => {
+    const proxy = instance?.proxy as any
+    const listeners = proxy?.$listeners ?? {}
+    if (listeners.previewCode || listeners['preview-code'])
+      return true
+    const vnodeListeners = proxy?.$vnode?.data?.on ?? proxy?.$vnode?.componentOptions?.listeners ?? {}
+    if (vnodeListeners.previewCode || vnodeListeners['preview-code'])
+      return true
+    const props = (proxy?.$vnode as any)?.props ?? instance?.vnode?.props
+    return !!(props && (props.onPreviewCode || props.onPreviewcode))
+  })
+})()
 const { t } = useSafeI18n()
 // No mermaid-specific handling here; NodeRenderer routes mermaid blocks.
 const codeEditor = ref<HTMLElement | null>(null)
@@ -175,8 +177,10 @@ let cleanupEditor: () => void = () => {}
 let safeClean = () => {}
 let refreshDiffPresentation: () => void = () => {}
 let createEditorPromise: Promise<void> | null = null
+let editorCreationGeneration = 0
 let detectLanguage: (code: string) => string = () => String(props.node.language ?? 'plaintext')
 let setTheme: (theme: any) => Promise<void> = async () => {}
+let whenRuntimeVisualReady: () => Promise<boolean> | boolean = () => true
 let runtimeMonacoOptions: Record<string, any> | null = null
 const inlineFoldProxyCleanups: Array<() => void> = []
 let deferredEditorVisualSyncRafId: number | null = null
@@ -313,6 +317,7 @@ if (typeof window !== 'undefined') {
         safeClean = helpers.safeClean || helpers.cleanupEditor || safeClean
         refreshDiffPresentation = helpers.refreshDiffPresentation || refreshDiffPresentation
         setTheme = helpers.setTheme || setTheme
+        whenRuntimeVisualReady = helpers.whenVisualReady || whenRuntimeVisualReady
         monacoReady.value = true
 
         if (codeEditor.value)
@@ -864,7 +869,7 @@ watch(
 watch(
   () => [props.node.originalCode, props.node.updatedCode, monacoLanguage.value, isDiff.value] as const,
   async ([originalCode, updatedCode, _language, diff]) => {
-    if (props.stream === false || !diff)
+    if (props.loading !== false || !diff)
       return
 
     if (createEditor && !editorCreated.value && codeEditor.value) {
@@ -887,7 +892,7 @@ watch(
 watch(
   () => props.node.code,
   async (newCode) => {
-    if (props.stream === false)
+    if (props.loading !== false)
       return
     if (!codeLanguage.value)
       codeLanguage.value = normalizeLanguageIdentifier(detectLanguage(newCode))
@@ -1134,13 +1139,26 @@ function setAutomaticLayout(expanded: boolean) {
   catch {}
 }
 
-async function runEditorCreation(el: HTMLElement) {
+function getEditorContentSignature() {
+  return isDiff.value
+    ? `diff\0${monacoLanguage.value}\0${props.node.originalCode ?? ''}\0${props.node.updatedCode ?? props.node.code ?? ''}`
+    : `single\0${monacoLanguage.value}\0${props.node.code ?? ''}`
+}
+
+function isCurrentEditorCreation(generation: number, el: HTMLElement, kind: 'diff' | 'single') {
+  return generation === editorCreationGeneration
+    && codeEditor.value === el
+    && desiredEditorKind.value === kind
+}
+
+async function runEditorCreation(el: HTMLElement, generation: number, kind: 'diff' | 'single') {
   if (!createEditor)
     return
 
   syncRuntimeMonacoOptions()
+  let renderedSignature = getEditorContentSignature()
 
-  if (isDiff.value) {
+  if (kind === 'diff') {
     safeClean()
     if (createDiffEditor)
       await createDiffEditor(el as HTMLElement, String(props.node.originalCode ?? ''), String(props.node.updatedCode ?? ''), monacoLanguage.value)
@@ -1150,8 +1168,10 @@ async function runEditorCreation(el: HTMLElement) {
   else {
     await createEditor(el as HTMLElement, props.node.code, monacoLanguage.value)
   }
+  if (!isCurrentEditorCreation(generation, el, kind))
+    return
 
-  const editor = isDiff.value ? getDiffEditorView() : getEditorView()
+  const editor = kind === 'diff' ? getDiffEditorView() : getEditorView()
   if (typeof resolvedMonacoOptions.value?.fontSize === 'number') {
     editor?.updateOptions({ fontSize: resolvedMonacoOptions.value.fontSize, automaticLayout: false })
     defaultCodeFontSize.value = resolvedMonacoOptions.value.fontSize
@@ -1178,38 +1198,88 @@ async function runEditorCreation(el: HTMLElement) {
       scheduleEditorVisualSync()
     })
   }
-  editorReady.value = true
+  while (isCurrentEditorCreation(generation, el, kind)) {
+    const latestSignature = getEditorContentSignature()
+    if (latestSignature !== renderedSignature) {
+      if (kind === 'diff') {
+        await Promise.resolve(updateDiffCode(
+          String(props.node.originalCode ?? ''),
+          String(props.node.updatedCode ?? props.node.code ?? ''),
+          monacoLanguage.value,
+        ))
+      }
+      else {
+        await Promise.resolve(updateCode(String(props.node.code ?? ''), monacoLanguage.value))
+      }
+      renderedSignature = latestSignature
+    }
+    const visualReady = await waitForEditorVisualReady(() => isCurrentEditorCreation(generation, el, kind))
+    if (!isCurrentEditorCreation(generation, el, kind))
+      return
+    if (!visualReady)
+      throw new Error('Editor surface did not paint')
+    if (renderedSignature !== getEditorContentSignature())
+      continue
+    editorReady.value = true
+    return
+  }
+}
+
+function hasRenderedEditorSurface() {
+  const surface = codeEditor.value?.querySelector<HTMLElement>('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')
+  if (!surface?.firstElementChild)
+    return false
+  const rect = surface.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+async function waitForEditorVisualReady(isCurrent: () => boolean) {
+  if (!await whenRuntimeVisualReady())
+    return false
+  for (let frame = 0; frame < 120; frame += 1) {
+    if (!isCurrent())
+      return false
+    if (hasRenderedEditorSurface()) {
+      await new Promise<void>(resolve => safeRaf(() => resolve()))
+      return isCurrent() && hasRenderedEditorSurface()
+    }
+    await new Promise<void>(resolve => safeRaf(() => resolve()))
+  }
+  return false
 }
 
 function ensureEditorCreation(el: HTMLElement) {
-  if (!createEditor)
+  if (!createEditor || props.loading !== false || !viewportReady.value)
     return null
   if (createEditorPromise)
     return createEditorPromise
 
   editorCreated.value = true
   editorReady.value = false
+  const generation = ++editorCreationGeneration
+  const kind = desiredEditorKind.value
   const pending = (async () => {
-    await runEditorCreation(el)
+    await runEditorCreation(el, generation, kind)
   })()
 
-  createEditorPromise = pending.finally(() => {
-    createEditorPromise = null
+  const tracked = pending.finally(() => {
+    if (createEditorPromise === tracked)
+      createEditorPromise = null
   })
+  createEditorPromise = tracked
   return createEditorPromise
 }
 
 // 延迟创建编辑器：仅在可见且准备就绪时创建，避免无意义的初始化
 const stopCreateEditorWatch = watch(
   () => [codeEditor.value, isDiff.value, props.stream, props.loading, monacoReady.value, viewportReady.value] as const,
-  async ([el, _isDiff, stream, loading, _monacoReady, visible]) => {
+  async ([el, _isDiff, _stream, loading, _monacoReady, visible]) => {
     if (!el || !createEditor)
       return
     if (!visible)
       return
 
-    // If streaming is disabled, defer editor creation until loading is finished
-    if (stream === false && loading !== false)
+    if (loading !== false)
       return
 
     const creation = ensureEditorCreation(el as HTMLElement)
@@ -1244,6 +1314,8 @@ watch(
 
     try {
       editorCreated.value = false
+      editorReady.value = false
+      editorCreationGeneration += 1
       createEditorPromise = null
       clearInlineFoldProxies()
       safeClean()
@@ -1465,6 +1537,8 @@ function buildRuntimeMonacoOptions() {
     themes: runtimeMonacoThemes.value,
     languages: runtimeMonacoLanguages.value,
     theme: resolveRequestedTheme(),
+    stream: false,
+    disableFileHeader: true,
     ...(isDiff.value ? { diffAppearance: effectiveDiffAppearance.value } : {}),
     onThemeChange() {
       syncEditorCssVars()
@@ -1569,6 +1643,8 @@ watch(
 
     try {
       editorCreated.value = false
+      editorReady.value = false
+      editorCreationGeneration += 1
       createEditorPromise = null
       clearInlineFoldProxies()
       safeClean()
@@ -1617,6 +1693,8 @@ onUnmounted(() => {
   // Ensure any RAF loops are stopped and editor resources are released
   stopExpandAutoResize()
   clearInlineFoldProxies()
+  editorCreationGeneration += 1
+  createEditorPromise = null
   if (deferredEditorVisualSyncRafId != null) {
     safeCancelRaf(deferredEditorVisualSyncRafId)
     deferredEditorVisualSyncRafId = null
@@ -1772,8 +1850,7 @@ onUnmounted(() => {
       <div
         ref="codeEditor"
         class="code-editor-container"
-        :class="[stream ? '' : 'code-height-placeholder']"
-        :style="{ visibility: editorReady ? 'visible' : 'hidden' }"
+        :class="[stream ? '' : 'code-height-placeholder', { 'is-staging': !editorReady }]"
         :aria-hidden="editorReady ? undefined : 'true'"
       />
       <div v-if="!editorReady" class="code-editor-fallback-surface">
@@ -1962,11 +2039,20 @@ onUnmounted(() => {
 .code-editor-layer {
   display: grid;
   min-width: 0;
+  position: relative;
 }
 
 .code-editor-layer > .code-editor-container,
 .code-editor-layer > .code-editor-fallback-surface {
   grid-area: 1 / 1;
+}
+
+.code-editor-layer > .code-editor-container.is-staging {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .code-editor-fallback-surface {

--- a/packages/markstream-vue2/src/components/CodeBlockNode/monaco.ts
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/monaco.ts
@@ -3,6 +3,17 @@ import { preload } from '../NodeRenderer/preloadMonaco'
 let mod: any = null
 let importAttempted = false
 
+const runtimeLoaders = [
+  () => import('stream-diffs'),
+  () => import('stream-monaco/legacy'),
+]
+
+function normalizeRuntimeModule(imported: any) {
+  if (typeof imported?.useMonaco === 'function')
+    return imported
+  return typeof imported?.default?.useMonaco === 'function' ? imported.default : null
+}
+
 async function warmupShikiTokenizer(m: any) {
   const getOrCreateHighlighter = m?.getOrCreateHighlighter
   if (typeof getOrCreateHighlighter !== 'function')
@@ -37,22 +48,21 @@ export async function getUseMonaco() {
   if (importAttempted)
     return null
 
-  try {
-    const imported = await import('stream-monaco/legacy')
-    mod = (imported as any)?.default ?? imported
-    await preload(mod)
-    const ok = await warmupShikiTokenizer(mod)
-    if (!ok) {
-      mod = null
-      importAttempted = true
-      return null
+  for (const load of runtimeLoaders) {
+    try {
+      const candidate = normalizeRuntimeModule(await load())
+      if (!candidate)
+        continue
+      await preload(candidate)
+      const ok = await warmupShikiTokenizer(candidate)
+      if (!ok)
+        continue
+      mod = candidate
+      return mod
     }
-    return mod
+    catch {}
   }
-  catch {
-    importAttempted = true
-    // Return null to indicate the module is not available
-    // The caller should handle the fallback gracefully
-    return null
-  }
+
+  importAttempted = true
+  return null
 }

--- a/packages/markstream-vue2/src/components/CodeBlockNode/monaco.ts
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/monaco.ts
@@ -22,7 +22,7 @@ async function warmupShikiTokenizer(m: any) {
   try {
     const highlighter = await getOrCreateHighlighter(
       ['vitesse-dark', 'vitesse-light'],
-      ['plaintext', 'text', 'javascript'],
+      ['javascript'],
     )
 
     if (highlighter && typeof highlighter.codeToTokens === 'function') {

--- a/packages/markstream-vue2/src/components/DefinitionListNode/DefinitionListNode.vue
+++ b/packages/markstream-vue2/src/components/DefinitionListNode/DefinitionListNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { computed, markRaw, version } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -26,11 +26,7 @@ const props = defineProps<{
 
 defineEmits(['copy'])
 
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 
 const definitionEntries = computed(() => {
   return props.node.items.flatMap((item, index) => ([

--- a/packages/markstream-vue2/src/components/FootnoteNode/FootnoteNode.vue
+++ b/packages/markstream-vue2/src/components/FootnoteNode/FootnoteNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { markRaw, version } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -22,11 +22,7 @@ const props = defineProps<{
 
 // 定义事件
 defineEmits(['copy'])
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 </script>
 
 <template>

--- a/packages/markstream-vue2/src/components/InlineCodeNode/InlineCodeNode.vue
+++ b/packages/markstream-vue2/src/components/InlineCodeNode/InlineCodeNode.vue
@@ -10,8 +10,10 @@ const props = defineProps<{
   }
 }>()
 
-const instance = getCurrentInstance()
-const attrs = computed<Record<string, unknown>>(() => ((instance?.proxy as any)?.$attrs ?? {}) as Record<string, unknown>)
+const attrs = (() => {
+  const proxy = getCurrentInstance()?.proxy as any
+  return computed<Record<string, unknown>>(() => (proxy?.$attrs ?? {}) as Record<string, unknown>)
+})()
 const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const inheritedTextStreamState = inject<Map<string, string> | undefined>('markstreamTextStreamState', undefined)
 const explicitFade = computed<boolean | undefined>(() => {

--- a/packages/markstream-vue2/src/components/ListItemNode/ListItemNode.vue
+++ b/packages/markstream-vue2/src/components/ListItemNode/ListItemNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { computed, markRaw, version } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -32,11 +32,7 @@ defineEmits<{
 
 const itemNode = computed(() => props.node ?? props.item)
 const liValueAttr = computed(() => (props.value == null ? {} : { value: props.value }))
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 </script>
 
 <template>

--- a/packages/markstream-vue2/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
+++ b/packages/markstream-vue2/src/components/MarkdownCodeBlockNode/MarkdownCodeBlockNode.vue
@@ -11,6 +11,7 @@ import {
 import { computed, getCurrentInstance, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue-demi'
 import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
+import { useViewportPriority } from '../../composables/viewportPriority'
 import { getLanguageIcon, languageIconsRevision, languageMap, normalizeLanguageIdentifier } from '../../utils'
 import { isDevEnvironment } from '../../utils/devEnv'
 
@@ -85,6 +86,9 @@ const rendererTarget = ref<HTMLElement | null>(null)
 const fallbackHtml = ref('')
 const rendererReady = ref(false)
 const hasStableRender = ref(false)
+const viewportReady = ref(typeof window === 'undefined')
+const registerVisibility = useViewportPriority()
+let viewportHandle: ReturnType<typeof registerVisibility> | null = null
 let renderObserver: MutationObserver | undefined
 let lastCommittedRenderSignature = ''
 let rendererMutationVersion = 0
@@ -427,6 +431,10 @@ function isCurrentRenderEpoch(epoch = renderEpoch) {
   return !disposed && epoch === renderEpoch
 }
 
+function canInitializeRenderer() {
+  return props.loading === false && viewportReady.value
+}
+
 function disposeCurrentRenderer(options: { resetStableRender?: boolean } = {}) {
   const current = renderer
   renderer = undefined
@@ -686,6 +694,11 @@ async function initRenderer(epoch: number) {
   if (!isCurrentRenderEpoch(epoch))
     return
 
+  if (!canInitializeRenderer()) {
+    renderFallback(props.node.code, true)
+    return
+  }
+
   await ensureStreamMarkdownLoaded()
   if (!isCurrentRenderEpoch(epoch))
     return
@@ -763,11 +776,6 @@ async function initRenderer(epoch: number) {
     return
   }
 
-  if (props.stream === false && props.loading) {
-    renderFallback(props.node.code, !hasStableRender.value)
-    return
-  }
-
   renderFallback(props.node.code, !hasStableRender.value)
   const previousMutationVersion = rendererMutationVersion
   const previousRendererHtml = rendererTarget.value?.innerHTML
@@ -814,6 +822,8 @@ function cleanupRenderer() {
   renderObserver = undefined
   disconnectRendererThemeObserver()
   pendingRenderSignature = null
+  viewportHandle?.destroy()
+  viewportHandle = null
   disposeCurrentRenderer({ resetStableRender: true })
 }
 
@@ -822,7 +832,6 @@ renderFallback(props.node.code, true)
 if (getCurrentInstance()) {
   onMounted(() => {
     startRendererThemeObserver()
-    void safeInitRenderer()
   })
   onBeforeUnmount(cleanupRenderer)
 }
@@ -830,6 +839,8 @@ else {
   void nextTick(async () => {
     await nextTick()
     startRendererThemeObserver()
+    if (!canInitializeRenderer())
+      return
     await safeInitRenderer()
     if (!lastCommittedRenderSignature && hasRendererContent()) {
       markRendererCommitted(
@@ -844,11 +855,31 @@ else {
 }
 
 watch(highlightRegistrationKey, async () => {
-  await safeInitRenderer()
+  if (canInitializeRenderer())
+    await safeInitRenderer()
 })
 
-watch(() => props.loading, (loading) => {
-  if (loading)
+watch(
+  () => container.value,
+  (el) => {
+    viewportHandle?.destroy()
+    viewportHandle = null
+    if (!el) {
+      viewportReady.value = false
+      return
+    }
+    const handle = registerVisibility(el, { rootMargin: '400px' })
+    viewportHandle = handle
+    viewportReady.value = handle.isVisible.value
+    handle.whenVisible.then(() => {
+      viewportReady.value = true
+    })
+  },
+  { immediate: true },
+)
+
+watch(() => [props.loading, viewportReady.value] as const, ([loading, visible]) => {
+  if (loading || !visible)
     return
   void safeInitRenderer()
 })
@@ -873,6 +904,11 @@ watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
     return
   }
 
+  if (!canInitializeRenderer()) {
+    renderFallback(code, true)
+    return
+  }
+
   if (!renderer || rendererNeedsReconfigure()) {
     renderFallback(code, !hasStableRender.value)
     await safeInitRenderer(epoch)
@@ -881,9 +917,6 @@ watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
   if (!isCurrentRenderEpoch(epoch))
     return
   if (!renderer)
-    return
-
-  if (props.stream === false && props.loading)
     return
 
   renderFallback(code, !hasStableRender.value)
@@ -915,7 +948,7 @@ watch(() => [props.node.code, props.node.language], async ([code, lang]) => {
 async function handleRendererThemeChange() {
   if (!codeBlockContent.value || !rendererTarget.value)
     return
-  if (!renderer)
+  if (!renderer && canInitializeRenderer())
     await safeInitRenderer()
   await syncRendererTheme()
   syncRenderedCssVars()

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -6,7 +6,7 @@ import type { CodeBlockMonacoOptions, CodeBlockMonacoTheme, CodeBlockNodeProps, 
 import { normalizeShikiLanguage } from 'markstream-core'
 import { getMarkdown, mergeCustomHtmlTags, parseMarkdownToStructure, resolveCustomHtmlTags } from 'stream-markdown-parser'
 import { h as createVNode } from 'vue'
-import { computed, getCurrentInstance, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch } from 'vue-demi'
+import { computed, getCurrentInstance, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, version, watch } from 'vue-demi'
 import AdmonitionNode from '../../components/AdmonitionNode'
 import BlockquoteNode from '../../components/BlockquoteNode'
 import CheckboxNode from '../../components/CheckboxNode'
@@ -43,7 +43,7 @@ import { getCodeBlockExtraProps } from '../../utils/codeBlockExtraProps'
 import { clampInfographicPreviewHeight, clampMermaidPreviewHeight, estimateInfographicPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber } from '../../utils/diagramHeight'
 import { getHtmlTagFromContent, shouldRenderUnknownHtmlTagAsText, stripCustomHtmlWrapper } from '../../utils/htmlRenderer'
 import { customComponentsRevision, getCustomNodeComponents } from '../../utils/nodeComponents'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import HtmlBlockNode from '../HtmlBlockNode/HtmlBlockNode.vue'
 import HtmlInlineNode from '../HtmlInlineNode/HtmlInlineNode.vue'
 import { MathBlockNodeAsync, MathInlineNodeAsync } from './asyncComponent'
@@ -220,22 +220,11 @@ const containerRef = ref<HTMLElement>()
 const viewportPriorityAutoDisabled = ref(false)
 const SCROLL_PARENT_OVERFLOW_RE = /auto|scroll|overlay/i
 const isClient = typeof window !== 'undefined'
-const instance = getCurrentInstance()
 const debugPerformanceEnabled = computed(() => props.debugPerformance && isClient && typeof console !== 'undefined')
-const attrs = computed<Record<string, unknown>>(() => ((instance?.proxy as any)?.$attrs ?? {}) as Record<string, unknown>)
 const textStreamState = new Map<string, string>()
 const streamRenderVersion = ref(0)
 const smoothStream = useSmoothMarkdownStream(props.smoothStreamingOptions)
-const resolvedShowTooltips = computed<boolean | undefined>(() => {
-  if (typeof props.showTooltips === 'boolean')
-    return props.showTooltips
-  const raw = attrs.value.showTooltips ?? attrs.value['show-tooltips']
-  if (raw === '' || raw === true || raw === 'true')
-    return true
-  if (raw === false || raw === 'false')
-    return false
-  return undefined
-})
+const resolvedShowTooltips = computed<boolean | undefined>(() => props.showTooltips)
 const inheritedHtmlPolicy = inject<{ value?: HtmlPolicy } | undefined>('markstreamHtmlPolicy', undefined)
 const inheritedSmoothStreaming = inject<{ value?: boolean } | undefined>('markstreamSmoothStreaming', undefined)
 const resolvedHtmlPolicy = computed<HtmlPolicy>(() => props.htmlPolicy ?? inheritedHtmlPolicy?.value ?? 'safe')
@@ -450,8 +439,9 @@ const effectiveCustomHtmlTagsSet = computed<Set<string>>(() => {
   return new Set(arr.map(t => String(t).trim().toLowerCase()).filter(Boolean))
 })
 
+const legacyVue26 = isLegacyVue26Version(version)
 const parsedNodes = computed<ParsedNode[]>(() => {
-  if (isLegacyVue26Vm(instance?.proxy as any) && !props.content && Array.isArray(props.nodes))
+  if (legacyVue26 && !props.content && Array.isArray(props.nodes))
     return EMPTY_PARSED_NODES
   // 解析 content 字符串为节点数组
   // If the consumer passed an explicit `nodes` array, return a shallow
@@ -583,22 +573,22 @@ const shouldObserveSlots = computed(() => !!registerNodeVisibility && (deferNode
 const liveNodeBufferResolved = computed(() => Math.max(0, props.liveNodeBuffer ?? 60))
 const focusIndex = ref(0)
 const nodeContentElements = new Map<number, HTMLElement | null>()
-const legacyVue26 = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm)
-})
-const legacyNodesMode = computed(() => legacyVue26.value && !props.content && Array.isArray(props.nodes))
+const legacyNodesMode = computed(() => legacyVue26 && !props.content && Array.isArray(props.nodes))
 const legacyNodeItems = computed<ParsedNode[]>(() => {
   if (!legacyNodesMode.value)
     return EMPTY_PARSED_NODES
   return markRaw(cloneParsedNodeList((props.nodes as unknown as ParsedNode[]) || []))
 })
 
+const getNodeRefs = (() => {
+  const proxy = getCurrentInstance()?.proxy as any
+  return () => proxy?.$refs as Record<string, any> | undefined
+})()
+
 function syncNodeRefs() {
-  const proxy = instance?.proxy as any
-  if (!proxy || !proxy.$refs)
+  const refs = getNodeRefs()
+  if (!refs)
     return
-  const refs = proxy.$refs as Record<string, any>
   const seen = new Set<number>()
   for (const item of visibleNodes.value) {
     const slot = resolveTemplateRef(refs[`node-slot-${item.index}`])
@@ -1991,7 +1981,7 @@ const legacyRenderedItems = computed(() => {
   })
 })
 const legacyStructuredContentMode = computed(() => {
-  if (!legacyVue26.value || !props.content)
+  if (!legacyVue26 || !props.content)
     return false
   return parsedNodes.value.some(node => isLegacyStructuredNode(node))
 })
@@ -2143,7 +2133,7 @@ function getRenderKey(node: ParsedNode, index: number) {
   const items = Array.isArray((node as any).items) ? (node as any).items.length : 0
   const rows = Array.isArray((node as any).rows) ? (node as any).rows.length : 0
 
-  if (!legacyVue26.value && !loading)
+  if (!legacyVue26 && !loading)
     return base
 
   const hasNestedStructure = children > 0 || items > 0 || rows > 0

--- a/packages/markstream-vue2/src/components/TableNode/TableNode.vue
+++ b/packages/markstream-vue2/src/components/TableNode/TableNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, onBeforeUnmount, ref, watch } from 'vue-demi'
-import { isLegacyVue26Vm } from '../../utils/vue26'
+import { computed, markRaw, onBeforeUnmount, ref, version, watch } from 'vue-demi'
+import { isLegacyVue26Version } from '../../utils/vue26'
 import NodeRenderer from '../NodeRenderer'
 import LegacyNodesRenderer from '../NodeRenderer/LegacyNodesRenderer.vue'
 
@@ -42,17 +42,17 @@ const props = defineProps<{
 }>()
 
 // 定义事件
-defineEmits(['copy'])
+const emit = defineEmits(['copy'])
+
+function handleCopy(payload: unknown) {
+  emit('copy', payload)
+}
 
 const isLoading = computed(() => props.node.loading ?? false)
 const bodyRows = computed(() => props.node.rows ?? [])
 const tableRef = ref<HTMLTableElement | null>(null)
 const columnWidths = ref<number[]>([])
-const instance = getCurrentInstance()
-const nestedRenderer = computed(() => {
-  const vm = instance?.proxy as any
-  return isLegacyVue26Vm(vm) ? LegacyNodesRenderer : NodeRenderer
-})
+const nestedRenderer = markRaw(isLegacyVue26Version(version) ? LegacyNodesRenderer : NodeRenderer)
 
 const MIN_COLUMN_WIDTH = 48
 
@@ -175,7 +175,7 @@ onBeforeUnmount(stopColumnResize)
               :index-key="`table-th-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"
-              @copy="$emit('copy', $event)"
+              @copy="handleCopy"
             />
             <button
               v-if="index < node.header.cells.length - 1"
@@ -213,7 +213,7 @@ onBeforeUnmount(stopColumnResize)
               :index-key="`table-td-${props.indexKey}`"
               :custom-id="props.customId"
               :typewriter="props.typewriter"
-              @copy="$emit('copy', $event)"
+              @copy="handleCopy"
             />
           </td>
         </tr>

--- a/packages/markstream-vue2/src/components/TextNode/TextNode.vue
+++ b/packages/markstream-vue2/src/components/TextNode/TextNode.vue
@@ -13,8 +13,10 @@ const props = defineProps<{
 }>()
 defineEmits(['copy'])
 const katexReady = useKatexReady()
-const instance = getCurrentInstance()
-const attrs = computed<Record<string, unknown>>(() => ((instance?.proxy as any)?.$attrs ?? {}) as Record<string, unknown>)
+const attrs = (() => {
+  const proxy = getCurrentInstance()?.proxy as any
+  return computed<Record<string, unknown>>(() => (proxy?.$attrs ?? {}) as Record<string, unknown>)
+})()
 const inheritedFade = inject<{ value?: boolean } | undefined>('markstreamFade', undefined)
 const inheritedTextStreamState = inject<Map<string, string> | undefined>('markstreamTextStreamState', undefined)
 const inheritedStreamVersion = inject<{ value?: number } | undefined>('markstreamStreamVersion', undefined)

--- a/packages/markstream-vue2/vite.config.tailwind.ts
+++ b/packages/markstream-vue2/vite.config.tailwind.ts
@@ -46,6 +46,10 @@ export default defineConfig({
     },
     rollupOptions: {
       external: (id: string) => {
+        if (id === 'stream-diffs' || id.startsWith('stream-diffs/'))
+          return true
+        if (/node_modules\/stream-diffs(?:\/|$)/.test(id))
+          return true
         if (id === 'stream-monaco' || id.startsWith('stream-monaco/'))
           return true
         if (/node_modules\/stream-monaco(?:\/|$)/.test(id))
@@ -61,6 +65,7 @@ export default defineConfig({
           'katex',
           'mermaid',
           'katex/contrib/mhchem',
+          'stream-diffs',
           'stream-monaco',
           'stream-markdown',
           'stream-markdown-parser',

--- a/packages/markstream-vue2/vite.config.ts
+++ b/packages/markstream-vue2/vite.config.ts
@@ -143,6 +143,10 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         external: (id: string) => {
+          if (id === 'stream-diffs' || id.startsWith('stream-diffs/'))
+            return true
+          if (/node_modules\/stream-diffs(?:\/|$)/.test(id))
+            return true
           if (id === 'stream-monaco' || id.startsWith('stream-monaco/'))
             return true
           if (/node_modules\/stream-monaco(?:\/|$)/.test(id))
@@ -166,6 +170,7 @@ export default defineConfig(({ mode }) => {
             'katex',
             'mermaid',
             'katex/contrib/mhchem',
+            'stream-diffs',
             'stream-monaco',
             'stream-markdown',
             'stream-markdown-parser',

--- a/playground-vue2-cli/vue.config.js
+++ b/playground-vue2-cli/vue.config.js
@@ -65,6 +65,21 @@ function setAliasIfExists(alias, key, filePath) {
 const markstreamVue2Root = resolvePackageRoot('markstream-vue2')
 const markstreamCoreRoot = resolvePackageRoot('markstream-core') || resolveNodeModulesPackageRoot('markstream-core')
 const streamMonacoRoot = resolvePackageRoot('stream-monaco')
+const streamDiffsRoot = resolvePackageRoot('stream-diffs') || resolveNodeModulesPackageRoot('stream-diffs')
+const linkedPierreDiffsRoot = streamDiffsRoot && path.join(streamDiffsRoot, 'node_modules/@pierre/diffs')
+const pierreDiffsRoot = resolvePackageRoot('@pierre/diffs')
+  || (linkedPierreDiffsRoot && fs.existsSync(linkedPierreDiffsRoot)
+    ? fs.realpathSync(linkedPierreDiffsRoot)
+    : null)
+const pierreDependencyRoot = pierreDiffsRoot && path.dirname(path.dirname(pierreDiffsRoot))
+const linkedPierreThemingRoot = pierreDependencyRoot && path.join(pierreDependencyRoot, '@pierre/theming')
+const pierreThemingRoot = linkedPierreThemingRoot && fs.existsSync(linkedPierreThemingRoot)
+  ? fs.realpathSync(linkedPierreThemingRoot)
+  : null
+const linkedPierreThemeRoot = pierreDependencyRoot && path.join(pierreDependencyRoot, '@pierre/theme')
+const pierreThemeRoot = linkedPierreThemeRoot && fs.existsSync(linkedPierreThemeRoot)
+  ? fs.realpathSync(linkedPierreThemeRoot)
+  : null
 const streamMarkdownRoot = resolvePackageRoot('stream-markdown') || resolveNodeModulesPackageRoot('stream-markdown')
 const floatingUiDomEntry = tryResolve('@floating-ui/dom')
 const floatingUiDomRoot = resolvePackageRoot('@floating-ui/dom')
@@ -163,6 +178,12 @@ setAliasIfExists(
 // workspace root.
 setAliasIfExists(alias, 'stream-monaco$', streamMonacoRoot ? path.join(streamMonacoRoot, 'dist/index.js') : null)
 setAliasIfExists(alias, 'stream-monaco', streamMonacoRoot ? path.join(streamMonacoRoot, 'dist') : null)
+setAliasIfExists(alias, 'stream-diffs$', streamDiffsRoot ? path.join(streamDiffsRoot, 'dist/index.mjs') : null)
+setAliasIfExists(alias, '@pierre/diffs$', pierreDiffsRoot ? path.join(pierreDiffsRoot, 'dist/index.js') : null)
+setAliasIfExists(alias, '@pierre/theming$', pierreThemingRoot ? path.join(pierreThemingRoot, 'dist/index.js') : null)
+setAliasIfExists(alias, '@pierre/theming/color$', pierreThemingRoot ? path.join(pierreThemingRoot, 'dist/color.js') : null)
+setAliasIfExists(alias, '@pierre/theming/themes$', pierreThemingRoot ? path.join(pierreThemingRoot, 'dist/themes.js') : null)
+setAliasIfExists(alias, '@pierre/theme', pierreThemeRoot ? path.join(pierreThemeRoot, 'dist') : null)
 
 // Make `monaco-editor` resolvable for Webpack 4 + pnpm.
 // We alias the package directory so both `monaco-editor` and subpath imports work.
@@ -212,6 +233,8 @@ function createOptionalIgnoreRegex() {
   const maybeIgnore = []
   if (!streamMarkdownRoot)
     maybeIgnore.push('stream-markdown')
+  if (!streamDiffsRoot)
+    maybeIgnore.push('stream-diffs')
   if (!tryResolve('stream-monaco'))
     maybeIgnore.push('stream-monaco')
   if (!monacoEditorRoot)
@@ -247,8 +270,15 @@ function createMonacoAssetCopyPlugins() {
 module.exports = {
   transpileDependencies: [
     'markstream-vue2',
+    '@pierre/diffs',
+    '@pierre/theme',
+    '@pierre/theming',
+    '@shikijs/transformers',
+    'diff',
+    'hast-util-to-html',
     'stream-markdown-parser',
     'stream-markdown',
+    'stream-diffs',
     'stream-monaco',
     'monaco-editor',
     'shiki',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       mermaid:
         specifier: '>=11'
         version: 11.12.2
+      stream-diffs:
+        specifier: '>=0.0.1'
+        version: 0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@2.7.16)
       stream-markdown:
         specifier: '>=0.0.16'
         version: 0.0.16(react@19.2.7)(shiki@4.3.1)(vue@2.7.16)
@@ -27514,6 +27517,16 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
+
+  stream-diffs@0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@2.7.16):
+    dependencies:
+      '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      vue: 2.7.16
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+      - react
+      - react-dom
 
   stream-diffs@0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3)):
     dependencies:

--- a/scripts/e2e-codeblock-highlight-stability.mjs
+++ b/scripts/e2e-codeblock-highlight-stability.mjs
@@ -168,6 +168,10 @@ async function collectRegression(page) {
 
   const seenHighlightBlocks = new Set()
   const regressedBlocks = new Set()
+  const changedHighlightedBlocks = new Set()
+  const changedHighlightDetails = []
+  const regressionDetails = []
+  const highlightedText = new Map()
   const uniqueProgress = new Set()
   let maxVisibleFallbacks = 0
 
@@ -175,22 +179,37 @@ async function collectRegression(page) {
   while (Date.now() - start < 20000) {
     const snapshot = await page.evaluate(() => {
       const blocks = Array.from(document.querySelectorAll('.code-block-container')).map((block, index) => {
+        const component = block.__vue__
         const render = block.querySelector('.code-block-render')
         const fallback = block.querySelector('.code-fallback-plain')
         const renderText = render?.textContent?.trim() || ''
         const fallbackText = fallback?.textContent?.trim() || ''
+        const renderStyle = render ? window.getComputedStyle(render) : null
         const style = fallback ? window.getComputedStyle(fallback) : null
+        const fallbackVisible = Boolean(
+          fallback
+          && fallbackText.length > 0
+          && style
+          && style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && Number(style.opacity || '1') > 0.05,
+        )
         return {
           index,
-          hasRenderContent: Boolean(renderText.length || render?.children.length),
-          fallbackVisible: Boolean(
-            fallback
-            && fallbackText.length > 0
-            && style
-            && style.display !== 'none'
-            && style.visibility !== 'hidden'
-            && Number(style.opacity || '1') > 0.05,
+          uid: component?._uid,
+          loading: component?.loading ?? component?.$props?.loading,
+          nodeLoading: component?.node?.loading ?? component?.$props?.node?.loading,
+          renderText,
+          fallbackText,
+          hasRenderContent: Boolean(
+            (renderText.length || render?.children.length)
+            && renderStyle
+            && renderStyle.display !== 'none'
+            && renderStyle.visibility !== 'hidden'
+            && Number(renderStyle.opacity || '1') > 0.05
+            && !fallbackVisible,
           ),
+          fallbackVisible,
         }
       })
 
@@ -208,12 +227,40 @@ async function collectRegression(page) {
 
     let visibleFallbacks = 0
     for (const block of snapshot.blocks) {
-      if (block.hasRenderContent)
+      if (block.hasRenderContent) {
         seenHighlightBlocks.add(block.index)
+        const previousText = highlightedText.get(block.index)
+        if (previousText != null && previousText !== block.renderText) {
+          changedHighlightedBlocks.add(block.index)
+          if (changedHighlightDetails.length < 20) {
+            changedHighlightDetails.push({
+              index: block.index,
+              progress: snapshot.progress,
+              loading: block.loading,
+              nodeLoading: block.nodeLoading,
+              previous: previousText.slice(0, 160),
+              next: block.renderText.slice(0, 160),
+            })
+          }
+        }
+        highlightedText.set(block.index, block.renderText)
+      }
       if (block.fallbackVisible)
         visibleFallbacks += 1
-      if (seenHighlightBlocks.has(block.index) && block.fallbackVisible)
+      if (seenHighlightBlocks.has(block.index) && block.fallbackVisible) {
         regressedBlocks.add(block.index)
+        if (regressionDetails.length < 20) {
+          regressionDetails.push({
+            index: block.index,
+            uid: block.uid,
+            progress: snapshot.progress,
+            loading: block.loading,
+            nodeLoading: block.nodeLoading,
+            renderText: block.renderText.slice(0, 120),
+            fallbackText: block.fallbackText?.slice(0, 120),
+          })
+        }
+      }
     }
     maxVisibleFallbacks = Math.max(maxVisibleFallbacks, visibleFallbacks)
 
@@ -223,9 +270,54 @@ async function collectRegression(page) {
     await page.waitForTimeout(120)
   }
 
+  const finalStart = Date.now()
+  while (Date.now() - finalStart < 12000 && seenHighlightBlocks.size === 0) {
+    const blocks = await page.evaluate(() => (
+      Array.from(document.querySelectorAll('.code-block-container')).map((block, index) => {
+        const render = block.querySelector('.code-block-render')
+        const fallback = block.querySelector('.code-fallback-plain')
+        const renderStyle = render ? window.getComputedStyle(render) : null
+        const fallbackStyle = fallback ? window.getComputedStyle(fallback) : null
+        const fallbackVisible = Boolean(
+          fallback
+          && fallback.textContent?.trim()?.length
+          && fallbackStyle
+          && fallbackStyle.display !== 'none'
+          && fallbackStyle.visibility !== 'hidden'
+          && Number(fallbackStyle.opacity || '1') > 0.05,
+        )
+        return {
+          index,
+          hasRenderContent: Boolean(
+            (render?.textContent?.trim()?.length || render?.children.length)
+            && renderStyle
+            && renderStyle.display !== 'none'
+            && renderStyle.visibility !== 'hidden'
+            && Number(renderStyle.opacity || '1') > 0.05
+            && !fallbackVisible,
+          ),
+          fallbackVisible,
+        }
+      })
+    ))
+
+    for (const block of blocks) {
+      if (block.hasRenderContent)
+        seenHighlightBlocks.add(block.index)
+      if (seenHighlightBlocks.has(block.index) && block.fallbackVisible)
+        regressedBlocks.add(block.index)
+    }
+
+    if (seenHighlightBlocks.size === 0)
+      await page.waitForTimeout(120)
+  }
+
   return {
     seenHighlightBlocks: Array.from(seenHighlightBlocks),
     regressedBlocks: Array.from(regressedBlocks),
+    changedHighlightedBlocks: Array.from(changedHighlightedBlocks),
+    changedHighlightDetails,
+    regressionDetails,
     uniqueProgress: Array.from(uniqueProgress).sort((a, b) => a - b),
     maxVisibleFallbacks,
   }
@@ -315,7 +407,9 @@ async function main() {
       lowContrastBlocks,
       unnormalizedTitleBlocks,
       consoleErrorCount: consoleErrors.length,
+      consoleErrors: consoleErrors.slice(0, 20),
       pageErrorCount: pageErrors.length,
+      pageErrors: pageErrors.slice(0, 20),
       screenshot,
     }
 
@@ -326,6 +420,9 @@ async function main() {
     }
     if (result.seenHighlightBlocks.length === 0) {
       throw new Error('No highlighted code block was observed during the run')
+    }
+    if (result.changedHighlightedBlocks.length > 0) {
+      throw new Error(`Highlighted code blocks kept updating: ${result.changedHighlightedBlocks.join(', ')}`)
     }
     if (result.consoleErrorCount > 0 || result.pageErrorCount > 0) {
       throw new Error(`Detected browser errors (console=${result.consoleErrorCount}, page=${result.pageErrorCount})`)

--- a/scripts/e2e-link-tooltip-streaming.mjs
+++ b/scripts/e2e-link-tooltip-streaming.mjs
@@ -194,7 +194,7 @@ async function collectTooltipRegression(page) {
 
   const samples = []
   const startedAt = Date.now()
-  while (Date.now() - startedAt < 20000) {
+  while (Date.now() - startedAt < 45000) {
     const tooltip = await readTooltipState(page)
     const progress = await readProgress(page)
     samples.push({ tooltip, progress })


### PR DESCRIPTION
## Summary
- hand completed Vue2 code blocks from the pre surface to stream-diffs once visible
- keep the fallback mounted until the runtime surface is painted
- preserve Vue 2.6/2.7 rendering compatibility and add Vue CLI runtime aliases

This PR is stacked on #574. Merge the core PR first.

## Verification
- `pnpm exec vitest run test/vue2-*.test.ts` (19 files, 90 tests)
- `pnpm --filter markstream-vue2 build`
- `pnpm play:vue2:build`
- `pnpm test:e2e:codeblock-highlight-stability`
- touched-file ESLint
- `git diff --check`

The browser E2E observed no highlight regressions, changed highlighted blocks, console errors, or page errors.