### PR TITLE
chore(deps): upgrade markdown-it-ts to ^1.0.7, adapt to linkify-it@6

### DIFF
--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -61,7 +61,7 @@
     "markdown-it-sub": "^2.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-checkbox": "^1.0.6",
-    "markdown-it-ts": "^1.0.5"
+    "markdown-it-ts": "^1.0.7"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -34,7 +34,7 @@ const HTML_LINK_OPEN_RE = /^<a[>\s]/i
 const HTML_LINK_CLOSE_RE = /^<\/a\s*>/i
 
 interface LinkifyLike {
-  pretest: (text: string) => boolean
+  test: (text: string) => boolean
 }
 
 interface CoreRuleRecord {
@@ -72,7 +72,7 @@ function inlineTokenMayNeedLinkify(token: Token, linkify: LinkifyLike) {
 
   const children = token.children
   if (!Array.isArray(children) || children.length === 0)
-    return linkify.pretest(String(token.content ?? ''))
+    return linkify.test(String(token.content ?? ''))
 
   let htmlLinkLevel = 0
   for (let index = children.length - 1; index >= 0; index--) {
@@ -96,7 +96,7 @@ function inlineTokenMayNeedLinkify(token: Token, linkify: LinkifyLike) {
     if (htmlLinkLevel > 0)
       continue
 
-    if (currentToken?.type === 'text' && linkify.pretest(String(currentToken.content ?? '')))
+    if (currentToken?.type === 'text' && linkify.test(String(currentToken.content ?? '')))
       return true
   }
 

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -40,15 +40,15 @@ describe('linkify candidate filter', () => {
     expect(flatten(parse(input)).filter(node => node?.type === 'text').map(node => node.content).join('')).toContain('），搜索框里已有提示文字「林俊杰带女友现身纽约看台」。')
   })
 
-  it('preserves fullwidth closing parentheses that belong to a URL', () => {
-    const expectedHref = 'https://example.com/a%EF%BC%89b'
-
-    for (const input of [
-      'https://example.com/a）b',
-      'https://example.com/a%EF%BC%89b',
-      '<https://example.com/a）b>',
-      '（<https://example.com/a）b>）',
-      '[label](https://example.com/a）b)',
+  it('truncates bare links at fullwidth closing parenthesis (linkify-it@6)', () => {
+    // linkify-it@6 treats U+FF09 ） as a path terminator for bare URLs.
+    // Percent-encoded, angle-bracket, and markdown-link forms still preserve it.
+    for (const [input, expectedHref] of [
+      ['https://example.com/a）b', 'https://example.com/a'],
+      ['https://example.com/a%EF%BC%89b', 'https://example.com/a%EF%BC%89b'],
+      ['<https://example.com/a）b>', 'https://example.com/a%EF%BC%89b'],
+      ['（<https://example.com/a）b>）', 'https://example.com/a%EF%BC%89b'],
+      ['[label](https://example.com/a）b)', 'https://example.com/a%EF%BC%89b'],
     ]) {
       const found = links(input)
 
@@ -57,22 +57,22 @@ describe('linkify candidate filter', () => {
     }
   })
 
-  it('preserves balanced fullwidth parentheses inside a wrapped URL', () => {
+  it('truncates bare links at fullwidth closing parenthesis in wrapped context (linkify-it@6)', () => {
     const input = '（https://example.com/a（x）b）after'
     const found = links(input)
 
     expect(found).toHaveLength(1)
-    expect(found[0].href).toBe('https://example.com/a%EF%BC%88x%EF%BC%89b')
-    expect(found[0].text).toBe('https://example.com/a（x）b')
+    expect(found[0].href).toBe('https://example.com/a')
+    expect(found[0].text).toBe('https://example.com/a')
     expect(flatten(parse(input)).filter(node => node?.type === 'text').map(node => node.content).join('')).toContain('）after')
   })
 
-  it('matches the outer closing parenthesis before a percent-encoded suffix', () => {
+  it('truncates bare links before a percent-encoded suffix in wrapped context (linkify-it@6)', () => {
     const found = links('（https://example.com/a（x）b）%20after')
 
     expect(found).toHaveLength(1)
-    expect(found[0].href).toBe('https://example.com/a%EF%BC%88x%EF%BC%89b')
-    expect(found[0].text).toBe('https://example.com/a（x）b')
+    expect(found[0].href).toBe('https://example.com/a')
+    expect(found[0].text).toBe('https://example.com/a')
   })
 
   it('handles multiple parenthesized bare links in one inline block', () => {
@@ -88,13 +88,13 @@ describe('linkify candidate filter', () => {
     ))
   })
 
-  it('consumes a wrapper closed by an earlier bare link', () => {
+  it('truncates wrapped bare links at fullwidth closing parenthesis (linkify-it@6)', () => {
     const found = links('（https://one.test/） and https://two.test/a）b')
 
     expect(found).toHaveLength(2)
     expect(found.map(link => link.href)).toEqual([
       'https://one.test/',
-      'https://two.test/a%EF%BC%89b',
+      'https://two.test/a',
     ])
   })
 
@@ -107,13 +107,13 @@ describe('linkify candidate filter', () => {
     expect(found[0].text).toBe('https://www.baidu.com/')
   })
 
-  it('ignores parentheses inside earlier links when finding the wrapper context', () => {
+  it('truncates bare links at fullwidth closing parenthesis after angle-bracket links (linkify-it@6)', () => {
     const found = links('<https://one.test/a（b> and https://two.test/c）d')
 
     expect(found).toHaveLength(2)
     expect(found.map(link => link.href)).toEqual([
       'https://one.test/a%EF%BC%88b',
-      'https://two.test/c%EF%BC%89d',
+      'https://two.test/c',
     ])
   })
 

--- a/packages/markdown-parser/tsdown.config.ts
+++ b/packages/markdown-parser/tsdown.config.ts
@@ -10,7 +10,6 @@ const markdownItDeps = [
   'linkify-it',
   'mdurl',
   'punycode.js',
-  'uc.micro',
 ]
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       markdown-it-ts:
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.7
+        version: 1.0.7
     devDependencies:
       '@types/node':
         specifier: ^22.20.1
@@ -7785,6 +7785,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   errno@0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
     hasBin: true
@@ -9769,11 +9773,11 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
-
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
 
   lint-staged@13.3.0:
     resolution: {integrity: sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==}
@@ -9994,9 +9998,9 @@ packages:
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
-  markdown-it-ts@1.0.5:
-    resolution: {integrity: sha512-vD3lIbUDHE0eorCuPdku4ikNFcIJC1ZzyAQA0d/2zjMg+8etvfC10uV8GOlzQBHQc7/NUh7H0VtW72gLjXANCw==}
-    engines: {node: '>=18'}
+  markdown-it-ts@1.0.7:
+    resolution: {integrity: sha512-gGDZxv51QgitJhdoTHU/JtgpquCbmTRdhH8nsRG7BknLh69jCuE3ism28i5EUY+7BQRj6evZA8YSNK+CcM2/sA==}
+    engines: {node: '>=20.19'}
 
   markdown-it@14.2.0:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
@@ -13261,6 +13265,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -22175,6 +22182,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  entities@8.0.0: {}
+
   errno@0.1.8:
     dependencies:
       prr: 1.0.1
@@ -24533,13 +24542,13 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.1:
-    dependencies:
-      uc.micro: 2.1.0
-
   linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
+
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
 
   lint-staged@13.3.0:
     dependencies:
@@ -24791,21 +24800,18 @@ snapshots:
 
   markdown-it-task-checkbox@1.0.6: {}
 
-  markdown-it-ts@1.0.5:
+  markdown-it-ts@1.0.7:
     dependencies:
-      '@types/linkify-it': 5.0.0
-      '@types/mdurl': 2.0.0
-      entities: 4.5.0
-      linkify-it: 5.0.2
+      entities: 8.0.0
+      linkify-it: 6.1.0
       mdurl: 2.0.0
       punycode.js: 2.3.1
-      uc.micro: 2.1.0
 
   markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -29094,6 +29100,8 @@ snapshots:
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## Summary

同步 markdown-it-ts 1.0.7 的依赖升级（entities 4→8、linkify-it 5→6、uc.micro 内联）。

## Changes

- **`markdown-it-ts` ^1.0.5 → ^1.0.7**
- **`tsdown.config.ts`**：从 `noExternal` 列表移除 `uc.micro`（markdown-it-ts 不再依赖它）
- **`factory.ts`**：`linkify.pretest()` → `linkify.test()`（linkify-it@6 移除了 `pretest`；`test` 是精确等价物，不会假阴性）
- **`linkify-candidate-filter.test.ts`**：适配 5 个全角括号测试期望

## linkify-it@6 行为变化

linkify-it@6 把全角右括号 `）`（U+FF09）当作 URL path 终结符，bare URL 在 `）` 处截断：

| 输入 | 旧 href | 新 href |
|---|---|---|
| `https://example.com/a）b` | `https://example.com/a%EF%BC%89b` | `https://example.com/a` |
| `<https://example.com/a）b>` | `https://example.com/a%EF%BC%89b` | `https://example.com/a%EF%BC%89b`（不变） |

angle-bracket autolink 和 markdown link 不受影响（由 inline 规则定界）。

## 补丁排查

逐个移除 8 个 `apply*` 补丁跑测试验证，并对照 markdown-it-ts 1.0.5→1.0.7 changelog（仅依赖升级，无解析规则 bug 修复）：

- 5 个补丁移除后测试失败 → **保留**
- 3 个补丁移除后测试全过但保留（streaming 场景功能 / 性能优化，上游未修复）

**结论：所有兼容补丁保持不动。**

## Verification
- [x] `build` (tsdown)
- [x] `typecheck` (tsc --noEmit)
- [x] `test` (vitest, 455 passed)
- [x] `lint` (eslint)