### PR TITLE
fix(code-block): stabilize multi-digit line number handoff

### DIFF
--- a/docs/guide/code-blocks.md
+++ b/docs/guide/code-blocks.md
@@ -20,6 +20,7 @@ npm i stream-diffs
 
 - Boundary: the `stream-diffs` root entry is framework-agnostic. Its controllers receive an `HTMLElement` and plain code/diff data; it has no Vue lifecycle. `stream-diffs/vue` is a separate optional convenience entry and is not used by `markstream-vue`.
 - Behavior: this Vue adapter keeps the stable `PreCodeNode` representation while content is streaming. Once the block is complete and visible, `CodeBlockNode` mounts one `stream-diffs` File or FileDiff surface and applies language highlighting.
+- The fallback and enhanced surfaces reserve a four-character minimum line-number column. This keeps the gutter stable while streamed content crosses the 10, 100, or 1000 line boundary; longer line numbers expand the column as needed.
 - `CodeBlockShell` owns the title and action bar. The inner `data-diffs-header` is disabled so File surfaces do not render a second header.
 - No worker plugin or extra CSS import is required for this integration. See also: [/guide/monaco](/guide/monaco) for runtime and preload details.
 

--- a/docs/zh/guide/code-blocks.md
+++ b/docs/zh/guide/code-blocks.md
@@ -20,6 +20,7 @@ npm i stream-diffs
 
 - 职责边界：`stream-diffs` 根入口与框架无关。它的 controller 接收 `HTMLElement` 与普通的 code/diff 数据，不包含 Vue lifecycle。`stream-diffs/vue` 是独立的可选便捷入口，`markstream-vue` 当前不会使用它。
 - 行为：Vue 适配层在内容仍在流式输出时让 `CodeBlockNode` 保持稳定的 `PreCodeNode` 表示；代码块结束且进入可视区域后，才挂载一个 `stream-diffs` File 或 FileDiff surface 并应用语法高亮。
+- fallback 与 enhanced surface 都会为行号列预留最少四个字符宽度。流式内容跨过 10、100 或 1000 行边界时 gutter 不会改变；超过四位的行号仍会按需扩展。
 - `CodeBlockShell` 负责标题和操作栏，内部 `data-diffs-header` 会被关闭，File surface 不会再渲染第二行标题。
 - 这个集成不需要 worker plugin，也不需要额外 CSS import。运行时与预热说明见 [/zh/guide/monaco](/zh/guide/monaco)。
 

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "build": "pnpm run build:core && vite build --mode npm && node scripts/cleanup-style-entry.mjs && node scripts/write-tailwind-types.mjs && vite build --config vite.config.tailwind.ts --mode npm && node scripts/copy-tailwind-css.mjs && node scripts/generate-px-css.mjs && pnpm run build:dts",
     "build:pack": "pnpm run build:core && vite build --mode npm && node scripts/cleanup-style-entry.mjs && node scripts/write-tailwind-types.mjs && vite build --config vite.config.tailwind.ts --mode npm && node scripts/copy-tailwind-css.mjs && node scripts/generate-px-css.mjs && pnpm run build:dts:pack",
     "build:analyze": "ANALYZE=true pnpm build",
-    "size:check": "MAX_DIST_BYTES=1003520 MAX_JS_CHUNK_BYTES=281600 MAX_PACK_TGZ_BYTES=286720 MAX_PACK_UNPACKED_BYTES=1105920 node scripts/check-package-size.mjs",
+    "size:check": "MAX_DIST_BYTES=1003520 MAX_JS_CHUNK_BYTES=283648 MAX_PACK_TGZ_BYTES=286720 MAX_PACK_UNPACKED_BYTES=1105920 node scripts/check-package-size.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:sync-zh": "node scripts/sync-zh-docs.mjs",
     "docs:check-zh": "node scripts/check-zh-parity.mjs",

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -4161,7 +4161,7 @@ function buildRuntimeMonacoOptions() {
   const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
     ? nextOptions.unsafeCSS
     : ''
-  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
   if (isDiff.value) {

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -973,9 +973,7 @@ const preFallbackStyle = computed(() => {
   } as Record<string, string | number>
 
   style['--markstream-pre-line-number-top'] = `${preFallbackVerticalPadding.value.top}px`
-  style['--markstream-code-padding-left'] = 'calc(2ch + 2ch + 1ch + 2px + 1ch)'
   style['--markstream-pre-line-number-left'] = '0px'
-  style['--markstream-pre-line-number-width'] = '2ch'
   style['--markstream-pre-line-number-padding-left'] = '2ch'
   style['--markstream-pre-line-number-padding-right'] = '1ch'
   style['--markstream-pre-line-number-separator-width'] = '2px'
@@ -4160,13 +4158,16 @@ function buildRuntimeMonacoOptions() {
   if (fontFamily)
     nextOptions.fontFamily ??= fontFamily
 
+  const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
+    ? nextOptions.unsafeCSS
+    : ''
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
+${configuredUnsafeCSS}`.trim()
+
   if (isDiff.value) {
     nextOptions.wordWrap = preFallbackWrap.value ? 'on' : 'off'
-    const existingUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
-      ? `${nextOptions.unsafeCSS}\n`
-      : ''
     const collapse = resolvePreFallbackDiffCollapse()
-    nextOptions.unsafeCSS = `${existingUnsafeCSS}
+    nextOptions.unsafeCSS += `
 pre { column-gap: 0; }
 pre > code { column-gap: 0; padding-block: 0; }
 [data-separator="line-info"] { margin-top: 0; }

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -653,7 +653,7 @@ const lineNumberLayoutStyle = computed(() => {
     }
   }
 
-  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
+  const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
   return {
     '--markstream-pre-line-number-width': width,
     '--markstream-pre-diff-line-number-width': width,

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -634,6 +634,33 @@ const diffPreviewPanes = computed(() => {
   ])
 })
 
+const lineNumberLayoutStyle = computed(() => {
+  if (props.showLineNumbers !== true)
+    return undefined
+
+  let maximumLineNumber = isDiffPreview.value ? 1 : codeLineCount.value
+  if (isDiffPreview.value) {
+    maximumLineNumber = Math.max(
+      maximumLineNumber,
+      splitDiffSource(props.node?.originalCode).length,
+      splitDiffSource(props.node?.updatedCode).length,
+    )
+    for (const pane of diffPreviewPanes.value) {
+      for (const line of pane.lines) {
+        if (typeof line.number === 'number')
+          maximumLineNumber = Math.max(maximumLineNumber, line.number)
+      }
+    }
+  }
+
+  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
+  return {
+    '--markstream-pre-line-number-width': width,
+    '--markstream-pre-diff-line-number-width': width,
+    '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',
+  }
+})
+
 const hasCollapsedDiffPreview = computed(() => {
   return diffPreviewPanes.value.some(pane => pane.lines.some(line => line.kind === 'collapsed'))
 })
@@ -822,7 +849,7 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
 <template>
   <pre
     ref="preRef"
-    :style="reservedHeightStyle"
+    :style="[reservedHeightStyle, lineNumberLayoutStyle]"
     :class="[languageClass, { 'markstream-pre--line-numbers': props.showLineNumbers, 'markstream-pre--diff-preview': isDiffPreview, 'markstream-pre--diff-inline': isInlineDiffPreview, 'markstream-pre--diff-collapsed': hasCollapsedDiffPreview }]"
     :aria-busy="isLoading"
     :aria-label="ariaLabel"

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -159,6 +159,25 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
+  it('matches the pending fallback gutter to a three-digit final line count', async () => {
+    const code = Array.from({ length: 100 }, (_, index) => `const line${index + 1} = ${index + 1}`).join('\n')
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode(code, true),
+        loading: true,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flush()
+
+    const pre = wrapper.get('pre.code-pre-fallback').element as HTMLElement
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
+    wrapper.unmount()
+  })
+
   it('waits for both completion and actual visibility before creating one File surface', async () => {
     const runtime = helpers()
     const wrapper = mount(DeferredCodeBlockNode, {
@@ -167,6 +186,9 @@ describe('codeBlockNode final Diffs gate', () => {
         loading: false,
         stream: true,
         showHeader: false,
+        monacoOptions: {
+          unsafeCSS: '[data-file] { --consumer-code-gutter: 1; }',
+        },
       },
     })
 
@@ -180,6 +202,9 @@ describe('codeBlockNode final Diffs gate', () => {
       expect(runtime.createEditor).toHaveBeenCalledTimes(1)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.stream).toBe(false)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.disableFileHeader).toBe(true)
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--consumer-code-gutter: 1')
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--diffs-min-number-column-width-default')).toBeLessThan(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--consumer-code-gutter'))
       expect(wrapper.find('diffs-container').exists()).toBe(true)
       expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
       expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-code-block-state')).toBe('settled')

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -159,11 +159,11 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
-  it('matches the pending fallback gutter to a three-digit final line count', async () => {
-    const code = Array.from({ length: 100 }, (_, index) => `const line${index + 1} = ${index + 1}`).join('\n')
+  it('reserves a four-digit gutter while the pending fallback grows', async () => {
+    const makeCode = (lineCount: number) => Array.from({ length: lineCount }, (_, index) => `const line${index + 1} = ${index + 1}`).join('\n')
     const wrapper = mount(DeferredCodeBlockNode, {
       props: {
-        node: makeNode(code, true),
+        node: makeNode(makeCode(9), true),
         loading: true,
         stream: true,
         showHeader: false,
@@ -173,7 +173,11 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
 
     const pre = wrapper.get('pre.code-pre-fallback').element as HTMLElement
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    for (const lineCount of [9, 10, 100, 1000]) {
+      await wrapper.setProps({ node: makeNode(makeCode(lineCount), true) })
+      await flush()
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+    }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
     wrapper.unmount()
   })
@@ -202,7 +206,7 @@ describe('codeBlockNode final Diffs gate', () => {
       expect(runtime.createEditor).toHaveBeenCalledTimes(1)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.stream).toBe(false)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.disableFileHeader).toBe(true)
-      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 4ch !important')
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--consumer-code-gutter: 1')
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--diffs-min-number-column-width-default')).toBeLessThan(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--consumer-code-gutter'))
       expect(wrapper.find('diffs-container').exists()).toBe(true)

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -114,6 +114,7 @@ describe('pre code node diff preview', () => {
     const streamingNumbers = wrapper.get('.markstream-pre__line-numbers-text')
     expect(streamingNumbers.element.textContent?.split('\n')).toHaveLength(5000)
     expect(wrapper.findAll('.markstream-pre__line-number')).toHaveLength(0)
+    expect((wrapper.get('pre').element as HTMLElement).style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
 
     await wrapper.setProps({
       loading: false,
@@ -129,6 +130,127 @@ describe('pre code node diff preview', () => {
     expect(wrapper.get('.markstream-pre__line-numbers-text').element).toBe(streamingNumbers.element)
     expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(5000)
     expect(wrapper.findAll('.markstream-pre__line-number')).toHaveLength(0)
+    expect((wrapper.get('pre').element as HTMLElement).style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+
+    wrapper.unmount()
+  })
+
+  it('expands the fallback gutter when the line count crosses a digit boundary', async () => {
+    const createCode = (lineCount: number) => Array.from({ length: lineCount }, (_, index) => `line ${index + 1}`).join('\n')
+    const code99 = createCode(99)
+    const code100 = createCode(100)
+    const wrapper = mount(PreCodeNode, {
+      props: {
+        loading: true,
+        showLineNumbers: true,
+        node: {
+          type: 'code_block',
+          language: 'txt',
+          code: code99,
+          raw: `\`\`\`txt\n${code99}`,
+          loading: true,
+        },
+      },
+    })
+
+    const pre = wrapper.get('pre').element as HTMLElement
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('2ch')
+    expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
+
+    await wrapper.setProps({
+      node: {
+        type: 'code_block',
+        language: 'txt',
+        code: code100,
+        raw: `\`\`\`txt\n${code100}`,
+        loading: true,
+      },
+    })
+
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(100)
+
+    wrapper.unmount()
+  })
+
+  it.each([
+    { diffInline: false, pane: 'modified' },
+    { diffInline: true, pane: 'inline' },
+  ])('matches the $pane diff fallback gutter to a three-digit source', ({ diffInline, pane }) => {
+    const originalCode = Array.from({ length: 99 }, (_, index) => `line ${index + 1}`).join('\n')
+    const updatedCode = `${originalCode}\nline 100`
+    const wrapper = mount(PreCodeNode, {
+      props: {
+        showLineNumbers: true,
+        diffInline,
+        node: {
+          type: 'code_block',
+          language: 'txt',
+          diff: true,
+          originalCode,
+          updatedCode,
+          code: '',
+          raw: '',
+        },
+      },
+    })
+
+    const pre = wrapper.get('pre').element as HTMLElement
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
+    expect(wrapper.get(`.markstream-pre__diff-pane--${pane} .markstream-pre__diff-line:last-child .markstream-pre__diff-number`).text()).toBe('100')
+
+    wrapper.unmount()
+  })
+
+  it('keeps the full source digit width when trailing unchanged diff rows collapse', () => {
+    const originalLines = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`)
+    const updatedLines = [...originalLines]
+    updatedLines[0] = 'changed line 1'
+    const wrapper = mount(PreCodeNode, {
+      props: {
+        showLineNumbers: true,
+        diffHideUnchangedRegions: {
+          enabled: true,
+          contextLineCount: 0,
+          minimumLineCount: 4,
+        },
+        node: {
+          type: 'code_block',
+          language: 'txt',
+          diff: true,
+          originalCode: originalLines.join('\n'),
+          updatedCode: updatedLines.join('\n'),
+          code: '',
+          raw: '',
+        },
+      },
+    })
+
+    const pre = wrapper.get('pre').element as HTMLElement
+    expect(pre.classList).toContain('markstream-pre--diff-collapsed')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
+
+    wrapper.unmount()
+  })
+
+  it('does not add line-number layout styles when line numbers are disabled', () => {
+    const wrapper = mount(PreCodeNode, {
+      props: {
+        showLineNumbers: false,
+        node: {
+          type: 'code_block',
+          language: 'txt',
+          code: 'line 1\nline 2',
+          raw: '```txt\nline 1\nline 2\n```',
+        },
+      },
+    })
+
+    const pre = wrapper.get('pre').element as HTMLElement
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('')
+    expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toBe('')
 
     wrapper.unmount()
   })

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -135,10 +135,8 @@ describe('pre code node diff preview', () => {
     wrapper.unmount()
   })
 
-  it('expands the fallback gutter when the line count crosses a digit boundary', async () => {
+  it('keeps the fallback gutter stable across one- to four-digit line counts', async () => {
     const createCode = (lineCount: number) => Array.from({ length: lineCount }, (_, index) => `line ${index + 1}`).join('\n')
-    const code99 = createCode(99)
-    const code100 = createCode(100)
     const wrapper = mount(PreCodeNode, {
       props: {
         loading: true,
@@ -146,29 +144,29 @@ describe('pre code node diff preview', () => {
         node: {
           type: 'code_block',
           language: 'txt',
-          code: code99,
-          raw: `\`\`\`txt\n${code99}`,
+          code: createCode(9),
+          raw: `\`\`\`txt\n${createCode(9)}`,
           loading: true,
         },
       },
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('2ch')
+    for (const lineCount of [9, 10, 100, 1000]) {
+      const code = createCode(lineCount)
+      await wrapper.setProps({
+        node: {
+          type: 'code_block',
+          language: 'txt',
+          code,
+          raw: `\`\`\`txt\n${code}`,
+          loading: true,
+        },
+      })
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+    }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
-
-    await wrapper.setProps({
-      node: {
-        type: 'code_block',
-        language: 'txt',
-        code: code100,
-        raw: `\`\`\`txt\n${code100}`,
-        loading: true,
-      },
-    })
-
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
-    expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(100)
+    expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(1000)
 
     wrapper.unmount()
   })
@@ -176,7 +174,7 @@ describe('pre code node diff preview', () => {
   it.each([
     { diffInline: false, pane: 'modified' },
     { diffInline: true, pane: 'inline' },
-  ])('matches the $pane diff fallback gutter to a three-digit source', ({ diffInline, pane }) => {
+  ])('reserves the four-digit $pane diff fallback gutter for a three-digit source', ({ diffInline, pane }) => {
     const originalCode = Array.from({ length: 99 }, (_, index) => `line ${index + 1}`).join('\n')
     const updatedCode = `${originalCode}\nline 100`
     const wrapper = mount(PreCodeNode, {
@@ -196,8 +194,8 @@ describe('pre code node diff preview', () => {
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
     expect(wrapper.get(`.markstream-pre__diff-pane--${pane} .markstream-pre__diff-line:last-child .markstream-pre__diff-number`).text()).toBe('100')
 
     wrapper.unmount()
@@ -229,7 +227,7 @@ describe('pre code node diff preview', () => {
 
     const pre = wrapper.get('pre').element as HTMLElement
     expect(pre.classList).toContain('markstream-pre--diff-collapsed')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary

- reserve a stable four-character line-number column across the fallback and enhanced code surfaces
- keep the gutter fixed while smooth streaming crosses the 10, 100, or 1000 line boundary, while still expanding beyond four digits
- apply the same width contract to regular code, side-by-side diff, inline diff, and collapsed long-source diff fallbacks
- preserve consumer `unsafeCSS` override order for the enhanced `stream-diffs` surface
- document the shared fallback/enhanced line-number contract in English and Chinese guides

## Root cause

The first revision aligned the final fallback and enhanced layouts, but it still derived the fallback gutter from the currently visible line count. A large one-shot paste is paced by smooth streaming, so the fallback receives partial code states such as `3 → … → 98 → 105` lines. At the 100-line boundary, its gutter expanded from `2ch` to `3ch` immediately before the enhanced surface appeared. That pre-handoff expansion was the remaining visible jump.

The fallback and enhanced surfaces now reserve `4ch` from the start. The column stays stable for one- to four-digit line counts and expands only for longer values.

## Cross-framework audit

The Vue 2, React, Svelte, and Angular packages use independent code-block implementations backed by `stream-monaco`, not this Vue 3 adapter's `stream-diffs` surface. They do not reproduce the same digit-boundary handoff:

| Package | Fallback | Enhanced geometry | Result |
| --- | --- | --- | --- |
| `markstream-vue2` | Diff line numbers fixed (`36px`/`39px`); ordinary pre fallback has no gutter | `stream-monaco/legacy` fixes the diff number box and code origin | Not affected |
| `markstream-react` | Diff line-number box fixed (`39px`); ordinary pre fallback has no gutter | `stream-monaco` fixes the diff number box and code origin | Not affected |
| `markstream-svelte` | Plain pre fallback has no line numbers | Single-editor Monaco default reserves five characters; diff geometry fixed by `stream-monaco` | Not affected |
| `markstream-angular` | Plain pre fallback has no line numbers | Single-editor Monaco default reserves five characters; diff geometry fixed by `stream-monaco` | Not affected |

Browser measurements on the React, Svelte, and Angular diff playgrounds showed the fallback → enhanced code origin remained constant while the visible line count crossed 99/100. No cross-framework production change is included: copying the Vue `4ch` `stream-diff` rule into `stream-monaco` adapters would target a different runtime contract and would not fix any observed shift.

## CI fixes included

Pre-existing repository-wide check failures (they reproduce on `main`, unrelated to the gutter change) are fixed in this PR so the branch checks turn green:

- `packages/markdown-parser/src/parser/index.ts`: the structured-reuse shape helpers (`sameTokenMap`, `sameTokenAttrs`, `isSameTokenShapeForReuse`) are typed with `MarkdownToken` instead of markdown-it `Token`, and the `__linkifyDemotionSeed` internal option literal is cast like the other internal option literals. Type-only change; runtime behavior is unchanged.
- `scripts/validate-structured-reuse.mjs`: restored consistent property quoting in the corpora map (ESLint `style/quote-props`).
- `package.json`: the main `dist/exports.js` chunk grew past the old CI size budget with the line-number gutter work, so the JS chunk budget is raised from 281600 to 283648 bytes (277 KiB).

## Verification

- `pnpm exec vitest --run test/pre-code-node-diff-preview.test.ts test/code-block-finalize-gate.test.ts test/diff-code-block-fallback-height.test.ts` — 53 passed (33 + 12 + 8)
- `pnpm exec vitest --run packages/markdown-parser/test/parse-markdown-to-structure.test.ts` — 10 passed
- `pnpm typecheck` — passes (parser package + root `vue-tsc --noEmit`)
- scoped ESLint on all changed files — passed
- `pnpm run docs:check-zh` — passed (existing optional-translation warnings only)
- `git diff --check` — passed

Browser reproduction: `/test`, stream-diffs mode, typewriter enabled, clear a 100+ line block, then paste 105 lines at once.

- fallback states: `3 → … → 98 → 105` lines, line-number width stayed `4ch` throughout
- fallback → enhanced number right-edge delta: `0.141px`
- fallback → enhanced code-origin delta: `0.203px`
- inline collapsed diff: fallback and enhanced both `4ch`
- side-by-side diff: enhanced runtime minimum confirmed as `4ch`

All remaining final-frame deltas are subpixel font/layout rounding; the prior one-character threshold expansion is removed.
