### PR TITLE
fix(octane): sync document theme atomically with Test Lab toggle

### DIFF
--- a/playground-octane/src/shared/TestLab.tsrx
+++ b/playground-octane/src/shared/TestLab.tsrx
@@ -3,7 +3,7 @@ import type { TestPageViewMode } from '../../../playground-shared/testPageState'
 import type { StreamPresetId } from './streamPresets'
 import type { StreamSliceMode, StreamTransportMode } from './useStreamSimulator'
 import { NodeRenderer } from 'markstream-octane'
-import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'octane'
+import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'octane'
 import { resolveMarkdownTextareaPaste } from '../../../playground-shared/markdownPaste'
 import { TEST_LAB_FRAMEWORKS, TEST_LAB_SAMPLES } from '../../../playground-shared/testLabFixtures'
 import { buildTestPageHref, decodeMarkdownHash, resolveFrameworkTestHref, resolveTestPageViewMode } from '../../../playground-shared/testPageState'
@@ -139,7 +139,7 @@ export function TestLab({ frameworkLabel, onGoHome }: TestLabProps) {
     window.localStorage.setItem(DARK_MODE_KEY, isDark ? 'dark' : 'light')
   }, [isDark])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof document === 'undefined')
       return
 

--- a/scripts/e2e-octane-playground.mjs
+++ b/scripts/e2e-octane-playground.mjs
@@ -287,7 +287,11 @@ async function main() {
 
     const testLabInitiallyDark = await testLab.evaluate(element => element.classList.contains('test-lab--dark'))
     await page.getByRole('button', { name: testLabInitiallyDark ? '切换浅色' : '切换暗色' }).click()
-    await page.waitForFunction(expected => document.querySelector('.test-lab')?.classList.contains('test-lab--dark') === expected, !testLabInitiallyDark)
+    await page.waitForFunction((expected) => {
+      const lab = document.querySelector('.test-lab')
+      return Boolean(lab?.classList.contains('test-lab--dark')) === expected
+        && document.documentElement.classList.contains('dark') === expected
+    }, !testLabInitiallyDark)
     const toggledTestTheme = await testLab.evaluate(element => ({
       htmlDark: document.documentElement.classList.contains('dark'),
       labDark: element.classList.contains('test-lab--dark'),


### PR DESCRIPTION
## 问题

CI 步骤 `Octane playground browser smoke (Ubuntu only)` 从 octane 合并（#606）起 6 次全部失败：

```
Error: The document theme did not follow the Test Lab toggle
    at main (scripts/e2e-octane-playground.mjs:295:5)
```

## 根因

octane 运行时（`octane@0.1.21`）的 `useEffect` 是 **post-paint 异步刷新**：`schedulePostPaint` → rAF → MessageChannel 任务。而 e2e 在 `.test-lab--dark` 类出现（render commit 同步发生）后立即读取 `documentElement`，在 CI 负载下 passive effect 尚未执行，读到旧主题值，断言失败。本地机器快，竞态窗口小，无法复现（macOS Chrome / Linux Chromium 均验证通过，含 6x CPU 节流）。

## 修复

1. **playground-octane/src/shared/TestLab.tsrx**：document 主题同步从 `useEffect` 改为 `useLayoutEffect`（octane 运行时在 commit 中同步执行 LAYOUT 阶段），点击主题切换与 `<html>` 类更新原子生效，消除竞态。
2. **scripts/e2e-octane-playground.mjs**：等待条件改为 lab 类 + document 主题同时翻转（与首页主题切换既有断言模式一致），即使未来有人改回 passive effect 也不会再 flaky。

## 验证

- 本地 `pnpm play:octane:build` + `node scripts/e2e-octane-playground.mjs` 通过
- 分支上 workflow_dispatch CI 全绿，`Octane playground browser smoke (Ubuntu only): success`