### PR TITLE
fix: scope LaTeX-command reconstruction to math contexts; fix list-fence html tail

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -2855,89 +2855,14 @@ function stripDanglingHtmlLikeTail(markdown: string) {
     return true
   }
 
-  const isInsideFencedCodeBlock = (src: string, pos: number) => {
-    let inFence = false
-    let fenceChar: '`' | '~' | '' = ''
-    let fenceLen = 0
-
-    const isIndentWs = (ch: string) => ch === ' ' || ch === '\t'
-
-    const parseFenceMarker = (line: string) => {
-      let i = 0
-      while (i < line.length && isIndentWs(line[i])) i++
-      const ch = line[i]
-      if (ch !== '`' && ch !== '~')
-        return null
-      let j = i
-      while (j < line.length && line[j] === ch) j++
-      const len = j - i
-      if (len < 3)
-        return null
-      return { markerChar: ch as '`' | '~', markerLen: len, rest: line.slice(j) }
-    }
-
-    const stripBlockquotePrefix = (line: string) => {
-      let i = 0
-      while (i < line.length && isIndentWs(line[i])) i++
-      let saw = false
-      while (i < line.length && line[i] === '>') {
-        saw = true
-        i++
-        while (i < line.length && isIndentWs(line[i])) i++
-      }
-      return saw ? line.slice(i) : null
-    }
-
-    const matchFence = (rawLine: string) => {
-      const direct = parseFenceMarker(rawLine)
-      if (direct)
-        return direct
-
-      const afterQuote = stripBlockquotePrefix(rawLine)
-      if (afterQuote == null)
-        return null
-
-      return parseFenceMarker(afterQuote)
-    }
-
-    let offset = 0
-    const lines = src.split(/\r?\n/)
-    for (const line of lines) {
-      const lineStart = offset
-      const lineEnd = offset + line.length
-
-      const pastTargetLine = pos < lineStart
-      if (pastTargetLine)
-        break
-
-      const fenceMatch = matchFence(line)
-      if (fenceMatch) {
-        const markerChar = fenceMatch.markerChar
-        const markerLen = fenceMatch.markerLen
-        if (inFence) {
-          if (markerChar === fenceChar && markerLen >= fenceLen) {
-            if (/^\s*$/.test(fenceMatch.rest)) {
-              inFence = false
-              fenceChar = ''
-              fenceLen = 0
-            }
-          }
-        }
-        else {
-          inFence = true
-          fenceChar = markerChar
-          fenceLen = markerLen
-        }
-      }
-
-      if (pos <= lineEnd)
-        break
-
-      offset = lineEnd + 1
-    }
-
-    return inFence
-  }
+  // Delegate to the full fence scanner used elsewhere: the previous local
+  // scanner only recognized direct and blockquote-prefixed fences, so a
+  // fence nested inside a list item (`- ```html` / `  <div`) was invisible
+  // and the incomplete `<div` tail got truncated from the code content on
+  // every non-final commit. `isInsideOpenMarkdownFenceBeforeOffset` also
+  // handles list/blockquote fence exit conditions (de-dent ends the fence).
+  const isInsideFencedCodeBlock = (src: string, pos: number) =>
+    isInsideOpenMarkdownFenceBeforeOffset(src, pos)
 
   // In streaming mode it's common to have an incomplete HTML-ish fragment at
   // the very end of the current buffer (e.g. '<fo' or '</think'). Letting it
@@ -3987,13 +3912,170 @@ function ensureBlankLineBeforeCustomHtmlBlocks(markdown: string, tags: string[])
   return out
 }
 
+/**
+ * Math-context scanner used to gate the transport-split LaTeX-command
+ * reconstruction. Tracks fenced code (including list/blockquote-prefixed
+ * fences via matchMarkdownFenceMarker), backtick spans, $$...$$ blocks,
+ * \[...\] spans and single-$ math.
+ *
+ * Single-$ math is line-scoped (markdown-it-math never lets $...$ span a
+ * line break): the opener state resets at every line break. A $ that is the
+ * last char of a line counts as an opener because a transport split can land
+ * exactly after it (`$\nabla$` -> "$" + newline + "abla$").
+ *
+ * The scanner is a pure function of the consumed text, so the append-only
+ * windowed fast path in getSafeMarkdown stays deterministic.
+ */
+function createLatexSplitMathScanner(source: string) {
+  let inFence = false
+  let fenceMarker: '`' | '~' | '' = ''
+  let fenceLen = 0
+  let inDollarBlock = false
+  let inBracketMath = false
+  let singleDollarOpen = false
+  let scanned = 0
+
+  const processLine = (line: string, _lineStartOffset: number) => {
+    const fenceMatch = matchMarkdownFenceMarker(line)
+    if (fenceMatch) {
+      if (inFence) {
+        if (fenceMatch.markerChar === fenceMarker && fenceMatch.markerLen >= fenceLen && /^\s*$/.test(fenceMatch.rest)) {
+          inFence = false
+          fenceMarker = ''
+          fenceLen = 0
+        }
+      }
+      else {
+        inFence = true
+        fenceMarker = fenceMatch.markerChar
+        fenceLen = fenceMatch.markerLen
+      }
+      return
+    }
+
+    if (inFence)
+      return
+
+    let i = 0
+    while (i < line.length) {
+      if (inDollarBlock) {
+        if (line.startsWith('$$', i) && !isEscapedDelimiterAt(line, i)) {
+          inDollarBlock = false
+          i += 2
+        }
+        else {
+          i++
+        }
+        continue
+      }
+
+      if (inBracketMath) {
+        if (line.startsWith('\\]', i) && !isEscapedDelimiterAt(line, i)) {
+          inBracketMath = false
+          i += 2
+        }
+        else {
+          i++
+        }
+        continue
+      }
+
+      const ch = line[i]
+      if (ch === '`') {
+        const runLen = countRepeatedChar(line, i, '`')
+        const closeIndex = findCodeSpanCloseIndex(line, i + runLen, runLen)
+        if (closeIndex === -1)
+          break // unclosed span: the rest of the line is code
+        i = closeIndex + runLen
+        continue
+      }
+
+      if (ch === '\\') {
+        const next = line[i + 1]
+        if (next === '[' && !isEscapedDelimiterAt(line, i)) {
+          inBracketMath = true
+          i += 2
+        }
+        else if (next === ']' && !isEscapedDelimiterAt(line, i) && !inBracketMath) {
+          i += 2
+        }
+        else {
+          i += 2 // escaped char (\$, \`, \\, ...)
+        }
+        continue
+      }
+
+      if (ch === '$') {
+        if (line[i + 1] === '$' && !isEscapedDelimiterAt(line, i)) {
+          inDollarBlock = true
+          singleDollarOpen = false
+          i += 2
+          continue
+        }
+        if (singleDollarOpen) {
+          singleDollarOpen = false
+          i++
+          continue
+        }
+        // Opener when followed by non-whitespace, or at end of line (a split
+        // can land right after the opener). A $ followed by a digit is
+        // currency in prose ("$5 total") and must not open math.
+        const after = line[i + 1]
+        if (after === undefined || ((after !== ' ' && after !== '\t') && !/\d/.test(after)))
+          singleDollarOpen = true
+        i++
+        continue
+      }
+
+      i++
+    }
+  }
+
+  const scanTo = (target: number) => {
+    while (scanned < target) {
+      const newlineIndex = source.indexOf('\n', scanned)
+      const lineEndRaw = newlineIndex === -1 || newlineIndex >= target ? target : newlineIndex
+      const lineEnd = lineEndRaw > scanned && source[lineEndRaw - 1] === '\r' ? lineEndRaw - 1 : lineEndRaw
+      const line = source.slice(scanned, lineEnd)
+      processLine(line, scanned)
+      if (newlineIndex === -1 || newlineIndex >= target) {
+        scanned = target
+        break
+      }
+      singleDollarOpen = false // single-$ math never spans a line
+      scanned = newlineIndex + 1
+    }
+  }
+
+  return {
+    scanTo,
+    inMath: () => inDollarBlock || inBracketMath || singleDollarOpen,
+  }
+}
+
 function transformStreamingSafeMarkdown(
   source: string,
   isFinal: boolean,
   md: MarkdownIt,
   options: ParseOptions,
 ) {
-  let safeMarkdown = source.replace(/([^\\])\r(ight|ho)/g, '$1\\r$2').replace(/([^\\])\r?\n(abla|eq|ot|exists)/g, '$1\\n$2')
+  // Reconstruct transport-split LaTeX commands ONLY inside open math contexts
+  // ($...$ / $$...$$ / \[...\]). The previous version rewrote every soft line
+  // break followed by `abla|eq|ot|exists`, which corrupted ordinary prose
+  // ("First.\nother things" gained a literal backslash-n and merged
+  // paragraphs). A bare CR (the \rho/\right split) cannot occur in prose, so
+  // that reconstruction stays ungated.
+  let safeMarkdown = source.replace(/([^\\])\r(ight|ho)/g, '$1\\r$2')
+  const latexSplitMathScanner = createLatexSplitMathScanner(safeMarkdown)
+  safeMarkdown = safeMarkdown.replace(/([^\\])\r?\n(abla|eq|ot|exists)/g, (full, before, cmd, offset) => {
+    // Consume up to (not including) the newline at offset+1: the $ that opens
+    // math may sit anywhere on this line, including as its last char.
+    latexSplitMathScanner.scanTo(offset + 1)
+    const shouldReconstruct = latexSplitMathScanner.inMath()
+    // Consume the newline itself: single-$ math is line-scoped and resets.
+    latexSplitMathScanner.scanTo(offset + full.length)
+    return shouldReconstruct ? `${before}\\n${cmd}` : full
+  })
 
   if (!isFinal) {
     if (safeMarkdown.endsWith('- *')) {

--- a/packages/markdown-parser/test/fence-streamcontent-regression.test.ts
+++ b/packages/markdown-parser/test/fence-streamcontent-regression.test.ts
@@ -140,3 +140,43 @@ describe('parseMarkdownToStructure - fence regression', () => {
     expect(JSON.stringify(nodes)).toContain('Hello')
   })
 })
+
+describe('parseMarkdownToStructure - list fence html tail (streaming)', () => {
+  it('keeps incomplete html content monotonic inside a list-nested fence', () => {
+    // Regression: the inner fence scanner in stripDanglingHtmlLikeTail used
+    // to miss list-item-prefixed fences, so an incomplete `<div` tail inside
+    // `- ```html` was truncated from the code content on every non-final
+    // commit (content flashed '' while typing `<d`). The streamed prefixes
+    // must match a cold parse of the same prefix at every step.
+    const md = getMarkdown('fence-list-html-tail')
+    const src = '- ```html\n  <div\n  ```\n'
+    for (let end = 1; end <= src.length; end++) {
+      const prefix = src.slice(0, end)
+      const streamed = parseMarkdownToStructure(prefix, md, {
+        final: false,
+        streamParse: true,
+        __reuseStableTopLevelNodes: true,
+      }) as any[]
+      const cold = parseMarkdownToStructure(prefix, getMarkdown(`fence-list-html-tail-cold-${end}`), {
+        final: false,
+        streamParse: false,
+      }) as any[]
+      const codeOf = (nodes: any[]) => {
+        const out: string[] = []
+        const walk = (ns: any[]) => {
+          for (const n of ns) {
+            if (n?.type === 'code_block')
+              out.push(String(n.code ?? ''))
+            for (const key of ['children', 'items']) {
+              if (Array.isArray(n?.[key]))
+                walk(n[key])
+            }
+          }
+        }
+        walk(nodes)
+        return out.join('|')
+      }
+      expect(codeOf(streamed), `streamed != cold at prefix ${end}: '${codeOf(streamed)}' vs '${codeOf(cold)}'`).toBe(codeOf(cold))
+    }
+  })
+})

--- a/packages/markdown-parser/test/node-source-map.test.ts
+++ b/packages/markdown-parser/test/node-source-map.test.ts
@@ -309,7 +309,7 @@ describe('node source map metadata', () => {
   })
 
   it('maps source ranges across math newline preprocessing that collapses lines', () => {
-    const nodes = parseMarkdownToStructure('x\nabla', getMarkdown('source-map-math-collapse'), {
+    const nodes = parseMarkdownToStructure('x $\nabla$', getMarkdown('source-map-math-collapse'), {
       final: true,
       includeSourceMap: true,
       streamParse: false,
@@ -319,7 +319,7 @@ describe('node source map metadata', () => {
   })
 
   it('maps source ranges across CRLF math newline preprocessing', () => {
-    const nodes = parseMarkdownToStructure('x\r\nabla', getMarkdown('source-map-math-crlf'), {
+    const nodes = parseMarkdownToStructure('x $\r\nabla$', getMarkdown('source-map-math-crlf'), {
       final: true,
       includeSourceMap: true,
       streamParse: false,
@@ -329,13 +329,32 @@ describe('node source map metadata', () => {
   })
 
   it('keeps CRLF math newline preprocessing on the default path without source maps', () => {
-    const nodes = parseMarkdownToStructure('x\r\nabla', getMarkdown('source-map-math-crlf-default'), {
+    const nodes = parseMarkdownToStructure('x $\r\nabla$', getMarkdown('source-map-math-crlf-default'), {
       final: true,
       streamParse: false,
     }) as any[]
 
-    expect(nodes[0]?.raw).toBe('x\\nabla')
+    expect(nodes[0]?.raw).toBe('x $\\nabla$')
     expect(nodes[0]?.sourceMap).toBeUndefined()
+  })
+
+  it('does not rewrite prose line breaks before other/equal/exists', () => {
+    const nodes = parseMarkdownToStructure('First.\nother things and\nequal parts below', getMarkdown('prose-softbreak-regression'), {
+      final: true,
+      streamParse: false,
+    }) as any[]
+
+    expect(nodes[0]?.raw).toBe('First.\nother things and\nequal parts below')
+    expect(nodes.length).toBe(1)
+  })
+
+  it('reconstructs split LaTeX commands inside single-$ math', () => {
+    const nodes = parseMarkdownToStructure('use $\nabla f$ here', getMarkdown('math-split-reconstruct'), {
+      final: true,
+      streamParse: false,
+    }) as any[]
+
+    expect(nodes[0]?.raw).toBe('use $\\nabla f$ here')
   })
 
   it('attaches source maps when root-level inline tokens expand to html blocks', () => {


### PR DESCRIPTION
Fixes #620

## 问题

`packages/markdown-parser/src/parser/index.ts` 里两个流式解析缺陷：

1. `transformStreamingSafeMarkdown` 在任何软换行后都会尝试重建被拆断的 LaTeX 命令（`\nabla`、`\neq`、`\not`、`\nexists`、`\rho`、`\right`），没检查是否处于数学上下文，导致普通段落里以 `other`/`equal`/`equation`/`exists`/`otto` 等开头的行被误判为断开的 LaTeX 命令，注入字面反斜杠 `n` 并把两段落错误合并。
2. `stripDanglingHtmlLikeTail` 的围栏内部扫描只认直接围栏和 blockquote 前缀围栏，没处理列表项内的围栏，导致列表项内嵌套代码块的不完整 HTML 尾部在流式中间态被整段截断。

复现细节和真实渲染截图见 #620。

## 修复

- 新增数学上下文扫描器（`$...$` / `$$...$$` / `\[...\]`，排除代码围栏/行内反引号；单 `$` 按 markdown-it-math 规则限定同一行，行末 `$` 视为开启符，`$` 后紧跟数字视为货币符号），LaTeX 命令重构只在确认处于数学上下文时触发；扫描器是已消费文本的纯函数，增量窗口快路径保持确定性不受影响。裸 CR 分支（`\rho`/`\right`）不会出现在普通段落里，未加门控。
- `stripDanglingHtmlLikeTail` 的内部围栏扫描委托给 `isInsideOpenMarkdownFenceBeforeOffset`，正确处理列表/blockquote 前缀及其围栏退出条件。

## 测试

- 缺陷 1：14 个单词场景（软换行 + 空行两种形式）全部验证干净；数学场景下 LaTeX 命令仍正确重建；两个既有的 source-map 快照测试改为数学上下文输入，并新增 2 个回归测试（普通段落不受影响 / 数学场景正确重建）。
- 缺陷 2：新增 `fence-streamcontent-regression.test.ts`，验证列表内嵌套 fence 的 HTML 尾部流式单调增长（`<` → `<d` → `<div`），且流式结果与一次性传入完整内容的结果一致。
- 全部现有测试通过：`472 passed (472)`。

## 复现 & 修复前后对比

Issue #620 里附了真实渲染截图（Puppeteer + 真实 Chromium，截图前用 `page.evaluate` 读取 DOM 内容做了断言）：

![缺陷1 修复前](https://cdn.vectojs.org/upstream-bugs/ms-m2-prose-before.png)
![缺陷1 修复后](https://cdn.vectojs.org/upstream-bugs/ms-m2-prose-after.png)
![缺陷2 修复前](https://cdn.vectojs.org/upstream-bugs/ms-m3-listfence-before.png)
![缺陷2 修复后](https://cdn.vectojs.org/upstream-bugs/ms-m3-listfence-after.png)
