### PR TITLE
fix: update mounted diff layout and resolve named themes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 6.0.11(rolldown@1.0.0-beta.45)(rollup@3.30.0)
       stream-diffs:
         specifier: latest
-        version: 0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3))
+        version: 0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3))
       stream-markdown:
         specifier: latest
         version: 0.0.15(react@19.2.7)(shiki@4.3.1)(vue@3.5.25(typescript@5.9.3))
@@ -12341,8 +12341,8 @@ packages:
   stream-browserify@2.0.2:
     resolution: {integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==}
 
-  stream-diffs@0.0.1:
-    resolution: {integrity: sha512-ljw+IPcxj3dj9zyKtv9QOxloByi72fVuprHahO8pIhqk787sLmNvygMONSs07NNjUvknLZN9sePKh+LYGDuoQQ==}
+  stream-diffs@0.0.2:
+    resolution: {integrity: sha512-mYH+kBCmrN2ebVPNkvQIFUSPemFxUPPPk+NT4H/wEzZ9NCt5Eaa8OE05f/1MA5HofZ64LYbTOliQTU6VghHeVA==}
     peerDependencies:
       vue: 3.5.25
     peerDependenciesMeta:
@@ -27585,7 +27585,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  stream-diffs@0.0.1(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3)):
+  stream-diffs@0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.25(typescript@5.9.3)):
     dependencies:
       '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -688,10 +688,6 @@ async function ensureMonacoRuntime() {
       if (typeof useMonaco !== 'function')
         return
 
-      const theme = resolveRequestedTheme()
-      if (theme && props.themes && Array.isArray(props.themes) && !props.themes.includes(theme))
-        throw new Error('Preferred theme not in provided themes array')
-
       runtimeMonacoOptions = buildRuntimeMonacoOptions()
       const helpers = useMonaco(runtimeMonacoOptions)
       createEditor = helpers.createEditor || createEditor
@@ -4373,9 +4369,6 @@ watch(
       if (isUnmounted || !codeEditor.value)
         return
     }
-    if (currentEditorKind.value === desiredEditorKind.value && editorCreated.value && editorMounted.value)
-      return
-
     try {
       editorMounted.value = false
       editorDisplayReady.value = false

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -432,4 +432,72 @@ describe('codeBlockNode final Diffs gate', () => {
     })
     wrapper.unmount()
   })
+
+  it('recreates a mounted FileDiff surface when its layout changes', async () => {
+    const runtime = helpers()
+    const diffNode = {
+      type: 'code_block' as const,
+      language: 'typescript',
+      code: '',
+      raw: '```diff\n-const before = 1\n+const after = 2\n```',
+      diff: true,
+      originalCode: 'const before = 1',
+      updatedCode: 'const after = 2',
+      loading: false,
+    }
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: diffNode,
+        loading: false,
+        stream: true,
+        showHeader: false,
+        monacoOptions: { renderSideBySide: true },
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(runtime.createDiffEditor).toHaveBeenCalledTimes(1))
+    expect(runtime.useMonaco.mock.calls[0]?.[0]?.renderSideBySide).toBe(true)
+    runtime.safeClean.mockClear()
+
+    await wrapper.setProps({ monacoOptions: { renderSideBySide: false } })
+    await vi.waitFor(() => {
+      expect(runtime.safeClean).toHaveBeenCalled()
+      expect(runtime.createDiffEditor).toHaveBeenCalledTimes(2)
+    })
+    expect(runtime.useMonaco.mock.calls[0]?.[0]?.renderSideBySide).toBe(false)
+
+    await wrapper.setProps({ monacoOptions: { renderSideBySide: true } })
+    await vi.waitFor(() => {
+      expect(runtime.createDiffEditor).toHaveBeenCalledTimes(3)
+    })
+    expect(runtime.useMonaco.mock.calls[0]?.[0]?.renderSideBySide).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('accepts a theme name that matches an object in the theme pool', async () => {
+    const runtime = helpers()
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const themed = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+        theme: 'github-dark',
+        themes: [{ name: 'github-dark' }],
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => {
+      expect(runtime.useMonaco).toHaveBeenCalledTimes(1)
+      expect(runtime.createEditor).toHaveBeenCalledTimes(1)
+      expect(wrapper.find('diffs-container').exists()).toBe(true)
+      expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
+    })
+    expect(runtime.useMonaco.mock.calls[0]?.[0]?.theme).toBe('github-dark')
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary

- rebuild an already mounted FileDiff surface when structural options such as `renderSideBySide` change
- allow a string theme name to resolve against a theme object pool without falling back to `<pre>`
- test both regressions and update the lockfile to `stream-diffs@0.0.2`

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm run build:parser && pnpm run build:core && pnpm test -- --run` (303 files, 2556 tests)
- `pnpm build`
- `pnpm check:ssr`
- `pnpm test:api`
- `pnpm docs:check-zh`
- `pnpm docs:check-llms`
- real-browser check with `stream-diffs@0.0.2`: object theme pool stayed enhanced, and one mounted surface switched inline → split → inline

Fixes #581