### PR TITLE
fix(parser): parse Windows file URLs as images

### DIFF
--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -138,14 +138,17 @@ function applyInlineUrlValidation(md: MarkdownItInstance) {
     return
 
   const markdownIt = md as MarkdownItInstance & { validateLink: (url: string) => boolean }
-  const imageValidateLink = markdownIt.validateLink
+  const markdownItValidateLink = markdownIt.validateLink
+  const imageValidateLink = (url: string) => markdownItValidateLink(url)
+    || (url.trim().toLowerCase().startsWith('file:///')
+      && !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' }))
   const markstreamMd = md as MarkdownItInstance & { __markstreamOriginalValidateLink?: (url: string) => boolean }
-  markstreamMd.__markstreamOriginalValidateLink = imageValidateLink
+  markstreamMd.__markstreamOriginalValidateLink = markdownItValidateLink
 
   ruler.at('link', (...args: any[]) => {
     const state = args[0] as InlineStateLike
     const activeMd = state.md
-    const validateLink = activeMd?.validateLink === imageValidateLink
+    const validateLink = activeMd?.validateLink === markdownItValidateLink
       ? activeMd.options?.validateLink
       : activeMd?.validateLink
     if (!activeMd || typeof validateLink !== 'function')

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -138,17 +138,14 @@ function applyInlineUrlValidation(md: MarkdownItInstance) {
     return
 
   const markdownIt = md as MarkdownItInstance & { validateLink: (url: string) => boolean }
-  const markdownItValidateLink = markdownIt.validateLink
-  const imageValidateLink = (url: string) => markdownItValidateLink(url)
-    || (url.trim().toLowerCase().startsWith('file:///')
-      && !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' }))
+  const imageValidateLink = markdownIt.validateLink
   const markstreamMd = md as MarkdownItInstance & { __markstreamOriginalValidateLink?: (url: string) => boolean }
-  markstreamMd.__markstreamOriginalValidateLink = markdownItValidateLink
+  markstreamMd.__markstreamOriginalValidateLink = imageValidateLink
 
   ruler.at('link', (...args: any[]) => {
     const state = args[0] as InlineStateLike
     const activeMd = state.md
-    const validateLink = activeMd?.validateLink === markdownItValidateLink
+    const validateLink = activeMd?.validateLink === imageValidateLink
       ? activeMd.options?.validateLink
       : activeMd?.validateLink
     if (!activeMd || typeof validateLink !== 'function')

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -1484,6 +1484,7 @@ export function parseInlineTokens(
     // mirror logic previously in the switch-case for 'link_open'
     resetCurrentTextNode()
     // 直接使用 parseLinkToken 来解析链接及其子节点，这能正确处理包含 code_inline 等复杂内容的链接
+    const linkStartIndex = i
     const { node, nextIndex } = parseLinkToken(tokens, i, options)
     i = nextIndex
 
@@ -1544,6 +1545,13 @@ export function parseInlineTokens(
             node.loading = false
         }
       }
+    }
+
+    if (
+      /^file:\/\/\/[a-z]:\//i.test(node.href)
+      && recoverMarkdownImageFromTrailingBang(node as unknown as MarkdownToken, linkStartIndex - 1)
+    ) {
+      return
     }
 
     if (recoverMarkdownLinkFromTrailingText(node as unknown as MarkdownToken))
@@ -1665,12 +1673,12 @@ export function parseInlineTokens(
     return true
   }
 
-  function recoverMarkdownImageFromTrailingBang(token: MarkdownToken): boolean {
+  function recoverMarkdownImageFromTrailingBang(token: MarkdownToken, previousTokenIndex = i - 1): boolean {
     if (token.type !== 'link')
       return false
 
     const previous = result[result.length - 1] as TextNode | undefined
-    const previousToken = tokens[i - 1]
+    const previousToken = tokens[previousTokenIndex]
     if (!previous || previous.type !== 'text' || previousToken?.type !== 'text')
       return false
 

--- a/test/inline-parsers/fix-link-inline.test.ts
+++ b/test/inline-parsers/fix-link-inline.test.ts
@@ -614,6 +614,29 @@ describe('inline parser fixes (link mid-states)', () => {
       expect(images[0].alt).toBe('劈叉少女')
       expect(links, `final: ${final}`).toHaveLength(0)
     }
+
+    for (let index = 2; index <= markdown.length; index++) {
+      const prefix = markdown.slice(0, index)
+      const nodes = parseMarkdownToStructure(prefix, md, { final: false })
+
+      expect(collectTarget(nodes as any[], 'image'), prefix).toHaveLength(1)
+      expect(collectLinks(nodes as any[]), prefix).toHaveLength(0)
+    }
+
+    const escapedNodes = parseMarkdownToStructure(`\\${markdown}`, md, { final: true })
+    expect(collectTarget(escapedNodes as any[], 'image')).toHaveLength(0)
+    expect(collectLinks(escapedNodes as any[])).toHaveLength(1)
+
+    const rejectingMd = getMarkdown('reject-windows-file-image', {
+      markdownItOptions: {
+        validateLink: () => false,
+      },
+    })
+    const rejectedNodes = parseMarkdownToStructure(markdown, rejectingMd, { final: true })
+    const rejectedImages = collectTarget(rejectedNodes as any[], 'image')
+    expect(rejectedImages).toHaveLength(1)
+    expect(rejectedImages[0]).toMatchObject({ src: '', loading: true })
+    expect(collectLinks(rejectedNodes as any[])).toHaveLength(0)
   })
 
   it('does not turn escaped exclamation plus link into an image mid-state', () => {

--- a/test/inline-parsers/fix-link-inline.test.ts
+++ b/test/inline-parsers/fix-link-inline.test.ts
@@ -602,6 +602,20 @@ describe('inline parser fixes (link mid-states)', () => {
     expect(finalLinks).toHaveLength(0)
   })
 
+  it('parses a Windows file URL image as an image instead of exclamation text and a link', () => {
+    const markdown = '![劈叉少女](file:///C:/Users/18616/dim-agent/artifacts/image-ms7gxc2x-391c1dc2.png)'
+    for (const final of [false, true]) {
+      const nodes = parseMarkdownToStructure(markdown, md, { final })
+      const images = collectTarget(nodes as any[], 'image')
+      const links = collectLinks(nodes as any[])
+
+      expect(images, `final: ${final}`).toHaveLength(1)
+      expect(images[0].src).toBe('file:///C:/Users/18616/dim-agent/artifacts/image-ms7gxc2x-391c1dc2.png')
+      expect(images[0].alt).toBe('劈叉少女')
+      expect(links, `final: ${final}`).toHaveLength(0)
+    }
+  })
+
   it('does not turn escaped exclamation plus link into an image mid-state', () => {
     const nodes = parseMarkdownToStructure('\\![Picture](https://imzbf.github.io/md-editor-rt/imgs/mark_emoji.gif', md, { final: false })
     const images = collectTarget(nodes as any[], 'image')


### PR DESCRIPTION
## Summary

- recover Windows drive-based `file:///C:/...` Markdown images as image nodes without changing global image URL validation
- prevent `![alt](file:///C:/...)` from being split into `!` text and a link
- preserve the existing separation between link and image validation for other local file URLs
- cover complete, escaped, validator-rejected, and every character-by-character streaming state

## Testing

- `pnpm run build:parser && pnpm run build:core && pnpm test -- --run` (307 files, 2632 tests)
- `pnpm lint`
- `pnpm typecheck`