### PR TITLE
fix(docs):  localize VitePress navbar by locale

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -861,6 +861,12 @@ export default defineConfig({
       title: 'Markstream',
       description: docsDefaultDescription,
       link: '/',
+      themeConfig: {
+        selectText: 'Languages',
+        label: 'English',
+        ariaLabel: 'Select language',
+        nav: rootNav,
+      },
     },
     zh: {
       label: '简体中文',
@@ -868,6 +874,12 @@ export default defineConfig({
       title: 'Markstream',
       description: '适用于 AI 应用的多框架流式 Markdown 渲染器家族',
       link: '/zh/',
+      themeConfig: {
+        selectText: '选择语言',
+        label: '简体中文',
+        ariaLabel: '选择语言',
+        nav: zhNav,
+      },
     },
   },
   themeConfig: {
@@ -885,20 +897,6 @@ export default defineConfig({
       '/zh/guide/': chineseGuideSidebar,
       '/zh/': chineseGuideSidebar,
       '/': englishGuideSidebar,
-    },
-    locales: {
-      root: {
-        selectText: 'Languages',
-        label: 'English',
-        ariaLabel: 'Select language',
-        nav: rootNav,
-      },
-      zh: {
-        selectText: '选择语言',
-        label: '简体中文',
-        ariaLabel: '选择语言',
-        nav: zhNav,
-      },
     },
   },
   transformPageData(pageData) {


### PR DESCRIPTION
## Summary

Fix VitePress locale configuration so the navbar switches correctly between English and Chinese.

## Changes

- [x] Move locale-specific navbar settings into `locales.*.themeConfig`
- [x] Remove the ineffective `themeConfig.locales` configuration

## Screenshots / Demo

- [ ] Added GIF/screenshot
- [ ] Shareable repro link

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test`
- [x] Build: `pnpm exec vitepress build docs`