### PR TITLE
fix: preserve user selection across streaming delta settles (Vue + React)

### DIFF
--- a/packages/markstream-react/src/components/TextNode/TextNode.tsx
+++ b/packages/markstream-react/src/components/TextNode/TextNode.tsx
@@ -9,6 +9,12 @@ interface StreamSegment {
   fading: boolean
 }
 
+// Settling merges the delta into the previous (settled) segment — the merge
+// keeps the previous segment's id so its span element is reused — but the
+// merged content must reach the DOM through SettledSegmentContent, which
+// appends new text nodes instead of mutating the existing one. Browsers
+// collapse a Selection anchored inside a text node as soon as that node is
+// mutated or replaced (verified in Chromium).
 function settleAndMergeSegments(segments: StreamSegment[], segmentId?: number) {
   return segments.reduce<StreamSegment[]>((result, segment) => {
     const nextSegment = segmentId == null || segment.id === segmentId
@@ -26,6 +32,36 @@ function settleAndMergeSegments(segments: StreamSegment[], segmentId?: number) {
     }
     return result
   }, [])
+}
+
+/**
+ * Renders a settled segment's content without ever mutating an existing text
+ * node: the initial content is rendered by JSX (SSR-safe), and every growth
+ * is appended as a NEW sibling text node. A non-prefix replacement rebuilds
+ * the node (the old content is gone anyway).
+ */
+function SettledSegmentContent({ content }: { content: string }) {
+  const initialRef = useRef(content)
+  const renderedRef = useRef(initialRef.current)
+  const spanRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    const el = spanRef.current
+    if (!el)
+      return
+    if (content.startsWith(renderedRef.current)) {
+      const increment = content.slice(renderedRef.current.length)
+      if (increment)
+        el.appendChild(document.createTextNode(increment))
+      renderedRef.current = content
+    }
+    else {
+      el.textContent = content
+      renderedRef.current = content
+    }
+  }, [content])
+
+  return <span ref={spanRef}>{initialRef.current}</span>
 }
 
 export function TextNode(props: NodeComponentProps<{ type: 'text', content: string, center?: boolean }>) {
@@ -71,11 +107,24 @@ export function TextNode(props: NodeComponentProps<{ type: 'text', content: stri
     }
 
     if (!fadeEnabled) {
-      setSegments(current => current.length === 1 && !current[0]?.fading && current[0].content === content
-        ? current
-        : content
-          ? [{ id: nextSegmentIdRef.current++, content, fading: false }]
-          : [])
+      // Append-only growth: every content change creates a NEW immutable
+      // segment. Replacing or mutating the existing segment's span would
+      // collapse a user Selection anchored inside its text node.
+      setSegments((current) => {
+        if (!content)
+          return []
+        const rendered = current.reduce((acc, segment) => acc + segment.content, '')
+        if (content === rendered)
+          return current
+        if (content.startsWith(rendered)) {
+          return [
+            ...current,
+            { id: nextSegmentIdRef.current++, content: content.slice(rendered.length), fading: false },
+          ]
+        }
+        // Non-prefix replacement: the old content is gone anyway.
+        return [{ id: nextSegmentIdRef.current++, content, fading: false }]
+      })
     }
     else if (content !== previousContent) {
       if (previousContent && content.startsWith(previousContent)) {
@@ -157,7 +206,9 @@ export function TextNode(props: NodeComponentProps<{ type: 'text', content: stri
             : undefined}
           onAnimationEnd={segment.fading ? () => settleSegment(segment.id) : undefined}
         >
-          {segment.content}
+          {segment.fading
+            ? segment.content
+            : <SettledSegmentContent content={segment.content} />}
         </span>
       ))}
     </span>

--- a/src/components/TextNode/TextNode.vue
+++ b/src/components/TextNode/TextNode.vue
@@ -39,7 +39,65 @@ const streamStateKey = computed(() => {
 const settledContent = ref(props.node.content)
 const streamedDelta = ref('')
 const streamFadeVersion = ref(0)
+// Template-bound value: rendered by SSR and never changed on the client, so
+// Vue never patches this text node after mount (patching would mutate it and
+// collapse a selection). All client updates flow through syncSettledText.
+const frozenTemplateContent = ref(props.node.content)
 let stopStreamVersionWatch: (() => void) | undefined
+
+// Selection-safe settled-text rendering. Browsers collapse a Selection
+// anchored inside a text node as soon as that node is mutated (nodeValue/
+// data) OR replaced (verified in Chromium). The settle path used to merge
+// the delta into the settled text, which re-rendered it with a NEW Text
+// node — the streaming-selection bug (same class as VectoJS KNOWN_ISSUES:110).
+// The settled node is therefore written ONCE and never touched again: each
+// delta settle appends the increment as a NEW sibling text node, so existing
+// nodes keep their identity and content forever.
+const settledTextEl = ref<HTMLElement | null>(null)
+const settledAppendsEl = ref<HTMLElement | null>(null)
+let frozenSettledText = ''
+let settledTextNode: Text | null = null
+function syncSettledText() {
+  const el = settledTextEl.value
+  if (!el)
+    return
+  const text = String(settledContent.value ?? '')
+  const appendsEl = settledAppendsEl.value
+
+  if (!settledTextNode) {
+    // Adopt the existing text node (including one rendered by SSR) instead
+    // of rewriting it.
+    settledTextNode = el.firstChild as Text | null
+    frozenSettledText = settledTextNode?.data ?? ''
+  }
+
+  if (!text.startsWith(frozenSettledText)) {
+    // Non-prefix replacement (message changed): rebuild everything. Any
+    // selection anchored in the old content is gone with the content itself.
+    el.textContent = text
+    settledTextNode = el.firstChild as Text | null
+    if (appendsEl)
+      appendsEl.textContent = ''
+    frozenSettledText = text
+    return
+  }
+
+  if (!settledTextNode && text) {
+    // First content write — this node is now frozen forever.
+    el.textContent = text
+    settledTextNode = el.firstChild as Text | null
+    frozenSettledText = text
+    return
+  }
+
+  if (text.length > frozenSettledText.length && appendsEl) {
+    // Growth: never touch the frozen node — append a new sibling text node.
+    appendsEl.appendChild(document.createTextNode(text.slice(frozenSettledText.length)))
+    frozenSettledText = text
+  }
+}
+
+watch([settledContent, settledTextEl, settledAppendsEl], syncSettledText, { immediate: true })
 
 function getRenderedContent() {
   return settledContent.value + streamedDelta.value
@@ -115,7 +173,14 @@ const streamedDeltaClass = computed(() => (
     :class="[node.center ? 'text-node-center' : '']"
     class="text-node"
   >
-    <span v-if="settledContent">{{ settledContent }}</span>
+    <span
+      v-show="settledContent !== ''"
+      ref="settledTextEl"
+    >{{ frozenTemplateContent }}</span>
+    <span
+      v-show="settledContent !== ''"
+      ref="settledAppendsEl"
+    />
     <span
       v-if="streamedDelta"
       class="text-node-stream-delta" :class="[streamedDeltaClass]"

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -24,7 +24,7 @@ exports[`markdownRender node e2e coverage > renders admonition node 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="admonition-stable-renderer-0-0-0"><span data-v-a84b8095="">Admonition content</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="admonition-stable-renderer-0-0-0"><span data-v-a84b8095="">Admonition content</span><span data-v-a84b8095=""></span>
                       <!--v-if--></span>
                     </p>
                   </transition-stub>
@@ -51,7 +51,7 @@ exports[`markdownRender node e2e coverage > renders blockquote node 1`] = `
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <blockquote data-v-8ae59609="" data-v-8dfe8a80="" class="blockquote blockquote-node" dir="auto" is-dark="false">
-          <p data-v-8ae59609="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="blockquote-markdown-renderer-0-paragraph-0"><span data-v-a84b8095="">Blockquote rendered content.</span>
+          <p data-v-8ae59609="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="blockquote-markdown-renderer-0-paragraph-0"><span data-v-a84b8095="">Blockquote rendered content.</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
           </p>
         </blockquote>
@@ -79,7 +79,7 @@ exports[`markdownRender node e2e coverage > renders checkbox nodes 1`] = `
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
                     <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-31e4c290="" data-v-93ee5c2d="" class="checkbox-node" role="img" aria-label="checked" index-key="list-item-markdown-renderer-0-0-0-0"><!-- Unchecked --><!-- Checked --><svg data-v-31e4c290="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" class="checkbox-icon checkbox-checked"><rect data-v-31e4c290="" x="3" y="3" width="18" height="18" rx="4" fill="currentColor"></rect><path data-v-31e4c290="" d="M9 12l2 2 4-4" stroke="hsl(var(--ms-background))" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>
-                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-0-0-2"><span data-v-a84b8095=""> Completed task</span>
+                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-0-0-2"><span data-v-a84b8095=""> Completed task</span><span data-v-a84b8095=""></span>
                       <!--v-if--></span>
                       <!---->
                     </p>
@@ -98,7 +98,7 @@ exports[`markdownRender node e2e coverage > renders checkbox nodes 1`] = `
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
                     <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-31e4c290="" data-v-93ee5c2d="" class="checkbox-node" role="img" aria-label="unchecked" index-key="list-item-markdown-renderer-0-1-0-0"><!-- Unchecked --><svg data-v-31e4c290="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" class="checkbox-icon checkbox-unchecked"><rect data-v-31e4c290="" x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="2"></rect></svg></span>
-                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-1-0-2"><span data-v-a84b8095=""> Pending task</span>
+                      <!----><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="list-item-markdown-renderer-0-1-0-2"><span data-v-a84b8095=""> Pending task</span><span data-v-a84b8095=""></span>
                       <!--v-if--></span>
                       <!---->
                     </p>
@@ -140,11 +140,11 @@ exports[`markdownRender node e2e coverage > renders complex inline code with emp
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><!--v-if--></span></strong><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span>
-              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><strong data-v-b1e65240="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0-0"><span data-v-a84b8095="">整合冗余条款：</span><span data-v-a84b8095=""></span><!--v-if--></span></strong><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-1"><span data-v-a84b8095=""> 将原</span><span data-v-a84b8095=""></span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-2"><span data-v-36040df8="">1-(5)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-3"><span data-v-a84b8095="">、</span><span data-v-a84b8095=""></span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-4"><span data-v-36040df8="">3-(3)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-5"><span data-v-a84b8095="">、</span><span data-v-a84b8095=""></span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-6"><span data-v-36040df8="">3-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-7"><span data-v-a84b8095="">中关于“缴纳费用”和“告知法律状态变化”的核心义务合并，统一放入</span><span data-v-a84b8095=""></span>
+              <!--v-if--></span><code data-v-36040df8="" class="inline-code" index-key="list-item-markdown-renderer-0-0-paragraph-8"><span data-v-36040df8="">1-(4)</span><!--v-if--></code><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-9"><span data-v-a84b8095="">“法律状态维护与通知义务”中，使其逻辑更集中，避免了在不同部分重复提及相似义务。</span><span data-v-a84b8095=""></span>
               <!--v-if--></span>
             </p>
           </li>
@@ -171,7 +171,7 @@ exports[`markdownRender node e2e coverage > renders definition list node 1`] = `
               <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="text">
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
-                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="text-node" index-key="definition-term-markdown-renderer-0-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Term</span>
+                  <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true"><span data-v-a84b8095="" data-v-8dfe8a80="" class="text-node" index-key="definition-term-markdown-renderer-0-0-0" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="">Term</span><span data-v-a84b8095=""></span>
                     <!--v-if--></span>
                   </transition-stub>
                 </div>
@@ -187,7 +187,7 @@ exports[`markdownRender node e2e coverage > renders definition list node 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="definition-desc-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Definition details</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="definition-desc-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Definition details</span><span data-v-a84b8095=""></span>
                       <!--v-if--></span>
                     </p>
                   </transition-stub>
@@ -213,8 +213,8 @@ exports[`markdownRender node e2e coverage > renders emoji node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Smile with </span>
-          <!--v-if--></span><span data-v-b001e831="" data-v-93ee5c2d="" class="emoji-node" index-key="markdown-renderer-0-1">😄</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> emoji.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Smile with </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-b001e831="" data-v-93ee5c2d="" class="emoji-node" index-key="markdown-renderer-0-1">😄</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> emoji.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -232,8 +232,8 @@ exports[`markdownRender node e2e coverage > renders emphasis node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><em data-v-ca49685e="" data-v-93ee5c2d="" class="emphasis-node"><span data-v-a84b8095="" data-v-ca49685e="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">italic text</span><!--v-if--></span></em><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><em data-v-ca49685e="" data-v-93ee5c2d="" class="emphasis-node"><span data-v-a84b8095="" data-v-ca49685e="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">italic text</span><span data-v-a84b8095=""></span><!--v-if--></span></em><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -251,8 +251,8 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">A footnote reference</span>
-          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">A footnote reference</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><sup data-v-ba0412bc="" data-v-93ee5c2d="" id="fnref-1" class="footnote-reference" index-key="markdown-renderer-0-1"><span data-v-ba0412bc="" href="#fnref--1" title="查看脚注 1" class="footnote-link cursor-pointer">[1]</span></sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -271,7 +271,7 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="footnote-markdown-renderer-1-0-0"><span data-v-a84b8095="">Footnote explanation</span>
+                    <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="footnote-markdown-renderer-1-0-0"><span data-v-a84b8095="">Footnote explanation</span><span data-v-a84b8095=""></span>
                       <!--v-if--></span><a data-v-31914872="" data-v-93ee5c2d="" class="footnote-anchor text-sm hover:underline cursor-pointer" href="#fnref-1" title="返回引用 1" index-key="footnote-markdown-renderer-1-0-1"> ↩︎ </a>
                     </p>
                   </transition-stub>
@@ -311,8 +311,8 @@ exports[`markdownRender node e2e coverage > renders hardbreak node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Line one</span>
-          <!--v-if--></span><br data-v-2587360c="" data-v-93ee5c2d="" class="hard-break" index-key="markdown-renderer-0-1"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">Line two</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Line one</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><br data-v-2587360c="" data-v-93ee5c2d="" class="hard-break" index-key="markdown-renderer-0-1"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">Line two</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -330,7 +330,7 @@ exports[`markdownRender node e2e coverage > renders heading node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <h1 data-v-9f883140="" data-v-8dfe8a80="" class="heading-node heading-1" dir="auto" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-9f883140="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Heading Node Title</span>
+        <h1 data-v-9f883140="" data-v-8dfe8a80="" class="heading-node heading-1" dir="auto" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-9f883140="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Heading Node Title</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </h1>
       </transition-stub>
@@ -348,10 +348,10 @@ exports[`markdownRender node e2e coverage > renders highlight node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Use </span>
-          <!--v-if--></span><mark data-v-9bc40b1b="" data-v-93ee5c2d="" class="highlight-node"><span data-v-a84b8095="" data-v-9bc40b1b="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">highlighted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Use </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><mark data-v-9bc40b1b="" data-v-93ee5c2d="" class="highlight-node"><span data-v-a84b8095="" data-v-9bc40b1b="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">highlighted text</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </mark><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for emphasis.</span>
+          </mark><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for emphasis.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -397,8 +397,8 @@ exports[`markdownRender node e2e coverage > renders inline code node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here is </span>
-          <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="markdown-renderer-0-1"><span data-v-36040df8="">const answer = 42</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> inline.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here is </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><code data-v-36040df8="" data-v-93ee5c2d="" class="inline-code" index-key="markdown-renderer-0-1"><span data-v-36040df8="">const answer = 42</span><!--v-if--></code><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> inline.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -416,10 +416,10 @@ exports[`markdownRender node e2e coverage > renders insert node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here comes </span>
-          <!--v-if--></span><ins data-v-1e673445="" data-v-93ee5c2d="" class="insert-node"><span data-v-a84b8095="" data-v-1e673445="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">inserted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Here comes </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><ins data-v-1e673445="" data-v-93ee5c2d="" class="insert-node"><span data-v-a84b8095="" data-v-1e673445="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">inserted text</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </ins><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> in the paragraph.</span>
+          </ins><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> in the paragraph.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -437,10 +437,10 @@ exports[`markdownRender node e2e coverage > renders link node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Visit </span>
-          <!--v-if--></span><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://vuejs.org" title="" aria-label="Link: https://vuejs.org" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-a84b8095="" data-v-994bfd08="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">Vue</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Visit </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://vuejs.org" title="" aria-label="Link: https://vuejs.org" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-a84b8095="" data-v-994bfd08="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">Vue</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </a><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> now.</span>
+          </a><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> now.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -458,9 +458,9 @@ exports[`markdownRender node e2e coverage > renders math inline node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Einstein wrote </span>
-          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-1"><span data-v-a84b8095="">$E=mc^2$</span>
-          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Einstein wrote </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-1"><span data-v-a84b8095="">$E=mc^2$</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -480,12 +480,12 @@ exports[`markdownRender node e2e coverage > renders ordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ol data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-decimal">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="1">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">First entry</span><span data-v-a84b8095=""></span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto" value="2">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Second entry</span><span data-v-a84b8095=""></span>
               <!--v-if--></span>
             </p>
           </li>
@@ -505,7 +505,7 @@ exports[`markdownRender node e2e coverage > renders paragraph and text node 1`] 
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Simple paragraph content rendered as plain text.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Simple paragraph content rendered as plain text.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -523,8 +523,8 @@ exports[`markdownRender node e2e coverage > renders reference node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span>
-          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -556,10 +556,10 @@ exports[`markdownRender node e2e coverage > renders strikethrough node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><del data-v-d7c2e36d="" data-v-93ee5c2d="" class="strikethrough-node"><span data-v-a84b8095="" data-v-d7c2e36d="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">deleted text</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><del data-v-d7c2e36d="" data-v-93ee5c2d="" class="strikethrough-node"><span data-v-a84b8095="" data-v-d7c2e36d="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">deleted text</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </del><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+          </del><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -577,8 +577,8 @@ exports[`markdownRender node e2e coverage > renders strong node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span>
-          <!--v-if--></span><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">bold text</span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">This is </span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><strong data-v-b1e65240="" data-v-93ee5c2d="" class="strong-node"><span data-v-a84b8095="" data-v-b1e65240="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">bold text</span><span data-v-a84b8095=""></span><!--v-if--></span></strong><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -596,10 +596,10 @@ exports[`markdownRender node e2e coverage > renders subscript node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Chemical formula H</span>
-          <!--v-if--></span><sub data-v-40ad1ac6="" data-v-93ee5c2d="" class="subscript-node"><span data-v-a84b8095="" data-v-40ad1ac6="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Chemical formula H</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><sub data-v-40ad1ac6="" data-v-93ee5c2d="" class="subscript-node"><span data-v-a84b8095="" data-v-40ad1ac6="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </sub><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">O is familiar.</span>
+          </sub><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095="">O is familiar.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -617,10 +617,10 @@ exports[`markdownRender node e2e coverage > renders superscript node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Math uses x</span>
-          <!--v-if--></span><sup data-v-9c4a3c09="" data-v-93ee5c2d="" class="superscript-node"><span data-v-a84b8095="" data-v-9c4a3c09="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Math uses x</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><sup data-v-9c4a3c09="" data-v-93ee5c2d="" class="superscript-node"><span data-v-a84b8095="" data-v-9c4a3c09="" class="text-node" index-key="markdown-renderer-0-1-0"><span data-v-a84b8095="">2</span><span data-v-a84b8095=""></span>
             <!--v-if--></span>
-          </sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> frequently.</span>
+          </sup><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> frequently.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -643,10 +643,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             <!--v-if-->
             <thead data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-0-0"><span data-v-a84b8095="">Name</span><span data-v-a84b8095=""></span>
                   <!--v-if--></span><button data-v-8fb37ab3="" type="button" class="table-node__resize-handle" aria-label="Resize columns 1 and 2"></button>
                 </th>
-                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span>
+                <th data-v-8fb37ab3="" dir="auto" class="text-left"><span data-v-a84b8095="" class="text-node" index-key="table-th-markdown-renderer-0-1-0"><span data-v-a84b8095="">Role</span><span data-v-a84b8095=""></span>
                   <!--v-if--></span>
                   <!--v-if-->
                 </th>
@@ -654,10 +654,10 @@ exports[`markdownRender node e2e coverage > renders table node 1`] = `
             </thead>
             <tbody data-v-8fb37ab3="">
               <tr data-v-8fb37ab3="">
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-0-0"><span data-v-a84b8095="">Alice</span><span data-v-a84b8095=""></span>
                   <!--v-if--></span>
                 </td>
-                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span>
+                <td data-v-8fb37ab3="" class="text-left" dir="auto"><span data-v-a84b8095="" class="text-node" index-key="table-td-markdown-renderer-0-0-1-0"><span data-v-a84b8095="">Developer</span><span data-v-a84b8095=""></span>
                   <!--v-if--></span>
                 </td>
               </tr>
@@ -682,7 +682,7 @@ exports[`markdownRender node e2e coverage > renders thematic break node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">First section.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">First section.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -700,7 +700,7 @@ exports[`markdownRender node e2e coverage > renders thematic break node 1`] = `
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching Monaco editor internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-2-0"><span data-v-a84b8095="">Second section.</span>
+        <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-2-0"><span data-v-a84b8095="">Second section.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>
@@ -720,12 +720,12 @@ exports[`markdownRender node e2e coverage > renders unordered list node 1`] = `
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <ul data-v-b195669a="" data-v-8dfe8a80="" class="list-node list-disc">
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-0-paragraph-0"><span data-v-a84b8095="">Item one</span><span data-v-a84b8095=""></span>
               <!--v-if--></span>
             </p>
           </li>
           <li data-v-d94d2511="" data-v-b195669a="" class="list-item" dir="auto">
-            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span>
+            <p data-v-d94d2511="" dir="auto" class="paragraph-node"><span data-v-a84b8095="" class="text-node" index-key="list-item-markdown-renderer-0-1-paragraph-0"><span data-v-a84b8095="">Item two</span><span data-v-a84b8095=""></span>
               <!--v-if--></span>
             </p>
           </li>

--- a/test/text-node-selection.test.ts
+++ b/test/text-node-selection.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import NodeRenderer from '../src/components/NodeRenderer'
+import { flushAll } from './setup/flush-all'
+
+describe('text node streaming selection', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function mountRenderer(content: string) {
+    return mount(NodeRenderer, {
+      props: {
+        content,
+        typewriter: true,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        parseCoalesceMs: 0,
+      },
+      attachTo: document.body,
+    })
+  }
+
+  function selectText(node: Text, start: number, end: number) {
+    const sel = document.getSelection()
+    const range = document.createRange()
+    range.setStart(node, start)
+    range.setEnd(node, end)
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+    return sel?.toString() ?? ''
+  }
+
+  it('keeps the settled text node identity and a selection across streaming settles', async () => {
+    const first = 'The quick brown fox jumps over the lazy dog.'
+    const content = `${first} And then some more words to stream in later. And even more trailing text arrives after that.`
+
+    const wrapper = mountRenderer('')
+    try {
+      await wrapper.setProps({ content: first })
+      await flushAll()
+
+      const settledSpan = wrapper.find('.text-node > span:first-child')
+      const textNodeBefore = settledSpan.element.firstChild as Text
+      expect(textNodeBefore.nodeType).toBe(Node.TEXT_NODE)
+      expect(textNodeBefore.textContent).toBe(first)
+
+      const selectedBefore = selectText(textNodeBefore, 4, 15)
+      expect(selectedBefore).toBe('quick brown')
+
+      // Streaming append: the settled node must not be replaced.
+      await wrapper.setProps({ content: `${first} And then some more words to stream in later.` })
+      await flushAll()
+      const textNodeAfter = wrapper.find('.text-node > span:first-child').element.firstChild as Text | null
+      expect(textNodeAfter, 'settled text node identity preserved across streaming append').toBe(textNodeBefore)
+      expect(document.getSelection()?.toString() ?? '', 'selection survives the streaming append').toBe(selectedBefore)
+
+      // Settle: the delta merges into the settled content — again without
+      // replacing or mutating the settled text node.
+      await wrapper.setProps({ content })
+      await flushAll()
+      const textNodeFinal = wrapper.find('.text-node > span:first-child').element.firstChild as Text | null
+      expect(textNodeFinal, 'settled text node identity preserved across settle').toBe(textNodeBefore)
+      expect(textNodeBefore.textContent).toBe(first)
+      expect(document.getSelection()?.toString() ?? '', 'selection survives the settle').toBe(selectedBefore)
+
+      // The full content must still render (settled + appended increments).
+      const outer = wrapper.find('.text-node')
+      expect(outer.element.textContent ?? '').toBe(content)
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps a selection across appends when typewriter is off', async () => {
+    const first = 'The quick brown fox jumps over the lazy dog.'
+    const second = `${first} And then some more words to stream in later.`
+
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: first,
+        typewriter: false,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        parseCoalesceMs: 0,
+      },
+      attachTo: document.body,
+    })
+    try {
+      await flushAll()
+      const settledSpan = wrapper.find('.text-node > span:first-child')
+      const textNodeBefore = settledSpan.element.firstChild as Text
+      const selectedBefore = selectText(textNodeBefore, 4, 15)
+      expect(selectedBefore).toBe('quick brown')
+
+      await wrapper.setProps({ content: second })
+      await flushAll()
+      const textNodeAfter = wrapper.find('.text-node > span:first-child').element.firstChild as Text | null
+      expect(textNodeAfter, 'settled text node identity preserved (typewriter off)').toBe(textNodeBefore)
+      expect(document.getSelection()?.toString() ?? '', 'selection survives (typewriter off)').toBe(selectedBefore)
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+})


### PR DESCRIPTION
Fixes #622

## 问题

每次流式 delta settle（增量内容从"临时展示"合并进"已确定"文本）都会修改或替换已经落地的 settled 文本节点：Vue 侧重写同一个文本节点，React 侧重新渲染整个 segment 的 span。浏览器的规则是——文本节点一旦被修改内容（`nodeValue`/`data`）或被替换，锚定其中的 `Selection` 就会被折叠成空；只有向 DOM 追加新的兄弟文本节点才不会影响已有选区（已在真实 Chromium 验证）。结果是用户在流式输出过程中选中已显示内容后，每次下一个 delta settle 都会无声清空选区。

复现细节和真实渲染截图（含像素级复核）见 #622。

## 修复

- **Vue**（`TextNode.vue`）：settled 内容改为模板绑定的一次性写入（SSR 安全），写入后永不再改动；每次 settle 把增量作为新文本节点追加进一个兄弟容器 span。非前缀的内容替换（旧内容整段作废）仍会重建节点，因为这种情况下旧内容本就没有保留价值。
- **React**（`TextNode.tsx`）：settle 仍遵循仓库原有的 DOM 约定（每个 settled segment 一个 span，id 稳定），但改为通过新组件 `SettledSegmentContent` 落地——初始内容走 JSX 渲染（SSR 安全），后续增量以追加新文本节点的方式接入；fade-off 路径不再在每次内容变化时重建 segment 的 span。

## 测试

新增 `test/text-node-selection.test.ts`（jsdom + `@vue/test-utils`），断言：
- 文本节点身份在追加和 settle 前后保持不变；
- 选区在追加和 settle 前后都存活（两种 typewriter 模式）。

仓库自身相关测试全部通过：`text-node-streaming-consistency`（12/12）、`react-text-node-streaming-fade`（8/8）、`ssr-render-to-string`（26/26）；e2e 快照更新以反映新增的（空）追加容器 span。相关套件合计 `27 passed (27)`。

## 复现 & 修复前后对比

Issue #622 里附了真实渲染截图（Puppeteer + 真实 Chromium，先用 `window.getSelection()` 断言选区状态，再对截图做了像素级颜色直方图复核确认高亮真实可见）：

![修复前：settle 后选区消失](https://cdn.vectojs.org/upstream-bugs/ms-d1-selection-before.png)
![修复后：settle 后选区保留](https://cdn.vectojs.org/upstream-bugs/ms-d1-selection-after.png)
