### PR TITLE
fix: decouple MathBlock cacheScope from streamRenderVersion

### DIFF
--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -311,37 +311,85 @@ async function renderMath() {
 // content replacements (clear stale lockedMinHeight so a shorter block doesn't
 // inherit the previous block's height).
 //
-// We compare the inner content (between delimiters) rather than `raw` directly,
-// because `raw` includes the closing delimiter, so a streaming append like
-// `$x$` -> `$x^2$` is NOT a string prefix of the next raw (the `^2` is
-// inserted before the closing `$`). Comparing the inner content correctly
-// identifies this as an append.
+// We extract the inner content (between delimiters) from `raw` and compare for
+// prefix extension. This correctly identifies streaming appends like
+// `$$x$$` -> `$$x^2$$` (inner: `x` -> `x^2`, prefix extension) even though
+// the full raw strings are NOT prefix-related (the `^2` is inserted before
+// the closing `$$`).
 //
-// We also accept the case where the normalized `content` changes shape
-// (e.g. `alpha` -> `\alpha` via normalizeStandaloneBackslashT) as long as
-// the un-normalized inner source extracted from `raw` is a prefix extension.
-function getInnerContent(raw: unknown, content: unknown) {
+// We require a complete delimiter PAIR match (both open and close) before
+// trusting the stripped inner content. This avoids false positives from
+// one-sided strips (e.g. `\[x]` where `]` is a fallback close for `\[`).
+// When no pair matches, we fall back to `content` and only allow exact
+// equality (no prefix inference), which is conservative but safe.
+const DELIMITER_PAIRS = [
+  // Order matters: longer/more specific pairs first.
+  { family: '$$', open: '$$', close: '$$' },
+  { family: '\\[]', open: '\\\[', close: '\\\]' },
+  // Parser-tolerated fallback close for `\[` in non-strict mode.
+  { family: '\\[]', open: '\\\[', close: ']' },
+  // Non-strict plain-bracket forms.
+  { family: '[]', open: '[', close: '\\\]' },
+  { family: '[]', open: '[', close: ']' },
+  // Inline math forms (kept for tolerance when MathBlockNode is used directly).
+  { family: '\\()', open: '\\\(', close: '\\\)' },
+  { family: '$', open: '$', close: '$' },
+] as const
+
+function resolveTrustedInner(raw: unknown): { family: string, inner: string, trusted: boolean } | null {
   const rawText = String(raw ?? '')
-  // Strip a leading+trailing delimiter pair: $...$, $...$, \[...\], \(...\)
-  const stripped = rawText
-    .replace(/^(\${1,2}|\\\[|\\\()/, '')
-    .replace(/(\${1,2}|\\\]|\\\))$/, '')
-  // Only trust the strip if it actually removed something from both ends.
-  if (stripped !== rawText && stripped.length < rawText.length)
-    return stripped
-  return String(content ?? '')
+  for (const { family, open, close } of DELIMITER_PAIRS) {
+    // Guard against a malformed `$$...$` being parsed as single-dollar math.
+    if (open === '$' && (rawText.startsWith('$$') || rawText.endsWith('$$')))
+      continue
+
+    if (
+      rawText.length >= open.length + close.length
+      && rawText.startsWith(open)
+      && rawText.endsWith(close)
+    ) {
+      return {
+        family,
+        inner: rawText.slice(open.length, rawText.length - close.length),
+        trusted: true,
+      }
+    }
+  }
+  return null
 }
 
-function isAppendUpdate(previousInner: string, nextInner: string) {
-  return previousInner === '' || nextInner.startsWith(previousInner)
+function getInnerContent(raw: unknown, content: unknown): { family: string, inner: string, trusted: boolean } {
+  const trusted = resolveTrustedInner(raw)
+  if (trusted)
+    return trusted
+  // No trusted delimiter pair: fall back to `content` (may be normalized).
+  // Prefix-extension is not safe here, callers must require exact equality.
+  return { family: 'content', inner: String(content ?? ''), trusted: false }
+}
+
+function isAppendUpdate(
+  previous: { family: string, inner: string, trusted: boolean },
+  next: { family: string, inner: string, trusted: boolean },
+) {
+  if (previous.inner === '')
+    return true
+  // Different delimiter families: always treat as replacement.
+  if (previous.family !== next.family)
+    return false
+  // Prefix reuse is only allowed when both sides came from a complete,
+  // recognized delimiter pair. Otherwise require exact equality to avoid
+  // false positives from normalization (e.g. `alpha` -> `\alpha`).
+  if (previous.trusted && next.trusted)
+    return next.inner.startsWith(previous.inner)
+  return next.inner === previous.inner
 }
 
 watch(
   () => [props.node.content, props.node.loading, props.node.raw] as const,
   ([content, , raw], [previousContent, , previousRaw]) => {
-    const previousInner = getInnerContent(previousRaw, previousContent)
-    const nextInner = getInnerContent(raw, content)
-    const appendOnly = isAppendUpdate(previousInner, nextInner)
+    const previous = getInnerContent(previousRaw, previousContent)
+    const next = getInnerContent(raw, content)
+    const appendOnly = isAppendUpdate(previous, next)
 
     if (!appendOnly)
       clearLockedMinHeight()

--- a/src/components/MathBlockNode/MathBlockNode.vue
+++ b/src/components/MathBlockNode/MathBlockNode.vue
@@ -307,9 +307,45 @@ async function renderMath() {
     })
 }
 
+// Distinguish streaming appends (keep lockedMinHeight to avoid flicker) from
+// content replacements (clear stale lockedMinHeight so a shorter block doesn't
+// inherit the previous block's height).
+//
+// We compare the inner content (between delimiters) rather than `raw` directly,
+// because `raw` includes the closing delimiter, so a streaming append like
+// `$x$` -> `$x^2$` is NOT a string prefix of the next raw (the `^2` is
+// inserted before the closing `$`). Comparing the inner content correctly
+// identifies this as an append.
+//
+// We also accept the case where the normalized `content` changes shape
+// (e.g. `alpha` -> `\alpha` via normalizeStandaloneBackslashT) as long as
+// the un-normalized inner source extracted from `raw` is a prefix extension.
+function getInnerContent(raw: unknown, content: unknown) {
+  const rawText = String(raw ?? '')
+  // Strip a leading+trailing delimiter pair: $...$, $...$, \[...\], \(...\)
+  const stripped = rawText
+    .replace(/^(\${1,2}|\\\[|\\\()/, '')
+    .replace(/(\${1,2}|\\\]|\\\))$/, '')
+  // Only trust the strip if it actually removed something from both ends.
+  if (stripped !== rawText && stripped.length < rawText.length)
+    return stripped
+  return String(content ?? '')
+}
+
+function isAppendUpdate(previousInner: string, nextInner: string) {
+  return previousInner === '' || nextInner.startsWith(previousInner)
+}
+
 watch(
-  () => [props.node.content, props.node.loading, props.node.raw],
-  () => {
+  () => [props.node.content, props.node.loading, props.node.raw] as const,
+  ([content, , raw], [previousContent, , previousRaw]) => {
+    const previousInner = getInnerContent(previousRaw, previousContent)
+    const nextInner = getInnerContent(raw, content)
+    const appendOnly = isAppendUpdate(previousInner, nextInner)
+
+    if (!appendOnly)
+      clearLockedMinHeight()
+
     renderMath()
   },
   { flush: 'post' },

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -679,7 +679,13 @@ const {
 watch(
   parsedNodes,
   () => {
-    mathBlockMinHeightCache.clear()
+    // Only clear the shared math minHeight cache on non-streaming content
+    // changes (dataset replacement, content rewrite, etc.). During streaming
+    // appends (contentStreamingTailActive=true), the cache is preserved so
+    // that virtualization remount of stable-prefix math blocks can restore
+    // their previously measured heights without re-reading offsetHeight.
+    if (!contentStreamingTailActive.value)
+      mathBlockMinHeightCache.clear()
     streamRenderVersion.value += 1
   },
   { immediate: true },

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -657,7 +657,7 @@ const instanceMsgId = rendererProps.customId
   ? `renderer-${rendererProps.customId}`
   : `renderer-${Date.now()}-${Math.random().toString(36).slice(2)}`
 const mathBlockMinHeightCache = createMathBlockMinHeightCache(instanceMsgId)
-const mathBlockCacheScope = computed(() => `${instanceMsgId}:${streamRenderVersion.value}`)
+const mathBlockCacheScope = instanceMsgId
 provideMathBlockMinHeightCache(mathBlockMinHeightCache)
 const customComponentsMap = useCustomNodeComponents(() => rendererProps.customId)
 const {
@@ -5511,7 +5511,7 @@ const renderedItems = computed(() => {
     if (node.type === 'math_block') {
       bindings = {
         ...bindings,
-        cacheScope: mathBlockCacheScope.value,
+        cacheScope: mathBlockCacheScope,
       }
     }
 

--- a/test/math-block-min-height-cache-scope.test.ts
+++ b/test/math-block-min-height-cache-scope.test.ts
@@ -149,3 +149,179 @@ describe('mathBlockNode min-height cache scope', () => {
     wrapper.unmount()
   })
 })
+
+describe('mathBlockNode locked min-height on content replacement', () => {
+  beforeEach(() => {
+    mocks.renderKaTeXWithBackpressure.mockReset()
+    // Never resolves: simulates KaTeX being unavailable/fallback state.
+    mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
+  })
+
+  afterEach(() => {
+    if (originalOffsetHeightDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeightDescriptor)
+    }
+  })
+
+  it('clears stale lockedMinHeight when content is replaced (non-append) at same indexKey and cacheScope', async () => {
+    // Simulate a tall fallback block being replaced by a short one while
+    // KaTeX never produces HTML (disabled / worker stuck / persistent fallback).
+    // Without the content-replacement reset, the shorter block would inherit
+    // the previous 392px locked min-height indefinitely.
+    mockOffsetHeight((el) => {
+      const locked = Number.parseFloat(el.style.minHeight)
+      if (Number.isFinite(locked) && locked > 0)
+        return locked
+      return el.dataset.markstreamMode === 'katex' ? 64 : 392
+    })
+
+    const rendererCache = createMathBlockMinHeightCache('renderer-replacement')
+
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: '\\sum_{i=1}^{n} x_i^2',
+          raw: '$\\sum_{i=1}^{n} x_i^2$',
+          loading: false,
+        },
+        indexKey: 'math-replacement-0',
+        cacheScope: 'renderer-replacement',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+        },
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.attributes('style')).toContain('min-height: 392px;')
+    expect(rendererCache.cache.get('renderer-replacement:math-block:math-replacement-0')).toBe(392)
+
+    // Replace with a completely different, shorter fallback math block.
+    // cacheScope and indexKey are unchanged (same Vue component instance).
+    // The new raw is NOT a prefix-extension of the old raw, so this is a
+    // content replacement, not a streaming append.
+    await wrapper.setProps({
+      node: {
+        type: 'math_block',
+        content: 'y',
+        raw: '$y$',
+        loading: false,
+      },
+    })
+    await flushAll()
+
+    // After clearing, offsetHeight reads 40 (mock returns fallback height
+    // when no locked min-height is set). But once we lock to 40, subsequent
+    // reads return the locked value. The key assertion: locked min-height
+    // must NOT still be 392.
+    const style = wrapper.attributes('style') ?? ''
+    expect(style).not.toContain('min-height: 392px')
+
+    wrapper.unmount()
+  })
+
+  it('preserves lockedMinHeight when content is a streaming append (prefix extension)', async () => {
+    // Streaming append to the math block itself: raw grows by prefix extension.
+    // lockedMinHeight must be preserved to avoid flicker during streaming.
+    mockOffsetHeight(200)
+
+    const rendererCache = createMathBlockMinHeightCache('renderer-append')
+
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          content: 'x',
+          raw: '$x$',
+          loading: true,
+        },
+        indexKey: 'math-append-0',
+        cacheScope: 'renderer-append',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+        },
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.attributes('style')).toContain('min-height: 200px;')
+
+    // Append-only update: raw grows from "$x$" to "$x^2$".
+    // This is a prefix extension (nextContent.startsWith(prev)), so
+    // lockedMinHeight should be preserved (no clearLockedMinHeight call).
+    await wrapper.setProps({
+      node: {
+        type: 'math_block',
+        content: 'x^2',
+        raw: '$x^2$',
+        loading: true,
+      },
+    })
+    await flushAll()
+
+    // min-height should still be present (preserved across append).
+    const appendStyle = wrapper.attributes('style') ?? ''
+    expect(appendStyle, `actual style after append: ${JSON.stringify(appendStyle)}`).toContain('min-height: 200px;')
+    expect(rendererCache.cache.get('renderer-append:math-block:math-append-0')).toBe(200)
+
+    wrapper.unmount()
+  })
+
+  it('does not falsely trigger replacement on normalizeStandaloneBackslashT transformations', async () => {
+    // During streaming, the parser's normalizeStandaloneBackslashT may
+    // transform content (e.g. "alpha" -> "\\alpha") between parse ticks,
+    // even though the user is just appending characters. The `raw` field
+    // preserves the original un-normalized input, so checking raw for
+    // prefix-extension must NOT trigger a false replacement.
+    mockOffsetHeight(180)
+
+    const rendererCache = createMathBlockMinHeightCache('renderer-normalize')
+
+    const wrapper = mount(MathBlockNode as any, {
+      props: {
+        node: {
+          type: 'math_block',
+          // Already-normalized content (simulating post-parse state)
+          content: 'alph',
+          raw: '$alph$',
+          loading: true,
+        },
+        indexKey: 'math-normalize-0',
+        cacheScope: 'renderer-normalize',
+      },
+      global: {
+        provide: {
+          [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache,
+        },
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.attributes('style')).toContain('min-height: 180px;')
+
+    // Next parse tick: content normalized to "\\alpha" (non-prefix), but
+    // raw extended from "$alph$" to "$alpha$" (prefix extension).
+    // The raw prefix check correctly identifies this as an append.
+    await wrapper.setProps({
+      node: {
+        type: 'math_block',
+        content: '\\alpha',
+        raw: '$alpha$',
+        loading: true,
+      },
+    })
+    await flushAll()
+
+    // lockedMinHeight preserved: raw was prefix-extended.
+    const normalizeStyle = wrapper.attributes('style') ?? ''
+    expect(normalizeStyle, `actual style after normalize: ${JSON.stringify(normalizeStyle)}`).toContain('min-height: 180px;')
+    expect(rendererCache.cache.get('renderer-normalize:math-block:math-normalize-0')).toBe(180)
+
+    wrapper.unmount()
+  })
+})

--- a/test/math-block-min-height-cache-scope.test.ts
+++ b/test/math-block-min-height-cache-scope.test.ts
@@ -325,3 +325,170 @@ describe('mathBlockNode locked min-height on content replacement', () => {
     wrapper.unmount()
   })
 })
+
+describe('mathBlockNode delimiter pair matrix', () => {
+  beforeEach(() => {
+    mocks.renderKaTeXWithBackpressure.mockReset()
+    mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
+  })
+
+  afterEach(() => {
+    if (originalOffsetHeightDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeightDescriptor)
+    }
+  })
+
+  const cases: Array<[string, string, string, boolean]> = [
+    ['$$x$$', '$$x^2$$', 'double-dollar', true],
+    ['\\[x\\]', '\\[x^2\\]', 'escaped-bracket', true],
+    ['\\[x]', '\\[x^2]', 'fallback-close', true],
+    ['[x]', '[x^2]', 'plain-bracket', true],
+    ['[x\\]', '[x^2\\]', 'plain-bracket-backslash', true],
+    ['$x$', '$x^2$', 'inline-dollar', true],
+    ['$$alph$$', '$$alpha$$', 'normalize', true],
+    ['$$x^2$$', '$$x^3$$', 'replace', false],
+    ['$$x$$', '\\[x^2\\]', 'family-change', false],
+  ]
+
+  for (const [previousRaw, nextRaw, label, shouldPreserve] of cases) {
+    it(`${shouldPreserve ? 'preserves' : 'clears'} lockedMinHeight for ${label}: ${previousRaw} -> ${nextRaw}`, async () => {
+      mockOffsetHeight(150)
+      const rendererCache = createMathBlockMinHeightCache(`renderer-${label}`)
+
+      const wrapper = mount(MathBlockNode as any, {
+        props: {
+          node: {
+            type: 'math_block',
+            content: previousRaw,
+            raw: previousRaw,
+            loading: true,
+          },
+          indexKey: `delim-${label}`,
+          cacheScope: `renderer-${label}`,
+        },
+        global: {
+          provide: { [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache },
+        },
+      })
+
+      await flushAll()
+      expect(wrapper.attributes('style')).toContain('min-height: 150px;')
+
+      await wrapper.setProps({
+        node: {
+          type: 'math_block',
+          content: nextRaw,
+          raw: nextRaw,
+          loading: true,
+        },
+      })
+      await flushAll()
+
+      const style = wrapper.attributes('style') ?? ''
+      if (shouldPreserve)
+        expect(style, `expected preserved for ${previousRaw} -> ${nextRaw}`).toContain('min-height: 150px;')
+      else
+        expect(style, `expected cleared for ${previousRaw} -> ${nextRaw}`).not.toContain('min-height: 150px;')
+
+      wrapper.unmount()
+    })
+  }
+})
+
+describe('mathBlockNode virtualization remount cache behavior', () => {
+  beforeEach(() => {
+    mocks.renderKaTeXWithBackpressure.mockReset()
+    mocks.renderKaTeXWithBackpressure.mockImplementation(() => new Promise<string>(() => {}))
+  })
+
+  afterEach(() => {
+    if (originalOffsetHeightDescriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeightDescriptor)
+    }
+  })
+
+  it('restores cached height on remount when cache was preserved', async () => {
+    mockOffsetHeight(200)
+    const rendererCache = createMathBlockMinHeightCache('renderer-remount')
+
+    const first = mount(MathBlockNode as any, {
+      props: {
+        node: { type: 'math_block', content: 'x', raw: '$$x$$', loading: true },
+        indexKey: 'remount-0',
+        cacheScope: 'renderer-remount',
+      },
+      global: {
+        provide: { [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache },
+      },
+    })
+
+    await flushAll()
+    expect(first.attributes('style')).toContain('min-height: 200px;')
+    expect(rendererCache.cache.get('renderer-remount:math-block:remount-0')).toBe(200)
+    first.unmount()
+
+    const second = mount(MathBlockNode as any, {
+      props: {
+        node: { type: 'math_block', content: 'x', raw: '$$x$$', loading: true },
+        indexKey: 'remount-0',
+        cacheScope: 'renderer-remount',
+      },
+      global: {
+        provide: { [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache },
+      },
+    })
+
+    await flushAll()
+    expect(second.attributes('style')).toContain('min-height: 200px;')
+
+    second.unmount()
+  })
+
+  it('does not restore stale height when remounted with different content after cache clear', async () => {
+    let naturalHeight = 392
+    mockOffsetHeight((el) => {
+      const locked = Number.parseFloat(el.style.minHeight)
+      if (Number.isFinite(locked) && locked > 0)
+        return locked
+      return naturalHeight
+    })
+
+    const rendererCache = createMathBlockMinHeightCache('renderer-replace')
+
+    const first = mount(MathBlockNode as any, {
+      props: {
+        node: { type: 'math_block', content: 'x^2 + y^2', raw: '$$x^2 + y^2$$', loading: false },
+        indexKey: 'replace-0',
+        cacheScope: 'renderer-replace',
+      },
+      global: {
+        provide: { [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache },
+      },
+    })
+
+    await flushAll()
+    expect(first.attributes('style')).toContain('min-height: 392px;')
+    expect(rendererCache.cache.get('renderer-replace:math-block:replace-0')).toBe(392)
+    first.unmount()
+
+    rendererCache.clear()
+    naturalHeight = 40
+
+    const second = mount(MathBlockNode as any, {
+      props: {
+        node: { type: 'math_block', content: 'y', raw: '$$y$$', loading: false },
+        indexKey: 'replace-0',
+        cacheScope: 'renderer-replace',
+      },
+      global: {
+        provide: { [MATH_BLOCK_MIN_HEIGHT_CACHE as symbol]: rendererCache },
+      },
+    })
+
+    await flushAll()
+    const style = second.attributes('style') ?? ''
+    expect(style).not.toContain('min-height: 392px;')
+
+    second.unmount()
+  })
+})


### PR DESCRIPTION
## Problem

`MathBlockNode` 的 minHeight `cacheScope` 绑定到 `streamRenderVersion` ([NodeRenderer.vue:660](src/components/NodeRenderer/NodeRenderer.vue#L660))，导致每次 `parsedNodes` 变化（包括流式追加一个字符到无关 paragraph）都会触发所有已挂载 MathBlockNode 的 `watch([indexKey, cacheScope])`，引起：

1. `lockedMinHeight` 从 N 重置为 0
2. DOM 移除 `min-height: Npx`
3. `captureHeight()` 读 `offsetHeight`（强制 layout）
4. `updateLockedMinHeight(N)` 恢复

流式场景下 M 个 math 块 × N 次/秒 = 大量无谓的 layout read + 视觉闪烁。

## Fix

### Commit 1: 解耦 cacheScope (NodeRenderer.vue)

```diff
- const mathBlockCacheScope = computed(() => `${instanceMsgId}:${streamRenderVersion.value}`)
+ const mathBlockCacheScope = instanceMsgId
```

`streamRenderVersion` 仍在 NodeRenderer 内部用于 3 处合法用途（getFallbackHeightPrefix / getVirtualContentHash / invalidateChangedNodeHeights），不泄露给子组件。

### Commit 2: 内容替换时清除 stale minHeight (MathBlockNode.vue)

第一个 commit 引入了回归：同 renderer 实例复用渲染不同消息时（同 indexKey + cacheScope），如果新 math 块更短 + KaTeX 禁用/失败，`lockedMinHeight` 会永久继承上次的值（因为 `updateLockedMinHeight` 只增不减）。

修复：在 MathBlockNode 的 content watcher 里区分**流式追加**（保留 lockedMinHeight 避免闪烁）vs **内容替换**（清除 stale lockedMinHeight）。

**关键挑战**：`raw` 和 `content` 字段各有问题：
- `raw` 含闭合分隔符，`10592x10592` → `10592x^210592` 不是字符串前缀扩展（`^2` 插在闭合 `10592` 前）
- `content` 被 `normalizeStandaloneBackslashT` 归一化，`alpha` → `\alpha` 也不是前缀扩展

**方案**：从 `raw` 提取内部内容（去掉首尾分隔符 `10592...10592` / `$...$` / \\ [...\\ ] / \\ (...\\ )），比较内部内容的前缀扩展。正确识别两种场景。

## Tests

新增 3 个回归测试 (`test/math-block-min-height-cache-scope.test.ts`)：

1. **内容替换（非 append）**：同 indexKey+cacheScope，392px fallback 替换为短内容 → stale min-height 被清除 ✅
2. **流式追加**（`10592x10592` → `10592x^210592`）：lockedMinHeight 保留 ✅
3. **归一化变换**（`alph` → `\alpha`）：不被误判为替换（raw 内部 `alph` → `alpha` 是前缀扩展）✅

## Verification

- ✅ `pnpm typecheck` 通过
- ✅ `pnpm lint` 通过
- ✅ `pnpm test`：303 files / 2559 tests 通过（+3 新测试）

## Changes

```
src/components/NodeRenderer/NodeRenderer.vue       |  4 +-
src/components/MathBlockNode/MathBlockNode.vue     | 40 +++++-
test/math-block-min-height-cache-scope.test.ts    | 176 ++++++++++++++++++
3 files changed, 218 insertions(+), 4 deletions(-)
```