### PR TITLE
fix(1.x): align pre fallback line-number gutter with stream-diffs surface

### DIFF
--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -735,7 +735,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
         // The Angular shell already owns the language/file header. Keep the
         // enhanced surface headerless so it matches the Vue 3 handoff contract.
         disableFileHeader: true,
-        unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim(),
       }
 

--- a/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
+++ b/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
@@ -106,7 +106,7 @@ export class PreCodeNodeComponent {
       return null
 
     const maximumLineNumber = this.codeLineCount
-    const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+    const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-pre-diff-line-number-width': width,

--- a/packages/markstream-angular/src/enhanceRenderedHtml.ts
+++ b/packages/markstream-angular/src/enhanceRenderedHtml.ts
@@ -644,10 +644,10 @@ async function renderMonaco(
     const originalPre = pre.cloneNode(true) as HTMLElement
     pre.replaceWith(shell.wrapper)
 
-    const configuredUnsafeCSS = typeof options.monacoOptions?.unsafeCSS === 'string'
+const configuredUnsafeCSS = typeof options.monacoOptions?.unsafeCSS === 'string'
       ? options.monacoOptions.unsafeCSS
       : ''
-    const runtimeUnsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+    const runtimeUnsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
     const helpers = monacoModule.useMonaco({
       themes: ['vitesse-dark', 'vitesse-light'],

--- a/packages/markstream-octane/src/components/CodeBlockNode/PreCodeNode.tsrx
+++ b/packages/markstream-octane/src/components/CodeBlockNode/PreCodeNode.tsrx
@@ -338,7 +338,7 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
   const lineNumberLayoutStyle = useMemo<OctaneStyle | undefined>(() => {
     if (showLineNumbers !== true || isDiffPreview)
       return undefined
-    const width = `${Math.max(4, String(codeLineCount).length)}ch`
+    const width = `${Math.max(2, String(codeLineCount).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
@@ -788,7 +788,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
       ? nextOptions.unsafeCSS
       : ''
-    nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+    nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
     return nextOptions

--- a/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
@@ -341,7 +341,7 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
   const lineNumberLayoutStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (showLineNumbers !== true || isDiffPreview)
       return undefined
-    const width = `${Math.max(4, String(codeLineCount).length)}ch`
+    const width = `${Math.max(2, String(codeLineCount).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/packages/markstream-svelte/src/components/CodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/CodeBlockNode.svelte
@@ -370,7 +370,7 @@
     }
     const padding = getCodePadding()
     const configuredUnsafeCSS = typeof raw.unsafeCSS === 'string' ? raw.unsafeCSS : ''
-    const unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+    const unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
     const finalOptions = {
       MAX_HEIGHT: maxHeight,

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -30,7 +30,7 @@
   let lineNumbersText = $derived(buildLineNumbersText(lineCount))
   let lineNumberLayoutStyle = $derived(
     showLineGutter
-      ? `--markstream-pre-line-number-width: ${Math.max(4, String(lineCount).length)}ch; --markstream-pre-diff-line-number-width: ${Math.max(4, String(lineCount).length)}ch; --markstream-code-padding-left: calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch));`
+      ? `--markstream-pre-line-number-width: ${Math.max(2, String(lineCount).length)}ch; --markstream-pre-diff-line-number-width: ${Math.max(2, String(lineCount).length)}ch; --markstream-code-padding-left: calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch));`
       : '',
   )
   let mergedStyle = $derived([lineNumberLayoutStyle, style].filter(Boolean).join(' '))

--- a/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -1690,7 +1690,7 @@ function buildRuntimeMonacoOptions() {
   const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
     ? nextOptions.unsafeCSS
     : ''
-  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
   return nextOptions

--- a/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
+++ b/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
@@ -95,7 +95,7 @@ const lineNumberLayoutStyle = computed(() => {
   if (props.showLineNumbers !== true || isDiffPreview.value)
     return undefined
   const maximumLineNumber = codeLineCount.value
-  const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
   return {
     '--markstream-pre-line-number-width': width,
     '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -4173,7 +4173,7 @@ function buildRuntimeMonacoOptions() {
   const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
     ? nextOptions.unsafeCSS
     : ''
-  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
   if (isDiff.value) {

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -653,7 +653,7 @@ const lineNumberLayoutStyle = computed(() => {
     }
   }
 
-  const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
   return {
     '--markstream-pre-line-number-width': width,
     '--markstream-pre-diff-line-number-width': width,


### PR DESCRIPTION
Cherry-pick of #649 onto the 1.x line (used by 1.1.2-beta consumers).

Same fix: fallback gutter floor 4ch -> 2ch and runtime surface default 4ch -> 2ch, so pre -> surface handoff no longer shifts the line-number column.

Also keeps the `configuredUnsafeCSS` concat structure that 1.x still has in the angular paths.