### PR TITLE
fix(parser): parse strong around ASCII quotes after Han text

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -30,8 +30,8 @@ const ESCAPABLE_PUNCTUATION = new Set(['\\', '(', ')', '[', ']', '`', '$', '|', 
 const WHITESPACE_RE = /\s/u
 const ASCII_PUNCTUATION_RE = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/
 const UNICODE_PUNCTUATION_RE = /\p{P}/u
-const CJK_OPENING_PUNCTUATION_RE = /^[《「『【〔〖〘〚〈（［｛“‘﹁﹃﹙﹛﹝]$/u
-const CJK_CLOSING_PUNCTUATION_RE = /^[》」』】〕〗〙〛〉）］｝”’﹂﹄﹚﹜﹞]$/u
+const CJK_OPENING_PUNCTUATION_RE = /^[\x22\x27《「『【〔〖〘〚〈（［｛“‘﹁﹃﹙﹛﹝]$/u
+const CJK_CLOSING_PUNCTUATION_RE = /^[\x22\x27》」』】〕〗〙〛〉）］｝”’﹂﹄﹚﹜﹞]$/u
 
 // Helper: detect likely URLs/hrefs (autolinks). Extracted so the
 // detection logic is easy to tweak and test.

--- a/packages/markdown-parser/test/issue-646-quote-strong.test.ts
+++ b/packages/markdown-parser/test/issue-646-quote-strong.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+function collectText(value: any): string {
+  if (!value || typeof value !== 'object')
+    return ''
+  if (value.type === 'text')
+    return String(value.content ?? '')
+  if (Array.isArray(value))
+    return value.map(collectText).join('')
+  return collectText(value.children)
+}
+
+function findStrongs(children: any[]) {
+  return children.filter((c: any) => c.type === 'strong')
+}
+
+const ISSUE_SAMPLE = '动力电池散热失效的核心逻辑可归纳为**"热量产生-传递-分配-排出"四环节的失配**,电芯在大倍率工况下产热功率急剧上升。'
+// Rendered text equals the source with the `**` markers consumed
+const ISSUE_SAMPLE_RENDERED = '动力电池散热失效的核心逻辑可归纳为"热量产生-传递-分配-排出"四环节的失配,电芯在大倍率工况下产热功率急剧上升。'
+
+describe('issue 646: strong with quote content after Han text', () => {
+  it.each([true, false])('parses the issue sample with straight quotes when final=%s', (final) => {
+    const nodes = parseMarkdownToStructure(ISSUE_SAMPLE, getMarkdown(`issue-646-${final}`), { final }) as any[]
+
+    // No text is lost (markers consumed, content intact)
+    expect(collectText(nodes)).toBe(ISSUE_SAMPLE_RENDERED)
+    // The quoted span should be a single strong node, not literal text
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].raw).toBe('**"热量产生-传递-分配-排出"四环节的失配**')
+    expect(strongs[0].children[0]).toMatchObject({
+      type: 'text',
+      content: '"热量产生-传递-分配-排出"四环节的失配',
+    })
+  })
+
+  it('keeps curly-quote content working as before', () => {
+    const markdown = '了**\u201C法\u201D**后'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-curly'), { final: true }) as any[]
+
+    expect(collectText(nodes)).toBe('了“法”后')
+    expect(findStrongs(nodes[0].children)).toHaveLength(1)
+  })
+
+  it('parses strong with ASCII single quotes after Han text', () => {
+    const markdown = '他说**\'关键\'**内容'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-single'), { final: true }) as any[]
+
+    // typographer smartens straight to curly quotes inside the span
+    expect(collectText(nodes)).toBe('他说‘关键’内容')
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].children[0]).toMatchObject({ type: 'text', content: '‘关键’' })
+  })
+
+  it('parses strong when the closing marker directly follows an ASCII closing quote', () => {
+    const markdown = '他说**"重点"**是工作'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-close-quote'), { final: true }) as any[]
+
+    expect(collectText(nodes)).toBe('他说“重点”是工作')
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].children[0]).toMatchObject({ type: 'text', content: '“重点”' })
+  })
+})


### PR DESCRIPTION
## Related issue
close: [#646](https://github.com/Simon-He95/markstream-vue/issues/646)

## Problem

`**"热量产生-传递-分配-排出"四环节的失配**,...` (ASCII straight quotes after a Han character) fails to parse as bold:

- markdown-it leaves the whole span as a single text token — typographer's smartquotes deliberately skips quote pairs surrounded by CJK letters (its "middle of word" rule), so ASCII quotes inside the span are **not** converted to curly quotes;
- the inline re-parser ([text-token-handler.ts](https://github.com/Simon-He95/markstream-vue/blob/main/packages/markdown-parser/src/parser/inline-parsers/text-token-handler.ts)) then rejects the opening `**` because ASCII `"` / `'` are missing from the CJK opening/closing punctuation sets in [delimiter-helpers.ts](https://github.com/Simon-He95/markstream-vue/blob/main/packages/markdown-parser/src/parser/inline-parsers/delimiter-helpers.ts), falling back to a broken `text + empty emphasis + text` split.

Curly quotes (`“...”`) already worked (added in issue-561); their ASCII counterparts were the gap.

## Changes

- `packages/markdown-parser/src/parser/inline-parsers/delimiter-helpers.ts`: add `\x22` (`"`) and `\x27` (`'`) to `CJK_OPENING_PUNCTUATION_RE` and `CJK_CLOSING_PUNCTUATION_RE`. The CJK exceptions only apply when adjacent to Han characters, so Latin text (`foo**"bar"**`) keeps CommonMark behavior.
- `packages/markdown-parser/test/issue-646-quote-strong.test.ts`: new regression tests (5 cases):
  - the exact issue sample (final=true and final=false) → single `strong` node, exact raw, no text loss;
  - curly-quote variant keeps working;
  - ASCII single quotes after Han text;
  - closing `**` directly following an ASCII closing quote.

## Verification

- `stream-markdown-parser`: 58 files / 520 tests pass (`pnpm --filter stream-markdown-parser exec vitest --run`)
- root-level strong/parser regressions (`fix-strong-tokens-parse`, issue386, issue600, SSR): 51 tests pass
- `pnpm --filter stream-markdown-parser typecheck` ✓, ESLint ✓ (changed files)