### PR TITLE
fix: standalone code fallback loses gutter padding when rendered as component root

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -4864,7 +4864,13 @@ onUnmounted(() => {
   grid-area: 1 / 1;
   z-index: 1;
 }
-:deep(.code-editor-layer > pre.code-pre-fallback) {
+/* No :deep() here (or for the pre.code-pre-fallback rules below): the
+   fallback <pre> is PreCodeNode's root element, and a child component's root
+   carries this SFC's scope id, so a plain scoped selector matches it both as
+   a descendant (inside .code-editor-layer) and as this component's own root
+   (the standalone fallback). :deep() would emit an ancestor selector that
+   cannot match the standalone-root case. */
+.code-editor-layer > pre.code-pre-fallback {
   grid-area: 1 / 1;
   position: relative;
   z-index: 2;
@@ -5122,7 +5128,7 @@ onUnmounted(() => {
   pointer-events: none;
 }
 
-:deep(pre.code-pre-fallback) {
+pre.code-pre-fallback {
   margin: 0;
   box-sizing: border-box;
   width: 100%;
@@ -5146,19 +5152,19 @@ onUnmounted(() => {
   );
 }
 
-:deep(pre.code-pre-fallback > code) {
+pre.code-pre-fallback :deep(code) {
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
   font-family: inherit;
 }
 
-:deep(pre.code-pre-fallback.is-wrap) {
+pre.code-pre-fallback.is-wrap {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
-:deep(pre.code-pre-fallback.markstream-pre--diff-preview) {
+pre.code-pre-fallback.markstream-pre--diff-preview {
   padding-left: 0;
   padding-right: 0;
 }


### PR DESCRIPTION
## Problem

When the Monaco enhancement is unavailable (e.g. the optional `stream-diffs` peer is missing or fails to load), `CodeBlockNode` flips `usePreCodeRender` and renders `PreCodeNode` **as the component root** with `class="code-pre-fallback"` and `show-line-numbers`.

The scoped styles for that fallback are written as `:deep(pre.code-pre-fallback)`, which compiles to an **ancestor** selector `[data-v-x] pre.code-pre-fallback`. A root `<pre>` has no ancestor carrying the scope id, so the rule never matches in the standalone case:

- the line-number gutter still renders (its rules are global), but the code gets no `padding-left` reservation → **line numbers overlap the code text**;
- `:deep(pre.code-pre-fallback > code)` misses too, so `<code>` loses the font/line-height inheritance (vertical drift in app skins).

Still present on `main` (1.0.9-beta.0).

## Screenshots & measurements

| Before (broken) | After (this PR) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/wbxl2000/markstream-vue/pr-602-screenshots/pr-602-screenshots/before.png) | ![after](https://raw.githubusercontent.com/wbxl2000/markstream-vue/pr-602-screenshots/pr-602-screenshots/after.png) |

Measured on the standalone fallback `<pre>` in the repro (computed styles + rects):

| | `padding-left` | gutter right edge → code left edge |
| --- | --- | --- |
| Before | `0px` | **38px overlap** (numbers painted over code) |
| After | `45.35px` (= `calc(6ch + 2px)` gutter) | 7px clearance, matching the in-container fallback |

## Fix

Drop `:deep()` and use plain scoped selectors for the rules that target the fallback `<pre>` itself. The `<pre>` is always `PreCodeNode`'s root element, and a child component's root carries the parent SFC's scope id (verified in the live DOM: the standalone `<pre>` carries `data-v-a7a1abdd` on itself), so `pre.code-pre-fallback[data-v-x]` matches **both** usages:

- standalone root (`usePreCodeRender` branch), and
- in-layer transition fallback (inside `.code-editor-layer`).

`pre.code-pre-fallback > code` becomes `pre.code-pre-fallback :deep(code)` so the scope anchor sits on the `<pre>` (the `<code>` is rendered by `PreCodeNode` and carries a different scope id).

Rules targeting diff-preview internals (`.markstream-pre__diff-pane`, etc.) keep `:deep()` — those elements only exist inside `.code-block-container`, where the ancestor form works.

## Minimal repro

1. `npm i vue markstream-vue@1.0.7` — do **not** install the optional `stream-diffs`/`stream-monaco` peers (this is the dependency state apps get when they upgrade markstream-vue without adding the new optional peers).
2. Render a multi-line ```text fence via `<MarkdownRender mode="chat" code-renderer="shiki" :defer-nodes-until-visible="false" :final="true" :code-block-props="{ loading: false }">`.
3. Once the Monaco loader fails, the block flips to the standalone fallback: line numbers overlap the code.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` (307 files / 2631 tests) all pass.
- Rebuilt `dist/index.px.css` now emits `pre.code-pre-fallback[data-v-x]` (was `[data-v-x] pre.code-pre-fallback`).
- The measurements above were taken with the patched build installed in the repro — no consumer-side CSS involved.