### PR TITLE
perf(parser): reuse link-rich stream prefixes

### DIFF
--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -10,6 +10,7 @@ import { applyFixLinkTokens } from './plugins/fixLinkTokens'
 import { applyFixListItem } from './plugins/fixListItem'
 import { applyFixStrongTokens } from './plugins/fixStrongTokens'
 import { applyFixTableTokens } from './plugins/fixTableTokens'
+import { registerCacheStableLinkValidator } from './plugins/linkTokenMetadata'
 import { applyMath } from './plugins/math'
 import { applyRenderRules } from './renderers'
 
@@ -199,8 +200,11 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
     },
   }) as unknown as MarkdownItInstance
 
-  if (!hasCustomValidateLink)
-    md.set({ validateLink: (url: string) => !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' }) })
+  if (!hasCustomValidateLink) {
+    const validateLink = (url: string) => !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' })
+    registerCacheStableLinkValidator(validateLink)
+    md.set({ validateLink })
+  }
 
   applyInlineUrlValidation(md)
 

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -232,6 +232,8 @@ function hasOnlyReusableInlineTokens(tokens: MarkdownToken[]): boolean {
   return tokens.every((token) => {
     if (!REUSABLE_INLINE_TOKEN_TYPES.has(token.type))
       return false
+    if (token.type === 'link' && token.meta?.markstreamLinkOrigin !== 'explicit')
+      return false
     if (token.type === 'link_open' && (token.markup === 'linkify' || token.markup === 'autolink'))
       return false
 
@@ -386,12 +388,16 @@ function processTopLevelTokensWithReuse(
   timing: ParseTimingMetrics | undefined,
 ) {
   const owner = md as unknown as object
-  const groups = getReusableTopLevelTokenGroups(tokens)
-  const cacheable = shouldUseTopLevelStreamParse(md, options)
+  const reuseEnabled = shouldUseTopLevelStreamParse(md, options)
     && canReuseStructuredStreamNodes(options)
-    && groups !== null
 
-  if (!cacheable) {
+  if (!reuseEnabled) {
+    structuredStreamCache.delete(owner)
+    return processTokensWithTiming(tokens, options, timing)
+  }
+
+  const groups = getReusableTopLevelTokenGroups(tokens)
+  if (!groups) {
     structuredStreamCache.delete(owner)
     return processTokensWithTiming(tokens, options, timing)
   }

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -138,6 +138,9 @@ const REUSABLE_INLINE_TOKEN_TYPES = new Set([
   'hardbreak',
   'ins_close',
   'ins_open',
+  'link',
+  'link_close',
+  'link_open',
   'mark_close',
   'mark_open',
   's_close',
@@ -228,6 +231,8 @@ function processTokensWithTiming(tokens: MarkdownToken[], options: ParseOptions 
 function hasOnlyReusableInlineTokens(tokens: MarkdownToken[]): boolean {
   return tokens.every((token) => {
     if (!REUSABLE_INLINE_TOKEN_TYPES.has(token.type))
+      return false
+    if (token.type === 'link_open' && (token.markup === 'linkify' || token.markup === 'autolink'))
       return false
 
     const children = token.children as MarkdownToken[] | null

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -4,6 +4,7 @@ import { normalizeCustomHtmlTags } from '../customHtmlTags'
 import { NON_STRUCTURING_HTML_TAGS, STANDARD_BLOCK_HTML_TAGS, STANDARD_HTML_TAGS, VOID_HTML_TAGS } from '../htmlTags'
 import { escapeTagForRegExp, findTagCloseIndexOutsideQuotes, parseTagAttrs } from '../htmlTagUtils'
 import { isMathLike } from '../plugins/isMathLike'
+import { isCacheStableLinkValidator, readSyntheticLinkOrigin } from '../plugins/linkTokenMetadata'
 import {
   getTolerantMathBlockBoundaryStreamKey,
   hasMarkstreamMathPlugin,
@@ -229,21 +230,30 @@ function processTokensWithTiming(tokens: MarkdownToken[], options: ParseOptions 
   return result
 }
 
-function hasOnlyReusableInlineTokens(tokens: MarkdownToken[]): boolean {
+function hasOnlyReusableInlineTokens(tokens: MarkdownToken[], validateLink: ParseOptions['validateLink']): boolean {
   return tokens.every((token) => {
     if (!REUSABLE_INLINE_TOKEN_TYPES.has(token.type))
       return false
-    if (token.type === 'link' && token.meta?.markstreamLinkOrigin !== 'explicit')
+    if (
+      (token.type === 'link' || token.type === 'link_open' || token.type === 'link_close')
+      && !isCacheStableLinkValidator(validateLink)
+    ) {
       return false
-    if (token.type === 'link_open' && (token.markup === 'linkify' || token.markup === 'autolink'))
+    }
+    if (token.type === 'link' && readSyntheticLinkOrigin(token) !== 'explicit')
+      return false
+    if ((token.type === 'link_open' || token.type === 'link_close') && token.markup !== '')
       return false
 
     const children = token.children as MarkdownToken[] | null
-    return !Array.isArray(children) || hasOnlyReusableInlineTokens(children)
+    return !Array.isArray(children) || hasOnlyReusableInlineTokens(children, validateLink)
   })
 }
 
-function getReusableTopLevelTokenGroups(tokens: MarkdownToken[]): ReusableTopLevelTokenGroups | null {
+function getReusableTopLevelTokenGroups(
+  tokens: MarkdownToken[],
+  validateLink: ParseOptions['validateLink'],
+): ReusableTopLevelTokenGroups | null {
   const groupStarts: number[] = []
   let mixed = false
   let index = 0
@@ -296,7 +306,7 @@ function getReusableTopLevelTokenGroups(tokens: MarkdownToken[]): ReusableTopLev
       if (current.type !== 'inline')
         continue
       const children = current.children as MarkdownToken[] | null
-      if (!Array.isArray(children) || !hasOnlyReusableInlineTokens(children))
+      if (!Array.isArray(children) || !hasOnlyReusableInlineTokens(children, validateLink))
         return null
     }
 
@@ -398,7 +408,7 @@ function processTopLevelTokensWithReuse(
     return processTokensWithTiming(tokens, options, timing)
   }
 
-  const groups = getReusableTopLevelTokenGroups(tokens)
+  const groups = getReusableTopLevelTokenGroups(tokens, options.validateLink)
   if (!groups) {
     structuredStreamCache.delete(owner)
     return processTokensWithTiming(tokens, options, timing)

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -115,6 +115,7 @@ interface StructuredStreamCacheEntry {
   nodes: ParsedNode[]
   stableGroupCount: number
   requireClosingStrong: boolean | undefined
+  validateLink: ParseOptions['validateLink']
 }
 
 interface StructuredStreamGroupBoundary {
@@ -354,6 +355,7 @@ function updateStructuredStreamCache(
       ? Math.max(0, groupStarts.length - 1)
       : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1),
     requireClosingStrong: options.requireClosingStrong,
+    validateLink: options.validateLink,
   })
 }
 
@@ -412,6 +414,7 @@ function processTopLevelTokensWithReuse(
     previous
     && stableGroupCount > 0
     && previous.requireClosingStrong === options.requireClosingStrong
+    && previous.validateLink === options.validateLink
     && source.startsWith(previous.source)
     && groupStarts.length >= stableGroupCount
     && (mode === 'append' || mode === 'tail')

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -13,6 +13,24 @@ type SyntheticLinkToken = MarkdownToken & {
   children?: MarkdownToken[] | null
 }
 
+type SyntheticLinkOrigin = 'autolink' | 'explicit' | 'linkify' | 'recovery'
+
+function getSyntheticLinkOrigin(markup: string | undefined): SyntheticLinkOrigin {
+  if (markup === 'linkify' || markup === 'autolink')
+    return markup
+  return 'recovery'
+}
+
+function setSyntheticLinkOrigin<T extends SyntheticLinkToken>(token: T, origin: SyntheticLinkOrigin): T {
+  Object.defineProperty(token, 'meta', {
+    configurable: true,
+    enumerable: false,
+    value: { markstreamLinkOrigin: origin },
+    writable: true,
+  })
+  return token
+}
+
 // Small helpers to reduce repetition when building token fragments
 function textToken(content: string): MarkdownToken {
   return {
@@ -48,14 +66,19 @@ function pushEmClose(arr: MarkdownToken[], type: number) {
   }
 }
 
-function createLinkToken(text: string, href: string, loading: boolean): SyntheticLinkToken {
+function createLinkToken(
+  text: string,
+  href: string,
+  loading: boolean,
+  origin: SyntheticLinkOrigin = 'recovery',
+): SyntheticLinkToken {
   let title = ''
   if (href.includes('"')) {
     const temps = href.split('"')
     href = temps[0].trim()
     title = temps[1].trim()
   }
-  return {
+  return setSyntheticLinkOrigin({
     type: 'link',
     loading,
     href,
@@ -69,7 +92,7 @@ function createLinkToken(text: string, href: string, loading: boolean): Syntheti
       },
     ],
     raw: String(`[${text}](${href})`),
-  }
+  }, origin)
 }
 
 function appendToLinkToken(link: SyntheticLinkToken, suffix: string) {
@@ -347,6 +370,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
       if (match) {
         let beforeText = curToken.content!.slice(0, match.index)
         const emphasisMatch = beforeText.match(/(\*+)$/)
+        const origin = getSyntheticLinkOrigin(tokens[i + 1]?.markup)
         const replacerTokens = []
         if (emphasisMatch) {
           beforeText = beforeText.slice(0, emphasisMatch.index)
@@ -360,7 +384,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
             href += tokens[i + 4]?.content || ''
             tokens[i + 4].content = ''
           }
-          replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')')))
+          replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')'), origin))
           pushEmClose(replacerTokens, type)
           if (tokens[i + 4]?.type === 'text') {
             const afterText = tokens[i + 4].content?.replace(/^\)\**/, '')
@@ -389,7 +413,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
             }
             // wrap the link with emphasis open/close tokens
             pushEmOpen(replacerTokens, type)
-            replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')')))
+            replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')'), origin))
             pushEmClose(replacerTokens, type)
             // we've already pushed the link, skip the standard push below
             if (tokens[i + 4]?.type === 'text') {
@@ -414,7 +438,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
             href += tokens[i + 4]?.content || ''
             tokens[i + 4].content = ''
           }
-          replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')')))
+          replacerTokens.push(createLinkToken(text, href, !tokens[i + 4]?.content?.startsWith(')'), origin))
           if (tokens[i + 4]?.type === 'text') {
             const afterText = tokens[i + 4].content?.replace(/^\)/, '')
             if (afterText)
@@ -444,14 +468,14 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
             tokens[i + 3].content = ''
           }
 
-          replacerTokens.push(createLinkToken(text, href, loading))
+          replacerTokens.push(createLinkToken(text, href, loading, 'linkify'))
           const afterText = tokens[i + 3].content?.replace(/^\)\**/, '')
           if (afterText)
             replacerTokens.push(textToken(afterText))
           tokens.splice(i - 4, 8, ...replacerTokens)
         }
         else {
-          replacerTokens.push({
+          replacerTokens.push(setSyntheticLinkOrigin({
             type: 'link',
             loading: true,
             href,
@@ -465,7 +489,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
               },
             ],
             raw: String(`[${text}](${href})`),
-          })
+          }, 'linkify'))
           tokens.splice(i - 4, 7, ...replacerTokens)
         }
         continue
@@ -535,7 +559,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
         }
       }
 
-      const linkToken: SyntheticLinkToken = {
+      const linkToken = setSyntheticLinkOrigin({
         type: 'link',
         loading: false,
         href,
@@ -549,7 +573,7 @@ function fixLinkToken(tokens: MarkdownToken[], raw?: string): MarkdownToken[] {
           },
         ],
         raw: String(`[${text}](${href})`),
-      }
+      }, curToken.markup ? getSyntheticLinkOrigin(curToken.markup) : 'explicit')
       replacerTokens.push(linkToken)
       if (emphasisMatch) {
         const type = emphasisMatch[1].length

--- a/packages/markdown-parser/src/plugins/fixLinkTokens.ts
+++ b/packages/markdown-parser/src/plugins/fixLinkTokens.ts
@@ -1,6 +1,8 @@
 import type { MarkdownIt } from '../markdown-it-types'
 import type { MarkdownToken } from '../types'
+import type { SyntheticLinkOrigin } from './linkTokenMetadata'
 import { inferLinkifyDemotionContext, isDecodedFromRawPunycode, shouldDemoteFilenameLikeLinkify } from '../parser/linkifyHeuristics'
+import { setSyntheticLinkOrigin } from './linkTokenMetadata'
 
 // We hard-stop FULLWIDTH exclamation mark used as CJK punctuation.
 // ASCII `!` is valid in URLs (path/query/fragment), so do not stop on it.
@@ -13,22 +15,10 @@ type SyntheticLinkToken = MarkdownToken & {
   children?: MarkdownToken[] | null
 }
 
-type SyntheticLinkOrigin = 'autolink' | 'explicit' | 'linkify' | 'recovery'
-
 function getSyntheticLinkOrigin(markup: string | undefined): SyntheticLinkOrigin {
   if (markup === 'linkify' || markup === 'autolink')
     return markup
   return 'recovery'
-}
-
-function setSyntheticLinkOrigin<T extends SyntheticLinkToken>(token: T, origin: SyntheticLinkOrigin): T {
-  Object.defineProperty(token, 'meta', {
-    configurable: true,
-    enumerable: false,
-    value: { markstreamLinkOrigin: origin },
-    writable: true,
-  })
-  return token
 }
 
 // Small helpers to reduce repetition when building token fragments

--- a/packages/markdown-parser/src/plugins/linkTokenMetadata.ts
+++ b/packages/markdown-parser/src/plugins/linkTokenMetadata.ts
@@ -1,0 +1,23 @@
+import type { MarkdownToken } from '../types'
+
+export type SyntheticLinkOrigin = 'autolink' | 'explicit' | 'linkify' | 'recovery'
+
+const syntheticLinkOrigins = new WeakMap<object, SyntheticLinkOrigin>()
+const cacheStableLinkValidators = new WeakSet<(url: string) => boolean>()
+
+export function setSyntheticLinkOrigin<T extends object>(token: T, origin: SyntheticLinkOrigin): T {
+  syntheticLinkOrigins.set(token, origin)
+  return token
+}
+
+export function readSyntheticLinkOrigin(token: MarkdownToken): SyntheticLinkOrigin | undefined {
+  return syntheticLinkOrigins.get(token)
+}
+
+export function registerCacheStableLinkValidator(validateLink: (url: string) => boolean) {
+  cacheStableLinkValidators.add(validateLink)
+}
+
+export function isCacheStableLinkValidator(validateLink: ((url: string) => boolean) | undefined) {
+  return validateLink === undefined || cacheStableLinkValidators.has(validateLink)
+}

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -110,12 +110,41 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes).toBeGreaterThan(0)
   })
 
+  it('skips reusable-token eligibility scans when structured reuse is disabled', () => {
+    const md = getMarkdown('stream-parser-disabled-structured-reuse-scan')
+    let eligibilityScans = 0
+    ;(md as any).core.ruler.after('fix_link_tokens', 'track_reusable_token_scans', (state: any) => {
+      for (const inline of state.tokens?.filter((token: any) => token.type === 'inline') ?? []) {
+        const children = inline.children
+        if (!Array.isArray(children))
+          continue
+        children.every = (...args: any[]) => {
+          eligibilityScans++
+          return Array.prototype.every.apply(children, args as any)
+        }
+      }
+    })
+
+    const source = `${buildLargeAppendFriendlyDoc(40)}[link](https://example.com)\n\n`
+    parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+    })
+    parseMarkdownToStructure(source, md, {
+      final: true,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+
+    expect(eligibilityScans).toBe(0)
+  })
+
   it('reuses stable prefixes containing explicit markdown links', () => {
     const md = getMarkdown('stream-parser-link-prefix-reuse')
     const coldMd = getMarkdown('stream-parser-link-prefix-reuse-cold')
     const base = `${Array.from(
       { length: 40 },
-      (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1}).`,
+      (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1})`,
     ).join('\n\n')}\n\n`
     const first = parseMarkdownToStructure(base, md, {
       final: false,
@@ -123,7 +152,7 @@ describe('parseMarkdownToStructure stream parser integration', () => {
       __reuseStableTopLevelNodes: true,
     } as any)
     const timing: { processTokensReusedTopLevelNodes?: number } = {}
-    const source = `${base}Appended paragraph with [another link](/guide/next).\n\n`
+    const source = `${base}Appended paragraph with [another link](/guide/next)\n\n`
     const second = parseMarkdownToStructure(source, md, {
       final: false,
       streamParse: true,
@@ -138,6 +167,139 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes).toBe(40)
     expect(second[0]).toBe(first[0])
     expect(second[39]).toBe(first[39])
+  })
+
+  it('reuses origin-tagged explicit synthetic links', () => {
+    const md = getMarkdown('stream-parser-explicit-synthetic-link-reuse')
+    const coldMd = getMarkdown('stream-parser-explicit-synthetic-link-reuse-cold')
+    const base = `${Array.from(
+      { length: 40 },
+      (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1}).`,
+    ).join('\n\n')}\n\n`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const inline = (md as any).stream.peek().find((token: any) => token.type === 'inline')
+    const synthetic = inline?.children?.find((token: any) => token.type === 'link')
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph.\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
+    expect(synthetic?.meta?.markstreamLinkOrigin).toBe('explicit')
+    expect(JSON.stringify(first)).not.toContain('markstreamLinkOrigin')
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+    }))
+    expect(timing.processTokensReusedTopLevelNodes).toBe(40)
+    expect(second[0]).toBe(first[0])
+    expect(second[39]).toBe(first[39])
+  })
+
+  it('does not reuse linkify-derived synthetic links', () => {
+    const installSyntheticLinkifyToken = (md: ReturnType<typeof getMarkdown>) => {
+      ;(md as any).core.ruler.before('fix_link_tokens', 'test_synthetic_linkify_reuse', (state: any) => {
+        const inline = state.tokens?.find((token: any) =>
+          token.type === 'inline' && token.content === 'SYNTHETIC_LINKIFY_CASE',
+        )
+        if (!inline)
+          return
+
+        inline.content = '[site](https://example.com) after'
+        inline.children = [
+          { type: 'text', content: '[site](', raw: '[site](' },
+          { type: 'link_open', tag: 'a', nesting: 1, markup: 'linkify', attrs: [['href', 'https://example.com']] },
+          { type: 'text', content: 'https://example.com', raw: 'https://example.com' },
+          { type: 'link_close', tag: 'a', nesting: -1, markup: 'linkify' },
+          { type: 'text', content: ') after', raw: ') after' },
+        ]
+      })
+    }
+
+    const md = getMarkdown('stream-parser-synthetic-linkify-reuse')
+    const coldMd = getMarkdown('stream-parser-synthetic-linkify-reuse-cold')
+    installSyntheticLinkifyToken(md)
+    installSyntheticLinkifyToken(coldMd)
+
+    const base = `SYNTHETIC_LINKIFY_CASE\n\n${buildLargeAppendFriendlyDoc(40)}`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph.\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+    const synthetic = (md as any).stream.peek().find((token: any) => token.type === 'inline')?.children?.[0]
+
+    expect(synthetic).toMatchObject({
+      type: 'link',
+      meta: { markstreamLinkOrigin: 'linkify' },
+      href: 'https://example.com',
+      loading: false,
+    })
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+    }))
+    expect(second[0]).not.toBe(first[0])
+    expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+  })
+
+  it('keeps loading-link completion and final transition cold-parse equivalent', () => {
+    const md = getMarkdown('stream-parser-loading-link-completion')
+    const coldMd = getMarkdown('stream-parser-loading-link-completion-cold')
+    const base = buildLargeAppendFriendlyDoc(40)
+    const stages = [
+      `${base}[x](http://a`,
+      `${base}[x](http://a)`,
+      `${base}[x](http://a)\n\nAppended paragraph.\n\n`,
+    ]
+
+    for (const [index, source] of stages.entries()) {
+      const timing: { processTokensReusedTopLevelNodes?: number } = {}
+      const streamed = parseMarkdownToStructure(source, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+        __timing: timing,
+      } as any)
+      const cold = parseMarkdownToStructure(source, coldMd, {
+        final: false,
+        streamParse: false,
+      })
+
+      expect(streamed).toEqual(cold)
+      if (index === 0) {
+        const inlineChildren = (md as any).stream.peek().flatMap((token: any) => token.children ?? [])
+        const synthetic = inlineChildren.find((token: any) => token.type === 'link')
+        expect(JSON.stringify(streamed)).toContain('"loading":true')
+        expect(synthetic?.meta?.markstreamLinkOrigin).toBe('linkify')
+        expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+      }
+    }
+
+    const source = stages.at(-1)!
+    expect(parseMarkdownToStructure(source, md, {
+      final: true,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: true,
+      streamParse: false,
+    }))
   })
 
   it('does not reuse unresolved links when an appended definition changes them', () => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -169,6 +169,37 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(second[39]).toBe(first[39])
   })
 
+  it('invalidates structured reuse when the effective link validator changes', () => {
+    const md = getMarkdown('stream-parser-validate-link-invalidation')
+    const coldMd = getMarkdown('stream-parser-validate-link-invalidation-cold')
+    const allowLinks = () => true
+    const denyLinks = () => false
+    const base = `[external](https://example.com)\n\n${buildLargeAppendFriendlyDoc(40)}`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      validateLink: allowLinks,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph.\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      validateLink: denyLinks,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+      validateLink: denyLinks,
+    }))
+    expect(second[0]).not.toBe(first[0])
+    expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+  })
+
   it('reuses origin-tagged explicit synthetic links', () => {
     const md = getMarkdown('stream-parser-explicit-synthetic-link-reuse')
     const coldMd = getMarkdown('stream-parser-explicit-synthetic-link-reuse-cold')
@@ -193,6 +224,8 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     } as any)
 
     expect(synthetic?.meta?.markstreamLinkOrigin).toBe('explicit')
+    expect(Object.prototype.propertyIsEnumerable.call(synthetic, 'meta')).toBe(false)
+    expect(JSON.stringify(synthetic)).not.toContain('markstreamLinkOrigin')
     expect(JSON.stringify(first)).not.toContain('markstreamLinkOrigin')
     expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
       final: false,

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getMarkdown, parseMarkdownToStructure } from '../src'
+import { readSyntheticLinkOrigin } from '../src/plugins/linkTokenMetadata'
 
 function buildLargeAppendFriendlyDoc(paragraphs: number) {
   return `${Array.from(
@@ -200,9 +201,52 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
   })
 
+  it('does not reuse linked prefixes when a validator changes behavior', () => {
+    const md = getMarkdown('stream-parser-mutable-validate-link')
+    const coldMd = getMarkdown('stream-parser-mutable-validate-link-cold')
+    let allowLinks = true
+    const validateLink = () => allowLinks
+    const base = `[external](https://example.com)\n\n${buildLargeAppendFriendlyDoc(40)}`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      validateLink,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+
+    allowLinks = false
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph.\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      validateLink,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+      validateLink,
+    }))
+    expect(second[0]).not.toBe(first[0])
+    expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+  })
+
   it('reuses origin-tagged explicit synthetic links', () => {
+    const installCustomLinkMeta = (md: ReturnType<typeof getMarkdown>) => {
+      ;(md as any).core.ruler.after('fix_link_tokens', 'add_custom_synthetic_link_meta', (state: any) => {
+        for (const token of state.tokens?.flatMap((token: any) => token.children ?? []) ?? []) {
+          if (token.type === 'link')
+            token.meta = { customId: 'abc' }
+        }
+      })
+    }
     const md = getMarkdown('stream-parser-explicit-synthetic-link-reuse')
     const coldMd = getMarkdown('stream-parser-explicit-synthetic-link-reuse-cold')
+    installCustomLinkMeta(md)
+    installCustomLinkMeta(coldMd)
     const base = `${Array.from(
       { length: 40 },
       (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1}).`,
@@ -223,8 +267,12 @@ describe('parseMarkdownToStructure stream parser integration', () => {
       __timing: timing,
     } as any)
 
-    expect(synthetic?.meta?.markstreamLinkOrigin).toBe('explicit')
-    expect(Object.prototype.propertyIsEnumerable.call(synthetic, 'meta')).toBe(false)
+    expect(readSyntheticLinkOrigin(synthetic)).toBe('explicit')
+    expect(synthetic?.meta).toEqual({ customId: 'abc' })
+    expect(Object.prototype.propertyIsEnumerable.call(synthetic, 'meta')).toBe(true)
+    expect({ ...synthetic }.meta).toEqual({ customId: 'abc' })
+    expect(Object.assign({}, synthetic).meta).toEqual({ customId: 'abc' })
+    expect(JSON.stringify(synthetic)).toContain('"customId":"abc"')
     expect(JSON.stringify(synthetic)).not.toContain('markstreamLinkOrigin')
     expect(JSON.stringify(first)).not.toContain('markstreamLinkOrigin')
     expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
@@ -279,10 +327,49 @@ describe('parseMarkdownToStructure stream parser integration', () => {
 
     expect(synthetic).toMatchObject({
       type: 'link',
-      meta: { markstreamLinkOrigin: 'linkify' },
       href: 'https://example.com',
       loading: false,
     })
+    expect(readSyntheticLinkOrigin(synthetic)).toBe('linkify')
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+    }))
+    expect(second[0]).not.toBe(first[0])
+    expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+  })
+
+  it('does not reuse link pairs with unknown markup', () => {
+    const installUnknownLinkMarkup = (md: ReturnType<typeof getMarkdown>) => {
+      ;(md as any).core.ruler.after('fix_link_tokens', 'test_unknown_link_markup', (state: any) => {
+        for (const token of state.tokens?.flatMap((token: any) => token.children ?? []) ?? []) {
+          if (token.type === 'link_open' || token.type === 'link_close')
+            token.markup = 'future-link'
+        }
+      })
+    }
+    const md = getMarkdown('stream-parser-unknown-link-markup')
+    const coldMd = getMarkdown('stream-parser-unknown-link-markup-cold')
+    installUnknownLinkMarkup(md)
+    installUnknownLinkMarkup(coldMd)
+    const base = `${Array.from(
+      { length: 40 },
+      (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1})`,
+    ).join('\n\n')}\n\n`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph.\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
     expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
       final: false,
       streamParse: false,
@@ -319,7 +406,7 @@ describe('parseMarkdownToStructure stream parser integration', () => {
         const inlineChildren = (md as any).stream.peek().flatMap((token: any) => token.children ?? [])
         const synthetic = inlineChildren.find((token: any) => token.type === 'link')
         expect(JSON.stringify(streamed)).toContain('"loading":true')
-        expect(synthetic?.meta?.markstreamLinkOrigin).toBe('linkify')
+        expect(readSyntheticLinkOrigin(synthetic)).toBe('linkify')
         expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
       }
     }

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -110,6 +110,62 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(timing.processTokensReusedTopLevelNodes).toBeGreaterThan(0)
   })
 
+  it('reuses stable prefixes containing explicit markdown links', () => {
+    const md = getMarkdown('stream-parser-link-prefix-reuse')
+    const coldMd = getMarkdown('stream-parser-link-prefix-reuse-cold')
+    const base = `${Array.from(
+      { length: 40 },
+      (_, index) => `Paragraph ${index + 1} with [link ${index + 1}](/guide/${index + 1}).`,
+    ).join('\n\n')}\n\n`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}Appended paragraph with [another link](/guide/next).\n\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+    }))
+    expect(timing.processTokensReusedTopLevelNodes).toBe(40)
+    expect(second[0]).toBe(first[0])
+    expect(second[39]).toBe(first[39])
+  })
+
+  it('does not reuse unresolved links when an appended definition changes them', () => {
+    const md = getMarkdown('stream-parser-appended-reference-invalidation')
+    const coldMd = getMarkdown('stream-parser-appended-reference-invalidation-cold')
+    const base = `[label][target]\n\n${buildLargeAppendFriendlyDoc(40)}`
+    const first = parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+    } as any)
+    const timing: { processTokensReusedTopLevelNodes?: number } = {}
+    const source = `${base}[target]: https://example.com\n`
+    const second = parseMarkdownToStructure(source, md, {
+      final: false,
+      streamParse: true,
+      __reuseStableTopLevelNodes: true,
+      __timing: timing,
+    } as any)
+
+    expect(second).toEqual(parseMarkdownToStructure(source, coldMd, {
+      final: false,
+      streamParse: false,
+    }))
+    expect(second[0]).not.toBe(first[0])
+    expect(timing.processTokensReusedTopLevelNodes ?? 0).toBe(0)
+  })
+
   it('keeps every reusable dirty-tail result equivalent to a cold parse', () => {
     const md = getMarkdown('stream-parser-structured-tail-equivalence')
     const coldMd = getMarkdown('stream-parser-structured-tail-equivalence-cold')

--- a/scripts/benchmark-real-corpus-performance.mjs
+++ b/scripts/benchmark-real-corpus-performance.mjs
@@ -349,6 +349,24 @@ function sumTiming(rows, key) {
   return round(rows.reduce((total, row) => total + Number(row.timing?.[key] || 0), 0))
 }
 
+function summarizeParserStreamRuns(streamRuns) {
+  return {
+    chunks: median(streamRuns.map(run => run.chunks)),
+    totalMedianMs: round(median(streamRuns.map(run => run.totalMs))),
+    medianCommitMs: round(median(streamRuns.map(run => run.medianCommitMs))),
+    p95CommitMs: round(median(streamRuns.map(run => run.p95CommitMs))),
+    maxCommitMs: round(median(streamRuns.map(run => run.maxCommitMs))),
+    finalFlushMedianMs: round(median(streamRuns.map(run => run.finalFlushMs))),
+    processTokensMedianMs: round(median(streamRuns.map(run => run.processTokensMs))),
+    processTokensInputTokens: round(median(streamRuns.map(run => run.processTokensInputTokens))),
+    processTokensReusedTopLevelNodes: round(median(streamRuns.map(run => run.processTokensReusedTopLevelNodes))),
+    parserTotalMedianMs: round(median(streamRuns.map(run => run.parseTotalMs))),
+    medianNodesBeforeFinal: median(streamRuns.map(run => run.nodesBeforeFinal)),
+    medianNodesAfterFinal: median(streamRuns.map(run => run.nodesAfterFinal)),
+    streamStats: streamRuns[Math.floor(streamRuns.length / 2)]?.streamStats ?? null,
+  }
+}
+
 async function runParserBenchmarks(corpus) {
   if (!existsSync(parserDistPath)) {
     throw new Error(
@@ -383,57 +401,64 @@ async function runParserBenchmarks(corpus) {
       }
     }
 
-    const streamRuns = []
-    for (let roundIndex = 0; roundIndex < parserWarmups + parserRounds; roundIndex++) {
-      const md = getMarkdown(`real-corpus-stream-${testCase.id}-${roundIndex}`)
-      md.stream?.reset?.()
-      let current = ''
-      const chunks = createChunks(testCase.markdown, streamChunkCount)
-      const commitDurations = []
-      const commitTimings = []
-      let lastNodes = []
+    const streamingResults = {}
+    for (const mode of [
+      { key: 'default', reuseStableTopLevelNodes: false },
+      { key: 'structuredReuse', reuseStableTopLevelNodes: true },
+    ]) {
+      const streamRuns = []
+      for (let roundIndex = 0; roundIndex < parserWarmups + parserRounds; roundIndex++) {
+        const md = getMarkdown(`real-corpus-stream-${mode.key}-${testCase.id}-${roundIndex}`)
+        md.stream?.reset?.()
+        let current = ''
+        const chunks = createChunks(testCase.markdown, streamChunkCount)
+        const commitDurations = []
+        const commitTimings = []
+        let lastNodes = []
 
-      for (const chunk of chunks) {
-        current += chunk
-        const timing = {}
-        const startedAt = performance.now()
-        lastNodes = parseMarkdownToStructure(current, md, {
-          final: false,
+        for (const chunk of chunks) {
+          current += chunk
+          const timing = {}
+          const startedAt = performance.now()
+          lastNodes = parseMarkdownToStructure(current, md, {
+            final: false,
+            streamParse: true,
+            ...(mode.reuseStableTopLevelNodes ? { __reuseStableTopLevelNodes: true } : {}),
+            __timing: timing,
+          })
+          commitDurations.push(performance.now() - startedAt)
+          commitTimings.push({ timing })
+        }
+
+        const finalTiming = {}
+        const finalStartedAt = performance.now()
+        const finalNodes = parseMarkdownToStructure(testCase.markdown, md, {
+          final: true,
           streamParse: true,
-          __reuseStableTopLevelNodes: true,
-          __timing: timing,
+          __timing: finalTiming,
         })
-        commitDurations.push(performance.now() - startedAt)
-        commitTimings.push({ timing })
-      }
+        const finalFlushMs = performance.now() - finalStartedAt
 
-      const finalTiming = {}
-      const finalStartedAt = performance.now()
-      const finalNodes = parseMarkdownToStructure(testCase.markdown, md, {
-        final: true,
-        streamParse: true,
-        __timing: finalTiming,
-      })
-      const finalFlushMs = performance.now() - finalStartedAt
-
-      if (roundIndex >= parserWarmups) {
-        streamRuns.push({
-          totalMs: commitDurations.reduce((total, value) => total + value, 0),
-          medianCommitMs: median(commitDurations),
-          p95CommitMs: percentile(commitDurations, 0.95),
-          maxCommitMs: Math.max(...commitDurations),
-          finalFlushMs,
-          chunks: chunks.length,
-          nodesBeforeFinal: lastNodes.length,
-          nodesAfterFinal: finalNodes.length,
-          processTokensMs: sumTiming(commitTimings, 'processTokensMs'),
-          processTokensInputTokens: sumTiming(commitTimings, 'processTokensInputTokens'),
-          processTokensReusedTopLevelNodes: sumTiming(commitTimings, 'processTokensReusedTopLevelNodes'),
-          parseTotalMs: sumTiming(commitTimings, 'parseMarkdownToStructureTotalMs'),
-          finalTiming,
-          streamStats: typeof md.stream?.stats === 'function' ? md.stream.stats() : null,
-        })
+        if (roundIndex >= parserWarmups) {
+          streamRuns.push({
+            totalMs: commitDurations.reduce((total, value) => total + value, 0),
+            medianCommitMs: median(commitDurations),
+            p95CommitMs: percentile(commitDurations, 0.95),
+            maxCommitMs: Math.max(...commitDurations),
+            finalFlushMs,
+            chunks: chunks.length,
+            nodesBeforeFinal: lastNodes.length,
+            nodesAfterFinal: finalNodes.length,
+            processTokensMs: sumTiming(commitTimings, 'processTokensMs'),
+            processTokensInputTokens: sumTiming(commitTimings, 'processTokensInputTokens'),
+            processTokensReusedTopLevelNodes: sumTiming(commitTimings, 'processTokensReusedTopLevelNodes'),
+            parseTotalMs: sumTiming(commitTimings, 'parseMarkdownToStructureTotalMs'),
+            finalTiming,
+            streamStats: typeof md.stream?.stats === 'function' ? md.stream.stats() : null,
+          })
+        }
       }
+      streamingResults[mode.key] = summarizeParserStreamRuns(streamRuns)
     }
 
     results.push({
@@ -448,21 +473,8 @@ async function runParserBenchmarks(corpus) {
         processTokensMedianMs: round(median(finalRuns.map(run => run.timing.processTokensMs ?? 0))),
         parserTotalMedianMs: round(median(finalRuns.map(run => run.timing.parseMarkdownToStructureTotalMs ?? 0))),
       },
-      streaming: {
-        chunks: median(streamRuns.map(run => run.chunks)),
-        totalMedianMs: round(median(streamRuns.map(run => run.totalMs))),
-        medianCommitMs: round(median(streamRuns.map(run => run.medianCommitMs))),
-        p95CommitMs: round(median(streamRuns.map(run => run.p95CommitMs))),
-        maxCommitMs: round(median(streamRuns.map(run => run.maxCommitMs))),
-        finalFlushMedianMs: round(median(streamRuns.map(run => run.finalFlushMs))),
-        processTokensMedianMs: round(median(streamRuns.map(run => run.processTokensMs))),
-        processTokensInputTokens: round(median(streamRuns.map(run => run.processTokensInputTokens))),
-        processTokensReusedTopLevelNodes: round(median(streamRuns.map(run => run.processTokensReusedTopLevelNodes))),
-        parserTotalMedianMs: round(median(streamRuns.map(run => run.parseTotalMs))),
-        medianNodesBeforeFinal: median(streamRuns.map(run => run.nodesBeforeFinal)),
-        medianNodesAfterFinal: median(streamRuns.map(run => run.nodesAfterFinal)),
-        streamStats: streamRuns[Math.floor(streamRuns.length / 2)]?.streamStats ?? null,
-      },
+      streaming: streamingResults.default,
+      structuredReuseStreaming: streamingResults.structuredReuse,
     })
   }
 
@@ -1828,11 +1840,16 @@ function formatBoolean(value) {
 
 function renderParserTable(parserResults) {
   const lines = [
-    '| Case | Bytes | Nodes | Final median | Process median | Stream total | Stream p95 commit | Processed tokens | Reused prefix nodes | Final flush |',
-    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Case | Mode | Bytes | Nodes | Final median | Process median | Stream total | Stream p95 commit | Processed tokens | Reused prefix nodes | Final flush |',
+    '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ]
   for (const row of parserResults) {
-    lines.push(`| ${row.id} | ${row.bytes} | ${formatNumber(row.final.medianNodes)} | ${formatMs(row.final.medianMs)} | ${formatMs(row.final.processTokensMedianMs)} | ${formatMs(row.streaming.totalMedianMs)} | ${formatMs(row.streaming.p95CommitMs)} | ${formatNumber(row.streaming.processTokensInputTokens)} | ${formatNumber(row.streaming.processTokensReusedTopLevelNodes)} | ${formatMs(row.streaming.finalFlushMedianMs)} |`)
+    for (const [mode, streaming] of [
+      ['public-default', row.streaming],
+      ['structured-reuse', row.structuredReuseStreaming],
+    ]) {
+      lines.push(`| ${row.id} | ${mode} | ${row.bytes} | ${formatNumber(row.final.medianNodes)} | ${formatMs(row.final.medianMs)} | ${formatMs(row.final.processTokensMedianMs)} | ${formatMs(streaming.totalMedianMs)} | ${formatMs(streaming.p95CommitMs)} | ${formatNumber(streaming.processTokensInputTokens)} | ${formatNumber(streaming.processTokensReusedTopLevelNodes)} | ${formatMs(streaming.finalFlushMedianMs)} |`)
+    }
   }
   return lines.join('\n')
 }

--- a/scripts/benchmark-real-corpus-performance.mjs
+++ b/scripts/benchmark-real-corpus-performance.mjs
@@ -717,10 +717,14 @@ function resetParsePerformance() {
 }
 
 function readParsePerformance() {
+  if (!debugPerformance)
+    return null
   return JSON.parse(JSON.stringify(window.__realCorpusParsePerformance ?? createParsePerformance()))
 }
 
 function diffParsePerformance(after, before) {
+  if (!after || !before)
+    return null
   const result = createParsePerformance()
   for (const key of [
     'parseCommitCount',
@@ -1830,6 +1834,14 @@ function formatNumber(value) {
   return typeof value === 'number' && Number.isFinite(value) ? String(Math.round(value)) : '-'
 }
 
+function formatDiagnosticMs(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(1) : 'N/A'
+}
+
+function formatDiagnosticNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? String(Math.round(value)) : 'N/A'
+}
+
 function formatPercent(value) {
   return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : '-'
 }
@@ -1861,7 +1873,7 @@ function renderBrowserRestoreTable(rows) {
   ]
   for (const row of rows) {
     const m = row.median
-    lines.push(`| ${row.id} | ${row.bytes} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.scriptDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatNumber(m.settledSnapshot?.domNodes)} | ${formatNumber(m.settledSnapshot?.slots)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatMs(m.heightStabilityWorst?.nonIgnoredMaxAbsDeltaPx)} | ${formatMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatMs(m.parsePerformance?.nodeReuseMs)} | ${formatMs(m.parsePerformance?.signatureMs)} | ${m.observers?.cls ?? '-'} |`)
+    lines.push(`| ${row.id} | ${row.bytes} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.scriptDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatNumber(m.settledSnapshot?.domNodes)} | ${formatNumber(m.settledSnapshot?.slots)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatMs(m.heightStabilityWorst?.nonIgnoredMaxAbsDeltaPx)} | ${formatDiagnosticMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatDiagnosticMs(m.parsePerformance?.nodeReuseMs)} | ${formatDiagnosticMs(m.parsePerformance?.signatureMs)} | ${m.observers?.cls ?? '-'} |`)
   }
   return lines.join('\n')
 }
@@ -1873,7 +1885,7 @@ function renderBrowserStreamTable(rows) {
   ]
   for (const row of rows) {
     const m = row.median
-    lines.push(`| ${row.id} | ${row.bytes} | ${row.runs[0]?.chunks ?? '-'} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.p95UpdateMs)} | ${formatMs(m.maxUpdateMs)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatNumber(m.heightJumps)} | ${formatNumber(m.observers?.mutationCount)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatNumber(m.parsePerformance?.processTokensReusedTopLevelNodes)} | ${formatMs(m.parsePerformance?.nodeReuseMs)} | ${formatMs(m.parsePerformance?.signatureMs)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} |`)
+    lines.push(`| ${row.id} | ${row.bytes} | ${row.runs[0]?.chunks ?? '-'} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.p95UpdateMs)} | ${formatMs(m.maxUpdateMs)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatNumber(m.heightJumps)} | ${formatNumber(m.observers?.mutationCount)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatDiagnosticMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatDiagnosticNumber(m.parsePerformance?.processTokensReusedTopLevelNodes)} | ${formatDiagnosticMs(m.parsePerformance?.nodeReuseMs)} | ${formatDiagnosticMs(m.parsePerformance?.signatureMs)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} |`)
   }
   return lines.join('\n')
 }
@@ -1893,7 +1905,7 @@ function renderBrowserChatRestoreTable(rows) {
       Number(m.firstTimelineSnapshot?.scrollHeight ?? 0)
       - Number(m.settledTimelineSnapshot?.scrollHeight ?? 0),
     )
-    lines.push(`| ${row.id} | ${row.bytes} | ${formatNumber(row.runs[0]?.itemCount)} | ${formatNumber(row.runs[0]?.markdownItemCount)} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.restoreReady?.elapsedMs)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.scriptDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatNumber(m.settledTimelineSnapshot?.totalHeight)} | ${formatMs(visibleTimelineDrift)} | ${formatMs(hiddenTimelineDrift)} | ${formatNumber(m.settledSnapshot?.domNodes)} | ${formatNumber(m.heightStabilityWorst?.visibleNonIgnoredChangedSlots)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatNumber(m.hiddenRestoreHeightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatMs(m.heightStabilityWorst?.visibleNonIgnoredMaxAbsDeltaPx)} | ${formatMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatMs(m.parsePerformance?.nodeReuseMs)} | ${formatMs(m.parsePerformance?.signatureMs)} | ${m.observers?.cls ?? '-'} |`)
+    lines.push(`| ${row.id} | ${row.bytes} | ${formatNumber(row.runs[0]?.itemCount)} | ${formatNumber(row.runs[0]?.markdownItemCount)} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.restoreReady?.elapsedMs)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.scriptDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatNumber(m.settledTimelineSnapshot?.totalHeight)} | ${formatMs(visibleTimelineDrift)} | ${formatMs(hiddenTimelineDrift)} | ${formatNumber(m.settledSnapshot?.domNodes)} | ${formatNumber(m.heightStabilityWorst?.visibleNonIgnoredChangedSlots)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatNumber(m.hiddenRestoreHeightStabilityWorst?.nonIgnoredChangedSlots)} | ${formatMs(m.heightStabilityWorst?.visibleNonIgnoredMaxAbsDeltaPx)} | ${formatDiagnosticMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatDiagnosticMs(m.parsePerformance?.nodeReuseMs)} | ${formatDiagnosticMs(m.parsePerformance?.signatureMs)} | ${m.observers?.cls ?? '-'} |`)
   }
   return lines.join('\n')
 }

--- a/scripts/benchmark-real-corpus-performance.mjs
+++ b/scripts/benchmark-real-corpus-performance.mjs
@@ -29,6 +29,7 @@ const browserSmoothStreamingOptions = readJsonObjectEnv('MARKSTREAM_REAL_CORPUS_
 const browserViewportWidth = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_VIEWPORT_WIDTH', 1280)
 const browserViewportHeight = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_VIEWPORT_HEIGHT', 900)
 const browserCpuThrottleRate = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_CPU_THROTTLE_RATE', 1)
+const browserDebugPerformance = process.env.MARKSTREAM_REAL_CORPUS_DEBUG_PERFORMANCE !== '0'
 const browserCoreSmoothStreamingDefaults = {
   minCharsPerSecond: 40,
   maxCharsPerSecond: 1000,
@@ -399,6 +400,7 @@ async function runParserBenchmarks(corpus) {
         lastNodes = parseMarkdownToStructure(current, md, {
           final: false,
           streamParse: true,
+          __reuseStableTopLevelNodes: true,
           __timing: timing,
         })
         commitDurations.push(performance.now() - startedAt)
@@ -425,6 +427,8 @@ async function runParserBenchmarks(corpus) {
           nodesBeforeFinal: lastNodes.length,
           nodesAfterFinal: finalNodes.length,
           processTokensMs: sumTiming(commitTimings, 'processTokensMs'),
+          processTokensInputTokens: sumTiming(commitTimings, 'processTokensInputTokens'),
+          processTokensReusedTopLevelNodes: sumTiming(commitTimings, 'processTokensReusedTopLevelNodes'),
           parseTotalMs: sumTiming(commitTimings, 'parseMarkdownToStructureTotalMs'),
           finalTiming,
           streamStats: typeof md.stream?.stats === 'function' ? md.stream.stats() : null,
@@ -452,6 +456,8 @@ async function runParserBenchmarks(corpus) {
         maxCommitMs: round(median(streamRuns.map(run => run.maxCommitMs))),
         finalFlushMedianMs: round(median(streamRuns.map(run => run.finalFlushMs))),
         processTokensMedianMs: round(median(streamRuns.map(run => run.processTokensMs))),
+        processTokensInputTokens: round(median(streamRuns.map(run => run.processTokensInputTokens))),
+        processTokensReusedTopLevelNodes: round(median(streamRuns.map(run => run.processTokensReusedTopLevelNodes))),
         parserTotalMedianMs: round(median(streamRuns.map(run => run.parseTotalMs))),
         medianNodesBeforeFinal: median(streamRuns.map(run => run.nodesBeforeFinal)),
         medianNodesAfterFinal: median(streamRuns.map(run => run.nodesAfterFinal)),
@@ -585,6 +591,7 @@ const timelineThreadKey = ref('')
 const timelineRef = ref(null)
 const smoothStreamingOptions = ${JSON.stringify(browserSmoothStreamingOptions)}
 const rendererOptions = ${JSON.stringify(browserRendererOptions)}
+const debugPerformance = ${JSON.stringify(browserDebugPerformance)}
 const finalTimelineMarkdownOptions = ${JSON.stringify(browserFinalTimelineMarkdownOptions)}
 const chatTranscriptDefinitions = ${JSON.stringify(chatTranscriptDefinitions)}
 const preparedChatStates = new Map()
@@ -606,6 +613,8 @@ function createParsePerformance() {
     streamCommitCount: 0,
     syncCommitCount: 0,
     tokenCloneMs: 0,
+    processTokensInputTokens: 0,
+    processTokensReusedTopLevelNodes: 0,
     processTokensMs: 0,
     parseMarkdownToStructureTotalMs: 0,
     nodeReuseMs: 0,
@@ -637,7 +646,13 @@ function installParsePerformanceHook() {
   window.__realCorpusParsePerformance = createParsePerformance()
   const originalInfo = console.info.bind(console)
   const streamCounterKeys = ['total', 'cacheHits', 'appendHits', 'tailHits', 'fullParses', 'chunkedParses']
-  const parseTimingKeys = ['tokenCloneMs', 'processTokensMs', 'parseMarkdownToStructureTotalMs']
+  const parseTimingKeys = [
+    'tokenCloneMs',
+    'processTokensInputTokens',
+    'processTokensReusedTopLevelNodes',
+    'processTokensMs',
+    'parseMarkdownToStructureTotalMs',
+  ]
   console.info = (...args) => {
     try {
       const label = args[0]
@@ -701,6 +716,8 @@ function diffParsePerformance(after, before) {
     'streamCommitCount',
     'syncCommitCount',
     'tokenCloneMs',
+    'processTokensInputTokens',
+    'processTokensReusedTopLevelNodes',
     'processTokensMs',
     'parseMarkdownToStructureTotalMs',
     'nodeReuseMs',
@@ -1434,7 +1451,7 @@ function renderTimelineItem(props) {
         ...props.markdownProps,
         ...(props.markdownProps.final ? finalTimelineMarkdownOptions : {}),
         class: 'bench-assistant-markdown',
-        debugPerformance: true,
+        debugPerformance,
         renderCodeBlocksAsPre: true,
         smoothStreamingOptions,
         batchRendering: true,
@@ -1498,7 +1515,7 @@ const App = defineComponent({
         mode: mode.value,
         smoothStreaming: smoothStreaming.value,
         smoothStreamingOptions,
-        debugPerformance: true,
+        debugPerformance,
         renderCodeBlocksAsPre: true,
         batchRendering: true,
         ...rendererOptions,
@@ -1562,6 +1579,8 @@ const parsePerformanceNumericKeys = [
   'streamCommitCount',
   'syncCommitCount',
   'tokenCloneMs',
+  'processTokensInputTokens',
+  'processTokensReusedTopLevelNodes',
   'processTokensMs',
   'parseMarkdownToStructureTotalMs',
   'nodeReuseMs',
@@ -1809,11 +1828,11 @@ function formatBoolean(value) {
 
 function renderParserTable(parserResults) {
   const lines = [
-    '| Case | Bytes | Nodes | Final median | Process median | Stream total | Stream p95 commit | Final flush |',
-    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Case | Bytes | Nodes | Final median | Process median | Stream total | Stream p95 commit | Processed tokens | Reused prefix nodes | Final flush |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ]
   for (const row of parserResults) {
-    lines.push(`| ${row.id} | ${row.bytes} | ${formatNumber(row.final.medianNodes)} | ${formatMs(row.final.medianMs)} | ${formatMs(row.final.processTokensMedianMs)} | ${formatMs(row.streaming.totalMedianMs)} | ${formatMs(row.streaming.p95CommitMs)} | ${formatMs(row.streaming.finalFlushMedianMs)} |`)
+    lines.push(`| ${row.id} | ${row.bytes} | ${formatNumber(row.final.medianNodes)} | ${formatMs(row.final.medianMs)} | ${formatMs(row.final.processTokensMedianMs)} | ${formatMs(row.streaming.totalMedianMs)} | ${formatMs(row.streaming.p95CommitMs)} | ${formatNumber(row.streaming.processTokensInputTokens)} | ${formatNumber(row.streaming.processTokensReusedTopLevelNodes)} | ${formatMs(row.streaming.finalFlushMedianMs)} |`)
   }
   return lines.join('\n')
 }
@@ -1832,12 +1851,12 @@ function renderBrowserRestoreTable(rows) {
 
 function renderBrowserStreamTable(rows) {
   const lines = [
-    '| Case | Bytes | Chunks | Total | Timed out | p95 update | Max update | Run frame p95 | Run frame max | Run dropped frames | Run long task | Run long-task busy | Height jumps | Mutations | Task | Layout | Parser total | Node reuse | Signature | Worst non-image/katex final height changes |',
-    '| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Case | Bytes | Chunks | Total | Timed out | p95 update | Max update | Run frame p95 | Run frame max | Run dropped frames | Run long task | Run long-task busy | Height jumps | Mutations | Task | Layout | Parser total | Reused prefix nodes | Node reuse | Signature | Worst non-image/katex final height changes |',
+    '| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ]
   for (const row of rows) {
     const m = row.median
-    lines.push(`| ${row.id} | ${row.bytes} | ${row.runs[0]?.chunks ?? '-'} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.p95UpdateMs)} | ${formatMs(m.maxUpdateMs)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatNumber(m.heightJumps)} | ${formatNumber(m.observers?.mutationCount)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatMs(m.parsePerformance?.nodeReuseMs)} | ${formatMs(m.parsePerformance?.signatureMs)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} |`)
+    lines.push(`| ${row.id} | ${row.bytes} | ${row.runs[0]?.chunks ?? '-'} | ${formatMs(m.totalMs)} | ${formatBoolean(m.runTimedOut)} | ${formatMs(m.p95UpdateMs)} | ${formatMs(m.maxUpdateMs)} | ${formatMs(m.observers?.frameP95Ms)} | ${formatMs(m.observers?.frameMaxMs)} | ${formatNumber(m.observers?.droppedFrameEstimate)} | ${formatMs(m.observers?.longTaskTotalMs)} | ${formatPercent(m.observers?.longTaskBusyRatio)} | ${formatNumber(m.heightJumps)} | ${formatNumber(m.observers?.mutationCount)} | ${formatMs(m.taskDurationMs)} | ${formatMs(m.layoutDurationMs)} | ${formatMs(m.parsePerformance?.parseMarkdownToStructureTotalMs)} | ${formatNumber(m.parsePerformance?.processTokensReusedTopLevelNodes)} | ${formatMs(m.parsePerformance?.nodeReuseMs)} | ${formatMs(m.parsePerformance?.signatureMs)} | ${formatNumber(m.heightStabilityWorst?.nonIgnoredChangedSlots)} |`)
   }
   return lines.join('\n')
 }
@@ -1993,6 +2012,7 @@ async function main() {
       browserViewportWidth,
       browserViewportHeight,
       browserCpuThrottleRate,
+      browserDebugPerformance,
       rendererOptions: browserRendererOptions,
       finalTimelineMarkdownOptions: browserFinalTimelineMarkdownOptions,
       standaloneFinalRestoreAutoExpectedOptions: browserStandaloneFinalRestoreAutoExpectedOptions,


### PR DESCRIPTION
## Summary

- reuse stable token-to-ParsedNode prefixes containing built-in explicit Markdown links
- store synthetic-link origin in private WeakMap state and reuse only explicit origin
- restrict link-containing prefix reuse to Markstream's known-stable default link validator
- keep custom/mutable validators, linkify, autolink, recovery, unmarked synthetic links, and unknown link markup on conservative fallback paths
- skip reusable-token eligibility scans when structured reuse is disabled
- report public/default parser and Renderer structured-reuse benchmark modes separately
- report clean-run parser diagnostics as `null` / `N/A` when instrumentation is disabled

No public API, `ParsedNode` shape, `MarkdownToken.meta` descriptor, or expected DOM output changes.

## Why

The proposed parser-to-renderer handoff was implemented and measured first. It reached 90 of 92 eligible browser commits, but a same-head clean comparison showed no meaningful Renderer-side gain: ScriptDuration about +0.1%, TaskDuration about -0.1%, and p95 update about +4.9%. The implementation and its state were removed.

Markdown tokenization was already using its dirty-tail path. The investigation instead found that explicit Markdown links caused the subsequent token-to-ParsedNode structured reuse path to reject nearly the entire real AI-chat corpus. This PR safely restores reuse at that `processTokens()` stage for link-rich streams using Markstream's default validation policy.

## Correctness boundaries

- standard built-in explicit link pairs are reusable; unknown markup is rejected
- synthetic origins are stored by token identity in an internal WeakMap; only explicit is reusable
- public token `meta` remains enumerable and available to hooks, spread, clone, and serialization
- only Markstream's internally-created cache-stable validator permits link-prefix reuse
- custom `parseOptions.validateLink`, `md.set()` validators, and factory custom validators fall back for link-containing groups
- mutable same-function validator behavior is compared with cold parsing and reuses zero old nodes
- incomplete/loading links, final transitions, and appended reference definitions are compared with cold parsing
- public/default, final, transforms, custom HTML, source maps, custom MarkdownIt, and registered plugins retain fallback behavior

## Performance

Real corpus: `docs/guide/ai-chat-streaming.md`, 160 chunks, Chrome CPU throttle x4.

Fresh instrumented browser median, identical neutral harness, three runs:

| Metric | Base | Head | Change |
| --- | ---: | ---: | ---: |
| Reused stable-prefix nodes | 12 | 2,547 | +2,535 |
| Tokens sent to processTokens | 21,441 | 1,603 | -92.52% |
| processTokens time | 145.4 ms | 46.2 ms | -68.23% |
| Parser total | 350.1 ms | 277.3 ms | -20.79% |

Fresh clean browser result, ABBA, ten runs per revision:

| Metric | Base | Head | Change |
| --- | ---: | ---: | ---: |
| ScriptDuration | 453.744 ms | 357.779 ms | -21.15% |
| TaskDuration | 2666.872 ms | 2559.029 ms | -4.04% |
| update p95 | 17.9 ms | 16.7 ms | -6.70% |
| frame p95 | 17.5 ms | 16.8 ms | -4.00% |
| JS heap | 35.042 MB | 35.561 MB | +1.48% |

The supported claim is limited to link-rich streaming Markdown workloads using the default policy. Harness checksum, safety changes, fresh raw interpretation, mechanism data, and public/default parser controls are recorded in the [latest safety follow-up](https://github.com/Simon-He95/markstream-vue/pull/609#issuecomment-5151342355). The earlier 20-run ABBA+BAAB raw data remains in the [neutral-harness follow-up](https://github.com/Simon-He95/markstream-vue/pull/609#issuecomment-5150818147).

## Risk and side effects

- eligible default-policy link-rich streams retain one prior structured snapshot and boundary list in a WeakMap
- eligibility scans can continue farther through explicit links on a later reuse miss
- custom validators deliberately give up link-containing prefix reuse because callback purity cannot be assumed
- changing link validation identity remains an additional cache invalidation boundary
- future unknown link origins or markup fall back instead of expanding reuse coverage

The public/default standalone parser does not enable internal stable-node reuse and remains within the 5% control guardrail.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- full Vitest: 307 files and 2,641 tests passed
- `pnpm test:api:strict`
- strict public API snapshot unchanged
- runtime exports, package exports, and subpath isolation passed
- clean and instrumented base/head benchmarks with an identical harness
