### PR TITLE
fix(parser): parse inline code inside links

### DIFF
--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -52,6 +52,20 @@ interface CoreStateLike {
   tokens?: Token[]
 }
 
+interface InlineRuleRecord {
+  name: string
+  fn: (...args: any[]) => unknown
+}
+
+interface InlineRulerWithNamedRules {
+  at: (ruleName: string, fn: (...args: any[]) => unknown) => void
+  getNamedRules?: () => InlineRuleRecord[]
+}
+
+interface InlineStateLike {
+  md?: MarkdownItInstance & { validateLink: (url: string) => boolean }
+}
+
 function inlineTokenMayNeedLinkify(token: Token, linkify: LinkifyLike) {
   if (token?.type !== 'inline')
     return false
@@ -115,6 +129,55 @@ function applyLinkifyCandidateFilter(md: MarkdownItInstance) {
   })
 }
 
+function applyInlineUrlValidation(md: MarkdownItInstance) {
+  const ruler = md.inline.ruler as InlineRulerWithNamedRules
+  const rules = ruler.getNamedRules?.()
+  const originalLink = rules?.find(rule => rule.name === 'link')?.fn
+  const originalImage = rules?.find(rule => rule.name === 'image')?.fn
+  if (typeof originalLink !== 'function' || typeof originalImage !== 'function')
+    return
+
+  const markdownIt = md as MarkdownItInstance & { validateLink: (url: string) => boolean }
+  const imageValidateLink = markdownIt.validateLink
+  const markstreamMd = md as MarkdownItInstance & { __markstreamOriginalValidateLink?: (url: string) => boolean }
+  markstreamMd.__markstreamOriginalValidateLink = imageValidateLink
+
+  ruler.at('link', (...args: any[]) => {
+    const state = args[0] as InlineStateLike
+    const activeMd = state.md
+    const validateLink = activeMd?.validateLink === imageValidateLink
+      ? activeMd.options?.validateLink
+      : activeMd?.validateLink
+    if (!activeMd || typeof validateLink !== 'function')
+      return originalLink(...args)
+
+    const originalValidateLink = activeMd.validateLink
+    activeMd.validateLink = validateLink
+    try {
+      return originalLink(...args)
+    }
+    finally {
+      activeMd.validateLink = originalValidateLink
+    }
+  })
+
+  ruler.at('image', (...args: any[]) => {
+    const state = args[0] as InlineStateLike
+    const activeMd = state.md
+    if (!activeMd)
+      return originalImage(...args)
+
+    const originalValidateLink = activeMd.validateLink
+    activeMd.validateLink = imageValidateLink
+    try {
+      return originalImage(...args)
+    }
+    finally {
+      activeMd.validateLink = originalValidateLink
+    }
+  })
+}
+
 export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
   const markdownItOptions = opts.markdownItOptions ?? {}
   const experimental = typeof markdownItOptions.experimental === 'object' && markdownItOptions.experimental !== null
@@ -138,6 +201,8 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
 
   if (!hasCustomValidateLink)
     md.set({ validateLink: (url: string) => !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' }) })
+
+  applyInlineUrlValidation(md)
 
   applyLinkifyCandidateFilter(md)
 

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -3781,8 +3781,20 @@ export function parseMarkdownToStructure(
   // Respect link validation from the md instance so customMarkdownIt(md) with
   // md.set({ validateLink }) is applied when we emit link nodes (tokens may
   // bypass the tokenizer's link rule, e.g. synthetic links from fixLinkTokens).
-  const mdAny = md as { options?: { validateLink?: (url: string) => boolean }, validateLink?: (url: string) => boolean }
-  const validateLink = options.validateLink ?? mdAny.options?.validateLink ?? (typeof mdAny.validateLink === 'function' ? mdAny.validateLink : undefined)
+  const mdAny = md as {
+    options?: { validateLink?: (url: string) => boolean }
+    validateLink?: (url: string) => boolean
+    __markstreamOriginalValidateLink?: (url: string) => boolean
+  }
+  const directValidateLink = typeof mdAny.validateLink === 'function'
+    && mdAny.__markstreamOriginalValidateLink
+    && mdAny.validateLink !== mdAny.__markstreamOriginalValidateLink
+    ? mdAny.validateLink
+    : undefined
+  const validateLink = options.validateLink
+    ?? directValidateLink
+    ?? mdAny.options?.validateLink
+    ?? (typeof mdAny.validateLink === 'function' ? mdAny.validateLink : undefined)
   const internalOptions: InternalParseOptions = {
     ...options,
     validateLink,

--- a/packages/markdown-parser/test/parse-link-with-code.test.ts
+++ b/packages/markdown-parser/test/parse-link-with-code.test.ts
@@ -2,6 +2,162 @@ import { describe, expect, it } from 'vitest'
 import { getMarkdown, parseMarkdownToStructure } from '../src'
 
 describe('parseMarkdownToStructure with code in link text', () => {
+  it('parses inline code as the child of a local file link', () => {
+    const md = getMarkdown()
+    const markdown = '[`on-send-interrupt.test.ts`](file:///Users/Simon/Github/best-agent/packages/cli-render/src/tests/on-send-interrupt.test.ts#L156-L190)'
+    const result = parseMarkdownToStructure(markdown, md, { final: true })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('paragraph')
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children[0]).toMatchObject({
+      type: 'link',
+      href: 'file:///Users/Simon/Github/best-agent/packages/cli-render/src/tests/on-send-interrupt.test.ts#L156-L190',
+      loading: false,
+      children: [
+        {
+          type: 'inline_code',
+          code: 'on-send-interrupt.test.ts',
+        },
+      ],
+    })
+  })
+
+  it('repairs each local file link when other inline code is present', () => {
+    const md = getMarkdown()
+    const markdown = '`prefix` [`a.ts`](file:///tmp/a.ts) and [`b.ts`](file:///tmp/b.ts)'
+    const result = parseMarkdownToStructure(markdown, md, { final: true })
+    const children = result[0].children
+
+    expect(children[0]).toMatchObject({ type: 'inline_code', code: 'prefix' })
+    expect(children.filter(node => node.type === 'link')).toMatchObject([
+      { href: 'file:///tmp/a.ts', children: [{ type: 'inline_code', code: 'a.ts' }] },
+      { href: 'file:///tmp/b.ts', children: [{ type: 'inline_code', code: 'b.ts' }] },
+    ])
+  })
+
+  it('supports balanced parentheses in a local file link destination', () => {
+    const md = getMarkdown()
+    const markdown = '[`a(b)c.ts`](file:///tmp/a(b)c.ts)'
+    const result = parseMarkdownToStructure(markdown, md, { final: true })
+
+    expect(result[0].children).toMatchObject([
+      {
+        type: 'link',
+        href: 'file:///tmp/a(b)c.ts',
+        children: [{ type: 'inline_code', code: 'a(b)c.ts' }],
+      },
+    ])
+  })
+
+  it('parses mixed text and code labels without scheme-specific recovery', () => {
+    const md = getMarkdown()
+    const result = parseMarkdownToStructure('[open `a.ts`](file:///tmp/a.ts)', md, { final: true })
+
+    expect(result[0].children).toMatchObject([
+      {
+        type: 'link',
+        href: 'file:///tmp/a.ts',
+        children: [
+          { type: 'text', content: 'open ' },
+          { type: 'inline_code', code: 'a.ts' },
+        ],
+      },
+    ])
+  })
+
+  it('uses the configured link validator for any accepted scheme', () => {
+    const md = getMarkdown('custom-link-scheme', {
+      markdownItOptions: {
+        validateLink: () => true,
+      },
+    })
+    const result = parseMarkdownToStructure('[`x`](file:////example.com/target)', md, { final: true })
+
+    expect(result[0].children).toMatchObject([
+      {
+        type: 'link',
+        href: 'file:////example.com/target',
+        children: [{ type: 'inline_code', code: 'x' }],
+      },
+    ])
+  })
+
+  it('uses link validators configured after Markdown creation', () => {
+    const md = getMarkdown()
+    md.set({ validateLink: () => true })
+    const result = parseMarkdownToStructure('[`x`](file:////example.com/target)', md, { final: true })
+
+    expect(result[0].children).toMatchObject([
+      {
+        type: 'link',
+        href: 'file:////example.com/target',
+        children: [{ type: 'inline_code', code: 'x' }],
+      },
+    ])
+  })
+
+  it('respects direct markdown-it link validator overrides', () => {
+    const rejectingMd = getMarkdown() as ReturnType<typeof getMarkdown> & { validateLink: () => boolean }
+    rejectingMd.validateLink = () => false
+    const rejected = parseMarkdownToStructure('[`x`](https://example.com)', rejectingMd, { final: true })
+
+    const allowingMd = getMarkdown() as ReturnType<typeof getMarkdown> & { validateLink: () => boolean }
+    allowingMd.validateLink = () => true
+    const allowed = parseMarkdownToStructure('[`x`](file:////example.com/target)', allowingMd, { final: true })
+    const autolink = parseMarkdownToStructure('<file:////example.com/target>', allowingMd, { final: true })
+
+    expect(rejected[0].children.some(node => node.type === 'link')).toBe(false)
+    expect(allowed[0].children.some(node => node.type === 'link')).toBe(true)
+    expect(autolink[0].children.some(node => node.type === 'link')).toBe(true)
+  })
+
+  it('keeps link validation separate from image validation', () => {
+    const md = getMarkdown()
+    const dataImage = parseMarkdownToStructure('![x](data:image/png;base64,AAAA)', md, { final: true })
+    const fileImage = parseMarkdownToStructure('![x](file:///tmp/x.png)', md, { final: true })
+    const linkedDataImage = parseMarkdownToStructure('[![x](data:image/png;base64,AAAA)](file:///tmp/x)', md, { final: true })
+
+    expect(dataImage[0].children.some(node => node.type === 'image')).toBe(true)
+    expect(fileImage[0].children.some(node => node.type === 'image')).toBe(false)
+    expect(linkedDataImage[0].children).toMatchObject([
+      {
+        type: 'link',
+        children: [{ type: 'image', src: 'data:image/png;base64,AAAA' }],
+      },
+    ])
+  })
+
+  it('unescapes recovered link destinations', () => {
+    const md = getMarkdown()
+    const result = parseMarkdownToStructure('[`a)`](file:///tmp/a\\).ts)', md, { final: true })
+
+    expect(result[0].children).toMatchObject([
+      {
+        type: 'link',
+        href: 'file:///tmp/a).ts',
+        children: [{ type: 'inline_code', code: 'a)' }],
+      },
+    ])
+  })
+
+  it('does not parse escaped or rejected local file links', () => {
+    const md = getMarkdown()
+    const escaped = parseMarkdownToStructure('\\[`x`](file:///tmp/x)', md, { final: true })
+    const escapedClose = parseMarkdownToStructure('[`x`\\](file:///tmp/x)', md, { final: true })
+    const entityEscaped = parseMarkdownToStructure('&#91;`x`](file:///tmp/x)', md, { final: true })
+    const hosted = parseMarkdownToStructure('[`x`](file:////example.com/tmp/x)', md, { final: true })
+    const rejectingMd = getMarkdown()
+    rejectingMd.set?.({ validateLink: () => false })
+    const rejected = parseMarkdownToStructure('[`x`](file:///tmp/x)', rejectingMd, { final: true })
+
+    expect(escaped[0].children.some(node => node.type === 'link')).toBe(false)
+    expect(escapedClose[0].children.some(node => node.type === 'link')).toBe(false)
+    expect(entityEscaped[0].children.some(node => node.type === 'link')).toBe(false)
+    expect(hosted[0].children.some(node => node.type === 'link')).toBe(false)
+    expect(rejected[0].children.some(node => node.type === 'link')).toBe(false)
+  })
+
   it('should parse links with inline code correctly', () => {
     const md = getMarkdown()
 


### PR DESCRIPTION
## Summary
- let markdown-it parse link labels containing inline code through its native link rule
- apply the configured link validator without matching any specific URL scheme
- keep link and image validation isolated, including nested images
- cover mixed labels, escaped destinations, multiple code links, and runtime validator updates

## Tests
- pnpm lint
- pnpm typecheck
- pnpm test -- --run (303 files, 2582 tests)