### PR TITLE
fix: align pre fallback line-number gutter with stream-diffs surface (2.0)

### DIFF
--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -718,7 +718,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
         // The Angular shell already owns the language/file header. Keep the
         // enhanced surface headerless so it matches the Vue 3 handoff contract.
         disableFileHeader: true,
-        unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }`,
+        unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }`,
       }
 
       this.runtimeOptions = options

--- a/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
+++ b/packages/markstream-angular/src/components/PreCodeNode/PreCodeNode.component.ts
@@ -106,7 +106,7 @@ export class PreCodeNodeComponent {
       return null
 
     const maximumLineNumber = this.codeLineCount
-    const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+    const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-pre-diff-line-number-width': width,

--- a/packages/markstream-angular/src/enhanceRenderedHtml.ts
+++ b/packages/markstream-angular/src/enhanceRenderedHtml.ts
@@ -642,7 +642,7 @@ async function renderCodeBlocks(
     const originalPre = pre.cloneNode(true) as HTMLElement
     pre.replaceWith(shell.wrapper)
 
-    const runtimeUnsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }`
+    const runtimeUnsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }`
     const helpers = monacoModule.useMonaco({
       themes: ['vitesse-dark', 'vitesse-light'],
       languages: Array.from(new Set([language, 'plaintext'])),

--- a/packages/markstream-octane/src/components/CodeBlockNode/PreCodeNode.tsrx
+++ b/packages/markstream-octane/src/components/CodeBlockNode/PreCodeNode.tsrx
@@ -338,7 +338,7 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
   const lineNumberLayoutStyle = useMemo<OctaneStyle | undefined>(() => {
     if (showLineNumbers !== true || isDiffPreview)
       return undefined
-    const width = `${Math.max(4, String(codeLineCount).length)}ch`
+    const width = `${Math.max(2, String(codeLineCount).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/CodeBlockNode.tsx
@@ -685,7 +685,7 @@ export function CodeBlockNode(rawProps: CodeBlockNodeProps & CodeBlockNodeReactE
     const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
       ? nextOptions.unsafeCSS
       : ''
-    nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+    nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
     return nextOptions

--- a/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
+++ b/packages/markstream-react/src/components/CodeBlockNode/PreCodeNode.tsx
@@ -341,7 +341,7 @@ export function PreCodeNode({ node, className, diffInline, showLineNumbers, styl
   const lineNumberLayoutStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (showLineNumbers !== true || isDiffPreview)
       return undefined
-    const width = `${Math.max(4, String(codeLineCount).length)}ch`
+    const width = `${Math.max(2, String(codeLineCount).length)}ch`
     return {
       '--markstream-pre-line-number-width': width,
       '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/packages/markstream-svelte/src/components/CodeBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/CodeBlockNode.svelte
@@ -371,7 +371,7 @@
     }
     const padding = getCodePadding()
     const configuredUnsafeCSS = typeof raw.unsafeCSS === 'string' ? raw.unsafeCSS : ''
-    const unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+    const unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
     const finalOptions = {
       MAX_HEIGHT: maxHeight,

--- a/packages/markstream-svelte/src/components/PreCodeNode.svelte
+++ b/packages/markstream-svelte/src/components/PreCodeNode.svelte
@@ -30,7 +30,7 @@
   let lineNumbersText = $derived(buildLineNumbersText(lineCount))
   let lineNumberLayoutStyle = $derived(
     showLineGutter
-      ? `--markstream-pre-line-number-width: ${Math.max(4, String(lineCount).length)}ch; --markstream-pre-diff-line-number-width: ${Math.max(4, String(lineCount).length)}ch; --markstream-code-padding-left: calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch));`
+      ? `--markstream-pre-line-number-width: ${Math.max(2, String(lineCount).length)}ch; --markstream-pre-diff-line-number-width: ${Math.max(2, String(lineCount).length)}ch; --markstream-code-padding-left: calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch));`
       : '',
   )
   let mergedStyle = $derived([lineNumberLayoutStyle, style].filter(Boolean).join(' '))

--- a/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -1305,7 +1305,7 @@ function buildRuntimeMonacoOptions() {
   const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
     ? nextOptions.unsafeCSS
     : ''
-  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
   return nextOptions

--- a/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
+++ b/packages/markstream-vue2/src/components/PreCodeNode/PreCodeNode.vue
@@ -95,7 +95,7 @@ const lineNumberLayoutStyle = computed(() => {
   if (props.showLineNumbers !== true || isDiffPreview.value)
     return undefined
   const maximumLineNumber = codeLineCount.value
-  const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
   return {
     '--markstream-pre-line-number-width': width,
     '--markstream-code-padding-left': 'calc(var(--markstream-pre-line-number-padding-left, 2ch) + var(--markstream-pre-line-number-width, 2ch) + var(--markstream-pre-line-number-padding-right, 1ch) + var(--markstream-pre-line-number-separator-width, 2px) + var(--markstream-pre-line-number-gap-to-code, 1ch))',

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -3663,7 +3663,7 @@ function buildStreamDiffsRuntimeOptions() {
   const configuredUnsafeCSS = typeof nextOptions.unsafeCSS === 'string'
     ? nextOptions.unsafeCSS
     : ''
-  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 4ch !important; }
+  nextOptions.unsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim()
 
   if (isDiff.value) {

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -653,7 +653,7 @@ const lineNumberLayoutStyle = computed(() => {
     }
   }
 
-  const width = `${Math.max(4, String(maximumLineNumber).length)}ch`
+  const width = `${Math.max(2, String(maximumLineNumber).length)}ch`
   return {
     '--markstream-pre-line-number-width': width,
     '--markstream-pre-diff-line-number-width': width,

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -159,7 +159,7 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
-  it('reserves a four-digit gutter while the pending fallback grows', async () => {
+  it('sizes the fallback gutter to the digit width as the pending fallback grows', async () => {
     const makeCode = (lineCount: number) => Array.from({ length: lineCount }, (_, index) => `const line${index + 1} = ${index + 1}`).join('\n')
     const wrapper = mount(DeferredCodeBlockNode, {
       props: {
@@ -173,10 +173,16 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
 
     const pre = wrapper.get('pre.code-pre-fallback').element as HTMLElement
-    for (const lineCount of [9, 10, 100, 1000]) {
+    const expectedWidths: Array<[number, string]> = [
+      [9, '2ch'],
+      [10, '2ch'],
+      [100, '3ch'],
+      [1000, '4ch'],
+    ]
+    for (const [lineCount, expectedWidth] of expectedWidths) {
       await wrapper.setProps({ node: makeNode(makeCode(lineCount), true) })
       await flush()
-      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe(expectedWidth)
     }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
     wrapper.unmount()
@@ -203,7 +209,7 @@ describe('codeBlockNode final Diffs gate', () => {
       expect(runtime.createEditor).toHaveBeenCalledTimes(1)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.stream).toBe(false)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.disableFileHeader).toBe(true)
-      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 4ch !important')
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
       expect(wrapper.find('diffs-container').exists()).toBe(true)
       expect(wrapper.find('pre.code-pre-fallback').exists()).toBe(false)
       expect(wrapper.get('[data-markstream-code-block="1"]').attributes('data-markstream-code-block-state')).toBe('settled')

--- a/test/markstream-angular-enhance.test.ts
+++ b/test/markstream-angular-enhance.test.ts
@@ -146,7 +146,7 @@ describe('markstream-angular enhanceRenderedHtml', () => {
     expect(monacoUseMonacoOptions[0]).toMatchObject({
       disableFileHeader: true,
     })
-    expect(monacoUseMonacoOptions[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 4ch !important')
+    expect(monacoUseMonacoOptions[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
     expect(monacoUseMonacoOptions[1]).toMatchObject({
       fontSize: 15,
       lineHeight: 24,

--- a/test/markstream-svelte-code-handoff.test.ts
+++ b/test/markstream-svelte-code-handoff.test.ts
@@ -20,8 +20,8 @@ describe('markstream-svelte code block handoff geometry', () => {
     expect(codeBlockSource).toContain('fontFamily: getCodeFontFamily()')
   })
 
-  it('reserves the fallback four-character line-number column in stream-diffs', () => {
-    const gutterRule = '--diffs-min-number-column-width-default: 4ch !important'
+  it('reserves the fallback two-character line-number column in stream-diffs', () => {
+    const gutterRule = '--diffs-min-number-column-width-default: 2ch !important'
     expect(codeBlockSource).toContain(gutterRule)
     expect(codeBlockSource.indexOf(gutterRule)).toBeLessThan(
       codeBlockSource.lastIndexOf('configuredUnsafeCSS'),

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -152,7 +152,13 @@ describe('pre code node diff preview', () => {
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    for (const lineCount of [9, 10, 100, 1000]) {
+    const expectedWidths: Array<[number, string]> = [
+      [9, '2ch'],
+      [10, '2ch'],
+      [100, '3ch'],
+      [1000, '4ch'],
+    ]
+    for (const [lineCount, expectedWidth] of expectedWidths) {
       const code = createCode(lineCount)
       await wrapper.setProps({
         node: {
@@ -163,7 +169,7 @@ describe('pre code node diff preview', () => {
           loading: true,
         },
       })
-      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe(expectedWidth)
     }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
     expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(1000)
@@ -174,7 +180,7 @@ describe('pre code node diff preview', () => {
   it.each([
     { diffInline: false, pane: 'modified' },
     { diffInline: true, pane: 'inline' },
-  ])('reserves the four-digit $pane diff fallback gutter for a three-digit source', ({ diffInline, pane }) => {
+  ])('reserves the three-digit $pane diff fallback gutter for a three-digit source', ({ diffInline, pane }) => {
     const originalCode = Array.from({ length: 99 }, (_, index) => `line ${index + 1}`).join('\n')
     const updatedCode = `${originalCode}\nline 100`
     const wrapper = mount(PreCodeNode, {
@@ -194,8 +200,8 @@ describe('pre code node diff preview', () => {
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
     expect(wrapper.get(`.markstream-pre__diff-pane--${pane} .markstream-pre__diff-line:last-child .markstream-pre__diff-number`).text()).toBe('100')
 
     wrapper.unmount()
@@ -227,7 +233,7 @@ describe('pre code node diff preview', () => {
 
     const pre = wrapper.get('pre').element as HTMLElement
     expect(pre.classList).toContain('markstream-pre--diff-collapsed')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Problem

The pre fallback gutter is sized `max(4, digits)ch` (hardcoded floor of 4ch in every framework's PreCodeNode), while the final stream-diffs surface only reserves the actual digit width (`--diffs-min-number-column-width-default`).

Consumer apps that narrow the surface column (e.g. via `monacoOptions.unsafeCSS`) see the line-number column jump on the pre -> surface handoff: fallback 4ch, surface 2ch.

## Change

- **PreCodeNode (vue3 / vue2 / react / svelte / angular / octane)**: floor the fallback gutter at `2ch` instead of `4ch`. Short blocks (<=99 lines) stay compact at 2ch; wide blocks still grow to the digit width (3ch for 100+ lines), matching the surface.
- **CodeBlockNode (all frameworks)**: default the runtime surface number-column width to `2ch` so the surface matches the fallback without requiring consumer overrides.

Verified in playground: 13-line block -> both states 2ch; 130-line block -> both states 3ch. No handoff jump.

2.0.0 counterpart; same fix already merged on 1.x (#650) and proposed on main (#651).