### PR TITLE
feat(angular): add stable stream-diffs handoff

### DIFF
--- a/packages/markstream-angular/README.md
+++ b/packages/markstream-angular/README.md
@@ -19,19 +19,22 @@ pnpm add markstream-angular @angular/core @angular/common
 
 Optional peer dependencies:
 
-- `stream-monaco` for Monaco-powered code blocks
+- `stream-diffs` for enhanced File/FileDiff and code blocks
+- `stream-monaco` as the Monaco runtime fallback
 - `mermaid` for Mermaid diagrams
 - `katex` for math rendering
 - `@terrastruct/d2` for D2 diagrams
 - `@antv/infographic` for infographic blocks
 
-Install only the peers your output actually needs. Plain Markdown does not require Mermaid, KaTeX, Monaco, D2, or Infographic.
+Install only the peers your output actually needs. Plain Markdown does not require Mermaid, KaTeX, Diffs, Monaco, D2, or Infographic.
 
 Example:
 
 ```bash
-pnpm add stream-monaco mermaid katex @terrastruct/d2 @antv/infographic
+pnpm add stream-diffs mermaid katex @terrastruct/d2 @antv/infographic
 ```
+
+Angular keeps the stable `<pre>` while a fence is incomplete or offscreen. After completion and visibility, it creates one final File/FileDiff surface in a staging layer and swaps only after the first stable frame. Pending creation is invalidated on destroy, collapse, or code-block identity change.
 
 ## Quick Start
 

--- a/packages/markstream-angular/package.json
+++ b/packages/markstream-angular/package.json
@@ -83,6 +83,7 @@
     "@terrastruct/d2": ">=0.1.33",
     "katex": ">=0.16.22",
     "mermaid": ">=11",
+    "stream-diffs": ">=0.0.1",
     "stream-monaco": ">=0.0.48"
   },
   "peerDependenciesMeta": {
@@ -96,6 +97,9 @@
       "optional": true
     },
     "mermaid": {
+      "optional": true
+    },
+    "stream-diffs": {
       "optional": true
     },
     "stream-monaco": {

--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -27,6 +27,7 @@ interface MonacoHelpers {
   getEditorView?: () => any
   getDiffEditorView?: () => any
   setTheme?: (theme?: CodeBlockMonacoTheme) => Promise<unknown> | unknown
+  whenVisualReady?: () => Promise<boolean> | boolean
 }
 
 @Component({
@@ -35,10 +36,12 @@ interface MonacoHelpers {
   imports: [CommonModule, PreCodeNodeComponent, HtmlPreviewFrameComponent],
   template: `
     <div
+      #container
       class="code-block-container"
       [class.is-dark]="resolvedIsDark"
       [class.is-plain-text]="isPlainTextLanguage"
       [class.is-rendering]="resolvedLoading"
+      [class.is-diff]="isDiff"
       [attr.data-markstream-monaco]="editorReady && !useFallback ? '1' : null"
       [attr.data-markstream-monaco-diff]="editorReady && isDiff && !useFallback ? '1' : null"
       [ngStyle]="containerStyle"
@@ -175,12 +178,25 @@ interface MonacoHelpers {
         [class.code-block-body--expanded]="expanded"
       >
         <ng-container *ngIf="!showLoadingPlaceholder; else loadingTpl">
-          <markstream-angular-pre-code-node *ngIf="useFallback; else editorTpl" [node]="node" />
+          <markstream-angular-pre-code-node
+            *ngIf="useFallback; else editorTpl"
+            [node]="node"
+            [showLineNumbers]="true"
+            [diffInline]="resolvedMonacoOptions.renderSideBySide === false"
+            [diffHideUnchangedRegions]="resolvedMonacoOptions.diffHideUnchangedRegions ?? true"
+          />
 
           <ng-template #editorTpl>
-            <div #editorHost class="code-editor-container" [style.visibility]="editorReady ? 'visible' : 'hidden'"></div>
-            <div *ngIf="!editorReady" style="position:absolute; inset:0; overflow:auto; padding:1rem;">
-              <pre class="code-fallback-plain m-0" [attr.aria-busy]="resolvedLoading" [attr.aria-label]="ariaLabel" tabindex="0"><code translate="no" [style.fontSize.px]="fontSize" [textContent]="resolvedCode"></code></pre>
+            <div class="code-editor-layer">
+              <div #editorHost class="code-editor-container" [class.is-staging]="!editorReady" [attr.aria-hidden]="!editorReady"></div>
+              <div *ngIf="!editorReady" class="code-editor-fallback-surface">
+                <markstream-angular-pre-code-node
+                  [node]="node"
+                  [showLineNumbers]="true"
+                  [diffInline]="resolvedMonacoOptions.renderSideBySide === false"
+                  [diffHideUnchangedRegions]="resolvedMonacoOptions.diffHideUnchangedRegions ?? true"
+                />
+              </div>
             </div>
           </ng-template>
         </ng-container>
@@ -215,6 +231,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   private readonly cdr = inject(ChangeDetectorRef)
   private readonly i18n = useSafeI18n()
 
+  @ViewChild('container') private container?: ElementRef<HTMLElement>
   @ViewChild('editorHost') private editorHost?: ElementRef<HTMLElement>
 
   @Input({ required: true }) node!: AngularRenderableNode
@@ -231,13 +248,19 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   fontSize = 14
 
   private helpers: MonacoHelpers | null = null
+  private runtimeOptions: Record<string, any> | null = null
+  private runtimeStructuralSignature = ''
   private createPromise: Promise<void> | null = null
   private syncPromise: Promise<void> | null = null
+  private syncQueued = false
+  private lifecycleId = 0
   private editorKind: 'single' | 'diff' | null = null
   private viewReady = false
   private destroyed = false
   private copyTimer: number | null = null
   private deferredHeightSyncRaf: number | null = null
+  private visibilityObserver: IntersectionObserver | null = null
+  private viewportReady = typeof window === 'undefined'
 
   get t() {
     return this.i18n.t
@@ -402,21 +425,28 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   }
 
   get showLoadingPlaceholder() {
-    return this.shouldDelayEditor
+    return !this.resolvedStream && this.resolvedLoading
   }
 
   get shouldDelayEditor() {
-    return !this.resolvedStream && this.resolvedLoading
+    return this.resolvedLoading || !this.viewportReady
   }
 
   get containerStyle() {
     const style: Record<string, string> = {}
+    const padding = this.resolvedMonacoOptions.padding as { top?: unknown, bottom?: unknown } | undefined
     const min = this.resolveCssSize(this.mergedProps.minWidth ?? this.context?.codeBlockThemes?.minWidth)
     const max = this.resolveCssSize(this.mergedProps.maxWidth ?? this.context?.codeBlockThemes?.maxWidth)
     if (min)
       style.minWidth = min
     if (max)
       style.maxWidth = max
+    style['--vscode-editor-font-size'] = `${this.fontSize}px`
+    style['--vscode-editor-line-height'] = `${Number(this.resolvedMonacoOptions.lineHeight) || 20}px`
+    style['--markstream-code-max-height'] = `${this.resolveMaxHeight()}px`
+    style['--markstream-code-padding-top'] = `${Number(padding?.top ?? 8) || 0}px`
+    style['--markstream-code-padding-bottom'] = `${Number(padding?.bottom ?? 8) || 0}px`
+    style['--markstream-code-white-space'] = this.resolvedMonacoOptions.wordWrap === 'off' ? 'pre' : 'pre-wrap'
     return style
   }
 
@@ -428,6 +458,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   ngAfterViewInit() {
     this.viewReady = true
     this.applyInitialFontSize()
+    this.observeViewport()
     void this.syncEditorState()
   }
 
@@ -442,6 +473,8 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
     this.destroyed = true
     if (this.copyTimer != null && typeof window !== 'undefined')
       window.clearTimeout(this.copyTimer)
+    this.visibilityObserver?.disconnect()
+    this.visibilityObserver = null
     this.cancelDeferredHeightSync()
     this.cleanupEditor()
   }
@@ -453,8 +486,17 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   toggleCollapsed() {
     this.collapsed = !this.collapsed
     this.inlinePreviewOpen = false
-    if (!this.collapsed)
+    if (this.collapsed) {
+      this.lifecycleId += 1
+      this.syncQueued = false
+      if (this.syncPromise) {
+        this.editorReady = false
+        this.cleanupEditor()
+      }
+    }
+    else {
       queueMicrotask(() => void this.syncEditorState())
+    }
     this.cdr.markForCheck()
   }
 
@@ -531,18 +573,32 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   }
 
   private async syncEditorState() {
+    const requestId = ++this.lifecycleId
     if (this.destroyed || !this.viewReady)
       return
-    if (this.collapsed || this.showLoadingPlaceholder) {
+    if (this.collapsed || this.shouldDelayEditor) {
       this.editorReady = false
       this.cdr.markForCheck()
       return
     }
 
     await this.ensureHelpers()
-    if (this.destroyed || this.useFallback || !this.helpers) {
+    if (
+      this.destroyed
+      || requestId !== this.lifecycleId
+      || this.collapsed
+      || this.shouldDelayEditor
+      || this.useFallback
+      || !this.helpers
+    ) {
       this.cdr.markForCheck()
       return
+    }
+
+    const runtimeStructureChanged = this.syncRuntimeOptions()
+    if (runtimeStructureChanged && this.editorKind) {
+      this.editorReady = false
+      this.cleanupEditor()
     }
 
     if (!this.editorHost?.nativeElement) {
@@ -551,8 +607,10 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
       return
     }
 
-    if (this.syncPromise)
+    if (this.syncPromise) {
+      this.syncQueued = true
       return this.syncPromise
+    }
 
     this.syncPromise = (async () => {
       try {
@@ -567,17 +625,27 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
         this.applyEditorFontSize()
         if (this.expanded || !this.resolvedLoading || !this.editorReady)
           this.applyEditorHeight()
+        if (!await this.waitForEditorVisualReady())
+          throw new Error('Editor surface did not paint')
+        if (this.destroyed || requestId !== this.lifecycleId)
+          return
         this.editorReady = true
         this.scheduleDeferredHeightSync()
       }
       catch {
-        this.useFallback = true
-        this.editorReady = false
-        this.cleanupEditor()
+        if (requestId === this.lifecycleId) {
+          this.useFallback = true
+          this.editorReady = false
+          this.cleanupEditor()
+        }
       }
       finally {
         this.syncPromise = null
         this.cdr.markForCheck()
+        if (this.syncQueued && !this.destroyed) {
+          this.syncQueued = false
+          queueMicrotask(() => void this.syncEditorState())
+        }
       }
     })()
 
@@ -597,21 +665,8 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
         return
       }
 
-      const options = {
-        wordWrap: 'on',
-        wrappingIndent: 'same',
-        readOnly: true,
-        minimap: { enabled: false },
-        lineNumbers: 'on',
-        revealDebounceMs: 75,
-        MAX_HEIGHT: 500,
-        fontSize: this.defaultFontSize,
-        themes: this.resolvedThemes,
-        theme: this.resolvedIsDark ? this.resolvedDarkTheme : this.resolvedLightTheme,
-        ...(this.resolvedMonacoOptions || {}),
-      }
-
-      this.helpers = monacoModule.useMonaco(options)
+      this.syncRuntimeOptions()
+      this.helpers = monacoModule.useMonaco(this.runtimeOptions ?? {})
     })()
 
     try {
@@ -620,6 +675,47 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
     finally {
       this.createPromise = null
     }
+  }
+
+  private syncRuntimeOptions() {
+    const next = {
+      wordWrap: 'off',
+      wrappingIndent: 'same',
+      readOnly: true,
+      minimap: { enabled: false },
+      lineNumbers: 'on',
+      revealDebounceMs: 75,
+      MAX_HEIGHT: 500,
+      fontSize: this.defaultFontSize,
+      lineHeight: Number(this.resolvedMonacoOptions.lineHeight) || 20,
+      padding: this.resolvedMonacoOptions.padding ?? { top: 8, bottom: 8 },
+      themes: this.resolvedThemes,
+      theme: this.resolvedIsDark ? this.resolvedDarkTheme : this.resolvedLightTheme,
+      ...(this.resolvedMonacoOptions || {}),
+      stream: false,
+      disableFileHeader: true,
+    }
+    const signature = JSON.stringify({
+      MAX_HEIGHT: next.MAX_HEIGHT,
+      diffHideUnchangedRegions: next.diffHideUnchangedRegions,
+      lineHeight: next.lineHeight,
+      padding: next.padding,
+      renderSideBySide: next.renderSideBySide,
+      wordWrap: next.wordWrap,
+    })
+    const changed = this.runtimeStructuralSignature !== '' && this.runtimeStructuralSignature !== signature
+    this.runtimeStructuralSignature = signature
+
+    if (!this.runtimeOptions) {
+      this.runtimeOptions = next
+      return changed
+    }
+    for (const key of Object.keys(this.runtimeOptions)) {
+      if (!(key in next))
+        delete this.runtimeOptions[key]
+    }
+    Object.assign(this.runtimeOptions, next)
+    return changed
   }
 
   private async recreateEditor(kind: 'single' | 'diff') {
@@ -646,6 +742,39 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
       this.resolvedCode,
       this.monacoLanguage,
     ))
+  }
+
+  private renderedEditorSurfaceRect() {
+    const host = this.editorHost?.nativeElement
+    const surface = host?.querySelector<HTMLElement>('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')
+    if (!surface?.firstElementChild)
+      return null
+    const rect = surface.getBoundingClientRect()
+    return rect.width > 0 && rect.height > 0
+      ? { height: rect.height, width: rect.width }
+      : null
+  }
+
+  private async waitForEditorVisualReady() {
+    if (this.helpers?.whenVisualReady && !await this.helpers.whenVisualReady())
+      return false
+    let previousRect: { height: number, width: number } | null = null
+    for (let frame = 0; frame < 120; frame += 1) {
+      if (this.destroyed)
+        return false
+      const rect = this.renderedEditorSurfaceRect()
+      if (
+        rect
+        && previousRect
+        && Math.abs(rect.width - previousRect.width) < 0.5
+        && Math.abs(rect.height - previousRect.height) < 0.5
+      ) {
+        return true
+      }
+      previousRect = rect
+      await new Promise<void>(resolve => window.requestAnimationFrame(() => resolve()))
+    }
+    return false
   }
 
   private async updateEditor() {
@@ -788,15 +917,38 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   }
 
   private cleanupEditor() {
+    const helpers = this.helpers
     try {
-      this.helpers?.safeClean?.()
+      helpers?.safeClean?.()
     }
     catch {}
-    try {
-      this.helpers?.cleanupEditor?.()
+    if (helpers?.cleanupEditor && helpers.cleanupEditor !== helpers.safeClean) {
+      try {
+        helpers.cleanupEditor()
+      }
+      catch {}
     }
-    catch {}
     this.editorKind = null
+  }
+
+  private observeViewport() {
+    const element = this.container?.nativeElement
+    if (!element)
+      return
+    if (typeof IntersectionObserver === 'undefined') {
+      this.viewportReady = true
+      return
+    }
+    this.visibilityObserver = new IntersectionObserver((entries) => {
+      if (!entries.some(entry => entry.isIntersecting || entry.intersectionRatio > 0))
+        return
+      this.viewportReady = true
+      this.visibilityObserver?.disconnect()
+      this.visibilityObserver = null
+      void this.syncEditorState()
+      this.cdr.markForCheck()
+    }, { rootMargin: '400px' })
+    this.visibilityObserver.observe(element)
   }
 
   private resolveCssSize(value: unknown) {

--- a/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
+++ b/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
@@ -1,33 +1,87 @@
+import type { OnChanges } from '@angular/core'
+import type { DiffPreviewCollapseOptions, DiffPreviewPane } from 'markstream-core'
 import type { AngularRenderableNode } from '../shared/node-helpers'
+import { CommonModule } from '@angular/common'
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { buildDiffPreviewPanes } from 'markstream-core'
 import { getString, normalizeCodeLanguage } from '../shared/node-helpers'
 
 @Component({
   selector: 'markstream-angular-pre-code-node',
   standalone: true,
-  template: `<pre [class]="languageClass" [attr.aria-busy]="loading" [attr.aria-label]="ariaLabel" [attr.data-language]="language" tabindex="0"><code translate="no" [textContent]="code"></code></pre>`,
+  imports: [CommonModule],
+  template: `
+    <pre
+      [class]="className"
+      [class.code-pre-fallback]="showLineNumbers"
+      [attr.aria-busy]="loading"
+      [attr.aria-label]="ariaLabel"
+      [attr.data-language]="language"
+      [attr.data-markstream-line-numbers]="showLineNumbers ? '1' : null"
+      tabindex="0"
+    ><code *ngIf="isDiffPreview; else plainCode" translate="no" class="markstream-pre__diff-code"><span *ngFor="let pane of diffPanes; trackBy: trackPane" class="markstream-pre__diff-pane" [ngClass]="pane.className"><span class="markstream-pre__diff-pane-content"><span *ngFor="let line of pane.lines; trackBy: trackLine" class="markstream-pre__diff-line" [ngClass]="['markstream-pre__diff-line--' + line.kind, line.empty ? 'markstream-pre__diff-line--empty' : '']"><span class="markstream-pre__diff-rail" aria-hidden="true"></span><span class="markstream-pre__diff-number" aria-hidden="true">{{ line.number }}</span><span class="markstream-pre__diff-content"><span class="markstream-pre__diff-content-inner">{{ line.code }}</span></span></span></span></span></code><ng-template #plainCode><span *ngIf="showLineNumbers" class="markstream-pre__line-numbers" aria-hidden="true"><span class="markstream-pre__line-numbers-text">{{ lineNumbers }}</span></span><code translate="no" class="markstream-pre__code" [textContent]="code"></code></ng-template></pre>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PreCodeNodeComponent {
+export class PreCodeNodeComponent implements OnChanges {
   @Input({ required: true }) node!: AngularRenderableNode
+  @Input() diffHideUnchangedRegions?: boolean | DiffPreviewCollapseOptions
+  @Input() diffInline = false
+  @Input() showLineNumbers = false
+
+  code = ''
+  diffPanes: DiffPreviewPane[] = []
+  lineNumbers = ''
 
   get language() {
     return normalizeCodeLanguage((this.node as any)?.language)
   }
 
-  get languageClass() {
-    return `language-${this.language}`
+  get className() {
+    return [
+      `language-${this.language}`,
+      this.showLineNumbers ? 'markstream-pre--line-numbers' : '',
+      this.isDiffPreview ? 'markstream-pre--diff-preview' : '',
+      this.isDiffPreview && this.diffInline ? 'markstream-pre--diff-inline' : '',
+      this.diffPanes.some(pane => pane.lines.some(line => line.kind === 'collapsed')) ? 'markstream-pre--diff-collapsed' : '',
+    ].filter(Boolean).join(' ')
   }
 
   get ariaLabel() {
     return this.language ? `Code block: ${this.language}` : 'Code block'
   }
 
-  get code() {
-    return getString((this.node as any)?.code)
-  }
-
   get loading() {
     return (this.node as any)?.loading === true
+  }
+
+  get isDiffPreview() {
+    return this.showLineNumbers && (this.node as any)?.diff === true
+  }
+
+  ngOnChanges() {
+    const value = getString((this.node as any)?.code)
+    this.code = this.loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+    this.lineNumbers = this.code.split(/\r\n|\n|\r/).map((_, index) => index + 1).join('\n')
+    this.diffPanes = this.isDiffPreview
+      ? buildDiffPreviewPanes({
+          code: (this.node as any)?.code,
+          hideUnchangedRegions: this.diffHideUnchangedRegions,
+          inline: this.diffInline,
+          language: (this.node as any)?.language,
+          loading: this.loading,
+          originalCode: (this.node as any)?.originalCode,
+          raw: (this.node as any)?.raw,
+          updatedCode: (this.node as any)?.updatedCode,
+        })
+      : []
+  }
+
+  trackPane(_: number, pane: DiffPreviewPane) {
+    return pane.key
+  }
+
+  trackLine(_: number, line: DiffPreviewPane['lines'][number]) {
+    return line.key
   }
 }

--- a/packages/markstream-angular/src/index.css
+++ b/packages/markstream-angular/src/index.css
@@ -1018,6 +1018,17 @@ body > div[id^="dmermaid-"] {
 .markstream-angular .code-block-container {
   --markstream-code-fallback-bg: #ffffff;
   --markstream-code-fallback-fg: #111827;
+  --markstream-diff-editor-bg: #ffffff;
+  --markstream-diff-editor-fg: #111827;
+  --markstream-diff-gutter-guide: rgba(148, 163, 184, 0.28);
+  --markstream-diff-pane-divider: rgba(148, 163, 184, 0.2);
+  --markstream-diff-line-number: #6b7280;
+  --markstream-diff-added-fg: #2f8f68;
+  --markstream-diff-removed-fg: #c24141;
+  --markstream-diff-added-line-fill: rgb(47 143 104 / 12%);
+  --markstream-diff-removed-line-fill: rgb(194 65 65 / 12%);
+  --markstream-diff-unchanged-fg: #475569;
+  --markstream-diff-unchanged-bg: rgba(148, 163, 184, 0.12);
   margin: 1rem 0;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.24);
@@ -1030,6 +1041,16 @@ body > div[id^="dmermaid-"] {
 .dark .markstream-angular .code-block-container {
   --markstream-code-fallback-bg: #111827;
   --markstream-code-fallback-fg: #e5e7eb;
+  --markstream-diff-editor-bg: #111111;
+  --markstream-diff-editor-fg: #d4d4d4;
+  --markstream-diff-gutter-guide: rgba(82, 82, 91, 0.62);
+  --markstream-diff-line-number: rgba(161, 161, 170, 0.72);
+  --markstream-diff-added-fg: #5eead4;
+  --markstream-diff-removed-fg: #fda4af;
+  --markstream-diff-added-line-fill: rgba(13, 148, 136, 0.2);
+  --markstream-diff-removed-line-fill: rgba(225, 29, 72, 0.2);
+  --markstream-diff-unchanged-fg: #cbd5e1;
+  --markstream-diff-unchanged-bg: rgba(24, 24, 27, 0.92);
   border-color: rgba(71, 85, 105, 0.55);
   background: #0f172a;
   box-shadow: 0 22px 44px -30px rgba(2, 6, 23, 0.95);
@@ -1112,6 +1133,250 @@ body > div[id^="dmermaid-"] {
 
 .markstream-angular .code-block-body {
   position: relative;
+}
+
+.markstream-angular .code-editor-layer {
+  display: grid;
+  min-width: 0;
+  position: relative;
+}
+
+.markstream-angular .code-editor-layer > .code-editor-container,
+.markstream-angular .code-editor-layer > .code-editor-fallback-surface {
+  grid-area: 1 / 1;
+}
+
+.markstream-angular .code-editor-layer > .code-editor-container.is-staging {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.markstream-angular .code-editor-fallback-surface {
+  min-width: 0;
+  overflow: auto;
+}
+
+.markstream-angular .code-pre-fallback {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  max-height: var(--markstream-code-max-height, 500px);
+  margin: 0;
+  padding: var(--markstream-code-padding-top, 8px) 0 var(--markstream-code-padding-bottom, 8px);
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+  background: var(--vscode-editor-background, var(--markstream-code-fallback-bg));
+  color: var(--vscode-editor-foreground, var(--markstream-code-fallback-fg));
+  font-family: var(--vscode-editor-font-family, "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  line-height: var(--vscode-editor-line-height, 20px);
+  font-variant-ligatures: none;
+  tab-size: 4;
+  white-space: var(--markstream-code-white-space, pre);
+}
+
+.markstream-angular .code-pre-fallback code {
+  color: inherit;
+  font: inherit;
+  background: transparent;
+}
+
+.markstream-angular .code-pre-fallback.markstream-pre--line-numbers {
+  --markstream-pre-line-number-width: 2ch;
+  --markstream-pre-line-number-padding-left: 2ch;
+  --markstream-pre-line-number-padding-right: 1ch;
+  --markstream-pre-line-number-separator-width: 2px;
+  --markstream-pre-line-number-box-width: calc(
+    var(--markstream-pre-line-number-padding-left)
+    + var(--markstream-pre-line-number-width)
+    + var(--markstream-pre-line-number-padding-right)
+    + var(--markstream-pre-line-number-separator-width)
+  );
+  --markstream-pre-code-left: calc(var(--markstream-pre-line-number-box-width) + 1ch);
+}
+
+.markstream-angular .code-pre-fallback > .markstream-pre__line-numbers {
+  position: absolute;
+  top: var(--markstream-code-padding-top, 8px);
+  left: 0;
+  box-sizing: content-box;
+  width: var(--markstream-pre-line-number-width);
+  min-width: var(--markstream-pre-line-number-width);
+  padding-left: var(--markstream-pre-line-number-padding-left);
+  padding-right: var(--markstream-pre-line-number-padding-right);
+  border-right: var(--markstream-pre-line-number-separator-width) solid var(--markstream-diff-gutter-guide);
+  color: var(--markstream-diff-line-number);
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  text-align: right;
+  pointer-events: none;
+  user-select: none;
+}
+
+.markstream-angular .code-pre-fallback > .markstream-pre__line-numbers > .markstream-pre__line-numbers-text {
+  display: block;
+  white-space: pre;
+}
+
+.markstream-angular .code-pre-fallback:not(.markstream-pre--diff-preview) > .markstream-pre__code {
+  display: block;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
+  padding-left: var(--markstream-pre-code-left);
+  padding-right: 1ch;
+}
+
+.markstream-angular .code-pre-fallback.markstream-pre--diff-preview {
+  --markstream-pre-diff-gutter-marker-width: 4px;
+  --markstream-pre-diff-line-number-width: 2ch;
+  --markstream-pre-diff-line-number-padding-left: 2ch;
+  --markstream-pre-diff-line-number-padding-right: 1ch;
+  --markstream-pre-diff-line-number-separator-width: 2px;
+  --markstream-pre-diff-line-number-box-width: calc(
+    var(--markstream-pre-diff-line-number-padding-left)
+    + var(--markstream-pre-diff-line-number-width)
+    + var(--markstream-pre-diff-line-number-padding-right)
+    + var(--markstream-pre-diff-line-number-separator-width)
+  );
+  --markstream-pre-diff-code-fill-left: var(--markstream-pre-diff-line-number-box-width);
+  --markstream-pre-diff-code-left: calc(var(--markstream-pre-diff-code-fill-left) + 1ch);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.markstream-angular .code-pre-fallback > .markstream-pre__diff-code {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  width: 100%;
+  min-width: 100%;
+  font: inherit;
+  line-height: inherit;
+}
+
+.markstream-angular .code-pre-fallback.markstream-pre--diff-inline > .markstream-pre__diff-code {
+  grid-template-columns: minmax(100%, max-content);
+  min-width: max-content;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-pane {
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-pane-content {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-pane--modified {
+  box-shadow: inset 1px 0 var(--markstream-diff-pane-divider);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
+  min-height: var(--vscode-editor-line-height, 20px);
+  padding-left: var(--markstream-pre-diff-code-left);
+  line-height: var(--vscode-editor-line-height, 20px);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 0 var(--markstream-pre-diff-code-fill-left);
+  z-index: 0;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-rail {
+  position: absolute;
+  z-index: 2;
+  inset: 0 auto 0 0;
+  width: var(--markstream-pre-diff-gutter-marker-width);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-number {
+  position: absolute;
+  z-index: 1;
+  inset: 0 auto 0 0;
+  box-sizing: border-box;
+  width: var(--markstream-pre-diff-line-number-box-width);
+  padding-left: var(--markstream-pre-diff-line-number-padding-left);
+  padding-right: var(--markstream-pre-diff-line-number-padding-right);
+  box-shadow: inset -1px 0 var(--markstream-diff-gutter-guide);
+  color: var(--markstream-diff-line-number);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  user-select: none;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-content {
+  position: relative;
+  z-index: 1;
+  display: block;
+  min-width: max-content;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--added::before,
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-number {
+  background: var(--markstream-diff-added-line-fill);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--removed::before,
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-number {
+  background: var(--markstream-diff-removed-line-fill);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-rail {
+  background: var(--markstream-diff-added-fg);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-rail {
+  background: var(--markstream-diff-removed-fg);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-number {
+  color: var(--markstream-diff-added-fg);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-number {
+  color: var(--markstream-diff-removed-fg);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--spacer > *,
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--spacer::before {
+  visibility: hidden;
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--collapsed {
+  min-height: 40px;
+  padding-left: 8px;
+  color: var(--markstream-diff-unchanged-fg);
+  line-height: 40px;
+  background: var(--markstream-diff-unchanged-bg);
+}
+
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--collapsed > .markstream-pre__diff-number,
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--collapsed > .markstream-pre__diff-rail,
+.markstream-angular .code-pre-fallback .markstream-pre__diff-line--collapsed::before {
+  display: none;
+}
+
+.markstream-angular .code-editor-fallback-surface > .code-fallback-plain {
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+  white-space: pre;
 }
 
 .code-block-body--expanded {

--- a/packages/markstream-angular/src/optional/monaco.ts
+++ b/packages/markstream-angular/src/optional/monaco.ts
@@ -3,6 +3,17 @@ let importAttempted = false
 let pendingImport: Promise<MonacoRuntimeModule | null> | null = null
 let workersPreloaded = false
 
+const runtimeLoaders = [
+  () => import('stream-diffs'),
+  () => import('stream-monaco'),
+]
+
+function normalizeRuntimeModule(imported: any): MonacoRuntimeModule | null {
+  if (typeof imported?.useMonaco === 'function')
+    return imported
+  return typeof imported?.default?.useMonaco === 'function' ? imported.default : null
+}
+
 export interface MonacoRuntimeHelpers {
   createEditor?: (container: HTMLElement, code: string, language: string) => Promise<unknown> | unknown
   createDiffEditor?: (container: HTMLElement, original: string, modified: string, language: string) => Promise<unknown> | unknown
@@ -14,6 +25,7 @@ export interface MonacoRuntimeHelpers {
   getEditorView?: () => unknown
   getDiffEditorView?: () => unknown
   refreshDiffPresentation?: () => unknown
+  whenVisualReady?: () => Promise<boolean> | boolean
 }
 
 export interface MonacoRuntimeModule {
@@ -25,12 +37,14 @@ export interface MonacoRuntimeModule {
 async function preloadWorkers(mod: any) {
   if (workersPreloaded)
     return
-  workersPreloaded = true
   const existingEnv = (globalThis as any)?.MonacoEnvironment
-  if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function'))
+  if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function')) {
+    workersPreloaded = true
     return
+  }
   if (typeof mod?.preloadMonacoWorkers === 'function')
     await mod.preloadMonacoWorkers()
+  workersPreloaded = true
 }
 
 async function warmupShikiTokenizer(mod: any) {
@@ -41,7 +55,7 @@ async function warmupShikiTokenizer(mod: any) {
   try {
     const highlighter = await getOrCreateHighlighter(
       ['vitesse-dark', 'vitesse-light'],
-      ['plaintext', 'text', 'javascript'],
+      ['javascript'],
     )
 
     if (highlighter && typeof highlighter.codeToTokens === 'function') {
@@ -65,24 +79,26 @@ export async function getUseMonaco(): Promise<MonacoRuntimeModule | null> {
     return null
 
   pendingImport = (async () => {
-    try {
-      const imported: any = await import('stream-monaco')
-      monacoModule = imported?.default ?? imported
-      await preloadWorkers(monacoModule)
+    for (const load of runtimeLoaders) {
+      try {
+        const imported: any = await load()
+        const candidate = normalizeRuntimeModule(imported)
+        if (!candidate)
+          continue
+        await preloadWorkers(candidate)
 
-      const ready = await warmupShikiTokenizer(monacoModule)
-      if (!ready) {
-        monacoModule = null
-        importAttempted = true
-        return null
+        const ready = await warmupShikiTokenizer(candidate)
+        if (!ready)
+          continue
+
+        monacoModule = candidate
+        return monacoModule
       }
+      catch {}
+    }
 
-      return monacoModule
-    }
-    catch {
-      importAttempted = true
-      return null
-    }
+    importAttempted = true
+    return null
   })()
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       mermaid:
         specifier: '>=11'
         version: 11.12.3
+      stream-diffs:
+        specifier: '>=0.0.1'
+        version: 0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3))
       stream-markdown-parser:
         specifier: workspace:*
         version: link:../markdown-parser

--- a/scripts/e2e-angular-playground.mjs
+++ b/scripts/e2e-angular-playground.mjs
@@ -322,7 +322,7 @@ async function waitForHomeCompletion(page, timeout = 180000) {
     const total = Number.parseInt(match[2], 10)
     const percent = Number.parseInt(match[3], 10)
     return total > 0 && current >= total && percent === 100
-  }, { timeout })
+  }, null, { timeout })
 }
 
 async function collectHomeCompletionMetrics(page) {
@@ -342,7 +342,8 @@ async function collectHomeCompletionMetrics(page) {
   })
 }
 
-async function waitForHomeStreamingCodeHighlight(page, timeout = 180000) {
+async function waitForHomeCompletedCodeHighlight(page, timeout = 180000) {
+  await page.locator('.panel.preview .markstream-angular .code-block-container').first().scrollIntoViewIfNeeded()
   const startedAt = Date.now()
   let lastSnapshot = null
 
@@ -359,21 +360,18 @@ async function waitForHomeStreamingCodeHighlight(page, timeout = 180000) {
         total,
         percent,
         done: total > 0 && current >= total && percent === 100,
-        monacoCount: document.querySelectorAll('.panel.preview .markstream-angular [data-markstream-monaco="1"]').length,
-        fallbackPreCount: document.querySelectorAll('.panel.preview .markstream-angular .code-fallback-plain').length,
+        monacoCount: document.querySelectorAll('.panel.preview .markstream-angular [data-markstream-monaco="1"] .stream-diffs-shell, .panel.preview .markstream-angular [data-markstream-monaco="1"] .monaco-editor, .panel.preview .markstream-angular [data-markstream-monaco="1"] .monaco-diff-editor').length,
+        fallbackPreCount: document.querySelectorAll('.panel.preview .markstream-angular .code-pre-fallback').length,
       }
     })
 
-    if (lastSnapshot.monacoCount > 0)
-      return lastSnapshot
-
-    if (lastSnapshot.done)
+    if (lastSnapshot.done && lastSnapshot.monacoCount > 0)
       return lastSnapshot
 
     await page.waitForTimeout(400)
   }
 
-  throw new Error(`Timed out waiting for a highlighted home code block: ${JSON.stringify(lastSnapshot)}`)
+  throw new Error(`Timed out waiting for a completed visible code block surface: ${JSON.stringify(lastSnapshot)}`)
 }
 
 async function collectHomeThinkingMetrics(page) {
@@ -486,8 +484,8 @@ async function verifyBaselineInteractions(page) {
 async function collectDiffMetrics(page) {
   return page.evaluate(() => ({
     wrapperCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"]').length,
-    monacoCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"] .monaco-editor').length,
-    monacoDiffCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"] .monaco-diff-editor').length,
+    monacoCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"] .stream-diffs-shell, .preview-surface [data-markstream-monaco="1"] .monaco-editor').length,
+    monacoDiffCount: document.querySelectorAll('.preview-surface [data-markstream-monaco-diff="1"] .stream-diffs-shell, .preview-surface [data-markstream-monaco-diff="1"] .monaco-diff-editor').length,
     badgeTexts: Array.from(document.querySelectorAll('.preview-surface .markstream-angular-enhanced-block__badge'))
       .map(node => node.textContent?.trim())
       .filter(Boolean),
@@ -517,7 +515,7 @@ async function collectThinkingMetrics(page) {
   return page.evaluate(() => ({
     thinkingCount: document.querySelectorAll('.preview-surface .thinking-node').length,
     mermaidSvgCount: document.querySelectorAll('.preview-surface .thinking-node .markstream-angular-mermaid svg').length,
-    monacoCount: document.querySelectorAll('.preview-surface .thinking-node [data-markstream-monaco="1"]').length,
+    monacoCount: document.querySelectorAll('.preview-surface .thinking-node [data-markstream-monaco="1"] .stream-diffs-shell, .preview-surface .thinking-node [data-markstream-monaco="1"] .monaco-editor, .preview-surface .thinking-node [data-markstream-monaco="1"] .monaco-diff-editor').length,
     listCount: document.querySelectorAll('.preview-surface .thinking-node li').length,
     previewExcerpt: (document.querySelector('.preview-surface')?.textContent || '').slice(0, 500),
   }))
@@ -545,7 +543,7 @@ async function waitForDiffEditors(page, timeout = 60000) {
   while (Date.now() - startedAt < timeout) {
     lastSnapshot = await page.evaluate(() => ({
       wrapperCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"]').length,
-      monacoCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"] .monaco-editor').length,
+      monacoCount: document.querySelectorAll('.preview-surface [data-markstream-monaco="1"] .stream-diffs-shell, .preview-surface [data-markstream-monaco="1"] .monaco-editor').length,
       badgeTexts: Array.from(document.querySelectorAll('.preview-surface .markstream-angular-enhanced-block__badge'))
         .map(node => node.textContent?.trim())
         .filter(Boolean),
@@ -586,8 +584,8 @@ async function collectStreamingMetrics(page) {
     const pill = document.querySelectorAll('.workspace-card .mini-pill')[1]
     const foot = document.querySelectorAll('.workspace-card__foot span')[3]
     return pill?.textContent?.trim() === 'Streaming'
-      && foot?.textContent?.includes('正在逐步追加中')
-  }, { timeout: 10000 })
+      && foot?.textContent?.includes('Streaming 中')
+  }, null, { timeout: 10000 })
 
   const earlyProgress = await readProgress()
 
@@ -597,8 +595,8 @@ async function collectStreamingMetrics(page) {
     const foot = document.querySelectorAll('.workspace-card__foot span')[3]
     return progress?.textContent?.trim() === '100%'
       && pill?.textContent?.trim() === 'Ready'
-      && foot?.textContent?.includes('已显示完整输入')
-  }, { timeout: 30000 })
+      && foot?.textContent?.includes('Angular renderer')
+  }, null, { timeout: 30000 })
 
   return {
     earlyProgress,
@@ -673,12 +671,12 @@ async function main() {
     const homeProgressText = (await page.locator('.meta').textContent()).trim()
     const homeStreamingHealth = await collectHomeStreamingHealth(page, homeProgressText)
     const homeHoverSelector = await waitForHomeHoverTarget(page)
-    const homeStreamingCodeHighlight = await waitForHomeStreamingCodeHighlight(page)
     const homeHoverDuringStreaming = await exerciseHomeHoverDuringStreaming(page, homeHoverSelector)
     const homeThinking = await collectHomeThinkingMetrics(page)
     const homeLinkTooltip = await collectHomeLinkTooltip(page)
     await waitForHomeCompletion(page)
     const homeCompletion = await collectHomeCompletionMetrics(page)
+    const homeStreamingCodeHighlight = await waitForHomeCompletedCodeHighlight(page)
     await page.getByRole('button', { name: 'Open /test' }).click()
     await page.waitForURL(new RegExp(`http://${host}:${port}/test$`), { timeout: 15000 })
     await page.waitForSelector('text=markstream-angular /test', { timeout: 30000 })
@@ -696,12 +694,14 @@ async function main() {
       const thinkingDebug = await collectThinkingDebug(page)
       throw new Error(`Timed out waiting for thinking Mermaid render: ${JSON.stringify(thinkingDebug)}`, { cause: error })
     }
-    await page.waitForSelector('.preview-surface .thinking-node [data-markstream-monaco="1"]', { timeout: 30000 })
+    await page.waitForSelector('.preview-surface .thinking-node [data-markstream-monaco="1"] .stream-diffs-shell, .preview-surface .thinking-node [data-markstream-monaco="1"] .monaco-editor, .preview-surface .thinking-node [data-markstream-monaco="1"] .monaco-diff-editor', { timeout: 30000 })
     const thinking = await collectThinkingMetrics(page)
 
     await page.getByRole('button', { name: 'Diff 与代码流' }).click()
     await waitForDiffEditors(page)
     const diff = await collectDiffMetrics(page)
+    if (diff.monacoDiffCount < 1)
+      throw new Error(`Expected a rendered Monaco diff surface, received ${diff.monacoDiffCount}`)
     await verifyDiffInteractions(page)
 
     await page.getByRole('button', { name: '结构压力' }).click()
@@ -748,7 +748,8 @@ async function main() {
     if (result.homeStreamingHealth.frameCount < 20 || result.homeStreamingHealth.metaText === result.homeProgressText) {
       throw new Error(`Home page became unresponsive while streaming: ${JSON.stringify(result.homeStreamingHealth)}`)
     }
-    if (result.homeCompletion.metaText !== '11268 / 11268 (100%)') {
+    const completionMatch = result.homeCompletion.metaText.match(/^(\d+)\s*\/\s*(\d+)\s*\((\d+)%\)$/)
+    if (!completionMatch || completionMatch[1] !== completionMatch[2] || completionMatch[3] !== '100') {
       throw new Error(`Home page did not reach full completion: ${JSON.stringify(result.homeCompletion)}`)
     }
     if (!result.homeCompletion.containsTaylor || !result.homeCompletion.containsOrthogonalComplement || !result.homeCompletion.containsHelloWorldTail) {
@@ -777,8 +778,8 @@ async function main() {
     if (!result.homeLinkTooltip.visible || !result.homeLinkTooltip.text.includes('https://github.com/Simon-He95/markstream-vue')) {
       throw new Error(`Home link tooltip did not match the shared singleton behavior: ${JSON.stringify(result.homeLinkTooltip)}`)
     }
-    if (result.homeStreamingCodeHighlight.monacoCount < 1 || result.homeStreamingCodeHighlight.done) {
-      throw new Error(`Home code blocks did not enter highlighted mode before stream completion: ${JSON.stringify(result.homeStreamingCodeHighlight)}`)
+    if (result.homeStreamingCodeHighlight.monacoCount < 1 || !result.homeStreamingCodeHighlight.done) {
+      throw new Error(`Completed visible code blocks did not enter highlighted mode: ${JSON.stringify(result.homeStreamingCodeHighlight)}`)
     }
     if (baseline.katexCount < 1 || baseline.mermaidSvgCount < 1 || baseline.infographicSvgCount < 1 || baseline.d2SvgCount < 1) {
       throw new Error(`Baseline enhancements did not all render: ${JSON.stringify(baseline)}`)


### PR DESCRIPTION
## Summary
- add optional stream-diffs runtime loading with stream-monaco fallback
- keep the pre surface until a completed, visible editor has painted stable geometry
- align Angular pre and enhanced code/diff layouts and invalidate pending work on collapse or identity changes
- extend real playground coverage for completed code and diff surfaces

## Verification
- `pnpm --filter markstream-angular typecheck`
- Angular unit suite: 15 files, 83 tests
- ESLint on touched TypeScript and E2E files
- `pnpm --filter markstream-angular build`
- `pnpm --dir playground-angular build`
- `node scripts/e2e-angular-playground.mjs` (streaming, code/diff handoff, collapse/expand, KaTeX, Mermaid, Infographic, D2, no console/page errors)