### PR TITLE
fix(release): isolate maintenance dist-tags

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release-stable
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -86,7 +86,6 @@ jobs:
         env:
           PACKAGE_NAME: ${{ steps.meta.outputs.pkg }}
           PACKAGE_VERSION: ${{ steps.meta.outputs.version }}
-          DIST_TAG: ${{ steps.meta.outputs.prerelease == 'true' && 'next' || 'latest' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -108,6 +107,7 @@ jobs:
             exit 0
           fi
 
+          DIST_TAG="$(node scripts/resolve-dist-tag.mjs "${PACKAGE_NAME}" "${PACKAGE_VERSION}")"
           TARBALL="${RUNNER_TEMP}/${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
           pnpm --dir "${PACKAGE_DIR}" pack --pack-destination "${RUNNER_TEMP}"
           npm publish "${TARBALL}" --access public --tag "${DIST_TAG}"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -13,6 +13,7 @@ permissions:
 
 concurrency:
   group: release-stable
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "build:demo": "vite build",
     "build:view": "vite preview",
     "changelog": "conventional-changelog -p angular --tag-prefix markstream-vue@ -i CHANGELOG.md -s -r 1",
-    "release": "bumpp --all --commit --no-tag --no-push --execute 'pnpm run docs:llms:generate && conventional-changelog -p angular --tag-prefix markstream-vue@ -i CHANGELOG.md -s -r 1' && pnpm run check:workspace-deps-published && pnpm publish $(node scripts/dist-tag.mjs) && node scripts/tag-package.mjs --package-json package.json --push",
+    "release": "bumpp --all --commit --no-tag --no-push --execute 'pnpm run docs:llms:generate && conventional-changelog -p angular --tag-prefix markstream-vue@ -i CHANGELOG.md -s -r 1' && pnpm run check:workspace-deps-published && DIST_TAG=\"$(node scripts/dist-tag.mjs)\" && pnpm publish --tag \"${DIST_TAG}\" && node scripts/tag-package.mjs --package-json package.json --push",
     "release:angular": "pnpm run -C packages/markstream-angular release",
     "release:octane": "pnpm run -C packages/markstream-octane release",
     "release:react": "pnpm run -C packages/markstream-react release",

--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
     "rollup": "^3.30.0",
     "rollup-plugin-dts": "^5.3.1",
     "rollup-plugin-visualizer": "^6.0.11",
+    "semver": "^7.8.5",
     "stream-diffs": "latest",
     "stream-markdown": "latest",
     "streamdown": "2.5.0",

--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --cache --fix",
     "prepublishOnly": "pnpm run build",
-    "release": "bumpp --commit --no-tag --no-push && npm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "bumpp --commit --no-tag --no-push && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && npm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "dependencies": {
     "markdown-it-container": "^4.0.0",

--- a/packages/markstream-angular/package.json
+++ b/packages/markstream-angular/package.json
@@ -74,7 +74,7 @@
     "prepublishOnly": "pnpm run build && pnpm run check:workspace-deps-published",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",
-    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && pnpm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && pnpm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "peerDependencies": {
     "@angular/common": ">=20",

--- a/packages/markstream-core/package.json
+++ b/packages/markstream-core/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --cache --fix",
     "prepublishOnly": "pnpm run build",
-    "release": "bumpp --commit --no-tag --no-push && npm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "bumpp --commit --no-tag --no-push && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && npm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "devDependencies": {
     "tsdown": "^0.15.12",

--- a/packages/markstream-octane/package.json
+++ b/packages/markstream-octane/package.json
@@ -92,7 +92,7 @@
     "size:check": "node ../../scripts/check-package-size.mjs",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",
-    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && pnpm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && pnpm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "peerDependencies": {
     "@antv/infographic": "^0.2.3",

--- a/packages/markstream-react/package.json
+++ b/packages/markstream-react/package.json
@@ -92,7 +92,7 @@
     "size:check": "node ../../scripts/check-package-size.mjs",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",
-    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && pnpm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && pnpm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "peerDependencies": {
     "@antv/infographic": "^0.2.3",

--- a/packages/markstream-svelte/package.json
+++ b/packages/markstream-svelte/package.json
@@ -81,7 +81,7 @@
     "prepublishOnly": "pnpm run build && pnpm run check:workspace-deps-published",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",
-    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && pnpm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && pnpm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "peerDependencies": {
     "@antv/infographic": "^0.2.3",

--- a/packages/markstream-vue2/package.json
+++ b/packages/markstream-vue2/package.json
@@ -107,7 +107,7 @@
     "size:check": "MAX_PACK_UNPACKED_BYTES=800000 node ../../scripts/check-package-size.mjs",
     "check:core-published": "node ../../scripts/check-core-published.mjs --package-json package.json --core-package-json ../markstream-core/package.json",
     "check:workspace-deps-published": "node ../../scripts/check-workspace-deps-published.mjs --package-json package.json",
-    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && pnpm publish --access public $(node ../../scripts/dist-tag.mjs) && node ../../scripts/tag-package.mjs --package-json package.json --push"
+    "release": "pnpm run check:workspace-deps-published && bumpp --all --commit --no-tag --no-push --execute 'pnpm --workspace-root run docs:llms:generate' && DIST_TAG=\"$(node ../../scripts/dist-tag.mjs)\" && pnpm publish --access public --tag \"${DIST_TAG}\" && node ../../scripts/tag-package.mjs --package-json package.json --push"
   },
   "peerDependencies": {
     "@antv/infographic": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^6.0.11
         version: 6.0.11(rolldown@1.2.0)(rollup@3.30.0)
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       stream-diffs:
         specifier: latest
         version: 0.0.2(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.25(typescript@5.9.3))

--- a/scripts/dist-tag.mjs
+++ b/scripts/dist-tag.mjs
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
-// Prints `--tag next` when the package being published is a prerelease version,
-// otherwise prints nothing. Intended for shell expansion inside `pnpm release`:
+// Prints the npm dist-tag arguments for shell expansion inside `pnpm release`:
 //
 //   pnpm publish --access public $(node ../../scripts/dist-tag.mjs)
 //
-// npm 11+ refuses to publish a prerelease version (e.g. `1.0.8-beta.0`) without
-// an explicit non-`latest` dist-tag, so prereleases are routed to `next` while
-// stable versions keep the default `latest` tag.
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
+import { resolvePublishedDistTag } from './resolve-dist-tag.mjs'
 
 const packageJsonPath = process.argv[2] ?? 'package.json'
-const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+const { name, version } = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+const distTag = resolvePublishedDistTag(name, version)
 
-if (typeof version === 'string' && version.includes('-'))
-  process.stdout.write('--tag next')
+process.stdout.write(`--tag ${distTag}`)

--- a/scripts/dist-tag.mjs
+++ b/scripts/dist-tag.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Prints the npm dist-tag arguments for shell expansion inside `pnpm release`:
+// Prints the npm dist-tag for use inside `pnpm release`:
 //
-//   pnpm publish --access public $(node ../../scripts/dist-tag.mjs)
+//   DIST_TAG="$(node ../../scripts/dist-tag.mjs)" && pnpm publish --tag "${DIST_TAG}"
 //
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
@@ -11,4 +11,4 @@ const packageJsonPath = process.argv[2] ?? 'package.json'
 const { name, version } = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 const distTag = resolvePublishedDistTag(name, version)
 
-process.stdout.write(`--tag ${distTag}`)
+process.stdout.write(distTag)

--- a/scripts/publish-current-package.mjs
+++ b/scripts/publish-current-package.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { resolvePublishedDistTag } from './resolve-dist-tag.mjs'
+import { resolveDistTag, resolvePublishedDistTag } from './resolve-dist-tag.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..')
@@ -86,7 +86,9 @@ const packageDir = path.dirname(packageJsonPath)
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 const dryRunPublishArgs = args.dryRun ? ['--dry-run', '--ignore-scripts'] : []
 const pnpmDryRunPublishArgs = args.dryRun ? [...dryRunPublishArgs, '--no-git-checks'] : []
-const distTag = resolvePublishedDistTag(packageJson.name, packageJson.version)
+const distTag = args.dryRun
+  ? resolveDistTag(packageJson.version)
+  : resolvePublishedDistTag(packageJson.name, packageJson.version)
 const distTagArgs = ['--tag', distTag]
 
 console.log(`[publish-current] ${packageJson.name}@${packageJson.version} (${distTagArgs.join(' ')})`)

--- a/scripts/publish-current-package.mjs
+++ b/scripts/publish-current-package.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { resolvePublishedDistTag } from './resolve-dist-tag.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..')
@@ -55,12 +56,6 @@ function packageVersionExists(name, version) {
   return result.status === 0 && result.stdout.trim() === version
 }
 
-// npm 11+ refuses to publish a prerelease version as `latest`; publish those
-// under the `next` dist-tag so the guard is satisfied and `latest` stays clean.
-function isPrerelease(version) {
-  return typeof version === 'string' && version.includes('-')
-}
-
 function gitCommit(ref) {
   const result = spawnSync('git', ['rev-parse', `${ref}^{}`], {
     cwd: repoRoot,
@@ -91,9 +86,10 @@ const packageDir = path.dirname(packageJsonPath)
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
 const dryRunPublishArgs = args.dryRun ? ['--dry-run', '--ignore-scripts'] : []
 const pnpmDryRunPublishArgs = args.dryRun ? [...dryRunPublishArgs, '--no-git-checks'] : []
-const prereleaseTagArgs = isPrerelease(packageJson.version) ? ['--tag', 'next'] : []
+const distTag = resolvePublishedDistTag(packageJson.name, packageJson.version)
+const distTagArgs = ['--tag', distTag]
 
-console.log(`[publish-current] ${packageJson.name}@${packageJson.version}${prereleaseTagArgs.length ? ` (${prereleaseTagArgs.join(' ')})` : ''}`)
+console.log(`[publish-current] ${packageJson.name}@${packageJson.version} (${distTagArgs.join(' ')})`)
 run('pnpm', ['-C', packageDir, 'run', 'build'])
 run('npm', ['config', 'get', 'registry'], packageDir)
 const published = !args.dryRun && packageVersionExists(packageJson.name, packageJson.version)
@@ -105,8 +101,8 @@ else {
   if (!args.dryRun)
     run('npm', ['whoami'], packageDir)
   if (packageDir === repoRoot)
-    run('pnpm', ['publish', '--access', 'public', ...prereleaseTagArgs, ...pnpmDryRunPublishArgs], packageDir)
+    run('pnpm', ['publish', '--access', 'public', ...distTagArgs, ...pnpmDryRunPublishArgs], packageDir)
   else
-    run('npm', ['publish', '--access', 'public', ...prereleaseTagArgs, ...dryRunPublishArgs], packageDir)
+    run('npm', ['publish', '--access', 'public', ...distTagArgs, ...dryRunPublishArgs], packageDir)
   run('node', ['scripts/tag-package.mjs', '--package-json', path.relative(repoRoot, packageJsonPath), ...(args.dryRun ? ['--dry-run', '--allow-dirty'] : ['--push'])])
 }

--- a/scripts/resolve-dist-tag.mjs
+++ b/scripts/resolve-dist-tag.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import semver from 'semver'
+
+function parseVersion(version, label) {
+  const parsed = semver.parse(version)
+  const canonical = parsed
+    ? `${parsed.version}${parsed.build.length > 0 ? `+${parsed.build.join('.')}` : ''}`
+    : null
+  if (!parsed || canonical !== version)
+    throw new Error(`[dist-tag] Invalid ${label} version: ${version}`)
+
+  return {
+    major: parsed.major,
+    prerelease: parsed.prerelease.length > 0,
+  }
+}
+
+function publishedMajor(distTags, tag) {
+  const version = distTags[tag]
+  return version === undefined ? null : parseVersion(version, `npm ${tag}`).major
+}
+
+export function resolveDistTagPlan(version, distTags = {}) {
+  if (!distTags || Array.isArray(distTags) || typeof distTags !== 'object')
+    throw new Error('[dist-tag] npm dist-tags response must be an object.')
+
+  const candidate = parseVersion(version, 'candidate')
+  const latestMajor = publishedMajor(distTags, 'latest')
+
+  if (!candidate.prerelease) {
+    const publishTag = latestMajor !== null && candidate.major < latestMajor ? 'legacy' : 'latest'
+    const requiredAliases = latestMajor !== null
+      && candidate.major > latestMajor
+      && distTags.legacy !== distTags.latest
+      ? [{ tag: 'legacy', version: distTags.latest }]
+      : []
+    return { publishTag, requiredAliases }
+  }
+
+  const nextMajor = publishedMajor(distTags, 'next')
+  const activeMajor = Math.max(latestMajor ?? -1, nextMajor ?? -1)
+  const publishTag = candidate.major < activeMajor ? 'legacy-next' : 'next'
+  const requiredAliases = publishTag === 'next'
+    && nextMajor !== null
+    && candidate.major > nextMajor
+    && distTags['legacy-next'] !== distTags.next
+    ? [{ tag: 'legacy-next', version: distTags.next }]
+    : []
+  return { publishTag, requiredAliases }
+}
+
+export function resolveDistTag(version, distTags = {}) {
+  return resolveDistTagPlan(version, distTags).publishTag
+}
+
+function assertCutoverAliases(packageName, requiredAliases) {
+  if (requiredAliases.length === 0)
+    return
+
+  // npm trusted publishing authorizes `npm publish`, but not dist-tag writes.
+  const commands = requiredAliases
+    .map(({ tag, version }) => `npm dist-tag add ${packageName}@${version} ${tag}`)
+    .join('\n')
+  throw new Error(`[dist-tag] Preserve the current release channel before publishing a new major:\n${commands}`)
+}
+
+export function readPublishedDistTags(packageName, run = spawnSync) {
+  const result = run('npm', ['view', packageName, 'dist-tags', '--json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    if (result.stderr?.includes('E404'))
+      return {}
+    throw new Error(`[dist-tag] Unable to read npm dist-tags for ${packageName}: ${result.stderr?.trim() || 'npm view failed'}`)
+  }
+
+  try {
+    return result.stdout.trim() ? JSON.parse(result.stdout) : {}
+  }
+  catch {
+    throw new Error(`[dist-tag] Invalid npm dist-tags response for ${packageName}.`)
+  }
+}
+
+export function resolvePublishedDistTag(packageName, version, run = spawnSync) {
+  const plan = resolveDistTagPlan(version, readPublishedDistTags(packageName, run))
+  assertCutoverAliases(packageName, plan.requiredAliases)
+  return plan.publishTag
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+  const [packageName, version] = process.argv.slice(2)
+  if (!packageName || !version)
+    throw new Error('Usage: node scripts/resolve-dist-tag.mjs <package-name> <version>')
+  process.stdout.write(resolvePublishedDistTag(packageName, version))
+}

--- a/test/release-dist-tag.test.ts
+++ b/test/release-dist-tag.test.ts
@@ -174,6 +174,6 @@ describe('release dist-tag routing', () => {
   it('serializes stable release workflows', () => {
     const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/release-stable.yml'), 'utf8')
 
-    expect(workflow).toMatch(/concurrency:\n {2}group: release-stable\n {2}cancel-in-progress: false/)
+    expect(workflow).toMatch(/concurrency:\n {2}group: release-stable\n {2}queue: max\n {2}cancel-in-progress: false/)
   })
 })

--- a/test/release-dist-tag.test.ts
+++ b/test/release-dist-tag.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -66,14 +67,40 @@ describe('release dist-tag routing', () => {
     })
   })
 
-  it('fails with the exact migration command when a cutover alias is missing', () => {
+  it.each([
+    [
+      '2.0.0-beta.1',
+      { latest: '1.0.9', next: '1.1.2-beta.2' },
+      'npm dist-tag add markstream-vue@1.1.2-beta.2 legacy-next',
+    ],
+    [
+      '2.0.0',
+      { latest: '1.0.9' },
+      'npm dist-tag add markstream-vue@1.0.9 legacy',
+    ],
+  ])('fails with the exact migration command for %s', (version, distTags, command) => {
     const run = () => ({
       status: 0,
-      stdout: JSON.stringify({ latest: '1.0.9', next: '1.1.2-beta.2' }),
+      stdout: JSON.stringify(distTags),
       stderr: '',
     })
-    expect(() => resolvePublishedDistTag('markstream-vue', '2.0.0-beta.1', run))
-      .toThrow('npm dist-tag add markstream-vue@1.1.2-beta.2 legacy-next')
+    expect(() => resolvePublishedDistTag('markstream-vue', version, run)).toThrow(command)
+  })
+
+  it('publishes on the new channels after both cutover aliases exist', () => {
+    const run = () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        'latest': '1.0.9',
+        'next': '1.1.2-beta.2',
+        'legacy': '1.0.9',
+        'legacy-next': '1.1.2-beta.2',
+      }),
+      stderr: '',
+    })
+
+    expect(resolvePublishedDistTag('markstream-vue', '2.0.0-beta.1', run)).toBe('next')
+    expect(resolvePublishedDistTag('markstream-vue', '2.0.0', run)).toBe('latest')
   })
 
   it('treats an npm 404 as the first package release', () => {
@@ -93,6 +120,60 @@ describe('release dist-tag routing', () => {
 
     expect(workflow).toContain('DIST_TAG="$(node scripts/resolve-dist-tag.mjs')
     expect(releaseCli).toContain('from \'./resolve-dist-tag.mjs\'')
+    expect(releaseCli).toContain('process.stdout.write(distTag)')
     expect(publishCurrent).toContain('from \'./resolve-dist-tag.mjs\'')
+  })
+
+  it.each([
+    ['package.json', 'scripts/dist-tag.mjs'],
+    ['packages/markdown-parser/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-angular/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-core/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-octane/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-react/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-svelte/package.json', '../../scripts/dist-tag.mjs'],
+    ['packages/markstream-vue2/package.json', '../../scripts/dist-tag.mjs'],
+  ])('resolves a tag before publishing in %s', (packageJsonPath, resolverPath) => {
+    const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), packageJsonPath), 'utf8'))
+    const release = packageJson.scripts.release
+    const assignment = `DIST_TAG="$(node ${resolverPath})"`
+    const assignmentIndex = release.indexOf(assignment)
+    const publishIndex = release.indexOf('publish', assignmentIndex + assignment.length)
+
+    expect(assignmentIndex).toBeGreaterThan(-1)
+    expect(release.slice(assignmentIndex + assignment.length)).toMatch(/^ && /)
+    expect(publishIndex).toBeGreaterThan(assignmentIndex)
+    expect(release.slice(publishIndex)).toMatch(/--tag "\$\{DIST_TAG\}"/)
+    expect(release).not.toMatch(/publish[^&]*\$\([^)]*dist-tag\.mjs\)/)
+  })
+
+  it.skipIf(process.platform === 'win32')('does not run publish when tag resolution fails', () => {
+    const result = spawnSync('sh', [
+      '-c',
+      'DIST_TAG="$(node -e \'process.exit(23)\')" && printf publish',
+    ], { encoding: 'utf8' })
+
+    expect(result.status).toBe(23)
+    expect(result.stdout).toBe('')
+  })
+
+  it.skipIf(process.platform === 'win32')('passes the resolved tag as one publish argument', () => {
+    const command = 'DIST_TAG="$(node -e \'process.stdout.write("legacy-next")\')" && node -e \'process.stdout.write(JSON.stringify(process.argv.slice(1)))\' -- --tag "$' + '{DIST_TAG}"'
+    const result = spawnSync('sh', ['-c', command], { encoding: 'utf8' })
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual(['--tag', 'legacy-next'])
+  })
+
+  it('keeps dry runs independent of the npm registry', () => {
+    const publishCurrent = readFileSync(resolve(process.cwd(), 'scripts/publish-current-package.mjs'), 'utf8')
+
+    expect(publishCurrent).toMatch(/const distTag = args\.dryRun\s+\? resolveDistTag\(packageJson\.version\)\s+: resolvePublishedDistTag\(packageJson\.name, packageJson\.version\)/)
+  })
+
+  it('serializes stable release workflows', () => {
+    const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/release-stable.yml'), 'utf8')
+
+    expect(workflow).toMatch(/concurrency:\n {2}group: release-stable\n {2}cancel-in-progress: false/)
   })
 })

--- a/test/release-dist-tag.test.ts
+++ b/test/release-dist-tag.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readPublishedDistTags, resolveDistTag, resolveDistTagPlan, resolvePublishedDistTag } from '../scripts/resolve-dist-tag.mjs'
+
+describe('release dist-tag routing', () => {
+  it.each([
+    ['2.0.0', { latest: '1.0.9' }, 'latest'],
+    ['1.0.10', { latest: '2.0.0' }, 'legacy'],
+    ['1.0.10', { latest: '1.0.9' }, 'latest'],
+    ['2.0.0-beta.1', { latest: '1.0.9', next: '1.1.2-beta.2' }, 'next'],
+    ['1.1.3-beta.1', { latest: '1.0.9', next: '2.0.0-beta.1' }, 'legacy-next'],
+    ['1.1.3-beta.1', { latest: '2.0.0' }, 'legacy-next'],
+    ['1.1.3-beta.1', { latest: '1.0.9', next: '1.1.2-beta.2' }, 'next'],
+    ['1.1.3+build.1', { latest: '1.0.9' }, 'latest'],
+    ['1.0.0', {}, 'latest'],
+    ['1.0.0-beta.1', {}, 'next'],
+  ])('routes %s against %j to %s', (version, distTags, expected) => {
+    expect(resolveDistTag(version, distTags)).toBe(expected)
+  })
+
+  it('fails closed for malformed published versions', () => {
+    expect(() => resolveDistTag('1.0.0', { latest: 'not-semver' })).toThrow('Invalid npm latest version')
+    expect(() => resolveDistTag('1.0.0-beta.1', { next: 'not-semver' })).toThrow('Invalid npm next version')
+  })
+
+  it.each([
+    '01.2.3',
+    '1.02.3',
+    '1.2.3-beta..1',
+    '1.2.3-beta_1',
+    '9007199254740992.0.0',
+    '1.2.3 ',
+    '1.2.3\n',
+  ])('rejects invalid candidate SemVer %s', (version) => {
+    expect(() => resolveDistTag(version)).toThrow('Invalid candidate version')
+  })
+
+  it('rejects non-canonical published SemVer', () => {
+    expect(() => resolveDistTag('2.0.0', { latest: '1.2.3 ' })).toThrow('Invalid npm latest version')
+    expect(() => resolveDistTag('2.0.0-beta.1', { next: '1.2.3\n' })).toThrow('Invalid npm next version')
+  })
+
+  it('requires the old channels to be preserved before a major cutover', () => {
+    expect(resolveDistTagPlan('2.0.0-beta.1', {
+      latest: '1.0.9',
+      next: '1.1.2-beta.2',
+    })).toEqual({
+      publishTag: 'next',
+      requiredAliases: [{ tag: 'legacy-next', version: '1.1.2-beta.2' }],
+    })
+    expect(resolveDistTagPlan('2.0.0', {
+      latest: '1.0.9',
+    })).toEqual({
+      publishTag: 'latest',
+      requiredAliases: [{ tag: 'legacy', version: '1.0.9' }],
+    })
+    expect(resolveDistTagPlan('2.0.0', {
+      'latest': '1.0.9',
+      'legacy': '1.0.9',
+      'next': '2.0.0-beta.1',
+      'legacy-next': '1.1.2-beta.2',
+    })).toEqual({
+      publishTag: 'latest',
+      requiredAliases: [],
+    })
+  })
+
+  it('fails with the exact migration command when a cutover alias is missing', () => {
+    const run = () => ({
+      status: 0,
+      stdout: JSON.stringify({ latest: '1.0.9', next: '1.1.2-beta.2' }),
+      stderr: '',
+    })
+    expect(() => resolvePublishedDistTag('markstream-vue', '2.0.0-beta.1', run))
+      .toThrow('npm dist-tag add markstream-vue@1.1.2-beta.2 legacy-next')
+  })
+
+  it('treats an npm 404 as the first package release', () => {
+    const run = () => ({ status: 1, stderr: 'npm error code E404' })
+    expect(readPublishedDistTags('new-package', run)).toEqual({})
+  })
+
+  it('fails closed when the registry cannot be read', () => {
+    const run = () => ({ status: 1, stderr: 'network timeout' })
+    expect(() => readPublishedDistTags('markstream-vue', run)).toThrow('Unable to read npm dist-tags')
+  })
+
+  it('uses the shared resolver in every stable publish path', () => {
+    const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/release-stable.yml'), 'utf8')
+    const releaseCli = readFileSync(resolve(process.cwd(), 'scripts/dist-tag.mjs'), 'utf8')
+    const publishCurrent = readFileSync(resolve(process.cwd(), 'scripts/publish-current-package.mjs'), 'utf8')
+
+    expect(workflow).toContain('DIST_TAG="$(node scripts/resolve-dist-tag.mjs')
+    expect(releaseCli).toContain('from \'./resolve-dist-tag.mjs\'')
+    expect(publishCurrent).toContain('from \'./resolve-dist-tag.mjs\'')
+  })
+})

--- a/test/release-gates.test.ts
+++ b/test/release-gates.test.ts
@@ -289,8 +289,8 @@ describe('release dependency gates', () => {
 
     expect(script).toContain('const dryRunPublishArgs = args.dryRun ? [\'--dry-run\', \'--ignore-scripts\'] : []')
     expect(script).toContain('const pnpmDryRunPublishArgs = args.dryRun ? [...dryRunPublishArgs, \'--no-git-checks\'] : []')
-    expect(script).toContain('[\'publish\', \'--access\', \'public\', ...prereleaseTagArgs, ...pnpmDryRunPublishArgs]')
-    expect(script).toContain('[\'publish\', \'--access\', \'public\', ...prereleaseTagArgs, ...dryRunPublishArgs]')
+    expect(script).toContain('[\'publish\', \'--access\', \'public\', ...distTagArgs, ...pnpmDryRunPublishArgs]')
+    expect(script).toContain('[\'publish\', \'--access\', \'public\', ...distTagArgs, ...dryRunPublishArgs]')
   })
 
   it('checks both runtime workspace packages for published versions', () => {

--- a/test/release-gates.test.ts
+++ b/test/release-gates.test.ts
@@ -289,6 +289,8 @@ describe('release dependency gates', () => {
 
     expect(script).toContain('const dryRunPublishArgs = args.dryRun ? [\'--dry-run\', \'--ignore-scripts\'] : []')
     expect(script).toContain('const pnpmDryRunPublishArgs = args.dryRun ? [...dryRunPublishArgs, \'--no-git-checks\'] : []')
+    expect(script).toContain('? resolveDistTag(packageJson.version)')
+    expect(script).toContain(': resolvePublishedDistTag(packageJson.name, packageJson.version)')
     expect(script).toContain('[\'publish\', \'--access\', \'public\', ...distTagArgs, ...pnpmDryRunPublishArgs]')
     expect(script).toContain('[\'publish\', \'--access\', \'public\', ...distTagArgs, ...dryRunPublishArgs]')
   })


### PR DESCRIPTION
## Summary

- route each package's stable and prerelease versions across `latest`, `next`, `legacy`, and `legacy-next` using that package's published major
- share one strict SemVer resolver across the tag workflow, package release commands, and current-package publisher
- fail closed before the first major cutover unless the existing channel has been preserved
- cover routing, registry failures, invalid SemVer, cutover guards, and all three publish entry points

This keeps future 1.x patches from moving `latest` or `next` back from 2.x while leaving independently versioned workspace packages on their own release lines.

## One-time cutover

The current npm tags are `latest=1.0.9` and `next=1.1.2-beta.2`. Before the first 2.x beta or stable publish, an authenticated maintainer must run the migration command printed by the guard:

```sh
npm dist-tag add markstream-vue@1.1.2-beta.2 legacy-next
npm dist-tag add markstream-vue@1.0.9 legacy
```

The workflow cannot perform these writes through npm trusted publishing: OIDC authorizes `npm publish`, not `npm dist-tag add`.

## Verification

- `pnpm vitest run` — 317 files / 2740 tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm install --frozen-lockfile`
- `git diff --check`

Related to #618 and #625.
