### PR TITLE
perf: optimize reference-heavy streaming

### DIFF
--- a/src/components/InlineCodeNode/InlineCodeNode.vue
+++ b/src/components/InlineCodeNode/InlineCodeNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { resolveStreamingTextUpdate } from 'markstream-core'
-import { computed, inject, ref, useAttrs, watch } from 'vue'
+import { computed, inject, onScopeDispose, ref, useAttrs, watch } from 'vue'
 
 const props = defineProps<{
   node: {
@@ -39,45 +39,62 @@ const streamStateKey = computed(() => {
 })
 const settledCode = ref(props.node.code)
 const streamedDelta = ref('')
-let lastStreamVersion: number | undefined = inheritedStreamVersion?.value
 const streamFadeVersion = ref(0)
+let stopStreamVersionWatch: (() => void) | undefined
 
 function getRenderedContent() {
   return settledCode.value + streamedDelta.value
 }
 
-function setFullContent(next: string) {
-  settledCode.value = next
-  streamedDelta.value = ''
+function stopWatchingStreamVersion() {
+  stopStreamVersionWatch?.()
+  stopStreamVersionWatch = undefined
 }
 
 function settleStreamedDelta() {
+  stopWatchingStreamVersion()
   if (!streamedDelta.value)
     return
   settledCode.value = getRenderedContent()
   streamedDelta.value = ''
 }
 
+function watchStreamVersionWhileDeltaActive() {
+  if (!streamedDelta.value || stopStreamVersionWatch || !inheritedStreamVersion)
+    return
+
+  const activeVersion = inheritedStreamVersion.value
+  stopStreamVersionWatch = watch(
+    () => inheritedStreamVersion.value,
+    (version) => {
+      if (version !== activeVersion)
+        settleStreamedDelta()
+    },
+    { flush: 'sync' },
+  )
+}
+
 watch(
-  [() => props.node.code, streamStateKey, fadeEnabled, () => inheritedStreamVersion?.value],
-  ([next, _key, _fade, version]) => {
+  [() => props.node.code, streamStateKey, fadeEnabled],
+  ([next]) => {
     const normalized = String(next ?? '')
     const key = streamStateKey.value
-    const versionChanged = version !== lastStreamVersion
-    lastStreamVersion = version
-
     const result = resolveStreamingTextUpdate({
       nextContent: normalized,
       persistedContent: key ? inheritedTextStreamState?.get(key) : undefined,
       currentState: { settledContent: settledCode.value, streamedDelta: streamedDelta.value },
       typewriterEnabled: fadeEnabled.value,
-      streamRenderVersionChanged: versionChanged,
     })
 
     settledCode.value = result.settledContent
     streamedDelta.value = result.streamedDelta
-    if (result.appended)
+    if (result.appended) {
       streamFadeVersion.value += 1
+      watchStreamVersionWhileDeltaActive()
+    }
+    else if (!streamedDelta.value) {
+      stopWatchingStreamVersion()
+    }
 
     if (key)
       inheritedTextStreamState?.set(key, normalized)
@@ -85,14 +102,7 @@ watch(
   { immediate: true },
 )
 
-watch(
-  fadeEnabled,
-  (enabled) => {
-    if (enabled)
-      return
-    setFullContent(getRenderedContent())
-  },
-)
+onScopeDispose(stopWatchingStreamVersion)
 
 const streamedDeltaClass = computed(() => (
   streamFadeVersion.value % 2 === 0

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -67,6 +67,11 @@ interface ParsedNodeStabilizeOptions {
   scanStartIndex?: number
 }
 
+type GlobalReferenceScanner = (previous: string, next: string) => [
+  mayAffectGlobalReferences: boolean,
+  scannedChars: number,
+]
+
 interface StablePrefixReuseContext {
   content: string
   previousContent: string
@@ -74,6 +79,7 @@ interface StablePrefixReuseContext {
   parseOptions: RendererParseOptions
   customMarkdownIt: NodeRendererProps['customMarkdownIt']
   md: MarkdownIt
+  scanGlobalReferenceAppend: GlobalReferenceScanner
 }
 
 export interface MarkdownParsingOptions {
@@ -525,53 +531,104 @@ function getDirtyTailNodeCount(
     : Math.max(nextNodes.length, previousNodes.length) - dirtyStartIndex
 }
 
-function mayContainGlobalReferenceDefinition(value: string) {
-  let labelStartIndex = -1
+function createGlobalReferenceScanner(): GlobalReferenceScanner {
+  let content = ''
+  // 0: outside a label; 1: inside `[...]`; 2: after the closing `]`.
+  let phase: 0 | 1 | 2 = 0
+  let escaped = false
+  let pendingDefinition = false
+  let lineHasContent = false
+  let previousWasCarriageReturn = false
 
-  for (let index = 0; index < value.length; index++) {
-    const char = value.charCodeAt(index)
-
-    if (labelStartIndex < 0) {
-      if (char === 91)
-        labelStartIndex = index
-      continue
-    }
-
-    if (char === 92) {
-      index += 1
-      continue
-    }
-
-    if (char === 91) {
-      labelStartIndex = index
-      continue
-    }
-
-    if (char !== 93)
-      continue
-
-    let cursor = index + 1
-    while (cursor < value.length) {
-      const nextChar = value.charCodeAt(cursor)
-      if (nextChar !== 9 && nextChar !== 32)
-        break
-      cursor += 1
-    }
-
-    if (value.charCodeAt(cursor) === 58)
-      return true
-
-    labelStartIndex = -1
+  function reset() {
+    content = ''
+    phase = 0
+    escaped = false
+    pendingDefinition = false
+    lineHasContent = false
+    previousWasCarriageReturn = false
   }
 
-  return false
-}
+  function scan(value: string) {
+    let mayAffectGlobalReferences = false
 
-function appendMayDefineGlobalReferences(previous: string, next: string) {
-  if (!previous || !next.startsWith(previous) || next.length <= previous.length)
-    return false
+    for (let index = 0; index < value.length; index++) {
+      const char = value.charCodeAt(index)
 
-  return mayContainGlobalReferenceDefinition(next)
+      if (char === 10 || char === 13) {
+        const isCrLfContinuation = char === 10 && previousWasCarriageReturn
+        previousWasCarriageReturn = char === 13
+        escaped = false
+        if (!isCrLfContinuation) {
+          if (!lineHasContent) {
+            pendingDefinition = false
+            phase = 0
+          }
+          lineHasContent = false
+        }
+        continue
+      }
+
+      previousWasCarriageReturn = false
+      const whitespace = char === 9 || char === 32
+      if (!whitespace) {
+        lineHasContent = true
+        if (pendingDefinition)
+          mayAffectGlobalReferences = true
+      }
+
+      if (!phase) {
+        if (char === 91)
+          phase = 1
+        continue
+      }
+
+      if (phase === 1) {
+        if (escaped) {
+          escaped = false
+          continue
+        }
+        if (char === 92) {
+          escaped = true
+          continue
+        }
+        if (char === 93)
+          phase = 2
+        continue
+      }
+
+      if (whitespace)
+        continue
+      if (char === 58) {
+        mayAffectGlobalReferences = true
+        pendingDefinition = true
+        continue
+      }
+
+      phase = char === 91 ? 1 : 0
+    }
+
+    return mayAffectGlobalReferences
+  }
+
+  return (previous, next) => {
+    if (!previous || !next.startsWith(previous) || next.length <= previous.length) {
+      reset()
+      return [true, 0]
+    }
+
+    let scannedChars = 0
+    if (content !== previous) {
+      reset()
+      scan(previous)
+      scannedChars = previous.length
+    }
+
+    const appended = next.slice(previous.length)
+    const mayAffectGlobalReferences = scan(appended)
+    content = next
+    return [mayAffectGlobalReferences, scannedChars + appended.length]
+  }
 }
 
 function hasRegisteredMarkdownPlugins(md: MarkdownIt) {
@@ -584,30 +641,24 @@ function hasCustomParserExtensions(md: MarkdownIt) {
 }
 
 function getStablePrefixScanStartIndex(context: StablePrefixReuseContext) {
-  if (context.previousDirtyStartIndex <= 0)
-    return 0
-  if (!context.content.startsWith(context.previousContent) || context.content.length <= context.previousContent.length)
-    return 0
-  if (context.parseOptions.final === true)
-    return 0
-  if (context.customMarkdownIt)
-    return 0
-  if (hasCustomParserExtensions(context.md))
-    return 0
-  if (appendMayDefineGlobalReferences(context.previousContent, context.content))
-    return 0
-
+  const [mayAffectGlobalReferences, referenceDefinitionScanChars] = context.scanGlobalReferenceAppend(
+    context.previousContent,
+    context.content,
+  )
   const options = context.parseOptions
-  if (
-    typeof options.preTransformTokens === 'function'
-    || typeof options.postTransformTokens === 'function'
-    || typeof options.postTransformNodes === 'function'
-    || (options.customHtmlTags?.length ?? 0) > 0
-  ) {
-    return 0
-  }
+  const scanStartIndex = context.previousDirtyStartIndex > 0
+    && options.final !== true
+    && !context.customMarkdownIt
+    && !hasCustomParserExtensions(context.md)
+    && !mayAffectGlobalReferences
+    && typeof options.preTransformTokens !== 'function'
+    && typeof options.postTransformTokens !== 'function'
+    && typeof options.postTransformNodes !== 'function'
+    && (options.customHtmlTags?.length ?? 0) === 0
+    ? context.previousDirtyStartIndex
+    : 0
 
-  return context.previousDirtyStartIndex
+  return [scanStartIndex, referenceDefinitionScanChars] as const
 }
 
 function compareCheapStringIfSafe(previous: string, next: string) {
@@ -950,6 +1001,7 @@ export function useMarkdownParsing(
   let previousNodeReuseSemanticKey = ''
   let previousContent = ''
   let previousExternalNodeMutationBoundary = false
+  const scanGlobalReferenceAppend = createGlobalReferenceScanner()
   let parseCoalesceTimer: ReturnType<typeof setTimeout> | undefined
   let parseCommitCount = 0
   let parseCoalescedCount = 0
@@ -1215,19 +1267,22 @@ export function useMarkdownParsing(
     let stabilizeMs = 0
     let parsed: ParsedNode[]
     let primeStartIndex = 0
+    let referenceDefinitionScanChars = 0
 
     if (canReuseParsedNodes) {
       const stabilizeStart = collectPerformanceMetrics
         ? getNow()
         : 0
-      const scanStartIndex = getStablePrefixScanStartIndex({
+      const [scanStartIndex, scannedChars] = getStablePrefixScanStartIndex({
         content,
         previousContent,
         previousDirtyStartIndex: parsedNodesDirtyStartIndexValue,
         parseOptions: mergedParseOptions.value,
         customMarkdownIt: props.customMarkdownIt,
         md,
+        scanGlobalReferenceAppend,
       })
+      referenceDefinitionScanChars = scannedChars
       const reuseDirtyTail = scanStartIndex <= 0
       if (signatureTiming) {
         const result = stabilizeParsedNodesWithMetrics(nextParsed, previousParsedNodes, signatureTiming, {
@@ -1293,6 +1348,7 @@ export function useMarkdownParsing(
         parseCommitCount,
         parseCoalescedCount,
         nodeReuseMs,
+        referenceDefinitionScanChars,
         signatureMs: signatureTiming?.signatureMs ?? 0,
         stabilizeSignatureMs: signatureTiming?.stabilizeSignatureMs ?? 0,
         primeSignatureMs: signatureTiming?.primeSignatureMs ?? 0,

--- a/src/components/TextNode/TextNode.vue
+++ b/src/components/TextNode/TextNode.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { resolveStreamingTextUpdate } from 'markstream-core'
-import { computed, inject, ref, useAttrs, watch } from 'vue'
+import { computed, inject, onScopeDispose, ref, useAttrs, watch } from 'vue'
 
 const props = defineProps<{
   node: {
@@ -38,45 +38,62 @@ const streamStateKey = computed(() => {
 })
 const settledContent = ref(props.node.content)
 const streamedDelta = ref('')
-let lastStreamVersion: number | undefined = inheritedStreamVersion?.value
 const streamFadeVersion = ref(0)
+let stopStreamVersionWatch: (() => void) | undefined
 
 function getRenderedContent() {
   return settledContent.value + streamedDelta.value
 }
 
-function setFullContent(next: string) {
-  settledContent.value = next
-  streamedDelta.value = ''
+function stopWatchingStreamVersion() {
+  stopStreamVersionWatch?.()
+  stopStreamVersionWatch = undefined
 }
 
 function settleStreamedDelta() {
+  stopWatchingStreamVersion()
   if (!streamedDelta.value)
     return
   settledContent.value = getRenderedContent()
   streamedDelta.value = ''
 }
 
+function watchStreamVersionWhileDeltaActive() {
+  if (!streamedDelta.value || stopStreamVersionWatch || !inheritedStreamVersion)
+    return
+
+  const activeVersion = inheritedStreamVersion.value
+  stopStreamVersionWatch = watch(
+    () => inheritedStreamVersion.value,
+    (version) => {
+      if (version !== activeVersion)
+        settleStreamedDelta()
+    },
+    { flush: 'sync' },
+  )
+}
+
 watch(
-  [() => props.node.content, streamStateKey, fadeEnabled, () => inheritedStreamVersion?.value],
-  ([next, _key, _fade, version]) => {
+  [() => props.node.content, streamStateKey, fadeEnabled],
+  ([next]) => {
     const normalized = String(next ?? '')
     const key = streamStateKey.value
-    const versionChanged = version !== lastStreamVersion
-    lastStreamVersion = version
-
     const result = resolveStreamingTextUpdate({
       nextContent: normalized,
       persistedContent: key ? inheritedTextStreamState?.get(key) : undefined,
       currentState: { settledContent: settledContent.value, streamedDelta: streamedDelta.value },
       typewriterEnabled: fadeEnabled.value,
-      streamRenderVersionChanged: versionChanged,
     })
 
     settledContent.value = result.settledContent
     streamedDelta.value = result.streamedDelta
-    if (result.appended)
+    if (result.appended) {
       streamFadeVersion.value += 1
+      watchStreamVersionWhileDeltaActive()
+    }
+    else if (!streamedDelta.value) {
+      stopWatchingStreamVersion()
+    }
 
     if (key)
       inheritedTextStreamState?.set(key, normalized)
@@ -84,14 +101,7 @@ watch(
   { immediate: true },
 )
 
-watch(
-  fadeEnabled,
-  (enabled) => {
-    if (enabled)
-      return
-    setFullContent(getRenderedContent())
-  },
-)
+onScopeDispose(stopWatchingStreamVersion)
 
 const streamedDeltaClass = computed(() => (
   streamFadeVersion.value % 2 === 0

--- a/test/text-node-streaming-consistency.test.ts
+++ b/test/text-node-streaming-consistency.test.ts
@@ -4,7 +4,7 @@
 
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { customRef, defineComponent, h, provide, ref } from 'vue'
 import InlineCodeNode from '../src/components/InlineCodeNode'
 import NodeRenderer from '../src/components/NodeRenderer'
 import TextNode from '../src/components/TextNode'
@@ -202,6 +202,47 @@ $$ where $\epsilon$ denotes the target accuracy, $n$ is the number of nodes, and
     }
   })
 
+  it.each([
+    ['text', TextNode, { type: 'text', content: 'stable', raw: 'stable' }],
+    ['inline code', InlineCodeNode, { type: 'inline_code', code: 'stable', raw: '`stable`' }],
+  ] as const)('does not subscribe a fade-enabled stable %s node to streamRenderVersion', async (_, component, node) => {
+    let version = 1
+    let versionReads = 0
+    const streamRenderVersion = customRef<number>((track, trigger) => ({
+      get() {
+        versionReads += 1
+        track()
+        return version
+      },
+      set(next) {
+        version = next
+        trigger()
+      },
+    }))
+    const wrapper = mount(component, {
+      props: { node } as any,
+      attrs: { fade: true },
+      global: {
+        provide: {
+          markstreamStreamVersion: streamRenderVersion,
+        },
+      },
+    })
+
+    try {
+      await flushAll()
+      versionReads = 0
+      streamRenderVersion.value = 2
+      await flushAll()
+
+      expect(versionReads).toBe(0)
+      expect(wrapper.text()).toBe('stable')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
   it('preserves active TextNode delta until streamRenderVersion changes', async () => {
     const streamRenderVersion = ref(1)
     const textStreamState = new Map<string, string>()
@@ -298,5 +339,165 @@ $$ where $\epsilon$ denotes the target accuracy, $n$ is the number of nodes, and
     finally {
       wrapper.unmount()
     }
+  })
+
+  it('settles an active delta when fade is disabled and resumes on the next append', async () => {
+    const content = ref('Hello')
+    const fade = ref(true)
+    const streamRenderVersion = ref(1)
+    const textStreamState = new Map<string, string>()
+    const Host = defineComponent({
+      setup() {
+        return () => h(TextNode, {
+          node: { type: 'text', content: content.value, raw: content.value },
+          fade: fade.value,
+          indexKey: 'text-0',
+        })
+      },
+    })
+    const wrapper = mount(Host, {
+      global: {
+        provide: {
+          markstreamTextStreamState: textStreamState,
+          markstreamStreamVersion: streamRenderVersion,
+        },
+      },
+    })
+
+    try {
+      content.value = 'HelloWorld'
+      await flushAll()
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('World')
+
+      fade.value = false
+      await flushAll()
+      expect(wrapper.find('.text-node-stream-delta').exists()).toBe(false)
+      expect(wrapper.text()).toBe('HelloWorld')
+
+      fade.value = true
+      content.value = 'HelloWorldAgain'
+      await flushAll()
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('Again')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('preserves an active delta when the stream state key changes', async () => {
+    const content = ref('Hello')
+    const streamStateKey = ref('text-0')
+    const streamRenderVersion = ref(1)
+    const textStreamState = new Map<string, string>()
+    const Host = defineComponent({
+      setup() {
+        return () => h(TextNode, {
+          node: { type: 'text', content: content.value, raw: content.value },
+          indexKey: streamStateKey.value,
+        })
+      },
+    })
+    const wrapper = mount(Host, {
+      global: {
+        provide: {
+          markstreamTextStreamState: textStreamState,
+          markstreamStreamVersion: streamRenderVersion,
+        },
+      },
+    })
+
+    try {
+      content.value = 'HelloWorld'
+      await flushAll()
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('World')
+
+      streamStateKey.value = 'text-1'
+      await flushAll()
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('World')
+      expect(textStreamState.get('text-1')).toBe('HelloWorld')
+
+      streamRenderVersion.value += 1
+      await flushAll()
+      expect(wrapper.find('.text-node-stream-delta').exists()).toBe(false)
+      expect(wrapper.text()).toBe('HelloWorld')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('settles the previous delta before a same-tick version bump and content append', async () => {
+    const content = ref('Hello')
+    const streamRenderVersion = ref(1)
+    const textStreamState = new Map<string, string>()
+    const Host = defineComponent({
+      setup() {
+        provide('markstreamTextStreamState', textStreamState)
+        provide('markstreamStreamVersion', streamRenderVersion)
+        return () => h(TextNode, {
+          node: { type: 'text', content: content.value, raw: content.value },
+          indexKey: 'text-0',
+        })
+      },
+    })
+    const wrapper = mount(Host)
+
+    try {
+      content.value = 'HelloWorld'
+      await flushAll()
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('World')
+
+      content.value = 'HelloWorldAgain'
+      streamRenderVersion.value += 1
+      await flushAll()
+
+      expect(wrapper.get('.text-node-stream-delta').text()).toBe('Again')
+      expect(wrapper.text()).toBe('HelloWorldAgain')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('stops the active stream version watcher when unmounted', async () => {
+    let version = 1
+    let versionReads = 0
+    const streamRenderVersion = customRef<number>((track, trigger) => ({
+      get() {
+        versionReads += 1
+        track()
+        return version
+      },
+      set(next) {
+        version = next
+        trigger()
+      },
+    }))
+    const wrapper = mount(TextNode, {
+      props: {
+        node: { type: 'text', content: 'Hello', raw: 'Hello' },
+      },
+      attrs: {
+        'index-key': 'text-0',
+      },
+      global: {
+        provide: {
+          markstreamTextStreamState: new Map<string, string>(),
+          markstreamStreamVersion: streamRenderVersion,
+        },
+      },
+    })
+
+    await wrapper.setProps({
+      node: { type: 'text', content: 'HelloWorld', raw: 'HelloWorld' },
+    })
+    await flushAll()
+    expect(wrapper.get('.text-node-stream-delta').text()).toBe('World')
+
+    wrapper.unmount()
+    versionReads = 0
+    streamRenderVersion.value = 2
+    await flushAll()
+    expect(versionReads).toBe(0)
   })
 })

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -1257,6 +1257,68 @@ describe('useMarkdownParsing performance behavior', () => {
     scope.stop()
   })
 
+  it('scans only the appended delta after priming global reference detection', () => {
+    const content = ref(buildParagraphs(20))
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {}, ref(true), logPerf)
+
+    content.value += '\n\nFirst appended paragraph.'
+    expect(state.parsedNodes.value).toHaveLength(21)
+
+    content.value += '\n\nSecond appended paragraph.'
+    expect(state.parsedNodes.value).toHaveLength(22)
+
+    logPerf.mockClear()
+    const appended = '\n\nThird appended paragraph.'
+    content.value += appended
+    expect(state.parsedNodes.value).toHaveLength(23)
+
+    expect(logPerf.mock.calls.at(-1)?.[1]).toMatchObject({
+      dirtyStartIndex: 22,
+      stablePrefixNodeCount: 22,
+      referenceDefinitionScanChars: appended.length,
+    })
+
+    scope.stop()
+  })
+
+  it('does not let an old reference definition force every later append to rescan the prefix', () => {
+    const content = ref('[foo][bar] and [new][baz]\n\n[bar]: https://example.com\n\nstable tail')
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {}, ref(true), logPerf)
+
+    expect(paragraphChildren(state.parsedNodes.value[0]).some(child => child.type === 'link')).toBe(true)
+
+    content.value += '\n\nFirst appended paragraph.'
+    expect(state.parsedNodes.value.at(-1)?.raw).toBe('First appended paragraph.')
+
+    content.value += '\n\nSecond appended paragraph.'
+    expect(state.parsedNodes.value.at(-1)?.raw).toBe('Second appended paragraph.')
+
+    logPerf.mockClear()
+    content.value += '\n\nThird appended paragraph.'
+    expect(state.parsedNodes.value.at(-1)?.raw).toBe('Third appended paragraph.')
+
+    expect(logPerf.mock.calls.at(-1)?.[1]).toMatchObject({
+      dirtyStartIndex: 4,
+      stablePrefixNodeCount: 4,
+    })
+
+    logPerf.mockClear()
+    content.value += '\n\n[baz]: https://example.com\n'
+    expect(state.parsedNodes.value.at(-1)?.raw).toBe('Third appended paragraph.')
+    const resolvedLinks = paragraphChildren(state.parsedNodes.value[0])
+      .filter(child => child.type === 'link') as Array<{ href?: string }>
+    expect(resolvedLinks).toHaveLength(2)
+    expect(resolvedLinks[1]?.href).toBe('https://example.com')
+    expect(logPerf.mock.calls.at(-1)?.[1]).toMatchObject({
+      dirtyStartIndex: 0,
+      stablePrefixNodeCount: 0,
+    })
+
+    scope.stop()
+  })
+
   it('does not skip prefix scans when appended reference definitions can affect earlier nodes', () => {
     const content = ref('[foo][bar]\n\nstable tail')
     const logPerf = vi.fn()
@@ -1280,6 +1342,99 @@ describe('useMarkdownParsing performance behavior', () => {
       stablePrefixNodeCount: 0,
     })
 
+    scope.stop()
+  })
+
+  it('tracks reference labels and separators across append boundaries', () => {
+    for (const chunks of [
+      ['[bar', ']', ': https://example.com\n'],
+      ['[foo\\', ']bar]', ': https://example.com\n'],
+    ]) {
+      const reference = chunks[0].startsWith('[bar') ? 'bar' : 'foo\\]bar'
+      const content = ref(`[x][${reference}]\n\nstable tail\n\n`)
+      const logPerf = vi.fn()
+      const { scope, state } = createParsingState(content, ref(false), {
+        parseOptions: { streamParse: false },
+      }, ref(true), logPerf)
+      const firstParagraph = state.parsedNodes.value[0]
+
+      for (const chunk of chunks) {
+        content.value += chunk
+        void state.parsedNodes.value
+      }
+
+      expect(state.parsedNodes.value[0]).not.toBe(firstParagraph)
+      expect(paragraphChildren(state.parsedNodes.value[0]).some(child => child.type === 'link')).toBe(true)
+      expect(logPerf.mock.calls.at(-1)?.[1]).toMatchObject({
+        dirtyStartIndex: 0,
+        stablePrefixNodeCount: 0,
+      })
+      scope.stop()
+    }
+  })
+
+  it('tracks CRLF reference states across append boundaries', () => {
+    const scenarios = [
+      {
+        initial: '[x][foo bar]\r\nstable tail\r\n\r\n',
+        chunks: ['[foo\r', '\nbar]', ': https://example.com\r', '\n'],
+        href: 'https://example.com',
+      },
+      {
+        initial: '[x][bar]\r\nstable tail\r\n\r\n',
+        chunks: ['[bar]', ':', '\r', '\n https://example.com\r', '\n'],
+        href: 'https://example.com',
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const content = ref(scenario.initial)
+      const logPerf = vi.fn()
+      const { scope, state } = createParsingState(content, ref(false), {
+        parseOptions: { streamParse: false },
+      }, ref(true), logPerf)
+      const firstParagraph = state.parsedNodes.value[0]
+
+      for (const chunk of scenario.chunks) {
+        content.value += chunk
+        void state.parsedNodes.value
+      }
+
+      const link = paragraphChildren(state.parsedNodes.value[0])
+        .find(child => child.type === 'link') as { href?: string } | undefined
+      const performedFullPrefixScan = logPerf.mock.calls.some(([, data]) => (
+        data.dirtyStartIndex === 0 && data.stablePrefixNodeCount === 0
+      ))
+      expect(state.parsedNodes.value[0]).not.toBe(firstParagraph)
+      expect(link?.href).toBe(scenario.href)
+      expect(performedFullPrefixScan).toBe(true)
+      scope.stop()
+    }
+  })
+
+  it('clears pending reference state after a CRLF blank line', () => {
+    const content = ref(`${buildParagraphs(4)}\r\n\r\n[unused]: https://example.com\r`)
+    const logPerf = vi.fn()
+    const { scope, state } = createParsingState(content, ref(false), {
+      parseOptions: { streamParse: false },
+    }, ref(true), logPerf)
+
+    content.value += '\n\r'
+    void state.parsedNodes.value
+    content.value += '\n'
+    void state.parsedNodes.value
+    content.value += 'ordinary tail'
+    void state.parsedNodes.value
+
+    logPerf.mockClear()
+    const appended = ' continues'
+    content.value += appended
+    void state.parsedNodes.value
+
+    expect(logPerf.mock.calls.at(-1)?.[1]).toMatchObject({
+      referenceDefinitionScanChars: appended.length,
+    })
+    expect(logPerf.mock.calls.at(-1)?.[1]?.dirtyStartIndex).toBeGreaterThan(0)
     scope.stop()
   })
 
@@ -1374,13 +1529,13 @@ describe('useMarkdownParsing performance behavior', () => {
     }
   })
 
-  it('does not skip prefix scans when container reference definitions can affect earlier nodes', () => {
-    for (const definition of [
-      '> [bar]: https://example.com',
-      '- [bar]: https://example.com',
-      '1. [bar]: https://example.com',
+  it('does not skip prefix scans when chunked container reference definitions can affect earlier nodes', () => {
+    for (const chunks of [
+      ['\n\n> [bar', ']', ': https://example.com\n'],
+      ['\n\n- [bar', ']', ': https://example.com\n'],
+      ['\n\n1. [bar', ']', ': https://example.com\n'],
     ]) {
-      const content = ref('[foo][bar]\n\nstable tail')
+      const content = ref('[foo][bar]\n\nstable tail\n\nappend')
       const logPerf = vi.fn()
       const { scope, state } = createParsingState(content, ref(false), {
         parseOptions: {
@@ -1391,11 +1546,10 @@ describe('useMarkdownParsing performance behavior', () => {
       const firstParagraph = state.parsedNodes.value[0]
       expect(paragraphChildren(firstParagraph).some(child => child.type === 'link')).toBe(false)
 
-      content.value = `${content.value}\n\nappend`
-      expect(state.parsedNodes.value.at(-1)?.raw).toBe('append')
-
-      logPerf.mockClear()
-      content.value = `${content.value}\n\n${definition}\n`
+      for (const chunk of chunks) {
+        content.value += chunk
+        void state.parsedNodes.value
+      }
       const secondParagraph = state.parsedNodes.value[0]
       const data = logPerf.mock.calls.at(-1)?.[1]
 
@@ -1408,6 +1562,70 @@ describe('useMarkdownParsing performance behavior', () => {
 
       scope.stop()
     }
+  })
+
+  it('matches fresh parsing while reference definitions stream across scanner boundaries', () => {
+    const fixtures = [
+      {
+        initial: '[x][bar]\n\nstable tail\n\n',
+        chunks: ['[bar', ']', ': https://example.com\n'],
+      },
+      {
+        initial: '[x][bar]\r\n\r\nstable tail\r\n\r\n',
+        chunks: ['[bar]\r', '\n:', ' https://example.com\r', '\n'],
+      },
+      {
+        initial: String.raw`[x][foo\]bar]
+
+stable tail
+
+`,
+        chunks: ['[foo\\', ']bar]', ': https://example.com\n'],
+      },
+      {
+        initial: String.raw`[x][foo\\bar]
+
+stable tail
+
+`,
+        chunks: [String.raw`[foo\\`, 'bar]', ': https://example.com\n'],
+      },
+      {
+        initial: '[x][foo bar]\n\nstable tail\n\n',
+        chunks: ['[foo\n', 'bar]', ': https://example.com\n'],
+      },
+      {
+        initial: '[x][bar]\n\nstable tail\n\n',
+        chunks: ['[bar]:', ' https://example.com\n', '  "title"\n'],
+      },
+      {
+        initial: '[x][bar]\n\nstable tail',
+        chunks: ['\n\n> [bar', ']', ': https://example.com\n'],
+      },
+      {
+        initial: '[x][missing]\n\nstable tail\n\n',
+        chunks: ['[missing]', '\n', '\n', ': https://example.com\n'],
+      },
+    ]
+
+    fixtures.forEach((fixture, fixtureIndex) => {
+      const content = ref(fixture.initial)
+      const { scope, state } = createParsingState(content, ref(false), {
+        parseOptions: { streamParse: false },
+      })
+
+      fixture.chunks.forEach((chunk, chunkIndex) => {
+        content.value += chunk
+        const fresh = parseMarkdownToStructure(
+          content.value,
+          getMarkdown(`reference-differential-${fixtureIndex}-${chunkIndex}`),
+          { streamParse: false },
+        )
+        expect(state.parsedNodes.value).toEqual(fresh)
+      })
+
+      scope.stop()
+    })
   })
 
   it('does not skip prefix scans when final parsing can change earlier nodes', () => {


### PR DESCRIPTION
## Summary

Optimize reference-heavy Markdown streaming by scanning only appended content when deciding whether global reference definitions can invalidate stable prefixes. Also subscribe text and inline-code nodes to `streamRenderVersion` only while they have an active streamed delta.

The browser real-corpus ABBA benchmark improves a 27.9K reference-heavy stream by 11.97%, while normal README streaming/restore and chat restore remain neutral. The final bundle is 281,022 bytes and passes the existing 281,600-byte CI budget without raising it.

## Changes

- [x] Replace repeated full-content reference detection with a stateful append scanner
- [x] Preserve conservative fallbacks for rewrites, final parsing, custom MarkdownIt, parser extensions, transform hooks, and custom HTML tags
- [x] Keep `referenceDefinitionScanChars` performance instrumentation
- [x] Watch `streamRenderVersion` only while `TextNode` / `InlineCodeNode` has an active delta
- [x] Stop active version watchers on settle and scope disposal
- [x] Add chunk-boundary, escaped-label, CRLF, differential parsing, fade transition, same-tick update, and watcher cleanup coverage

## Performance evidence

### Reference-heavy browser streaming

Fixture: 27,943 characters, 180 sections, an existing reference definition near the top, 80 streaming chunks, ABBA order.

| Metric | HEAD | Candidate | Change |
| --- | ---: | ---: | ---: |
| Total streaming time | 1662.3 ms | 1463.4 ms | **-11.97%** |
| Node reuse work | 23.8–28.9 ms | 4.4–4.9 ms | lower |
| Signature work | 19.7–24.6 ms | 2.0–2.8 ms | lower |

Settled DOM measurements were identical across all runs: scroll height 29,038, 2,529 DOM nodes, 362 slots, no placeholders or pending math.

A second parser workload measured wall time -10.58% and signature calls -99.09%. Normal README streaming/restore and docs chat restore were neutral.

### Known trade-off

This is not a universal streaming speedup. A stress case with 50–200 simultaneously active text deltas is about 5–6% slower because active nodes recreate their watcher per commit. Typical long-document streaming has many stable nodes and few active tail nodes, which is the workload optimized here.

## Correctness

- `streamParse: false`: zero differential mismatch in accumulated deterministic/random append coverage
- `streamParse: true`: HEAD and candidate matched on all 4,527 incremental AST hashes across 424 cases
- Candidate-only mismatch: 0
- Final parse mismatch: 0 / 424
- Browser E2E: identical settled DOM/text/height, no page errors, console errors, or timeouts

## Bundle size

`dist/exports.js` clean builds:

```text
281,022
281,022
281,022
```

- Target used during review: <= 281,100 bytes
- Existing CI budget: <= 281,600 bytes
- Verified with CI's pnpm 10.33.4 command chain (`build:parser`, clean `build`, `size:check`)

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot — not applicable; no intended visual change
- [ ] Shareable repro link — not applicable; covered by browser benchmark and DOM snapshots

## Checklist

- [x] Lint: `pnpm lint` (clean worktree)
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` — 303 files / 2,604 tests passed
- [x] Build: `pnpm build` (library + CSS)
- [x] Size: `pnpm size:check`
