### PR TITLE
fix(parser): preserve adjacent same-line HTML blocks

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -2514,6 +2514,18 @@ function mergeSplitTopLevelHtmlBlocks(nodes: ParsedNode[], final: boolean, sourc
 
     const currentContent = String(node.content ?? nodeRaw)
     const currentRaw = String(node.raw ?? currentContent)
+    const currentRawEnd = nodePos + currentRaw.length
+    if (
+      nodePos !== -1
+      && exact.end < currentRawEnd
+      && source.slice(nodePos, currentRawEnd) === currentRaw
+    ) {
+      sourceHtmlCursor = currentRawEnd
+      if (options?.includeSourceMap)
+        node.sourceMap = createSourceMapFromOffsets(source, nodePos, currentRawEnd, options)
+      continue
+    }
+
     const nextContent = buildHtmlBlockContent(exact.raw, tag, exact.closed)
     const desiredLoading = !final && !exact.closed
     const needsExpansion = currentContent !== nextContent || currentRaw !== exact.raw || Boolean(node.loading) !== desiredLoading

--- a/packages/markdown-parser/test/issue-600-same-line-html-siblings.test.ts
+++ b/packages/markdown-parser/test/issue-600-same-line-html-siblings.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+const issue600Html = '<p>First paragraph</p><p><br></p><p>Second paragraph</p><p>Third paragraph</p>'
+
+function rawContent(nodes: any[]) {
+  return nodes.map(node => String(node.raw ?? '')).join('')
+}
+
+describe('issue 600 same-line html sibling regression', () => {
+  it.each([true, false])('preserves every adjacent paragraph when final is %s', (final) => {
+    const nodes = parseMarkdownToStructure(issue600Html, getMarkdown(`issue-600-${final}`), {
+      final,
+    }) as any[]
+
+    expect(rawContent(nodes)).toBe(issue600Html)
+    expect(rawContent(nodes)).toContain('<p><br></p>')
+    expect(rawContent(nodes)).toContain('<p>Third paragraph</p>')
+  })
+
+  it.each([
+    '<div><p>Nested paragraph</p></div><section>Section sibling</section>',
+    '<p data-example="<section>">Quoted attribute</p><p>Sibling</p>',
+    '<script>const example = "<p>not a sibling</p>"</script><p>Actual sibling</p>',
+    '<p>Before void</p><br><p>After void</p>',
+    '<p>Before comment</p><!-- sibling comment --><p>After comment</p>',
+    '<p>Paragraph</p>same-line text',
+  ])('does not discard a same-line tail from %s', (html) => {
+    const nodes = parseMarkdownToStructure(html, getMarkdown(`issue-600-edge-${html}`), {
+      final: true,
+    }) as any[]
+
+    expect(rawContent(nodes)).toBe(html)
+  })
+
+  it('preserves every streaming prefix and the final transition', () => {
+    const md = getMarkdown('issue-600-stream')
+    const firstClose = issue600Html.indexOf('</p>') + '</p>'.length
+
+    for (let end = firstClose; end <= issue600Html.length; end++) {
+      const prefix = issue600Html.slice(0, end)
+      const nodes = parseMarkdownToStructure(prefix, md, { final: false }) as any[]
+
+      expect(rawContent(nodes), `stream prefix ending at ${end}`).toBe(prefix)
+    }
+
+    const finalNodes = parseMarkdownToStructure(issue600Html, md, { final: true }) as any[]
+    expect(rawContent(finalNodes)).toBe(issue600Html)
+    expect(finalNodes.every(node => node.loading === false)).toBe(true)
+  })
+
+  it('maps the preserved fragment to its complete source line', () => {
+    const nodes = parseMarkdownToStructure(issue600Html, getMarkdown('issue-600-source-map'), {
+      final: true,
+      includeSourceMap: true,
+    }) as any[]
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.sourceMap).toEqual({ startLine: 0, endLine: 1 })
+  })
+})

--- a/test/issue600-renderer-regression.test.ts
+++ b/test/issue600-renderer-regression.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { flushAll } from './setup/flush-all'
+
+let MarkdownRender: any
+
+describe('issue 600 renderer regression', () => {
+  beforeAll(async () => {
+    MarkdownRender = (await import('../src/components/NodeRenderer')).default
+  })
+
+  it('renders all adjacent same-line html blocks with the trusted policy', async () => {
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: '<p>First paragraph</p><p><br></p><p>Second paragraph</p><p>Third paragraph</p>',
+        final: true,
+        htmlPolicy: 'trusted',
+      },
+    })
+    await flushAll()
+
+    const paragraphs = wrapper.findAll('.html-block-node p')
+    expect(paragraphs).toHaveLength(4)
+    expect(paragraphs.map(paragraph => paragraph.text())).toEqual([
+      'First paragraph',
+      '',
+      'Second paragraph',
+      'Third paragraph',
+    ])
+  })
+
+  it('keeps the siblings when streaming content becomes final', async () => {
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: '<p>First paragraph</p><p><br>',
+        final: false,
+        htmlPolicy: 'trusted',
+      },
+    })
+    await flushAll()
+
+    await wrapper.setProps({
+      content: '<p>First paragraph</p><p><br></p><p>Second paragraph</p><p>Third paragraph</p>',
+      final: true,
+    })
+    await flushAll()
+
+    expect(wrapper.findAll('.html-block-node p').map(paragraph => paragraph.text())).toEqual([
+      'First paragraph',
+      '',
+      'Second paragraph',
+      'Third paragraph',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- keep a complete source-backed HTML block token instead of truncating it at the first closing element
- preserve adjacent mixed tags, raw-text tags, comments, void elements, and same-line trailing content
- cover progressive streaming prefixes, the final transition, source maps, and trusted Vue rendering

Closes #600

## Tests

- `pnpm run -C packages/markdown-parser test:run`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest --run --testTimeout=10000`