### PR TITLE
fix: only strip a trailing fence-marker line from unclosed fence content

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/fence-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/fence-parser.ts
@@ -1,7 +1,11 @@
 import type { CodeBlockNode, MarkdownToken } from '../../types'
 
-// Strip a final line that looks like a fence marker (``` etc.)
-const TRAILING_FENCE_LINE_RE = /\r?\n[ \t]*`+\s*$/
+// A trailing line made of the fence's own marker character that is long
+// enough to be a valid closing fence for it.
+function TRAILING_OWN_FENCE_LINE_RE(marker: string, minLen: number) {
+  return new RegExp(`\r?\n[ \\t]*${marker}{${minLen},}[ \\t]*$`)
+}
+
 // Unified diff metadata/header line prefixes to skip when splitting a diff
 const DIFF_HEADER_PREFIXES = ['diff ', 'index ', '--- ', '+++ ', '@@ ']
 // Newline splitter reused in this module
@@ -119,15 +123,21 @@ export function parseFenceToken(token: MarkdownToken): CodeBlockNode {
 
   // Defensive sanitization: sometimes a closing fence line (e.g. ``` or ``)
   // can accidentally end up inside `token.content` (for example when
-  // the parser/mapping is confused). Remove a trailing line that only
-  // contains backticks and optional whitespace so we don't render stray
-  // ` or `` characters at the end of the code output. This is a
-  // conservative cleanup and only strips a final line that looks like a
-  // fence marker (starts with optional spaces then one or more ` and
-  // only whitespace until end-of-string).
+  // the parser/mapping is confused during streaming). This cleanup is ONLY
+  // valid for the streaming/unclosed case, and ONLY when the trailing line
+  // could actually be the fence's own closing marker (same character, at
+  // least as long as the opening run). A closed fence carries authoritative
+  // content and must never be altered: a nested fence inside a 4-backtick
+  // outer block legitimately ends with a ``` line, and a ``` fence whose
+  // code ends in a backtick-only line keeps it.
   let content = String(token.content ?? '')
-  if (TRAILING_FENCE_LINE_RE.test(content))
-    content = content.replace(TRAILING_FENCE_LINE_RE, '')
+  if (!closed && token.markup) {
+    const marker = token.markup[0]
+    const minLen = token.markup.length
+    const trailingFenceLineRe = TRAILING_OWN_FENCE_LINE_RE(marker, minLen)
+    if (trailingFenceLineRe.test(content))
+      content = content.replace(trailingFenceLineRe, '')
+  }
 
   if (diff) {
     const { original, updated } = splitUnifiedDiff(content, closed === true)

--- a/test/fence-trailing-backtick.test.ts
+++ b/test/fence-trailing-backtick.test.ts
@@ -2,18 +2,64 @@ import { parseFenceToken } from 'stream-markdown-parser'
 import { describe, expect, it } from 'vitest'
 
 describe('fence parser trailing fence cleanup', () => {
-  it('removes a trailing line that only contains backticks from token.content', () => {
+  it('removes a trailing fence-marker line from UNCLOSED (streaming) fence content', () => {
     const token: any = {
       type: 'fence',
       info: 'ts',
       content: 'const a = 1\n```',
+      markup: '```',
       map: [0, 2],
+      meta: { closed: false },
     }
 
     const node = parseFenceToken(token as any)
     expect(node).toBeDefined()
     expect((node as any).code).toBe('const a = 1')
     expect((node as any).raw).toBe('const a = 1')
+  })
+
+  it('keeps a trailing backtick-only line in CLOSED fence content', () => {
+    // A closed fence's content is authoritative: a nested fence inside a
+    // 4-backtick outer block, or code whose last line is a backtick-only
+    // line, legitimately ends with one. Only the streaming/unclosed case is
+    // ambiguous (a misplaced closing line), and only for the fence's OWN
+    // marker character.
+    const token: any = {
+      type: 'fence',
+      info: 'ts',
+      content: 'const a = 1\n```',
+      markup: '```',
+      map: [0, 2],
+    }
+    const node = parseFenceToken(token as any)
+    expect((node as any).code).toBe('const a = 1\n```')
+    expect((node as any).raw).toBe('const a = 1\n```')
+  })
+
+  it('does not strip a backtick line when the fence marker is a tilde', () => {
+    const token: any = {
+      type: 'fence',
+      info: 'text',
+      content: 'a\n```',
+      markup: '~~~',
+      map: [0, 2],
+      meta: { closed: false },
+    }
+    const node = parseFenceToken(token as any)
+    expect((node as any).code).toBe('a\n```')
+  })
+
+  it('does not strip a shorter marker run than the opening fence', () => {
+    const token: any = {
+      type: 'fence',
+      info: 'text',
+      content: '```\nline\n```',
+      markup: '````',
+      map: [0, 3],
+      meta: { closed: false },
+    }
+    const node = parseFenceToken(token as any)
+    expect((node as any).code).toBe('```\nline\n```')
   })
 
   it('keeps legitimate content that contains backticks not on their own line', () => {


### PR DESCRIPTION
Fixes #616

## 问题

`parseFenceToken` 里的收尾清理逻辑无条件删除代码内容最后一行“纯反引号”的行，没有检查：
- fence 是否已 `closed`（闭合内容是权威内容）
- 反引号数量是否达到开启标记的长度
- fence 的标记字符是否真的是反引号（`~~~` 围栏同样受影响）

导致嵌套围栏、以纯反引号收尾的合法代码内容被截断。详见 issue 里用真实渲染截图验证过的复现。

## 修复

- 把无条件正则 `TRAILING_FENCE_LINE_RE` 换成按 fence 自己的标记字符 + 最小长度动态构造的 `TRAILING_OWN_FENCE_LINE_RE(marker, minLen)`；
- 只在 `meta.closed === false`（流式未闭合）时才尝试清理——这原本就是这段逻辑要处理的场景（误放的收尾行只会出现在流式中间态）；已闭合的 fence 内容不再被改写。

## 测试

新增 3 个用例到 `test/fence-trailing-backtick.test.ts`：
- 闭合 fence 保留纯反引号收尾行；
- 4 反引号外层嵌套 3 反引号内层，内层收尾行保留；
- `~~~` 围栏内容以反引号结尾时不受影响。

现有测试全部通过：`472 passed (472)`。

## 复现 & 修复前后对比

Issue 里附了真实渲染截图（Puppeteer + 真实 Chromium，截图前用 `page.evaluate` 读取 DOM 内容做了断言）：
- 修复前：![](https://cdn.vectojs.org/upstream-bugs/ms-m1-fence-before.png)
- 修复后：![](https://cdn.vectojs.org/upstream-bugs/ms-m1-fence-after.png)
