### PR TITLE
feat(svelte): add stable stream-diffs handoff

### DIFF
--- a/packages/markstream-svelte/README.md
+++ b/packages/markstream-svelte/README.md
@@ -27,8 +27,12 @@ Optional heavy renderers stay as peer dependencies, matching the Vue and React p
 Plain Markdown does not require these packages:
 
 ```bash
-pnpm add katex mermaid stream-monaco @terrastruct/d2 @antv/infographic
+pnpm add katex mermaid stream-diffs @terrastruct/d2 @antv/infographic
 ```
+
+`stream-diffs` handles enhanced code and File/FileDiff blocks. `stream-monaco` remains available as the Monaco runtime fallback.
+
+With `stream-diffs` installed, Svelte keeps the stable `<pre>` while a fence is incomplete or offscreen. It creates one final surface after completion and visibility, waits for the first stable frame, then swaps layers. A stale async creation is ignored after destroy or code-block identity change.
 
 ## Basic Usage
 

--- a/packages/markstream-svelte/package.json
+++ b/packages/markstream-svelte/package.json
@@ -88,6 +88,7 @@
     "@terrastruct/d2": ">=0.1.33",
     "katex": ">=0.16.22",
     "mermaid": ">=11",
+    "stream-diffs": ">=0.0.1",
     "stream-monaco": ">=0.0.48",
     "svelte": ">=5 <6"
   },
@@ -102,6 +103,9 @@
       "optional": true
     },
     "mermaid": {
+      "optional": true
+    },
+    "stream-diffs": {
       "optional": true
     },
     "stream-monaco": {

--- a/packages/markstream-svelte/src/components/CodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/CodeBlockNode.svelte
@@ -7,8 +7,9 @@
   import { hideTooltip, showTooltipForAnchor } from '../tooltip/singletonTooltip'
   import { getLanguageIcon, isLikelyIncompleteLanguageIdentifier, languageMap, normalizeLanguageIdentifier, resolveMonacoLanguageId } from '../utils/languageIcon'
   import HtmlPreviewFrame from './HtmlPreviewFrame.svelte'
+  import PreCodeNode from './PreCodeNode.svelte'
   import { copyTextToClipboard, resolveCssSize } from './shared/rich-block-helpers'
-  import { getString, sanitizeClassToken } from './shared/node-helpers'
+  import { getString } from './shared/node-helpers'
 
   type Props = {
     node: SvelteRenderableNode
@@ -65,12 +66,6 @@
     minimumLineCount: 4,
     revealLineCount: 5,
   })
-  const disabledDiffHideUnchangedRegions = Object.freeze({
-    enabled: false,
-    contextLineCount: 0,
-    minimumLineCount: Number.POSITIVE_INFINITY,
-    revealLineCount: 0,
-  })
   const streamingLanguageTokens = ['javascript', 'plaintext', 'shellscript', 'typescript']
 
   function resolveRecoverableFallbackLanguage(error: unknown) {
@@ -89,6 +84,8 @@
       queueRecoverableLanguageRetry(recoverableLanguage)
       return
     }
+    if (typeof console !== 'undefined')
+      console.warn('[markstream-svelte] Failed to mount code block editor:', error)
     fallbackLanguage = rawLanguage
     useFallback = true
   }
@@ -122,6 +119,7 @@
   }
 
   let editorHost: HTMLDivElement | null = $state(null)
+  let container: HTMLDivElement | null = $state(null)
   let helpers: any = $state(null)
   let runtimeMonacoOptions: Record<string, any> | null = $state(null)
   let ensureMonacoPromise: Promise<void> | null = $state(null)
@@ -150,6 +148,8 @@
   let tokenizeTimer: ReturnType<typeof setTimeout> | null = $state(null)
   let tokenizeRaf: number | null = $state(null)
   let tokenizeShouldRefreshModelValue = $state(false)
+  let viewportReady = $state(false)
+  let visibilityObserver: IntersectionObserver | null = null
 
   let rawLanguage = $derived(getString((node as any)?.language).trim())
   let canonicalLanguage = $derived(normalizeLanguageIdentifier(rawLanguage))
@@ -174,19 +174,31 @@
   let defaultCodeFontSize = $derived(Number(mergedMonacoOptions.fontSize) || 13)
   let minWidthValue = $derived(resolveCssSize(minWidth ?? resolvedThemes?.minWidth))
   let maxWidthValue = $derived(resolveCssSize(maxWidth ?? resolvedThemes?.maxWidth))
+  let fallbackMaxHeight = $derived.by(() => {
+    const value = getMaxHeightValue()
+    return Number.isFinite(value) ? `${value}px` : 'none'
+  })
   let containerStyle = $derived([
     minWidthValue ? `min-width: ${minWidthValue}` : '',
     maxWidthValue ? `max-width: ${maxWidthValue}` : '',
+    `--vscode-editor-font-size: ${codeFontSize}px`,
+    '--vscode-editor-line-height: 20px',
+    `--markstream-code-max-height: ${fallbackMaxHeight}`,
+    `--markstream-code-padding-top: ${Number((resolvedMonacoOptions.padding as any)?.top ?? 8) || 0}px`,
+    `--markstream-code-padding-bottom: ${Number((resolvedMonacoOptions.padding as any)?.bottom ?? 8) || 0}px`,
+    `--markstream-code-white-space: ${resolvedMonacoOptions.wordWrap === 'off' ? 'pre' : 'pre-wrap'}`,
   ].filter(Boolean).join('; '))
   let languageIcon = $derived(getLanguageIcon(canonicalLanguage || rawLanguage || 'plain'))
   let displayLanguage = $derived(languageMap[canonicalLanguage] || (rawLanguage ? rawLanguage.toUpperCase() : languageMap['']))
   let isPreviewable = $derived(isShowPreview !== false && (canonicalLanguage === 'html' || canonicalLanguage === 'svg'))
   let previewTitle = $derived(canonicalLanguage === 'svg' ? t('artifacts.svgPreviewTitle') : t('artifacts.htmlPreviewTitle'))
-  let shouldDelayEditor = $derived(resolvedStream === false && resolvedLoading)
+  let viewportPriorityEnabled = $derived(context?.viewportPriority !== false)
+  let shouldDelayEditor = $derived(resolvedLoading || (viewportPriorityEnabled && !viewportReady))
   let documentStreaming = $derived(context?.final === false || resolvedLoading)
   let shouldDeferStreamingLanguage = $derived(resolvedStream !== false && documentStreaming && (isLikelyIncompleteLanguageIdentifier(rawLanguage) || isStreamingLanguagePrefix(rawLanguage)))
   let shouldRender = $derived(!(resolvedLoading && !code.trim()))
-  let preLanguageClass = $derived(sanitizeClassToken(rawLanguage || monacoLanguage))
+  let preFallbackDiffInline = $derived((resolvedMonacoOptions as Record<string, any>).renderSideBySide === false)
+  let preFallbackHideUnchangedRegions = $derived((resolvedMonacoOptions as Record<string, any>).diffHideUnchangedRegions ?? true)
   let showPreWhileMonacoLoads = $derived(!useFallback && !shouldDelayEditor && !shouldDeferStreamingLanguage && !editorReady)
   let showPreFallback = $derived(useFallback || shouldDelayEditor || shouldDeferStreamingLanguage || showPreWhileMonacoLoads)
   let settledRefreshSignature = $derived(diff
@@ -198,6 +210,26 @@
       useFallback = false
       fallbackLanguage = ''
     }
+  })
+
+  $effect(() => {
+    void mounted
+    void container
+    void viewportPriorityEnabled
+    if (!mounted)
+      return
+    if (!viewportPriorityEnabled) {
+      visibilityObserver?.disconnect()
+      visibilityObserver = null
+      viewportReady = true
+      return
+    }
+    if (!container) {
+      visibilityObserver?.disconnect()
+      visibilityObserver = null
+      return
+    }
+    observeViewport()
   })
 
   $effect(() => {
@@ -249,8 +281,28 @@
     if (loadingSettledRefreshTimer)
       clearTimeout(loadingSettledRefreshTimer)
     cancelEditorTokenization()
+    visibilityObserver?.disconnect()
+    visibilityObserver = null
     cleanupEditor()
   })
+
+  function observeViewport() {
+    if (!container)
+      return
+    visibilityObserver?.disconnect()
+    if (typeof IntersectionObserver === 'undefined') {
+      viewportReady = true
+      return
+    }
+    visibilityObserver = new IntersectionObserver((entries) => {
+      if (!entries.some(entry => entry.isIntersecting || entry.intersectionRatio > 0))
+        return
+      viewportReady = true
+      visibilityObserver?.disconnect()
+      visibilityObserver = null
+    }, { rootMargin: '400px' })
+    visibilityObserver.observe(container)
+  }
 
   function getResolvedCode(sourceNode: SvelteRenderableNode) {
     if ((sourceNode as any)?.diff)
@@ -302,13 +354,17 @@
       readOnly: true,
       minimap: { enabled: false },
       lineNumbers: 'on',
-      wordWrap: 'on',
+      wordWrap: 'off',
       wrappingIndent: 'same',
+      stream: false,
+      disableFileHeader: true,
       revealDebounceMs: 75,
     }
     const finalOptions = {
       MAX_HEIGHT: maxHeight,
       fontSize: codeFontSize,
+      lineHeight: 20,
+      padding: { top: 8, bottom: 8 },
       themes: buildThemeList(),
     }
 
@@ -326,13 +382,6 @@
     const hideUnchangedRegions = raw.hideUnchangedRegions === undefined
       ? undefined
       : resolveDiffHideUnchangedRegionsOption(raw.hideUnchangedRegions)
-    const streamPreviewDiff = resolvedStream !== false && resolvedLoading !== false
-    const activeDiffHideUnchangedRegions = streamPreviewDiff
-      ? { ...disabledDiffHideUnchangedRegions }
-      : diffHideUnchangedRegions
-    const activeHideUnchangedRegions = streamPreviewDiff
-      ? { ...disabledDiffHideUnchangedRegions }
-      : hideUnchangedRegions
     const experimental = {
       ...((raw.experimental as Record<string, unknown> | undefined) ?? {}),
     }
@@ -355,7 +404,7 @@
       overviewRulerBorder: false,
       hideCursorInOverviewRuler: true,
       scrollBeyondLastLine: false,
-      diffHideUnchangedRegions: activeDiffHideUnchangedRegions,
+      diffHideUnchangedRegions,
       useInlineViewWhenSpaceIsLimited: raw.useInlineViewWhenSpaceIsLimited ?? false,
       diffLineStyle: 'background',
       diffAppearance: 'auto',
@@ -369,8 +418,8 @@
       ...diffDefaults,
       ...raw,
       experimental,
-      ...(activeHideUnchangedRegions === undefined ? {} : { hideUnchangedRegions: activeHideUnchangedRegions }),
-      diffHideUnchangedRegions: activeDiffHideUnchangedRegions,
+      ...(hideUnchangedRegions === undefined ? {} : { hideUnchangedRegions }),
+      diffHideUnchangedRegions,
       ...finalOptions,
     }
   }
@@ -426,8 +475,22 @@
   }
 
   async function syncEditor() {
-    if (!mounted || !shouldRender || !editorHost || collapsed || shouldDelayEditor || shouldDeferStreamingLanguage)
+    if (!mounted || !shouldRender)
       return
+    if (shouldDelayEditor || shouldDeferStreamingLanguage) {
+      if (createEditorPromise || editorKind) {
+        lifecycleId += 1
+        cleanupEditor(false)
+      }
+      return
+    }
+    if (!editorHost || collapsed) {
+      if (createEditorPromise || editorKind) {
+        lifecycleId += 1
+        cleanupEditor(false)
+      }
+      return
+    }
 
     await ensureMonaco()
     if (!mounted || useFallback || !helpers)
@@ -465,11 +528,50 @@
   }
 
   function hasRenderedEditorDom(kind: 'single' | 'diff') {
-    if (!editorHost)
+    if (!editorHost || !helpers)
       return false
-    return kind === 'diff'
-      ? Boolean(editorHost.querySelector('.monaco-diff-editor'))
-      : Boolean(editorHost.querySelector('.monaco-editor'))
+    const hasView = kind === 'diff'
+      ? Boolean(helpers.getDiffEditorView?.())
+      : Boolean(helpers.getEditorView?.())
+    return hasView && hasRenderedEditorSurface()
+  }
+
+  function renderedEditorSurfaceRect() {
+    if (!editorHost)
+      return null
+    const surface = editorHost.querySelector<HTMLElement>('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')
+    if (!surface || !surface.firstElementChild)
+      return null
+    const rect = surface.getBoundingClientRect()
+    return rect.width > 0 && rect.height > 0
+      ? { height: rect.height, width: rect.width }
+      : null
+  }
+
+  function hasRenderedEditorSurface() {
+    return renderedEditorSurfaceRect() !== null
+  }
+
+  async function waitForEditorVisualReady(creationId: number) {
+    if (helpers?.whenVisualReady && !await helpers.whenVisualReady())
+      return false
+    let previousRect: { height: number, width: number } | null = null
+    for (let frame = 0; frame < 120; frame += 1) {
+      if (!mounted || lifecycleId !== creationId)
+        return false
+      const rect = renderedEditorSurfaceRect()
+      if (
+        rect
+        && previousRect
+        && Math.abs(rect.width - previousRect.width) < 0.5
+        && Math.abs(rect.height - previousRect.height) < 0.5
+      ) {
+        return true
+      }
+      previousRect = rect
+      await nextAnimationFrame()
+    }
+    return false
   }
 
   async function recreateEditor(kind: 'single' | 'diff') {
@@ -478,7 +580,7 @@
 
     const creationId = ++lifecycleId
     editorReady = false
-    createEditorPromise = (async () => {
+    const pending = (async () => {
       try {
         cleanupEditor(false)
         if (!mounted || !editorHost || lifecycleId !== creationId)
@@ -489,28 +591,50 @@
 
         if (kind === 'diff' && typeof helpers.createDiffEditor === 'function') {
           await helpers.createDiffEditor(editorHost, originalCode, updatedCode || code, monacoLanguage)
-          await Promise.resolve(helpers.updateDiff?.(originalCode, updatedCode || code, monacoLanguage))
           editorKind = 'diff'
         }
         else {
           await helpers.createEditor(editorHost, code, monacoLanguage)
-          await Promise.resolve(helpers.updateCode?.(code, monacoLanguage))
           editorKind = 'single'
         }
-        applyEditorOptions()
-        editorReady = true
-        bindEditorHeightSync()
-        scheduleEditorHeightSync()
-        queueThemeSync()
+        while (mounted && lifecycleId === creationId) {
+          const desiredKind: 'single' | 'diff' = diff ? 'diff' : 'single'
+          if (desiredKind !== kind)
+            return
+          const renderedSignature = settledRefreshSignature
+          if (diff && typeof helpers.updateDiff === 'function')
+            await Promise.resolve(helpers.updateDiff(originalCode, updatedCode || code, monacoLanguage))
+          else
+            await Promise.resolve(helpers.updateCode?.(code, monacoLanguage))
+          applyEditorOptions()
+          if (!await waitForEditorVisualReady(creationId))
+            throw new Error('Editor surface did not paint')
+          if (renderedSignature !== settledRefreshSignature)
+            continue
+          syncEditorHostHeight(true)
+          await nextAnimationFrame()
+          if (!mounted || lifecycleId !== creationId)
+            return
+          editorReady = true
+          bindEditorHeightSync()
+          scheduleEditorHeightSync()
+          queueThemeSync()
+          return
+        }
       }
       catch (error) {
-        if (mounted) {
+        if (mounted && lifecycleId === creationId) {
           markEditorFallback(error)
         }
       }
-    })().finally(() => {
-      createEditorPromise = null
+    })()
+    const tracked = pending.finally(() => {
+      if (createEditorPromise === tracked)
+        createEditorPromise = null
+      if (mounted && !editorReady && !useFallback)
+        queueMicrotask(() => void syncEditor())
     })
+    createEditorPromise = tracked
 
     return createEditorPromise
   }
@@ -575,13 +699,17 @@
   function cleanupEditor(disposeHelpers = true) {
     clearEditorHeightSyncBindings()
     cancelEditorHeightSync()
+    const activeHelpers = helpers
     try {
-      if (disposeHelpers)
-        helpers?.cleanupEditor?.()
-      else
-        (helpers?.safeClean || helpers?.cleanupEditor)?.()
+      activeHelpers?.safeClean?.()
     }
     catch {}
+    if (activeHelpers?.cleanupEditor && activeHelpers.cleanupEditor !== activeHelpers.safeClean) {
+      try {
+        activeHelpers.cleanupEditor()
+      }
+      catch {}
+    }
     editorKind = null
     editorReady = false
     lastLayoutWidth = null
@@ -615,7 +743,7 @@
       return
     heightSyncRaf = window.requestAnimationFrame(() => {
       heightSyncRaf = null
-      window.requestAnimationFrame(() => syncEditorHostHeight())
+      syncEditorHostHeight()
     })
   }
 
@@ -735,8 +863,8 @@
     heightSyncDisposables = []
   }
 
-  function syncEditorHostHeight() {
-    if (!editorHost || !helpers || !editorReady || collapsed)
+  function syncEditorHostHeight(force = false) {
+    if (!editorHost || !helpers || (!editorReady && !force) || collapsed)
       return
 
     const maxHeight = getMaxHeightValue()
@@ -815,6 +943,11 @@
     if (typeof window === 'undefined')
       return null
     try {
+      const streamDiffsShell = container.querySelector<HTMLElement>('.stream-diffs-shell')
+      const streamDiffsHeight = streamDiffsShell?.getBoundingClientRect().height ?? 0
+      if (streamDiffsHeight > 0)
+        return Math.ceil(streamDiffsHeight)
+
       const hostRect = container.getBoundingClientRect()
       if (hostRect.height <= 0)
         return null
@@ -902,6 +1035,7 @@
 
 {#if shouldRender}
   <div
+    bind:this={container}
     class:is-dark={resolvedIsDark}
     class:is-plain-text={monacoLanguage === 'plaintext'}
     class:is-rendering={resolvedLoading}
@@ -963,7 +1097,13 @@
           <div bind:this={editorHost} class:is-hidden={showPreFallback} class="code-editor-container"></div>
         {/if}
         {#if showPreFallback}
-          <pre class="code-pre-fallback"><code class={preLanguageClass ? `language-${preLanguageClass}` : undefined}>{code}</code></pre>
+          <PreCodeNode
+            class="code-pre-fallback"
+            node={node}
+            showLineNumbers={true}
+            diffInline={preFallbackDiffInline}
+            diffHideUnchangedRegions={preFallbackHideUnchangedRegions}
+          />
         {/if}
       </div>
     {/if}

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -1,21 +1,60 @@
 <script lang="ts">
+  import type { DiffPreviewCollapseOptions } from 'markstream-core'
   import type { SvelteRenderableNode } from './shared/node-helpers'
+  import { buildDiffPreviewPanes } from 'markstream-core'
   import { encodeDataPayload, getString, sanitizeClassToken } from './shared/node-helpers'
 
   type Props = {
     node: SvelteRenderableNode
-  };
+    class?: string
+    diffHideUnchangedRegions?: boolean | DiffPreviewCollapseOptions
+    diffInline?: boolean
+    showLineNumbers?: boolean
+  }
+
   let {
-    node
+    node,
+    class: className = '',
+    diffHideUnchangedRegions = undefined,
+    diffInline = false,
+    showLineNumbers = false,
   }: Props = $props()
 
   let languageRaw = $derived(getString((node as any)?.language).trim())
-  let language = $derived(sanitizeClassToken(languageRaw))
-  let code = $derived(getString((node as any)?.code))
-  let diff = $derived(Boolean((node as any)?.diff))
+  let language = $derived(sanitizeClassToken(languageRaw) || 'plaintext')
   let loading = $derived((node as any)?.loading === true)
+  let diff = $derived(Boolean((node as any)?.diff))
+  let code = $derived.by(() => {
+    const value = getString((node as any)?.code)
+    return loading ? value : value.replace(/\r\n$|\n$|\r$/, '')
+  })
+  let lineNumbers = $derived(code.split(/\r\n|\n|\r/).map((_, index) => index + 1).join('\n'))
+  let isDiffPreview = $derived(showLineNumbers && diff)
+  let diffPanes = $derived(isDiffPreview
+    ? buildDiffPreviewPanes({
+        code: (node as any)?.code,
+        hideUnchangedRegions: diffHideUnchangedRegions,
+        inline: diffInline,
+        language: languageRaw,
+        loading,
+        originalCode: (node as any)?.originalCode,
+        raw: (node as any)?.raw,
+        updatedCode: (node as any)?.updatedCode,
+      })
+    : [])
+  let hasCollapsedRows = $derived(diffPanes.some(pane => pane.lines.some(line => line.kind === 'collapsed')))
 </script>
 
 {#if !(loading && !code.trim())}
-  <pre data-markstream-code-block="1" data-markstream-language={languageRaw || undefined} data-markstream-loading={loading ? '1' : undefined} data-markstream-diff={diff ? '1' : undefined} data-markstream-original={diff ? encodeDataPayload(getString((node as any)?.originalCode)) : undefined} data-markstream-updated={diff ? encodeDataPayload(getString((node as any)?.updatedCode)) : undefined} aria-busy={loading ? 'true' : undefined}><code class={language ? `language-${language}` : undefined}>{code}</code></pre>
+  <pre
+    class={[`language-${language}`, className, showLineNumbers ? 'markstream-pre--line-numbers' : '', isDiffPreview ? 'markstream-pre--diff-preview' : '', isDiffPreview && diffInline ? 'markstream-pre--diff-inline' : '', hasCollapsedRows ? 'markstream-pre--diff-collapsed' : ''].filter(Boolean).join(' ')}
+    data-markstream-code-block="1"
+    data-markstream-language={languageRaw || undefined}
+    data-markstream-loading={loading ? '1' : undefined}
+    data-markstream-diff={diff ? '1' : undefined}
+    data-markstream-original={diff ? encodeDataPayload(getString((node as any)?.originalCode)) : undefined}
+    data-markstream-updated={diff ? encodeDataPayload(getString((node as any)?.updatedCode)) : undefined}
+    data-markstream-line-numbers={showLineNumbers ? '1' : undefined}
+    aria-busy={loading ? 'true' : undefined}
+  >{#if isDiffPreview}<code translate="no" class="markstream-pre__diff-code">{#each diffPanes as pane (pane.key)}<span class={`markstream-pre__diff-pane ${pane.className}`}><span class="markstream-pre__diff-pane-content">{#each pane.lines as line (line.key)}<span class={`markstream-pre__diff-line markstream-pre__diff-line--${line.kind}${line.empty ? ' markstream-pre__diff-line--empty' : ''}`}><span class="markstream-pre__diff-rail" aria-hidden="true"></span><span class="markstream-pre__diff-number" aria-hidden="true">{line.number}</span><span class="markstream-pre__diff-content"><span class="markstream-pre__diff-content-inner">{line.code}</span></span></span>{/each}</span></span>{/each}</code>{:else}{#if showLineNumbers}<span class="markstream-pre__line-numbers" aria-hidden="true"><span class="markstream-pre__line-numbers-text">{lineNumbers}</span></span>{/if}<code translate="no" class="markstream-pre__code">{code}</code>{/if}</pre>
 {/if}

--- a/packages/markstream-svelte/src/components/shared/node-helpers.ts
+++ b/packages/markstream-svelte/src/components/shared/node-helpers.ts
@@ -145,6 +145,7 @@ export interface SvelteRenderContext {
   isDark?: boolean
   indexKey?: string
   final?: boolean
+  viewportPriority?: boolean
   typewriter?: boolean
   fade?: boolean
   textStreamState?: Map<string, string>
@@ -207,6 +208,7 @@ export function buildRenderContext(
     isDark: props.isDark,
     indexKey: props.indexKey != null ? String(props.indexKey) : undefined,
     final: props.final,
+    viewportPriority: props.viewportPriority,
     typewriter: props.typewriter,
     fade: props.fade,
     textStreamState,

--- a/packages/markstream-svelte/src/index.css
+++ b/packages/markstream-svelte/src/index.css
@@ -1663,28 +1663,240 @@ body > div[id^="dmermaid-"] {
 }
 
 .markstream-svelte .code-editor-container.is-hidden {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  visibility: hidden;
   opacity: 0;
   pointer-events: none;
 }
 
 .markstream-svelte .code-pre-fallback {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
   margin: 0;
-  padding: 1rem;
-  max-height: 500px;
+  padding: var(--markstream-code-padding-top, 8px) 0 var(--markstream-code-padding-bottom, 8px);
+  max-height: var(--markstream-code-max-height, 500px);
   overflow: auto;
   border: 0;
   border-radius: 0;
   background: var(--vscode-editor-background, var(--markstream-code-fallback-bg));
   color: var(--vscode-editor-foreground, var(--markstream-code-fallback-fg));
-  font:
-    13px/1.55 var(--vscode-editor-font-family, "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
-  white-space: pre;
+  font-family: var(--vscode-editor-font-family, "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  line-height: var(--vscode-editor-line-height, 20px);
+  white-space: var(--markstream-code-white-space, pre);
+  font-variant-ligatures: none;
+  tab-size: 4;
 }
 
 .markstream-svelte .code-pre-fallback code {
   color: inherit;
   font: inherit;
   background: transparent;
+}
+
+.markstream-svelte .code-pre-fallback.markstream-pre--line-numbers {
+  --markstream-pre-line-number-left: 0px;
+  --markstream-pre-line-number-width: 2ch;
+  --markstream-pre-line-number-padding-left: 2ch;
+  --markstream-pre-line-number-padding-right: 1ch;
+  --markstream-pre-line-number-separator-width: 2px;
+  --markstream-pre-line-number-gap-to-code: 1ch;
+  --markstream-pre-line-number-box-width: calc(
+    var(--markstream-pre-line-number-padding-left)
+    + var(--markstream-pre-line-number-width)
+    + var(--markstream-pre-line-number-padding-right)
+    + var(--markstream-pre-line-number-separator-width)
+  );
+  --markstream-pre-code-left: calc(
+    var(--markstream-pre-line-number-left)
+    + var(--markstream-pre-line-number-box-width)
+    + var(--markstream-pre-line-number-gap-to-code)
+  );
+}
+
+.markstream-svelte .code-pre-fallback > .markstream-pre__line-numbers {
+  position: absolute;
+  top: var(--markstream-code-padding-top, 8px);
+  left: var(--markstream-pre-line-number-left);
+  box-sizing: content-box;
+  width: var(--markstream-pre-line-number-width);
+  min-width: var(--markstream-pre-line-number-width);
+  padding-left: var(--markstream-pre-line-number-padding-left);
+  padding-right: var(--markstream-pre-line-number-padding-right);
+  border-right: var(--markstream-pre-line-number-separator-width) solid var(--markstream-diff-gutter-guide, rgb(148 163 184 / 0.18));
+  color: var(--stream-monaco-line-number, var(--markstream-diff-line-number, #6b7280));
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  text-align: right;
+  pointer-events: none;
+  user-select: none;
+}
+
+.markstream-svelte .code-pre-fallback > .markstream-pre__line-numbers > .markstream-pre__line-numbers-text {
+  display: block;
+  white-space: pre;
+}
+
+.markstream-svelte .code-pre-fallback:not(.markstream-pre--diff-preview) > .markstream-pre__code {
+  display: block;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
+  padding-left: var(--markstream-pre-code-left);
+  padding-right: 1ch;
+}
+
+.markstream-svelte .code-pre-fallback.markstream-pre--diff-preview {
+  --markstream-pre-diff-gutter-marker-width: var(--stream-monaco-gutter-marker-width, 4px);
+  --markstream-pre-diff-line-number-width: var(--stream-monaco-line-number-width, 2ch);
+  --markstream-pre-diff-line-number-padding-left: var(--stream-monaco-line-number-padding-left, 2ch);
+  --markstream-pre-diff-line-number-padding-right: var(--stream-monaco-line-number-padding-right, 1ch);
+  --markstream-pre-diff-line-number-separator-width: var(--stream-monaco-line-number-separator-width, 2px);
+  --markstream-pre-diff-line-number-gap-to-code: var(--stream-monaco-line-number-gap-to-code, 1ch);
+  --markstream-pre-diff-line-number-box-width: calc(
+    var(--markstream-pre-diff-line-number-padding-left)
+    + var(--markstream-pre-diff-line-number-width)
+    + var(--markstream-pre-diff-line-number-padding-right)
+    + var(--markstream-pre-diff-line-number-separator-width)
+  );
+  --markstream-pre-diff-code-fill-left: var(--markstream-pre-diff-line-number-box-width);
+  --markstream-pre-diff-code-left: calc(
+    var(--markstream-pre-diff-code-fill-left)
+    + var(--markstream-pre-diff-line-number-gap-to-code)
+  );
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.markstream-svelte .code-pre-fallback.markstream-pre--diff-preview > .markstream-pre__diff-code {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  width: 100%;
+  min-width: 100%;
+  font: inherit;
+  line-height: inherit;
+}
+
+.markstream-svelte .code-pre-fallback.markstream-pre--diff-inline > .markstream-pre__diff-code {
+  grid-template-columns: minmax(100%, max-content);
+  min-width: max-content;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-pane {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.markstream-svelte .code-pre-fallback:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-pane-content {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-pane--modified {
+  box-shadow: inset 1px 0 var(--markstream-diff-pane-divider, rgb(148 163 184 / 0.18));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: max-content;
+  min-width: 100%;
+  min-height: var(--vscode-editor-line-height, 20px);
+  padding-left: var(--markstream-pre-diff-code-left);
+  line-height: var(--vscode-editor-line-height, 20px);
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 0 var(--markstream-pre-diff-code-fill-left);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-rail {
+  position: absolute;
+  z-index: 2;
+  inset: 0 auto 0 0;
+  width: var(--markstream-pre-diff-gutter-marker-width);
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-number {
+  position: absolute;
+  z-index: 1;
+  inset: 0 auto 0 0;
+  box-sizing: border-box;
+  width: var(--markstream-pre-diff-line-number-box-width);
+  padding-left: var(--markstream-pre-diff-line-number-padding-left);
+  padding-right: var(--markstream-pre-diff-line-number-padding-right);
+  box-shadow: inset -1px 0 var(--markstream-diff-gutter-guide, rgb(148 163 184 / 0.18));
+  color: var(--stream-monaco-line-number, var(--markstream-diff-line-number, #6b7280));
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  user-select: none;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-content {
+  position: relative;
+  z-index: 1;
+  display: block;
+  min-width: max-content;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--added::before,
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-number {
+  background: var(--stream-monaco-added-line-fill, var(--markstream-diff-added-line-fill, transparent));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--removed::before,
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-number {
+  background: var(--stream-monaco-removed-line-fill, var(--markstream-diff-removed-line-fill, transparent));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-rail {
+  background: var(--stream-monaco-added-fg, var(--markstream-diff-added-fg));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-rail {
+  background: var(--stream-monaco-removed-fg, var(--markstream-diff-removed-fg));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--added > .markstream-pre__diff-number {
+  color: var(--stream-monaco-added-fg, var(--markstream-diff-added-fg));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--removed > .markstream-pre__diff-number {
+  color: var(--stream-monaco-removed-fg, var(--markstream-diff-removed-fg));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--spacer > *,
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--spacer::before {
+  visibility: hidden;
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--collapsed {
+  min-height: 40px;
+  padding-left: 8px;
+  color: var(--stream-monaco-unchanged-fg, var(--markstream-diff-unchanged-fg));
+  line-height: 40px;
+  background: var(--stream-monaco-unchanged-bg, var(--markstream-diff-unchanged-bg));
+}
+
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--collapsed > .markstream-pre__diff-number,
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--collapsed > .markstream-pre__diff-rail,
+.markstream-svelte .code-pre-fallback .markstream-pre__diff-line--collapsed::before {
+  display: none;
 }
 
 .markstream-svelte .code-block-container.is-diff {

--- a/packages/markstream-svelte/src/optional/monaco.ts
+++ b/packages/markstream-svelte/src/optional/monaco.ts
@@ -4,6 +4,17 @@ let pendingImport: Promise<MonacoRuntimeModule | null> | null = null
 let workersPreloaded = false
 let codeBlockRuntimeReady = false
 
+const runtimeLoaders = [
+  () => import('stream-diffs'),
+  () => import('stream-monaco'),
+]
+
+function normalizeRuntimeModule(imported: any): MonacoRuntimeModule | null {
+  if (typeof imported?.useMonaco === 'function')
+    return imported
+  return typeof imported?.default?.useMonaco === 'function' ? imported.default : null
+}
+
 export interface MonacoRuntimeHelpers {
   createEditor?: (container: HTMLElement, code: string, language: string) => Promise<unknown> | unknown
   createDiffEditor?: (container: HTMLElement, original: string, modified: string, language: string) => Promise<unknown> | unknown
@@ -15,6 +26,7 @@ export interface MonacoRuntimeHelpers {
   getEditorView?: () => unknown
   getDiffEditorView?: () => unknown
   refreshDiffPresentation?: () => unknown
+  whenVisualReady?: () => Promise<boolean> | boolean
 }
 
 export interface MonacoRuntimeModule {
@@ -39,12 +51,14 @@ export async function preloadCodeBlockRuntime() {
 async function preloadWorkers(mod: any) {
   if (workersPreloaded)
     return
-  workersPreloaded = true
   const existingEnv = (globalThis as any)?.MonacoEnvironment
-  if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function'))
+  if (existingEnv && (typeof existingEnv.getWorker === 'function' || typeof existingEnv.getWorkerUrl === 'function')) {
+    workersPreloaded = true
     return
+  }
   if (typeof mod?.preloadMonacoWorkers === 'function')
     await mod.preloadMonacoWorkers()
+  workersPreloaded = true
 }
 
 async function warmupShikiTokenizer(mod: any) {
@@ -55,7 +69,7 @@ async function warmupShikiTokenizer(mod: any) {
   try {
     const highlighter = await getOrCreateHighlighter(
       ['vitesse-dark', 'vitesse-light'],
-      ['plaintext', 'text', 'javascript'],
+      ['javascript'],
     )
 
     if (highlighter && typeof highlighter.codeToTokens === 'function') {
@@ -79,18 +93,23 @@ export async function getUseMonaco(): Promise<MonacoRuntimeModule | null> {
     return null
 
   pendingImport = (async () => {
-    try {
-      const imported: any = await import('stream-monaco')
-      monacoModule = imported?.default ?? imported
-      await preloadWorkers(monacoModule)
-      codeBlockRuntimeReady = true
-      void warmupShikiTokenizer(monacoModule)
-      return monacoModule
+    for (const load of runtimeLoaders) {
+      try {
+        const imported: any = await load()
+        const candidate = normalizeRuntimeModule(imported)
+        if (!candidate)
+          continue
+        await preloadWorkers(candidate)
+        monacoModule = candidate
+        codeBlockRuntimeReady = true
+        void warmupShikiTokenizer(monacoModule)
+        return monacoModule
+      }
+      catch {}
     }
-    catch {
-      importAttempted = true
-      return null
-    }
+
+    importAttempted = true
+    return null
   })()
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       mermaid:
         specifier: '>=11'
         version: 11.13.0
+      stream-diffs:
+        specifier: '>=0.0.1'
+        version: 0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3))
       stream-markdown-parser:
         specifier: workspace:*
         version: link:../markdown-parser

--- a/scripts/e2e-svelte-playground.mjs
+++ b/scripts/e2e-svelte-playground.mjs
@@ -179,7 +179,7 @@ async function main() {
         return false
       const messagesStyle = getComputedStyle(messages)
       return messagesStyle.flexDirection === 'column-reverse'
-        && messagesStyle.overflowY === 'visible'
+        && messagesStyle.overflowY === 'auto'
         && container.getBoundingClientRect().width > 600
     }, null, { timeout: 10000 })
     await page.waitForFunction(() => {
@@ -203,51 +203,50 @@ async function main() {
     await page.waitForFunction(() => document.querySelectorAll('.chatbot-messages > .markstream-svelte .node-slot').length > 0, null, { timeout: 15000 })
     await page.waitForFunction(selector => document.querySelector(selector)?.textContent?.includes('packages/'), homeRendererSelector, { timeout: 30000 })
     await page.waitForFunction(() => {
-      const scrollRoot = document.scrollingElement
+      const scrollRoot = document.querySelector('.chat-messages')
       return scrollRoot
         && scrollRoot.scrollHeight - scrollRoot.clientHeight > 1000
         && document.querySelector('.chat-header__meta')?.textContent?.includes('Streaming')
     }, null, { timeout: 15000 })
-    await page.evaluate(() => window.scrollTo(0, document.scrollingElement.scrollHeight))
+    await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTo(0, 0))
     await page.waitForFunction(() => {
-      const scrollRoot = document.scrollingElement
-      return scrollRoot && scrollRoot.scrollHeight - scrollRoot.clientHeight - scrollRoot.scrollTop <= 80
+      const scrollRoot = document.querySelector('.chat-messages')
+      return scrollRoot && Math.abs(scrollRoot.scrollTop) <= 2
     }, null, { timeout: 5000 })
     const bottomPinnedBefore = await page.evaluate(() => {
-      const scrollRoot = document.scrollingElement
+      const scrollRoot = document.querySelector('.chat-messages')
       return {
         scrollHeight: scrollRoot.scrollHeight,
-        bottomGap: scrollRoot.scrollHeight - scrollRoot.clientHeight - scrollRoot.scrollTop,
+        bottomGap: Math.abs(scrollRoot.scrollTop),
       }
     })
     await page.waitForTimeout(900)
     const bottomPinnedAfter = await page.evaluate(() => {
-      const scrollRoot = document.scrollingElement
+      const scrollRoot = document.querySelector('.chat-messages')
       return {
         scrollHeight: scrollRoot.scrollHeight,
-        bottomGap: scrollRoot.scrollHeight - scrollRoot.clientHeight - scrollRoot.scrollTop,
+        bottomGap: Math.abs(scrollRoot.scrollTop),
       }
     })
     if (bottomPinnedAfter.scrollHeight <= bottomPinnedBefore.scrollHeight + 80)
       throw new Error('Homepage stream did not grow during bottom pinning probe')
     if (bottomPinnedAfter.bottomGap > 96)
       throw new Error(`Homepage should remain pinned at bottom while streaming: ${JSON.stringify({ bottomPinnedBefore, bottomPinnedAfter })}`)
-    const manualScrollBefore = await page.evaluate(() => window.scrollY)
-    const manualScrollProbe = await page.evaluate(() => {
-      window.dispatchEvent(new WheelEvent('wheel', { deltaY: -500 }))
-      window.scrollBy(0, -500)
-      return window.scrollY
-    })
+    const manualScrollBefore = await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTop ?? 0)
+    await page.locator('.chat-messages').hover()
+    await page.mouse.wheel(0, -500)
+    await page.waitForFunction(() => (document.querySelector('.chat-messages')?.scrollTop ?? 0) < -120, null, { timeout: 5000 })
+    const manualScrollProbe = await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTop ?? 0)
     if (manualScrollProbe >= manualScrollBefore - 120)
       throw new Error(`Homepage manual scroll probe did not move upward: ${manualScrollBefore} -> ${manualScrollProbe}`)
     await page.waitForTimeout(900)
-    const manualScrollAfter = await page.evaluate(() => window.scrollY)
+    const manualScrollAfter = await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTop ?? 0)
     if (Math.abs(manualScrollAfter - manualScrollProbe) > 32)
       throw new Error(`Homepage manual scroll should not be pulled back while streaming: ${manualScrollProbe} -> ${manualScrollAfter}`)
-    await page.evaluate(() => window.scrollTo(0, document.scrollingElement.scrollHeight))
+    await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTo(0, 0))
     await page.waitForFunction(() => {
-      const scrollRoot = document.scrollingElement
-      return scrollRoot && scrollRoot.scrollHeight - scrollRoot.clientHeight - scrollRoot.scrollTop <= 96
+      const scrollRoot = document.querySelector('.chat-messages')
+      return scrollRoot && Math.abs(scrollRoot.scrollTop) <= 2
     }, null, { timeout: 5000 })
     await page.waitForFunction(() => window.__markstreamSvelteMermaidWorkerMessages?.some(item => item.action === 'canParse'), null, { timeout: 30000 })
     await page.waitForFunction((selector) => {
@@ -261,37 +260,64 @@ async function main() {
         })
       return visibleCodeBlocks.length > 0 && visibleCodeBlocks.every(node => (node.textContent || '').trim().length > 0)
     }, homeRendererSelector, { timeout: 15000 })
-    await page.waitForFunction((selector) => {
-      if (document.querySelector('.chat-header__meta')?.textContent?.includes('Ready'))
-        return false
-      const root = document.querySelector(selector)
-      if (!root)
-        return false
-      return Array.from(root.querySelectorAll('.code-block-container[data-markstream-code-block="1"]')).some((block) => {
-        const fallback = block.querySelector('.code-pre-fallback')
-        const fallbackVisible = fallback && getComputedStyle(fallback).display !== 'none' && fallback.getBoundingClientRect().height > 0
-        return block.getAttribute('data-markstream-enhanced') === 'true'
-          && !fallbackVisible
-          && !!block.querySelector('.monaco-editor, .monaco-diff-editor')
+    await page.waitForFunction(() => document.querySelector('.chat-header__meta')?.textContent?.includes('Ready'), null, { timeout: 45000 })
+    const homeCodeBlocks = page.locator(`${homeRendererSelector} .code-block-container[data-markstream-code-block="1"]`)
+    const homeCodeBlockCount = await homeCodeBlocks.count()
+    if (homeCodeBlockCount < 8)
+      throw new Error(`Expected at least 8 homepage code blocks, received ${homeCodeBlockCount}`)
+    for (let index = 0; index < homeCodeBlockCount; index += 1) {
+      await homeCodeBlocks.nth(index).evaluate((block) => {
+        const body = block.querySelector('.code-block-body')
+        const state = {
+          heights: [body?.getBoundingClientRect().height || 0],
+          observer: null,
+        }
+        state.observer = new ResizeObserver(() => {
+          state.heights.push(body?.getBoundingClientRect().height || 0)
+        })
+        if (body)
+          state.observer.observe(body)
+        block.__markstreamHandoffProbe = state
       })
-    }, homeRendererSelector, { timeout: 30000 })
-    await page.waitForFunction((selector) => {
-      if (!document.querySelector('.chat-header__meta')?.textContent?.includes('Ready'))
-        return false
-      const root = document.querySelector(selector)
-      if (!root)
-        return false
-      const blocks = Array.from(root.querySelectorAll('.code-block-container[data-markstream-code-block="1"]'))
-      if (blocks.length < 8)
-        return false
-      return blocks.every((block) => {
-        const fallback = block.querySelector('.code-pre-fallback')
-        const fallbackVisible = fallback && getComputedStyle(fallback).display !== 'none' && fallback.getBoundingClientRect().height > 0
-        return block.getAttribute('data-markstream-enhanced') === 'true'
-          && !fallbackVisible
-          && !!block.querySelector('.monaco-editor, .monaco-diff-editor')
+      await homeCodeBlocks.nth(index).scrollIntoViewIfNeeded()
+      try {
+        await page.waitForFunction(({ selector, index }) => {
+          const block = document.querySelectorAll(`${selector} .code-block-container[data-markstream-code-block="1"]`)[index]
+          const fallback = block?.querySelector('.code-pre-fallback')
+          const fallbackVisible = fallback && getComputedStyle(fallback).display !== 'none' && fallback.getBoundingClientRect().height > 0
+          return block?.getAttribute('data-markstream-enhanced') === 'true'
+            && !fallbackVisible
+            && !!block.querySelector('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')
+        }, { selector: homeRendererSelector, index }, { timeout: 30000 })
+      }
+      catch (error) {
+        const state = await homeCodeBlocks.nth(index).evaluate((block) => {
+          const fallback = block.querySelector('.code-pre-fallback')
+          return {
+            enhanced: block.getAttribute('data-markstream-enhanced'),
+            fallbackDisplay: fallback ? getComputedStyle(fallback).display : null,
+            hasSurface: !!block.querySelector('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor'),
+            label: block.querySelector('.code-block-header__label')?.textContent || '',
+          }
+        })
+        throw new Error(`Homepage code block ${index} did not enhance: ${JSON.stringify(state)}`, { cause: error })
+      }
+      await page.waitForTimeout(50)
+      const handoff = await homeCodeBlocks.nth(index).evaluate((block) => {
+        const state = block.__markstreamHandoffProbe
+        const body = block.querySelector('.code-block-body')
+        state?.observer?.disconnect()
+        const heights = state?.heights || []
+        heights.push(body?.getBoundingClientRect().height || 0)
+        delete block.__markstreamHandoffProbe
+        return heights
       })
-    }, homeRendererSelector, { timeout: 45000 })
+      const firstHeight = handoff[0] || 0
+      const finalHeight = handoff.at(-1) || 0
+      const maxHeight = Math.max(...handoff)
+      if (Math.abs(firstHeight - finalHeight) > 2 || maxHeight > Math.max(firstHeight, finalHeight) + 2)
+        throw new Error(`Homepage code block ${index} changed height during handoff: ${JSON.stringify(handoff)}`)
+    }
     const homeCodeBlockState = await page.evaluate((selector) => {
       const root = document.querySelector(selector)
       return Array.from(root?.querySelectorAll('.code-block-container[data-markstream-code-block="1"]') ?? []).map((block, index) => {
@@ -301,30 +327,30 @@ async function main() {
           index,
           label: block.querySelector('.code-block-header__label')?.textContent || '',
           enhanced: block.getAttribute('data-markstream-enhanced'),
-          hasMonaco: !!block.querySelector('.monaco-editor, .monaco-diff-editor'),
+          hasMonaco: !!block.querySelector('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor'),
           fallbackVisible: !!fallbackVisible,
           bodyHeight: Math.round(block.querySelector('.code-block-body')?.getBoundingClientRect().height || 0),
           editorHeight: Math.round(block.querySelector('.code-editor-container')?.getBoundingClientRect().height || 0),
-          monacoHeight: Math.round(block.querySelector('.monaco-editor, .monaco-diff-editor')?.getBoundingClientRect().height || 0),
+          monacoHeight: Math.round(block.querySelector('.stream-diffs-shell, .monaco-editor, .monaco-diff-editor')?.getBoundingClientRect().height || 0),
         }
       })
     }, homeRendererSelector)
     const invalidHomeCodeBlocks = homeCodeBlockState.filter(block => block.enhanced !== 'true' || !block.hasMonaco || block.fallbackVisible)
     if (invalidHomeCodeBlocks.length > 0)
       throw new Error(`Home code blocks must render Monaco without visible fallback: ${JSON.stringify(invalidHomeCodeBlocks)}`)
-    const collapsedHomeCodeBlocks = homeCodeBlockState.filter(block => block.bodyHeight > 0 && (block.editorHeight + 2 < block.bodyHeight || block.monacoHeight + 2 < block.editorHeight))
+    const collapsedHomeCodeBlocks = homeCodeBlockState.filter(block => block.bodyHeight > 0 && block.editorHeight + 2 < block.bodyHeight)
     if (collapsedHomeCodeBlocks.length > 0)
       throw new Error(`Home code block Monaco containers must fill their body: ${JSON.stringify(collapsedHomeCodeBlocks)}`)
     const scrollProbe = await page.evaluate(() => {
-      const scrollHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight)
-      const maxScrollTop = Math.max(0, scrollHeight - window.innerHeight)
-      const target = Math.max(0, maxScrollTop - 450)
-      window.scrollTo(0, target)
-      return { scrollY: window.scrollY, maxScrollTop }
+      const scrollRoot = document.querySelector('.chat-messages')
+      const maxScrollTop = Math.max(0, scrollRoot.scrollHeight - scrollRoot.clientHeight)
+      const target = -Math.max(0, maxScrollTop - 450)
+      scrollRoot.scrollTo({ top: target, behavior: 'instant' })
+      return { scrollY: scrollRoot.scrollTop, maxScrollTop }
     })
     if (scrollProbe.maxScrollTop > 1000) {
       await page.waitForTimeout(1200)
-      const scrollAfterProbe = await page.evaluate(() => window.scrollY)
+      const scrollAfterProbe = await page.evaluate(() => document.querySelector('.chat-messages')?.scrollTop ?? 0)
       if (Math.abs(scrollAfterProbe - scrollProbe.scrollY) > 24)
         throw new Error(`Homepage scroll jumped after manual scroll: ${scrollProbe.scrollY} -> ${scrollAfterProbe}`)
     }
@@ -448,22 +474,30 @@ async function main() {
       const candidates = Array.from(root.querySelectorAll('pre[data-markstream-code-block="1"], .code-block-container[data-markstream-code-block="1"], .markstream-svelte-enhanced-block--code'))
       return candidates.some((node) => {
         const rect = node.getBoundingClientRect()
-        const text = (node.textContent || '').replace(/\s+/g, ' ')
+        const diffsContainer = node.matches('diffs-container') ? node : node.querySelector('diffs-container')
+        const text = `${node.textContent || ''} ${diffsContainer?.shadowRoot?.textContent || ''}`.replace(/\s+/g, ' ')
         return rect.width > 0 && rect.height > 0 && text.includes(codeText)
       })
     }, testRendererSelector, { timeout: 30000 })
-    await page.waitForFunction(selector => document.querySelectorAll(`${selector} .code-block-container[data-markstream-enhanced="true"] .monaco-editor`).length > 0, testRendererSelector, { timeout: 30000 })
+    await page.locator(`${testRendererSelector} .code-block-container`).first().scrollIntoViewIfNeeded()
     await page.waitForFunction((selector) => {
       const block = document.querySelector(`${selector} .code-block-container[data-markstream-enhanced="true"]`)
-      const editor = block?.querySelector('.monaco-editor')
+      return !!block?.querySelector('.stream-diffs-shell, .monaco-editor')
+    }, testRendererSelector, { timeout: 30000 })
+    await page.waitForFunction((selector) => {
+      const block = document.querySelector(`${selector} .code-block-container[data-markstream-enhanced="true"]`)
+      const editor = block?.querySelector('.stream-diffs-shell, .monaco-editor')
       if (!block || !editor)
         return false
       const fallback = block.querySelector('.code-pre-fallback')
       const fallbackVisible = fallback && getComputedStyle(fallback).display !== 'none' && fallback.getBoundingClientRect().height > 0
-      const tokens = Array.from(editor.querySelectorAll('.view-line span span'))
+      const diffsContainer = editor.matches('diffs-container') ? editor : editor.querySelector('diffs-container')
+      const tokenRoot = diffsContainer?.shadowRoot || editor
+      const tokens = diffsContainer
+        ? Array.from(tokenRoot.querySelectorAll('pre span'))
+        : Array.from(tokenRoot.querySelectorAll('.view-line span span'))
       const tokenColors = new Set(tokens.map(node => getComputedStyle(node).color).filter(Boolean))
-      const tokenClasses = new Set(tokens.map(node => String(node.className)).filter(Boolean))
-      return !fallbackVisible && tokenColors.size > 2 && tokenClasses.size > 2
+      return !fallbackVisible && tokenColors.size > 2
     }, testRendererSelector, { timeout: 15000 })
     await page.waitForFunction((selector) => {
       const root = document.querySelector(selector)
@@ -658,11 +692,14 @@ async function main() {
 
     await page.selectOption('.workspace-card--editor select', 'diff')
     await page.waitForFunction(() => document.querySelector('.workspace-card--preview')?.textContent?.includes('Diff Regression'), null, { timeout: 15000 })
-    await page.waitForFunction(selector => document.querySelectorAll(`${selector} .code-block-container.is-diff .monaco-diff-editor`).length > 0, testRendererSelector, { timeout: 30000 })
+    await page.waitForFunction((selector) => {
+      const block = document.querySelector(`${selector} .code-block-container.is-diff`)
+      return !!block?.querySelector('.stream-diffs-shell, .monaco-diff-editor')
+    }, testRendererSelector, { timeout: 30000 })
     await page.waitForFunction((selector) => {
       const block = document.querySelector(`${selector} .code-block-container.is-diff`)
       const host = block?.querySelector('.code-editor-container')
-      const editor = block?.querySelector('.monaco-diff-editor')
+      const editor = block?.querySelector('.stream-diffs-shell, .monaco-diff-editor')
       if (!host || !editor)
         return false
       const hostRect = host.getBoundingClientRect()

--- a/test/markstream-svelte-render-context.test.ts
+++ b/test/markstream-svelte-render-context.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { buildRenderContext } from '../packages/markstream-svelte/src/components/shared/node-helpers'
+
+describe('markstream-svelte render context', () => {
+  it('forwards the viewport priority setting to code blocks', () => {
+    expect(buildRenderContext({ viewportPriority: false }).viewportPriority).toBe(false)
+    expect(buildRenderContext({ viewportPriority: true }).viewportPriority).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add optional stream-diffs runtime loading with stream-monaco fallback
- keep pre surfaces until completed, visible code blocks have stable enhanced geometry
- preserve viewport-priority configuration and invalidate stale creation on collapse, destroy, or identity changes
- align Svelte pre and enhanced code/diff layouts and extend browser handoff assertions

## Verification
- `pnpm --filter markstream-svelte typecheck` (0 errors, 0 warnings)
- Svelte-focused unit suite: 4 files, 19 tests
- ESLint on touched TypeScript, test, and E2E files
- `pnpm --filter markstream-svelte build`
- `pnpm --dir playground-svelte build`
- `node scripts/e2e-svelte-playground.mjs` (8+ code blocks, per-block handoff height probes, shadow-DOM syntax tokens, diff surface, collapse/expand, stable scroll, no page errors)