### PR TITLE
fix(parser): parse strong around ASCII quotes after Han text (2.0 port)

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/delimiter-helpers.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/delimiter-helpers.ts
@@ -3,8 +3,8 @@ import { ESCAPABLE_PUNCTUATION } from './literal-text-helpers'
 const WHITESPACE_RE = /\s/u
 const ASCII_PUNCTUATION_RE = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/
 const UNICODE_PUNCTUATION_RE = /\p{P}/u
-const CJK_OPENING_PUNCTUATION_RE = /^[《「『【〔〖〘〚〈（［｛“‘﹁﹃﹙﹛﹝]$/u
-const CJK_CLOSING_PUNCTUATION_RE = /^[》」』】〕〗〙〛〉）］｝”’﹂﹄﹚﹜﹞]$/u
+const CJK_OPENING_PUNCTUATION_RE = /^[\x22\x27《「『【〔〖〘〚〈（［｛“‘﹁﹃﹙﹛﹝]$/u
+const CJK_CLOSING_PUNCTUATION_RE = /^[\x22\x27》」』】〕〗〙〛〉）］｝”’﹂﹄﹚﹜﹞]$/u
 
 export function countUnescapedAsterisks(str: string): number {
   let count = 0

--- a/packages/markdown-parser/test/issue-646-quote-strong.test.ts
+++ b/packages/markdown-parser/test/issue-646-quote-strong.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+function collectText(value: any): string {
+  if (!value || typeof value !== 'object')
+    return ''
+  if (value.type === 'text')
+    return String(value.content ?? '')
+  if (Array.isArray(value))
+    return value.map(collectText).join('')
+  return collectText(value.children)
+}
+
+function findStrongs(children: any[]) {
+  return children.filter((c: any) => c.type === 'strong')
+}
+
+const ISSUE_SAMPLE = '动力电池散热失效的核心逻辑可归纳为**"热量产生-传递-分配-排出"四环节的失配**,电芯在大倍率工况下产热功率急剧上升。'
+// Rendered text equals the source with the `**` markers consumed
+const ISSUE_SAMPLE_RENDERED = '动力电池散热失效的核心逻辑可归纳为"热量产生-传递-分配-排出"四环节的失配,电芯在大倍率工况下产热功率急剧上升。'
+
+describe('issue 646: strong with quote content after Han text', () => {
+  it.each([true, false])('parses the issue sample with straight quotes when final=%s', (final) => {
+    const nodes = parseMarkdownToStructure(ISSUE_SAMPLE, getMarkdown(`issue-646-${final}`), { final }) as any[]
+
+    // No text is lost (markers consumed, content intact)
+    expect(collectText(nodes)).toBe(ISSUE_SAMPLE_RENDERED)
+    // The quoted span should be a single strong node, not literal text
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].raw).toBe('**"热量产生-传递-分配-排出"四环节的失配**')
+    expect(strongs[0].children[0]).toMatchObject({
+      type: 'text',
+      content: '"热量产生-传递-分配-排出"四环节的失配',
+    })
+  })
+
+  it('keeps curly-quote content working as before', () => {
+    const markdown = '了**\u201C法\u201D**后'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-curly'), { final: true }) as any[]
+
+    expect(collectText(nodes)).toBe('了“法”后')
+    expect(findStrongs(nodes[0].children)).toHaveLength(1)
+  })
+
+  it('parses strong with ASCII single quotes after Han text', () => {
+    const markdown = '他说**\'关键\'**内容'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-single'), { final: true }) as any[]
+
+    // typographer smartens straight to curly quotes inside the span
+    expect(collectText(nodes)).toBe('他说‘关键’内容')
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].children[0]).toMatchObject({ type: 'text', content: '‘关键’' })
+  })
+
+  it('parses strong when the closing marker directly follows an ASCII closing quote', () => {
+    const markdown = '他说**"重点"**是工作'
+    const nodes = parseMarkdownToStructure(markdown, getMarkdown('issue-646-close-quote'), { final: true }) as any[]
+
+    expect(collectText(nodes)).toBe('他说“重点”是工作')
+    const strongs = findStrongs(nodes[0].children)
+    expect(strongs).toHaveLength(1)
+    expect(strongs[0].children[0]).toMatchObject({ type: 'text', content: '“重点”' })
+  })
+})


### PR DESCRIPTION
Port of #647 (`453c49a`) to the 2.0 inline-parser split.

In the 2.0 line the CJK punctuation sets live in `delimiter-helpers.ts` instead of the monolith `index.ts`, so the fix needs its own commit here.

### Changes
- `delimiter-helpers.ts`: add ASCII `"` (`\\x22`) and `'` (`\\x27`) to the CJK opening/closing punctuation sets
- Add `issue-646-quote-strong.test.ts` (identical to main's copy; test infra confirmed identical)

### Verification
- New tests: 5/5 passed
- Adjacent regressions (issue-561, strict-strong, strong-math): 26/26 passed

close: #646