### PR TITLE
fix(CodeBlockNode): enhance scroll restoration after collapse for long code blocks

### DIFF
--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -76,7 +76,7 @@ Markstream is a family of streaming Markdown renderers for AI applications. This
 
 ### stream-markdown-parser
 - Package name: stream-markdown-parser
-- Version: 1.1.5
+- Version: 1.1.6
 - Maturity label: stable
 - Framework/runtime: Any JavaScript or TypeScript app
 - Description: Framework-agnostic streaming Markdown parser that outputs structured nodes for Markstream renderers and custom render pipelines.

--- a/docs/public/llms-full.zh-CN.txt
+++ b/docs/public/llms-full.zh-CN.txt
@@ -76,7 +76,7 @@ Markstream 是面向 AI 应用的多框架流式 Markdown 渲染器家族。本�
 
 ### stream-markdown-parser
 - 包名：stream-markdown-parser
-- 版本：1.1.5
+- 版本：1.1.6
 - 成熟度标签：稳定
 - 框架/运行时：任意 JavaScript 或 TypeScript 应用
 - 描述：Framework-agnostic streaming Markdown parser that outputs structured nodes for Markstream renderers and custom render pipelines.

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -2869,6 +2869,7 @@ function updateCollapsedHeight(options: EditorHostHeightSyncOptions = {}) {
       const h = applyCollapsedContainerHeight(container, measuredHeight, max, {
         clearEstimatedFloor: true,
         allowBelowEstimatedFloor: foldedDiffReadyForShrink || allowBelowPlainEstimatedFloor || allowBelowStreamingDiffEstimatedFloor,
+        preserveScrollableOverflow: shouldRestoreScrollableOverflow(container),
       })
       if (hasVisibleCollapsedDiffSummary && h < max - PIXEL_EPSILON)
         lastStableCollapsedDiffHeight.value = Math.max(lastStableCollapsedDiffHeight.value ?? 0, h)

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -210,6 +210,8 @@ const heightBeforeCollapse = ref<number | null>(null)
 const lastStableCollapsedDiffHeight = ref<number | null>(null)
 let collapsedDiffHandlesMouseWheel: boolean | null = null
 let resumeGuardFrames = 0
+// Visible height alone cannot reveal overflow after the container is clipped by its maximum height.
+let wasScrollableBeforeCollapse = false
 const registerVisibility = useViewportPriority()
 const viewportPriorityOptions = useViewportPriorityOptions()
 const offscreenHeavyNodeDeferral = useOffscreenHeavyNodeDeferral()
@@ -2482,6 +2484,7 @@ function applyCollapsedContainerHeight(
   options: {
     clearEstimatedFloor?: boolean
     allowBelowEstimatedFloor?: boolean
+    preserveScrollableOverflow?: boolean
   } = {},
 ) {
   const renderedStreamingDiffHeight = isDiff.value && props.loading !== false
@@ -2514,11 +2517,27 @@ function applyCollapsedContainerHeight(
     container.style.overflow = 'hidden'
   }
   else {
-    const shouldScroll = contentHeight > maxHeight + PIXEL_EPSILON
+    const shouldScroll = options.preserveScrollableOverflow === true
+      || contentHeight > maxHeight + PIXEL_EPSILON
     container.style.overflow = shouldScroll ? 'auto' : 'hidden'
   }
 
   return nextHeight
+}
+
+function hasScrollableOverflow(container: HTMLElement, visibleHeight = 0) {
+  const rectHeight = Math.ceil(container.getBoundingClientRect?.().height || 0)
+  const viewportHeight = Math.max(visibleHeight, container.clientHeight || 0, rectHeight)
+  return viewportHeight > 0
+    && container.scrollHeight > viewportHeight + PIXEL_EPSILON
+}
+
+function shouldRestoreScrollableOverflow(container: HTMLElement) {
+  return !isDiff.value
+    && (
+      wasScrollableBeforeCollapse
+      || hasScrollableOverflow(container, heightBeforeCollapse.value ?? 0)
+    )
 }
 
 function syncCollapsedDiffScrollHandling(container: HTMLElement) {
@@ -2728,6 +2747,7 @@ function updateCollapsedHeight(options: EditorHostHeightSyncOptions = {}) {
       if (heightBeforeCollapse.value != null) {
         const h = applyCollapsedContainerHeight(container, heightBeforeCollapse.value, max, {
           allowBelowEstimatedFloor: foldedDiffReadyForShrink,
+          preserveScrollableOverflow: shouldRestoreScrollableOverflow(container),
         })
         adjustScrollAfterHeightChange(container, oldHeight, h)
         return
@@ -2861,6 +2881,7 @@ function updateCollapsedHeight(options: EditorHostHeightSyncOptions = {}) {
     if (heightBeforeCollapse.value != null) {
       const h = applyCollapsedContainerHeight(container, heightBeforeCollapse.value, max, {
         allowBelowEstimatedFloor: foldedDiffReadyForShrink,
+        preserveScrollableOverflow: shouldRestoreScrollableOverflow(container),
       })
       adjustScrollAfterHeightChange(container, oldHeight, h)
       return
@@ -3526,8 +3547,15 @@ function toggleExpand() {
 function toggleHeaderCollapse() {
   isCollapsed.value = !isCollapsed.value
   if (isCollapsed.value) {
+    wasScrollableBeforeCollapse = false
     if (codeEditor.value) {
       const rectH = Math.ceil((codeEditor.value.getBoundingClientRect?.().height) || 0)
+      wasScrollableBeforeCollapse = !isDiff.value
+        && (
+          hasScrollableOverflow(codeEditor.value, rectH)
+          || codeEditor.value.style.overflow === 'auto'
+          || codeEditor.value.style.overflowY === 'auto'
+        )
       if (rectH > 0)
         heightBeforeCollapse.value = rectH
     }

--- a/test/code-block-collapse-scroll.test.ts
+++ b/test/code-block-collapse-scroll.test.ts
@@ -1,0 +1,152 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import CodeBlockNode from '../src/components/CodeBlockNode/CodeBlockNode.vue'
+import { resetCodeBlockRuntimeReadyForTest } from '../src/components/CodeBlockNode/runtime'
+
+function helpers() {
+  return (globalThis as any).__streamMonacoHelpers
+}
+
+function makeNode(lineCount: number) {
+  const code = Array.from({ length: lineCount }, (_, index) => `const line${index} = ${index}`).join('\n')
+  return {
+    type: 'code_block' as const,
+    language: 'typescript',
+    code,
+    raw: `\`\`\`typescript\n${code}\n\`\`\``,
+    loading: false,
+  }
+}
+
+function installHostMetrics(host: HTMLElement, visibleHeight: number, contentHeight: number) {
+  Object.defineProperties(host, {
+    clientHeight: {
+      configurable: true,
+      get: () => visibleHeight,
+    },
+    scrollHeight: {
+      configurable: true,
+      get: () => contentHeight,
+    },
+  })
+  host.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 800,
+    bottom: visibleHeight,
+    width: 800,
+    height: visibleHeight,
+    toJSON: () => ({}),
+  }) as DOMRect
+}
+
+async function flush() {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise<void>(resolve => setTimeout(resolve, 0))
+}
+
+function resetHelpers(contentHeight: number) {
+  resetCodeBlockRuntimeReadyForTest()
+  const runtime = helpers()
+  const editorView = {
+    getModel: () => ({ getValue: () => '', getLineCount: () => 100 }),
+    getOption: () => 18,
+    updateOptions: vi.fn(),
+    layout: vi.fn(),
+    getContentHeight: () => contentHeight,
+  }
+
+  runtime.useMonaco.mockReset().mockImplementation(() => runtime)
+  runtime.createEditor.mockReset().mockImplementation(async (container: HTMLElement) => {
+    container.replaceChildren(document.createElement('diffs-container'))
+  })
+  runtime.createDiffEditor.mockReset()
+  runtime.updateCode.mockReset()
+  runtime.updateDiff.mockReset()
+  runtime.getEditor.mockReset().mockReturnValue(null)
+  runtime.getEditorView.mockReset().mockReturnValue(editorView)
+  runtime.getDiffEditorView.mockReset().mockReturnValue(editorView)
+  runtime.cleanupEditor.mockReset()
+  runtime.safeClean.mockReset()
+  runtime.refreshDiffPresentation.mockReset()
+  runtime.setTheme.mockReset()
+  runtime.whenVisualReady = vi.fn(() => Promise.resolve(true))
+}
+
+function mountCodeBlock(lineCount: number) {
+  return mount(CodeBlockNode, {
+    props: {
+      node: makeNode(lineCount),
+      loading: false,
+      stream: true,
+      showCopyButton: false,
+      showExpandButton: false,
+      showFontSizeButtons: false,
+      showPreviewButton: false,
+      showTooltips: false,
+      monacoOptions: { MAX_HEIGHT: 500 },
+    },
+  })
+}
+
+describe('code block scroll restoration after collapse', () => {
+  beforeEach(() => {
+    resetHelpers(1200)
+  })
+
+  afterEach(() => {
+    delete helpers().whenVisualReady
+    vi.restoreAllMocks()
+  })
+
+  it('keeps a long code block scrollable after collapsing and re-expanding', async () => {
+    const wrapper = mountCodeBlock(100)
+
+    await vi.waitFor(() => {
+      expect(helpers().createEditor).toHaveBeenCalledTimes(1)
+      expect((wrapper.get('.code-editor-container').element as HTMLElement).style.overflow).toBe('auto')
+    })
+
+    const host = wrapper.get('.code-editor-container').element as HTMLElement
+    installHostMetrics(host, 500, 1200)
+    host.scrollTop = 180
+
+    await wrapper.get('button[aria-pressed="false"]').trigger('click')
+    await wrapper.get('button[aria-pressed="true"]').trigger('click')
+    await flush()
+
+    expect(host.clientHeight).toBe(500)
+    expect(host.scrollHeight).toBe(1200)
+    expect(host.scrollTop).toBe(180)
+    expect(host.style.overflow).toBe('auto')
+
+    wrapper.unmount()
+  })
+
+  it('keeps a short code block non-scrollable after collapsing and re-expanding', async () => {
+    resetHelpers(120)
+    const wrapper = mountCodeBlock(5)
+
+    await vi.waitFor(() => {
+      expect(helpers().createEditor).toHaveBeenCalledTimes(1)
+      expect((wrapper.get('.code-editor-container').element as HTMLElement).style.overflow).toBe('hidden')
+    })
+
+    const host = wrapper.get('.code-editor-container').element as HTMLElement
+    installHostMetrics(host, 120, 120)
+
+    await wrapper.get('button[aria-pressed="false"]').trigger('click')
+    await wrapper.get('button[aria-pressed="true"]').trigger('click')
+    await flush()
+
+    expect(host.style.height).toBe('120px')
+    expect(host.style.overflow).toBe('hidden')
+
+    wrapper.unmount()
+  })
+})

--- a/test/code-block-collapse-scroll.test.ts
+++ b/test/code-block-collapse-scroll.test.ts
@@ -8,6 +8,9 @@ function helpers() {
   return (globalThis as any).__streamMonacoHelpers
 }
 
+let reportedContentHeight = 0
+let triggerEditorContentSizeChange = () => {}
+
 function makeNode(lineCount: number) {
   const code = Array.from({ length: lineCount }, (_, index) => `const line${index} = ${index}`).join('\n')
   return {
@@ -53,12 +56,18 @@ async function flush() {
 function resetHelpers(contentHeight: number) {
   resetCodeBlockRuntimeReadyForTest()
   const runtime = helpers()
+  reportedContentHeight = contentHeight
+  triggerEditorContentSizeChange = () => {}
   const editorView = {
     getModel: () => ({ getValue: () => '', getLineCount: () => 100 }),
     getOption: () => 18,
     updateOptions: vi.fn(),
     layout: vi.fn(),
-    getContentHeight: () => contentHeight,
+    getContentHeight: () => reportedContentHeight,
+    onDidContentSizeChange: (callback: () => void) => {
+      triggerEditorContentSizeChange = callback
+      return { dispose: vi.fn() }
+    },
   }
 
   runtime.useMonaco.mockReset().mockImplementation(() => runtime)
@@ -118,6 +127,14 @@ describe('code block scroll restoration after collapse', () => {
 
     await wrapper.get('button[aria-pressed="false"]').trigger('click')
     await wrapper.get('button[aria-pressed="true"]').trigger('click')
+    await flush()
+
+    reportedContentHeight = 500
+    triggerEditorContentSizeChange()
+    await wrapper.setProps({ monacoOptions: { MAX_HEIGHT: 500, fontSize: 13 } })
+    await wrapper.setProps({ monacoOptions: { MAX_HEIGHT: 500, fontSize: 14 } })
+    await wrapper.setProps({ monacoOptions: { MAX_HEIGHT: 500, fontSize: 15 } })
+    await flush()
     await flush()
 
     expect(host.clientHeight).toBe(500)


### PR DESCRIPTION
## Summary

Fixes an issue where a long Markdown code block could scroll normally at first, but became unscrollable after being collapsed and expanded again.

## Root Cause

When the code block was collapsed, its capped visible height (`500px`) was treated as the full content height during expansion. The component therefore incorrectly determined that the content did not overflow and changed `overflow` to `hidden`.

## Changes

- Track whether the code block was scrollable before collapsing.
- Restore `overflow: auto` when expanding a previously scrollable code block.
- Check the current DOM overflow as an additional safeguard.
- Add regression tests for scrolling after the collapse-and-expand cycle.
- Preserve the existing behavior for short code blocks, diff mode, and manual expansion.

## Verification

- [x] `pnpm typecheck`
- [x] All tests pass: 304 test files and 2,617 tests
- [x] Relevant ESLint checks pass
- [x] Manually verified that the code block remains scrollable after collapsing and expanding
- [x] `pnpm build`

## Before

A long code block stopped scrolling after the following sequence:

1. Scroll the code block.
2. Collapse it.
3. Expand it again.

## After

The expanded code block retains `overflow: auto` and can continue scrolling normally.