### PR TITLE
fix(mermaid): keep unscaled height when zoomed before collapse or re-render

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -1019,7 +1019,10 @@ function updateContainerHeight(newContainerWidth?: number, options?: { force?: b
     const containerWidth
       = newContainerWidth ?? mermaidContainer.value.clientWidth
     const renderedSvgWidth = svgElement.getBoundingClientRect().width
-    const effectiveWidth = renderedSvgWidth > 0 ? renderedSvgWidth : containerWidth
+    // getBoundingClientRect() 会受 CSS transform(scale) 影响返回缩放后的视觉宽度，
+    // 在 zoom != 1 时（缩放/拖拽后折叠再展开、或渲染完成）会导致高度被错误压缩，
+    // 因此这里除以 zoom 还原为未缩放的布局宽度再计算高度。
+    const effectiveWidth = renderedSvgWidth > 0 ? renderedSvgWidth / Math.max(0.01, zoom.value) : containerWidth
     const maxHeight = resolveMaxContainerHeight()
     const newHeight = effectiveWidth * aspectRatio
     const resolvedHeight = maxHeight == null ? newHeight : Math.min(newHeight, maxHeight)

--- a/test/mermaid-max-height.test.ts
+++ b/test/mermaid-max-height.test.ts
@@ -120,4 +120,53 @@ describe('mermaid block max height', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps the unscaled height when zoomed out (getBoundingClientRect is transform-affected)', async () => {
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'mermaid',
+          code: 'graph LR\nA-->B\n',
+          raw: '```mermaid\ngraph LR\nA-->B\n```',
+        },
+        loading: false,
+      },
+      attachTo: document.body,
+    })
+
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).showSource = false
+    await nextTick()
+
+    const content = wrapper.get('div._mermaid').element as HTMLElement
+    content.innerHTML = '<svg viewBox="0 0 100 2000"></svg>'
+    const svg = content.querySelector('svg') as SVGElement
+
+    const wrapperEl = wrapper.get('[data-mermaid-wrapper]').element as HTMLElement
+    const container = wrapperEl.parentElement as HTMLElement
+    Object.defineProperty(container, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    })
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    // Simulate zoom = 0.5: browsers return the *scaled* visual width from
+    // getBoundingClientRect() (jsdom itself always reports 0, so stub it).
+    setupState.zoom = 0.5
+    Object.defineProperty(svg, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 50, height: 1000 }),
+    })
+
+    setupState.updateContainerHeight()
+    await nextTick()
+
+    // Unscaled width is 50 / 0.5 = 100 -> height = 100 * (2000 / 100) = 2000px.
+    // Regression: the scaled width (50) was used directly, shrinking the
+    // content height to 1000px and cropping the diagram after collapse/expand.
+    expect(content.style.height).toBe('2000px')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## 描述

修复 #654：Mermaid 图在「缩小 → 拖拽 → 折叠 → 展开」后被裁剪、显示不全。

## 根因

折叠用 `v-show`（`display:none`），展开时 ResizeObserver 触发 `updateContainerHeight()`。该函数用 `svgElement.getBoundingClientRect().width` 作为有效宽度 —— 该值**受 CSS `transform: scale()` 影响**返回缩放后的视觉宽度，导致高度按缩放比例错误重算（实测 795px → 477px），容器高度收缩，配合平移状态表现为图被裁剪。

除折叠/展开外，渲染完成、partial 渲染、缓存恢复三条路径在 zoom ≠ 1 时都会触发同一问题。

## 修复

计算有效宽度时除以当前 zoom，还原为未缩放布局宽度；`zoom = 1` 时行为完全不变。

## 测试

- 新增回归测试：模拟 `zoom = 0.5` + 缩放后的 `getBoundingClientRect`，断言内容高度保持未缩放值
- 修复前测试失败（1000px ≠ 2000px），修复后通过
- mermaid 相关 33 个测试全部通过；`eslint` / `typecheck` 通过

close: #654