### PR TITLE
fix(react): recover WebSocket-streamed code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "test:perf:height-estimation-experiment": "node scripts/benchmark-height-estimation-experiment.mjs",
     "test:e2e:diff-folding": "node scripts/e2e-diff-folding.mjs",
     "test:e2e:codeblock-highlight-stability": "node scripts/e2e-codeblock-highlight-stability.mjs",
+    "test:e2e:react-websocket-code-blocks": "pnpm run build:parser && pnpm --filter markstream-core build && node scripts/e2e-react-websocket-code-blocks.mjs",
     "test:e2e:height-estimation-experiment": "node scripts/e2e-height-estimation-experiment.mjs",
     "test:e2e:main-playground-performance": "node scripts/e2e-main-playground-performance.mjs",
     "test:e2e:playground-performance": "node scripts/e2e-playground-performance.mjs",

--- a/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
@@ -300,6 +300,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
   const editorHeightSyncDisposablesRef = useRef<any[]>([])
   const diffDomHeightObserverRef = useRef<MutationObserver | null>(null)
   const expandedRef = useRef(false)
+  const failedMonacoLanguageRef = useRef<string | undefined>(undefined)
 
   const [useFallback, setUseFallback] = useState(false)
   const [viewportReady, setViewportReady] = useState(() => typeof window === 'undefined')
@@ -855,7 +856,13 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     }
   }, [node.diff, resolvedSurfaceIsDark])
 
-  const shouldDelayEditor = stream === false && loading
+  const hasStreamingCode = useMemo(() => {
+    return node.code.length > 0
+      || (node.originalCode?.length ?? 0) > 0
+      || (node.updatedCode?.length ?? 0) > 0
+  }, [node.code, node.originalCode, node.updatedCode])
+  const shouldDelayEditor = (stream === false && loading)
+    || (stream !== false && loading && !hasStreamingCode)
 
   // Vue parity: keep theme in sync without recreating Monaco.
   useEffect(() => {
@@ -992,8 +999,10 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
         setEditorReady(true)
       }
       catch {
-        if (editorLifecycleIdRef.current === creationId)
+        if (editorLifecycleIdRef.current === creationId) {
+          failedMonacoLanguageRef.current = monacoLanguage
           setUseFallback(true)
+        }
       }
     })()
 
@@ -1049,8 +1058,15 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
   ])
 
   useEffect(() => {
-    if (useFallback)
+    if (useFallback) {
+      const failedLanguage = failedMonacoLanguageRef.current
+      if (failedLanguage === undefined || failedLanguage === monacoLanguage)
+        return
+      failedMonacoLanguageRef.current = undefined
+      resetEditorInstance()
+      setUseFallback(false)
       return
+    }
     if (!monacoReady)
       return
     if (!viewportReady)
@@ -1060,7 +1076,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
       return
     }
     void ensureEditorCreation()
-  }, [collapsed, ensureEditorCreation, monacoReady, resetEditorInstance, shouldDelayEditor, useFallback, viewportReady])
+  }, [collapsed, ensureEditorCreation, monacoLanguage, monacoReady, resetEditorInstance, shouldDelayEditor, useFallback, viewportReady])
 
   useEffect(() => {
     if (useFallback)
@@ -1233,18 +1249,6 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     if (canonicalLanguage === 'html')
       setInlinePreviewOpen(v => !v)
   }, [canonicalLanguage, isPreviewable, node, props, t])
-
-  if (useFallback) {
-    return (
-      <PreCodeNode
-        className="code-fallback-plain m-0"
-        diffInline={preFallbackDiffInline}
-        node={node as any}
-        showLineNumbers={Boolean(node.diff)}
-        style={preFallbackStyle}
-      />
-    )
-  }
 
   return (
     <div
@@ -1495,7 +1499,15 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
       <div className={`code-block-body${collapsed ? ' code-block-body--collapsed' : ''}${expanded ? ' code-block-body--expanded' : ''}`}>
         {!collapsed && (stream ? true : !loading) && (
           useFallback
-            ? <PreCodeNode node={node as any} />
+            ? (
+                <PreCodeNode
+                  className="code-fallback-plain m-0"
+                  diffInline={preFallbackDiffInline}
+                  node={node}
+                  showLineNumbers={Boolean(node.diff)}
+                  style={preFallbackStyle}
+                />
+              )
             : (
                 <div className="code-editor-layer">
                   <div

--- a/scripts/e2e-react-websocket-code-blocks.mjs
+++ b/scripts/e2e-react-websocket-code-blocks.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright-core'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const playgroundDir = path.join(repoRoot, 'playground-react19')
+const host = '127.0.0.1'
+
+function isPortOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port })
+    socket.on('connect', () => {
+      socket.end()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function findFreePort(start = 4180, end = 4210) {
+  for (let port = start; port <= end; port += 1) {
+    if (!await isPortOpen(port))
+      return port
+  }
+  throw new Error(`No free port found in ${start}-${end}`)
+}
+
+async function waitForPort(port, timeoutMs = 30000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isPortOpen(port))
+      return
+    await new Promise(resolve => setTimeout(resolve, 150))
+  }
+  throw new Error(`Timed out waiting for ${host}:${port}`)
+}
+
+function resolveChromeLaunchOptions() {
+  const candidates = [
+    process.env.PLAYWRIGHT_CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return {
+        executablePath: candidate,
+        headless: true,
+      }
+    }
+  }
+
+  return {
+    channel: 'chrome',
+    headless: true,
+  }
+}
+
+function startDevServer(port) {
+  const logs = []
+  const child = spawn(
+    'pnpm',
+    ['exec', 'vite', '--host', host, '--port', String(port), '--strictPort'],
+    {
+      cwd: playgroundDir,
+      env: {
+        ...process.env,
+        CI: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  const appendLogs = (chunk) => {
+    logs.push(String(chunk))
+    if (logs.length > 120)
+      logs.splice(0, logs.length - 120)
+  }
+
+  child.stdout.on('data', appendLogs)
+  child.stderr.on('data', appendLogs)
+
+  return {
+    child,
+    getLogs: () => logs.join(''),
+  }
+}
+
+function stopServer(child) {
+  if (!child || child.killed)
+    return
+  try {
+    child.kill('SIGTERM')
+  }
+  catch {}
+}
+
+function assert(condition, message) {
+  if (!condition)
+    throw new Error(message)
+}
+
+async function main() {
+  const port = await findFreePort()
+  const server = startDevServer(port)
+  let browser
+
+  try {
+    await waitForPort(port)
+    browser = await chromium.launch(resolveChromeLaunchOptions())
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } })
+
+    await page.addInitScript(() => {
+      // Exercise the WebSocket profile deterministically. Sampling 0.75 from
+      // its 4–8 character range produces seven-character transport chunks.
+      Math.random = () => 0.75
+      localStorage.setItem('vmr-settings-stream-delay-min', '8')
+      localStorage.setItem('vmr-settings-stream-delay-max', '20')
+      localStorage.setItem('vmr-settings-stream-chunk-size-min', '4')
+      localStorage.setItem('vmr-settings-stream-chunk-size-max', '8')
+      localStorage.setItem('vmr-settings-stream-burstiness', '22')
+      localStorage.setItem('vmr-settings-stream-transport-mode', 'readable-stream')
+      localStorage.setItem('vmr-settings-stream-slice-mode', 'pure-random')
+    })
+
+    await page.goto(`http://${host}:${port}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByRole('heading', { name: 'markstream-react19' }).waitFor()
+
+    const profileSelect = page.locator('label').filter({ hasText: 'Stream Profile' }).locator('..').locator('select')
+    assert(await profileSelect.inputValue() === 'websocket', 'The playground did not activate the WebSocket stream profile')
+
+    await page.waitForFunction(
+      () => document.body.textContent?.includes('这种联系可以进一步深化'),
+      undefined,
+      { timeout: 60000 },
+    )
+    await page.waitForTimeout(1500)
+
+    const result = await page.evaluate(() => {
+      const expectedLanguages = ['Shell', 'JavaScript', 'JSON', 'Python', 'C++', 'Vue', 'JavaScript', 'JavaScript']
+      const blocks = Array.from(document.querySelectorAll('[data-node-type="code_block"]')).slice(0, expectedLanguages.length)
+      return {
+        expectedCount: expectedLanguages.length,
+        blocks: blocks.map((slot, index) => ({
+          index: index + 1,
+          expectedLanguage: expectedLanguages[index],
+          language: slot.querySelector('.code-block-header')?.textContent?.replace(/\s+/g, ' ').trim() ?? '',
+          hasShell: Boolean(slot.querySelector('.code-block-container')),
+          hasMonaco: Boolean(slot.querySelector('.monaco-editor')),
+          hasBareFallback: Boolean(slot.querySelector(':scope > .node-content > pre')),
+        })),
+      }
+    })
+
+    assert(
+      result.blocks.length === result.expectedCount,
+      `Expected ${result.expectedCount} regular code blocks, found ${result.blocks.length}`,
+    )
+
+    const degradedBlocks = result.blocks.filter(block =>
+      !block.hasShell
+      || !block.hasMonaco
+      || block.hasBareFallback
+      || block.language !== block.expectedLanguage,
+    )
+    assert(
+      degradedBlocks.length === 0,
+      `WebSocket streaming permanently degraded code blocks: ${JSON.stringify(degradedBlocks)}`,
+    )
+
+    console.log('[e2e-react-websocket-code-blocks] WebSocket code blocks remained enhanced')
+  }
+  catch (error) {
+    const logs = server.getLogs().trim()
+    if (logs) {
+      console.error('--- React 19 playground logs ---')
+      console.error(logs)
+      console.error('--- end playground logs ---')
+    }
+    throw error
+  }
+  finally {
+    await browser?.close()
+    stopServer(server.child)
+  }
+}
+
+await main()


### PR DESCRIPTION
## Summary

- prevent React code blocks from initializing Monaco before streamed fence content is available
- retry Monaco when a partial streamed language identifier becomes its final language
- keep temporary/final plaintext fallback inside the normal code-block shell
- add a deterministic React 19 WebSocket-profile E2E regression test

## Reproduction

1. Start the React 19 playground.
2. Set **Stream Profile** to **WebSocket**.
3. Restart the stream.
4. Some fenced blocks (for example steps 2 and 8) permanently render as bare text, while other blocks (such as the JSON diff in step 3) still render with the enhanced editor.

In observed playground runs this is specific to the WebSocket stream profile. Its small, bursty chunks can split a fence info string such as `javascript` into an intermediate language like `javas`. React attempted to create Monaco with that partial language, the initialization failed, and `useFallback` stayed latched after the complete language arrived.

## Fix

- delay streaming editor creation until the code block has body content
- remember the language that failed Monaco initialization
- reset the fallback and recreate the editor when the streamed language changes
- preserve the complete code-block UI while fallback content is shown

## Screenshots

**Broken: step 8 is rendered as bare text instead of an enhanced JavaScript block.**

![Step 8 rendered as bare text](https://raw.githubusercontent.com/zhsama/markstream-vue/9b0d7d5f1e7b805d5566b4d62428e395ed69e088/.github/pr-assets/react-websocket-code-blocks/step-8-bare-code.png)

**Control: step 3 is correctly rendered as an enhanced JSON diff block during the same WebSocket run.**

![Step 3 correctly rendered as an enhanced diff](https://raw.githubusercontent.com/zhsama/markstream-vue/9b0d7d5f1e7b805d5566b4d62428e395ed69e088/.github/pr-assets/react-websocket-code-blocks/step-3-enhanced-diff.png)

**Broken: step 2 is also rendered as bare text instead of an enhanced JavaScript block.**

![Step 2 rendered as bare text](https://raw.githubusercontent.com/zhsama/markstream-vue/9b0d7d5f1e7b805d5566b4d62428e395ed69e088/.github/pr-assets/react-websocket-code-blocks/step-2-bare-code.png)

## Validation

- `pnpm test:e2e:react-websocket-code-blocks`
- `pnpm --filter markstream-react typecheck`
- `pnpm --filter markstream-react build`
- `pnpm lint`
- `pnpm typecheck`
- `npx react-doctor@latest --verbose --scope changed` (no changed-source diagnostics)
