### PR TITLE
test: sync gutter assertions for 2ch fallback floor to 1.x

### DIFF
--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -735,7 +735,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
         // The Angular shell already owns the language/file header. Keep the
         // enhanced surface headerless so it matches the Vue 3 handoff contract.
         disableFileHeader: true,
-unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
+        unsafeCSS: `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }
 ${configuredUnsafeCSS}`.trim(),
       }
 

--- a/packages/markstream-angular/src/enhanceRenderedHtml.ts
+++ b/packages/markstream-angular/src/enhanceRenderedHtml.ts
@@ -644,7 +644,7 @@ async function renderMonaco(
     const originalPre = pre.cloneNode(true) as HTMLElement
     pre.replaceWith(shell.wrapper)
 
-const configuredUnsafeCSS = typeof options.monacoOptions?.unsafeCSS === 'string'
+    const configuredUnsafeCSS = typeof options.monacoOptions?.unsafeCSS === 'string'
       ? options.monacoOptions.unsafeCSS
       : ''
     const runtimeUnsafeCSS = `[data-file], [data-diff] { --diffs-min-number-column-width-default: 2ch !important; }

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -159,7 +159,7 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
-  it('reserves a four-digit gutter while the pending fallback grows', async () => {
+  it('sizes the fallback gutter to the digit width as the pending fallback grows', async () => {
     const makeCode = (lineCount: number) => Array.from({ length: lineCount }, (_, index) => `const line${index + 1} = ${index + 1}`).join('\n')
     const wrapper = mount(DeferredCodeBlockNode, {
       props: {
@@ -173,10 +173,16 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
 
     const pre = wrapper.get('pre.code-pre-fallback').element as HTMLElement
-    for (const lineCount of [9, 10, 100, 1000]) {
+    const expectedWidths: Array<[number, string]> = [
+      [9, '2ch'],
+      [10, '2ch'],
+      [100, '3ch'],
+      [1000, '4ch'],
+    ]
+    for (const [lineCount, expectedWidth] of expectedWidths) {
       await wrapper.setProps({ node: makeNode(makeCode(lineCount), true) })
       await flush()
-      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe(expectedWidth)
     }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
     wrapper.unmount()
@@ -206,7 +212,7 @@ describe('codeBlockNode final Diffs gate', () => {
       expect(runtime.createEditor).toHaveBeenCalledTimes(1)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.stream).toBe(false)
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.disableFileHeader).toBe(true)
-      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 4ch !important')
+      expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS).toContain('--consumer-code-gutter: 1')
       expect(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--diffs-min-number-column-width-default')).toBeLessThan(runtime.useMonaco.mock.calls[0]?.[0]?.unsafeCSS.indexOf('--consumer-code-gutter'))
       expect(wrapper.find('diffs-container').exists()).toBe(true)

--- a/test/markstream-angular-enhance.test.ts
+++ b/test/markstream-angular-enhance.test.ts
@@ -149,7 +149,7 @@ describe('markstream-angular enhanceRenderedHtml', () => {
     expect(monacoUseMonacoOptions[0]).toMatchObject({
       disableFileHeader: true,
     })
-    expect(monacoUseMonacoOptions[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 4ch !important')
+    expect(monacoUseMonacoOptions[0]?.unsafeCSS).toContain('--diffs-min-number-column-width-default: 2ch !important')
     expect(monacoUseMonacoOptions[0]?.unsafeCSS).toContain('--consumer-angular-gutter: 1')
     expect(String(monacoUseMonacoOptions[0]?.unsafeCSS).indexOf('--diffs-min-number-column-width-default'))
       .toBeLessThan(String(monacoUseMonacoOptions[0]?.unsafeCSS).indexOf('--consumer-angular-gutter'))

--- a/test/markstream-svelte-code-handoff.test.ts
+++ b/test/markstream-svelte-code-handoff.test.ts
@@ -20,8 +20,8 @@ describe('markstream-svelte code block handoff geometry', () => {
     expect(codeBlockSource).toContain('fontFamily: getCodeFontFamily()')
   })
 
-  it('reserves the fallback four-character line-number column in stream-diffs', () => {
-    const gutterRule = '--diffs-min-number-column-width-default: 4ch !important'
+  it('reserves the fallback two-character line-number column in stream-diffs', () => {
+    const gutterRule = '--diffs-min-number-column-width-default: 2ch !important'
     expect(codeBlockSource).toContain(gutterRule)
     expect(codeBlockSource.indexOf(gutterRule)).toBeLessThan(
       codeBlockSource.lastIndexOf('configuredUnsafeCSS'),

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -152,7 +152,13 @@ describe('pre code node diff preview', () => {
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    for (const lineCount of [9, 10, 100, 1000]) {
+    const expectedWidths: Array<[number, string]> = [
+      [9, '2ch'],
+      [10, '2ch'],
+      [100, '3ch'],
+      [1000, '4ch'],
+    ]
+    for (const [lineCount, expectedWidth] of expectedWidths) {
       const code = createCode(lineCount)
       await wrapper.setProps({
         node: {
@@ -163,7 +169,7 @@ describe('pre code node diff preview', () => {
           loading: true,
         },
       })
-      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
+      expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe(expectedWidth)
     }
     expect(pre.style.getPropertyValue('--markstream-code-padding-left')).toContain('var(--markstream-pre-line-number-width, 2ch)')
     expect(wrapper.get('.markstream-pre__line-numbers-text').element.textContent?.split('\n')).toHaveLength(1000)
@@ -174,7 +180,7 @@ describe('pre code node diff preview', () => {
   it.each([
     { diffInline: false, pane: 'modified' },
     { diffInline: true, pane: 'inline' },
-  ])('reserves the four-digit $pane diff fallback gutter for a three-digit source', ({ diffInline, pane }) => {
+  ])('reserves the three-digit $pane diff fallback gutter for a three-digit source', ({ diffInline, pane }) => {
     const originalCode = Array.from({ length: 99 }, (_, index) => `line ${index + 1}`).join('\n')
     const updatedCode = `${originalCode}\nline 100`
     const wrapper = mount(PreCodeNode, {
@@ -194,8 +200,8 @@ describe('pre code node diff preview', () => {
     })
 
     const pre = wrapper.get('pre').element as HTMLElement
-    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('4ch')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-line-number-width')).toBe('3ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
     expect(wrapper.get(`.markstream-pre__diff-pane--${pane} .markstream-pre__diff-line:last-child .markstream-pre__diff-number`).text()).toBe('100')
 
     wrapper.unmount()
@@ -227,7 +233,7 @@ describe('pre code node diff preview', () => {
 
     const pre = wrapper.get('pre').element as HTMLElement
     expect(pre.classList).toContain('markstream-pre--diff-collapsed')
-    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('4ch')
+    expect(pre.style.getPropertyValue('--markstream-pre-diff-line-number-width')).toBe('3ch')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
Syncs the test/format follow-up from main (#651, commit `3d3191a73`) to 1.x.

#650 already shipped the gutter fix (`max(4,`) -> `max(2,``) + default 2ch unsafeCSS) on 1.x; this brings the matching test updates:

- `test/pre-code-node-diff-preview.test.ts`, `test/code-block-finalize-gate.test.ts`: assert digit-width gutters (2ch/3ch/4ch for 10/100/1000 lines) instead of a flat 4ch
- `test/markstream-angular-enhance.test.ts`, `test/markstream-svelte-code-handoff.test.ts`: assert `2ch !important` unsafeCSS default
- fixes indentation regressions in the two angular files (`unsafeCSS` / `configuredUnsafeCSS` lines)

Verified locally: lint clean, 54 tests pass.