### PR TITLE
fix(parser): stop parenthesized bare links at CJK boundary

### DIFF
--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -127,6 +127,22 @@ function collectLinkifyText(tokens: MarkdownToken[], openIndex: number, closeInd
   return text || null
 }
 
+function firstUnmatchedFullwidthClosingParen(input: string) {
+  let depth = 0
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]
+    if (char === '（') {
+      depth++
+    }
+    else if (char === '）') {
+      if (depth === 0)
+        return index
+      depth--
+    }
+  }
+  return -1
+}
+
 export function applyFixLinkTokens(md: MarkdownIt) {
   // Run after the inline rule so markdown-it has produced inline tokens
   // for block-level tokens; we then adjust each inline token's children
@@ -162,20 +178,38 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
   const hasInlineCode = tokens.some(token => token.type === 'code_inline')
   const fullwidthParenDepthAtLink = new Map<MarkdownToken, number>()
   let fullwidthParenDepth = 0
-  let linkDepth = 0
-  for (const token of tokens) {
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]
     if (token.type === 'link_open') {
-      if (linkDepth === 0 && token.markup === 'linkify')
+      let closeIndex = -1
+      for (let candidate = index + 1; candidate < tokens.length; candidate++) {
+        if (tokens[candidate]?.type === 'link_close') {
+          closeIndex = candidate
+          break
+        }
+      }
+
+      if (closeIndex !== -1 && token.markup === 'linkify') {
         fullwidthParenDepthAtLink.set(token, fullwidthParenDepth)
-      linkDepth++
+        const linkText = collectLinkifyText(tokens, index, closeIndex)
+        const stopAt = fullwidthParenDepth > 0 && linkText
+          ? firstUnmatchedFullwidthClosingParen(linkText)
+          : -1
+        if (stopAt !== -1 && linkText) {
+          for (const char of linkText.slice(stopAt)) {
+            if (char === '（')
+              fullwidthParenDepth++
+            else if (char === '）' && fullwidthParenDepth > 0)
+              fullwidthParenDepth--
+          }
+        }
+      }
+
+      if (closeIndex !== -1)
+        index = closeIndex
       continue
     }
-    if (token.type === 'link_close') {
-      if (linkDepth > 0)
-        linkDepth--
-      continue
-    }
-    if (linkDepth > 0 || token.type !== 'text' || typeof token.content !== 'string')
+    if (token.type !== 'text' || typeof token.content !== 'string')
       continue
     for (const char of token.content) {
       if (char === '（')
@@ -223,21 +257,9 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
           && linkText?.includes('）')
           && (fullwidthParenDepthAtLink.get(curToken) ?? 0) > 0
         ) {
-          let nestedLinkParenDepth = 0
-          for (let j = 0; j < linkText.length; j++) {
-            const char = linkText[j]
-            if (char === '（') {
-              nestedLinkParenDepth++
-            }
-            else if (char === '）') {
-              if (nestedLinkParenDepth === 0) {
-                if (stopAt === -1 || j < stopAt)
-                  stopAt = j
-                break
-              }
-              nestedLinkParenDepth--
-            }
-          }
+          const fullwidthParenStop = firstUnmatchedFullwidthClosingParen(linkText)
+          if (fullwidthParenStop !== -1 && (stopAt === -1 || fullwidthParenStop < stopAt))
+            stopAt = fullwidthParenStop
         }
 
         const hrefStop = firstIndexOfAny(href, LINKIFY_HARD_STOP_CHARS)

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -5,6 +5,7 @@ import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFile
 // We hard-stop FULLWIDTH exclamation mark used as CJK punctuation.
 // ASCII `!` is valid in URLs (path/query/fragment), so do not stop on it.
 const LINKIFY_HARD_STOP_CHARS = ['！'] as const
+const PARENTHESIZED_LINKIFY_HARD_STOP_CHARS = ['！', '）'] as const
 
 type SyntheticLinkToken = MarkdownToken & {
   href?: string
@@ -194,13 +195,31 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
           continue
         }
 
-        const hrefStop = firstIndexOfAny(href, LINKIFY_HARD_STOP_CHARS)
+        let hardStopChars: readonly string[] = LINKIFY_HARD_STOP_CHARS
+        if (curToken.markup === 'linkify' && linkText?.includes('）')) {
+          let fullwidthParenDepth = 0
+          for (let j = 0; j < i; j++) {
+            const preceding = tokens[j]
+            if (preceding?.type !== 'text' || typeof preceding.content !== 'string')
+              continue
+            for (const char of preceding.content) {
+              if (char === '（')
+                fullwidthParenDepth++
+              else if (char === '）' && fullwidthParenDepth > 0)
+                fullwidthParenDepth--
+            }
+          }
+          if (fullwidthParenDepth > 0)
+            hardStopChars = PARENTHESIZED_LINKIFY_HARD_STOP_CHARS
+        }
+
+        const hrefStop = firstIndexOfAny(href, hardStopChars)
         // Prefer splitting by the visible text token, but also trim href if it contains stop chars.
         for (let j = i + 1; j < closeIdx; j++) {
           const t = tokens[j]
           if (t?.type !== 'text' || typeof t.content !== 'string')
             continue
-          const stopAt = firstIndexOfAny(t.content, LINKIFY_HARD_STOP_CHARS)
+          const stopAt = firstIndexOfAny(t.content, hardStopChars)
           if (stopAt === -1)
             continue
 

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -5,7 +5,6 @@ import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFile
 // We hard-stop FULLWIDTH exclamation mark used as CJK punctuation.
 // ASCII `!` is valid in URLs (path/query/fragment), so do not stop on it.
 const LINKIFY_HARD_STOP_CHARS = ['！'] as const
-const PARENTHESIZED_LINKIFY_HARD_STOP_CHARS = ['！', '）'] as const
 
 type SyntheticLinkToken = MarkdownToken & {
   href?: string
@@ -160,9 +159,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
   if (tokens.length < 3)
     return tokens
 
-  // 如果包含 code_inline 类型的 token，说明是包含内联代码的链接，直接返回原样，避免错误处理
-  if (tokens.some(token => token.type === 'code_inline'))
-    return tokens
+  const hasInlineCode = tokens.some(token => token.type === 'code_inline')
 
   const linkifyDemotionContext = inferLinkifyDemotionContext(raw)
   for (let i = 0; i <= tokens.length - 1; i++) {
@@ -186,7 +183,8 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
         const linkText = collectLinkifyText(tokens, i, closeIdx)
         const href = getHrefFromLinkOpen(curToken)
         if (
-          curToken.markup === 'linkify'
+          !hasInlineCode
+          && curToken.markup === 'linkify'
           && linkText
           && !isDecodedFromRawPunycode(linkText, href, raw)
           && shouldDemoteFilenameLikeLinkify(linkText, linkifyDemotionContext)
@@ -195,11 +193,23 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
           continue
         }
 
-        let hardStopChars: readonly string[] = LINKIFY_HARD_STOP_CHARS
+        let stopAt = firstIndexOfAny(linkText ?? '', LINKIFY_HARD_STOP_CHARS)
         if (curToken.markup === 'linkify' && linkText?.includes('）')) {
           let fullwidthParenDepth = 0
+          let priorLinkDepth = 0
           for (let j = 0; j < i; j++) {
             const preceding = tokens[j]
+            if (preceding?.type === 'link_open') {
+              priorLinkDepth++
+              continue
+            }
+            if (preceding?.type === 'link_close') {
+              if (priorLinkDepth > 0)
+                priorLinkDepth--
+              continue
+            }
+            if (priorLinkDepth > 0)
+              continue
             if (preceding?.type !== 'text' || typeof preceding.content !== 'string')
               continue
             for (const char of preceding.content) {
@@ -209,23 +219,42 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
                 fullwidthParenDepth--
             }
           }
-          if (fullwidthParenDepth > 0)
-            hardStopChars = PARENTHESIZED_LINKIFY_HARD_STOP_CHARS
+          if (fullwidthParenDepth > 0) {
+            let nestedLinkParenDepth = 0
+            for (let j = 0; j < linkText.length; j++) {
+              const char = linkText[j]
+              if (char === '（') {
+                nestedLinkParenDepth++
+              }
+              else if (char === '）') {
+                if (nestedLinkParenDepth === 0) {
+                  if (stopAt === -1 || j < stopAt)
+                    stopAt = j
+                  break
+                }
+                nestedLinkParenDepth--
+              }
+            }
+          }
         }
 
-        const hrefStop = firstIndexOfAny(href, hardStopChars)
+        const hrefStop = firstIndexOfAny(href, LINKIFY_HARD_STOP_CHARS)
         // Prefer splitting by the visible text token, but also trim href if it contains stop chars.
+        let remainingStopAt = stopAt
         for (let j = i + 1; j < closeIdx; j++) {
           const t = tokens[j]
           if (t?.type !== 'text' || typeof t.content !== 'string')
             continue
-          const stopAt = firstIndexOfAny(t.content, hardStopChars)
-          if (stopAt === -1)
+          if (remainingStopAt >= t.content.length) {
+            remainingStopAt -= t.content.length
             continue
+          }
+          if (remainingStopAt < 0)
+            break
 
-          const stopChar = t.content[stopAt]
-          const before = t.content.slice(0, stopAt)
-          let tail = t.content.slice(stopAt)
+          const stopChar = t.content[remainingStopAt]
+          const before = t.content.slice(0, remainingStopAt)
+          let tail = t.content.slice(remainingStopAt)
           // Move remaining text tokens that were inside the linkify span to the tail.
           for (let k = j + 1; k < closeIdx; k++) {
             const tk = tokens[k]
@@ -243,7 +272,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
           }
 
           let newHref = href
-          if (hrefStop !== -1) {
+          if (stopChar === '！' && hrefStop !== -1) {
             newHref = href.slice(0, hrefStop)
           }
           else if (tail) {
@@ -270,6 +299,8 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
         }
       }
     }
+    if (hasInlineCode)
+      continue
     if (curToken?.type === 'em_open' && tokens[i - 1]?.type === 'text' && tokens[i - 1].content?.endsWith('*')) {
       const beforeText = tokens[i - 1].content?.replace(/(\*+)$/, '') || ''
       tokens[i - 1].content = beforeText
@@ -647,6 +678,9 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
       }
     }
   }
+
+  if (hasInlineCode)
+    return tokens
 
   // Post-pass: linkify-it strips trailing ASCII punctuation like `!`, but in some URLs
   // it's meaningful (e.g. `?q=!`, `#!`). Merge a standalone leading `!` text token

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -160,6 +160,30 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
     return tokens
 
   const hasInlineCode = tokens.some(token => token.type === 'code_inline')
+  const fullwidthParenDepthAtLink = new Map<MarkdownToken, number>()
+  let fullwidthParenDepth = 0
+  let linkDepth = 0
+  for (const token of tokens) {
+    if (token.type === 'link_open') {
+      if (linkDepth === 0 && token.markup === 'linkify')
+        fullwidthParenDepthAtLink.set(token, fullwidthParenDepth)
+      linkDepth++
+      continue
+    }
+    if (token.type === 'link_close') {
+      if (linkDepth > 0)
+        linkDepth--
+      continue
+    }
+    if (linkDepth > 0 || token.type !== 'text' || typeof token.content !== 'string')
+      continue
+    for (const char of token.content) {
+      if (char === '（')
+        fullwidthParenDepth++
+      else if (char === '）' && fullwidthParenDepth > 0)
+        fullwidthParenDepth--
+    }
+  }
 
   const linkifyDemotionContext = inferLinkifyDemotionContext(raw)
   for (let i = 0; i <= tokens.length - 1; i++) {
@@ -194,46 +218,24 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
         }
 
         let stopAt = firstIndexOfAny(linkText ?? '', LINKIFY_HARD_STOP_CHARS)
-        if (curToken.markup === 'linkify' && linkText?.includes('）')) {
-          let fullwidthParenDepth = 0
-          let priorLinkDepth = 0
-          for (let j = 0; j < i; j++) {
-            const preceding = tokens[j]
-            if (preceding?.type === 'link_open') {
-              priorLinkDepth++
-              continue
+        if (
+          curToken.markup === 'linkify'
+          && linkText?.includes('）')
+          && (fullwidthParenDepthAtLink.get(curToken) ?? 0) > 0
+        ) {
+          let nestedLinkParenDepth = 0
+          for (let j = 0; j < linkText.length; j++) {
+            const char = linkText[j]
+            if (char === '（') {
+              nestedLinkParenDepth++
             }
-            if (preceding?.type === 'link_close') {
-              if (priorLinkDepth > 0)
-                priorLinkDepth--
-              continue
-            }
-            if (priorLinkDepth > 0)
-              continue
-            if (preceding?.type !== 'text' || typeof preceding.content !== 'string')
-              continue
-            for (const char of preceding.content) {
-              if (char === '（')
-                fullwidthParenDepth++
-              else if (char === '）' && fullwidthParenDepth > 0)
-                fullwidthParenDepth--
-            }
-          }
-          if (fullwidthParenDepth > 0) {
-            let nestedLinkParenDepth = 0
-            for (let j = 0; j < linkText.length; j++) {
-              const char = linkText[j]
-              if (char === '（') {
-                nestedLinkParenDepth++
+            else if (char === '）') {
+              if (nestedLinkParenDepth === 0) {
+                if (stopAt === -1 || j < stopAt)
+                  stopAt = j
+                break
               }
-              else if (char === '）') {
-                if (nestedLinkParenDepth === 0) {
-                  if (stopAt === -1 || j < stopAt)
-                    stopAt = j
-                  break
-                }
-                nestedLinkParenDepth--
-              }
+              nestedLinkParenDepth--
             }
           }
         }

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -30,6 +30,33 @@ describe('linkify candidate filter', () => {
     expect(found[0].text).toBe('example.com')
   })
 
+  it('stops a bare link at a fullwidth closing parenthesis', () => {
+    const input = '当前浏览器预览打开的是 **百度首页**（https://www.baidu.com/），搜索框里已有提示文字「林俊杰带女友现身纽约看台」。'
+    const found = links(input)
+
+    expect(found).toHaveLength(1)
+    expect(found[0].href).toBe('https://www.baidu.com/')
+    expect(found[0].text).toBe('https://www.baidu.com/')
+    expect(flatten(parse(input)).filter(node => node?.type === 'text').map(node => node.content).join('')).toContain('），搜索框里已有提示文字「林俊杰带女友现身纽约看台」。')
+  })
+
+  it('preserves fullwidth closing parentheses that belong to a URL', () => {
+    const expectedHref = 'https://example.com/a%EF%BC%89b'
+
+    for (const input of [
+      'https://example.com/a）b',
+      'https://example.com/a%EF%BC%89b',
+      '<https://example.com/a）b>',
+      '（<https://example.com/a）b>）',
+      '[label](https://example.com/a）b)',
+    ]) {
+      const found = links(input)
+
+      expect(found).toHaveLength(1)
+      expect(found[0].href).toBe(expectedHref)
+    }
+  })
+
   it('does not linkify bare links inside markdown link labels', () => {
     const found = links('[example.com](https://target.test)')
 

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -88,6 +88,16 @@ describe('linkify candidate filter', () => {
     ))
   })
 
+  it('consumes a wrapper closed by an earlier bare link', () => {
+    const found = links('（https://one.test/） and https://two.test/a）b')
+
+    expect(found).toHaveLength(2)
+    expect(found.map(link => link.href)).toEqual([
+      'https://one.test/',
+      'https://two.test/a%EF%BC%89b',
+    ])
+  })
+
   it('stops a wrapped bare link when the paragraph also contains inline code', () => {
     const input = '`note`（https://www.baidu.com/）'
     const found = links(input)

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -67,6 +67,27 @@ describe('linkify candidate filter', () => {
     expect(flatten(parse(input)).filter(node => node?.type === 'text').map(node => node.content).join('')).toContain('）after')
   })
 
+  it('matches the outer closing parenthesis before a percent-encoded suffix', () => {
+    const found = links('（https://example.com/a（x）b）%20after')
+
+    expect(found).toHaveLength(1)
+    expect(found[0].href).toBe('https://example.com/a%EF%BC%88x%EF%BC%89b')
+    expect(found[0].text).toBe('https://example.com/a（x）b')
+  })
+
+  it('handles multiple parenthesized bare links in one inline block', () => {
+    const found = links(Array.from(
+      { length: 32 },
+      (_, index) => `（https://example.com/${index}）`,
+    ).join(' '))
+
+    expect(found).toHaveLength(32)
+    expect(found.map(link => link.href)).toEqual(Array.from(
+      { length: 32 },
+      (_, index) => `https://example.com/${index}`,
+    ))
+  })
+
   it('stops a wrapped bare link when the paragraph also contains inline code', () => {
     const input = '`note`（https://www.baidu.com/）'
     const found = links(input)

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -57,6 +57,35 @@ describe('linkify candidate filter', () => {
     }
   })
 
+  it('preserves balanced fullwidth parentheses inside a wrapped URL', () => {
+    const input = '（https://example.com/a（x）b）after'
+    const found = links(input)
+
+    expect(found).toHaveLength(1)
+    expect(found[0].href).toBe('https://example.com/a%EF%BC%88x%EF%BC%89b')
+    expect(found[0].text).toBe('https://example.com/a（x）b')
+    expect(flatten(parse(input)).filter(node => node?.type === 'text').map(node => node.content).join('')).toContain('）after')
+  })
+
+  it('stops a wrapped bare link when the paragraph also contains inline code', () => {
+    const input = '`note`（https://www.baidu.com/）'
+    const found = links(input)
+
+    expect(found).toHaveLength(1)
+    expect(found[0].href).toBe('https://www.baidu.com/')
+    expect(found[0].text).toBe('https://www.baidu.com/')
+  })
+
+  it('ignores parentheses inside earlier links when finding the wrapper context', () => {
+    const found = links('<https://one.test/a（b> and https://two.test/c）d')
+
+    expect(found).toHaveLength(2)
+    expect(found.map(link => link.href)).toEqual([
+      'https://one.test/a%EF%BC%88b',
+      'https://two.test/c%EF%BC%89d',
+    ])
+  })
+
   it('does not linkify bare links inside markdown link labels', () => {
     const found = links('[example.com](https://target.test)')
 

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -277,6 +277,42 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
   })
 
+  it('keeps a parenthesized bare link stable when its closing punctuation arrives', () => {
+    const md = getMarkdown('stream-parser-fullwidth-link-boundary')
+    const coldMd = getMarkdown('stream-parser-fullwidth-link-boundary-cold')
+    const base = buildLargeAppendFriendlyDoc(40)
+    const prefix = `${base}当前浏览器预览打开的是 **百度首页**（`
+    const stages = [
+      { suffix: 'https://www.baidu', types: ['text', 'strong', 'text', 'link'] },
+      { suffix: 'https://www.baidu.com/', types: ['text', 'strong', 'text', 'link'] },
+      { suffix: 'https://www.baidu.com/）', types: ['text', 'strong', 'text', 'link', 'text'] },
+      { suffix: 'https://www.baidu.com/），搜索框', types: ['text', 'strong', 'text', 'link', 'text'] },
+    ]
+
+    for (const stage of stages) {
+      const source = prefix + stage.suffix
+      const streamed = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      } as any)
+      const cold = parseMarkdownToStructure(source, coldMd, {
+        final: false,
+        streamParse: false,
+      })
+      const children = (streamed.at(-1) as any).children
+
+      expect(streamed).toEqual(cold)
+      expect(children.map((node: any) => node.type)).toEqual(stage.types)
+      expect(children.find((node: any) => node.type === 'link')?.href).toBe(
+        stage.suffix.includes('.com') ? 'https://www.baidu.com/' : 'https://www.baidu',
+      )
+    }
+
+    expect(getStreamStats(md).tailHits).toBeGreaterThan(0)
+    expect(getStreamStats(md).fullParses).toBe(1)
+  })
+
   it('does not reuse mixed streaming nodes for a final sync parse', () => {
     const md = getMarkdown('stream-parser-mixed-final-fallback')
     const source = Array.from({ length: 4 }, (_, index) => buildMixedSection(index + 1)).join('')


### PR DESCRIPTION
## Summary

- stop a bare link at a fullwidth closing parenthesis only when the inline context contains an unmatched fullwidth opening parenthesis
- preserve literal and percent-encoded fullwidth parentheses in ordinary URLs, angle autolinks, and explicit Markdown links
- cover incremental tail parsing to prevent link/text type jitter while streaming

## Verification

- parser test suite: 437 tests passed
- focused link and streaming tests: 70 tests passed
- root link parsing tests: 15 tests passed
- pnpm typecheck
- ESLint on changed files
- parser build and built-output parsing probe