### PR TITLE
fix(mermaid): prevent fullscreen diagram clipping

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -1056,6 +1056,12 @@ function mountModalClone() {
   clone.style.height = '100%'
   clone.style.maxHeight = '100%'
 
+  const content = clone.querySelector('._mermaid') as HTMLElement | null
+  if (content) {
+    content.style.contain = 'none'
+    content.style.contentVisibility = 'visible'
+  }
+
   // find the wrapper inside the clone using the data attribute and keep a ref
   const wrapper = clone.querySelector(
     '[data-mermaid-wrapper]',

--- a/test/mermaid-max-height.test.ts
+++ b/test/mermaid-max-height.test.ts
@@ -104,4 +104,20 @@ describe('mermaid block max height', () => {
 
     wrapper.unmount()
   })
+
+  it('does not paint-contain fullscreen SVG content at the preview height', async () => {
+    const { wrapper, content } = await renderWithMaxHeight('500px')
+    content.innerHTML = '<svg viewBox="0 0 100 200"></svg>'
+
+    ;(wrapper.vm as any).openModal()
+    await nextTick()
+    await nextTick()
+
+    const modalContent = document.body.querySelector<HTMLElement>('[data-mermaid-modal-clone="1"] ._mermaid')
+    expect(modalContent?.style.height).toBe('2000px')
+    expect(modalContent?.style.contain).toBe('none')
+    expect(modalContent?.style.contentVisibility).toBe('visible')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary

Prevent tall Mermaid diagrams from being paint-clipped after opening the fullscreen modal and dragging vertically. The modal clone now renders outside the preview containment boundary while leaving normal preview containment unchanged.

## Changes

- [x] Disable paint containment and content visibility deferral for the fullscreen clone
- [x] Add a regression test for fullscreen SVG content taller than the capped preview

## Screenshots / Demo

- [ ] Added GIF/screenshot
- [x] Manually reproduced with the reported sequence diagram and verified the final note remains visible after dragging

## Checklist

- [x] Lint: pnpm lint
- [x] Typecheck: pnpm typecheck
- [x] Tests: pnpm vitest run (303 files, 2615 tests)
- [x] Build: pnpm build (library + CSS)