### PR TITLE
docs: prepare 2.0 beta migration

### DIFF
--- a/.agents/skills/markstream-install/SKILL.md
+++ b/.agents/skills/markstream-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markstream-install
-description: Install and wire markstream-vue, markstream-react, markstream-vue2, markstream-angular, or markstream-svelte into an existing repository. Use when Codex needs to choose the right package, install the smallest framework-specific peer-dependency set, fix CSS/reset order, choose Vue 3 renderer and code-block modes, decide between `content`, `nodes`, and Vue 3 virtual-scroll coordination, or add a minimal working renderer example.
+description: Install and wire markstream-vue, markstream-react, markstream-vue2, markstream-angular, or markstream-svelte into an existing repository. Use when Codex needs to choose the right package, install the smallest framework-specific peer-dependency set, fix CSS/reset order, choose Vue 3 renderer mode and built-in, plain, or custom code-block paths, decide between `content`, `nodes`, and Vue 3 virtual-scroll coordination, or add a minimal working renderer example.
 ---
 
 # Markstream Install
@@ -17,10 +17,10 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
    - Use `markstream-svelte` only for Svelte 5 apps.
 2. Install the smallest peer set that matches the requested features.
    - Add peers only for features the user actually needs. Check the chosen package's `peerDependencies`; peer availability differs by renderer.
-   - For Vue 3 code blocks, use `stream-diffs` for the enhanced File/Diff surface (`code-renderer="stream-diffs"`); `code-renderer="pre"` needs no code peer.
+   - Vue 3 fenced code uses the built-in renderer automatically. Add `stream-diffs` for the enhanced File/Diff surface, omit it for automatic `<pre><code>` fallback, or set `render-code-blocks-as-pre` to force the plain path.
    - Add `@antv/infographic` plus `setInfographicLoader(...)` only when infographic fences are needed.
    - Do not install every optional peer by default.
-   - For Vue 3 enhanced code-block preloading, use `preloadCodeBlockRuntime` or `getStreamDiffsRuntime` from `markstream-vue`.
+   - For Vue 3 enhanced code-block preloading, use `preloadCodeBlockRuntime` from `markstream-vue`. If the application intentionally owns a runtime controller, import that advanced API directly from `stream-diffs`.
 3. Fix CSS order.
    - Put reset styles before Markstream styles.
    - In Tailwind or UnoCSS projects, use `@import 'markstream-*/index.css' layer(components);`.
@@ -30,10 +30,10 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
     - Use `content` for static or low-frequency rendering.
     - In Vue 3 apps with long AI conversations, thread restore, or an existing message virtualizer such as `vue-virtual-scroller`, do not stop at a trivial renderer. Use `MarkstreamVirtualTimeline` or `useMarkstreamVirtualAdapter()` and follow `docs/guide/performance.md`.
     - For Vue 3, choose renderer `mode` by surface before tuning lower-level props.
-      - `mode="chat"`: AI chat or SSE output; lightweight batches, `<pre>` code rendering by default, `fade=false`, `max-live-nodes=0`, and `smooth-streaming="auto"`.
-      - `mode="docs"`: rich document surfaces; default mode, larger batches, tooltips, fade, and enhanced `stream-diffs` code blocks when the peer is installed.
+      - `mode="chat"`: AI chat or SSE output; lightweight batches, `fade=false`, `max-live-nodes=0`, and `smooth-streaming="auto"`.
+      - `mode="docs"`: rich document surfaces; default mode, larger batches, tooltips, and fade.
       - `mode="minimal"`: lightweight non-chat surfaces.
-      - Choose regular fenced-code rendering with `code-renderer="stream-diffs" | "pre"`; `render-code-blocks-as-pre` is the legacy boolean override and takes precedence when true.
+      - Regular fenced code uses the built-in renderer, enhanced by `stream-diffs` when installed. Use `render-code-blocks-as-pre` for a forced plain path or `setCustomComponents(customId, { code_block: ... })` for a scoped application-owned renderer.
     - For streaming AI chat in other Markstream packages, start with `content` and built-in smooth streaming.
       - Auto mode is the default: `smoothStreaming="auto"` / `smooth-streaming="auto"`.
       - Auto pacing activates when `typewriter=true` or `maxLiveNodes <= 0` / `max-live-nodes <= 0`.
@@ -70,6 +70,7 @@ Read [references/scenarios.md](references/scenarios.md) before making dependency
 - When the request includes SSR, explicitly gate browser-only peers behind client-only boundaries.
 - Do not widen HTML or Mermaid security defaults unless the user explicitly needs trusted legacy compatibility.
 - Enhanced code blocks in every Markstream package use `stream-diffs`; there is no `stream-monaco` or Shiki direct integration in current versions.
+- Direct `CodeBlockNode` and top-level renderer configuration use the same `codeBlockOptions` / `CodeBlockOptions` contract. Keep component chrome in `codeBlockProps`; do not nest runtime options there.
 - If compatibility requires it, scope the opt-out to the trusted surface with `htmlPolicy` / `html-policy="trusted"` and `mermaidProps.isStrict = false` instead of changing app-wide defaults blindly.
 
 ## Useful Doc Targets

--- a/.agents/skills/markstream-migration/SKILL.md
+++ b/.agents/skills/markstream-migration/SKILL.md
@@ -61,7 +61,7 @@ Inspect `package.json`, the lockfile, imports, and renderer props before changin
    - Install only the adapter used by the application. Add parser or core directly only when the application imports it directly.
    - Keep packages on the same prerelease generation; do not mix unrelated beta versions.
 3. Apply only the required dependency and API changes from [references/vue-1x-to-2x.md](references/vue-1x-to-2x.md).
-   - Remove both former code-block runtimes and their options.
+   - Remove both former code-block runtimes. Rename supported `monacoOptions` / `codeBlockMonacoOptions` fields to the shared `codeBlockOptions` contract and delete unsupported Monaco-only fields.
    - Add `stream-diffs` only when enhanced code or diff blocks are required; otherwise use the plain fallback.
    - Preserve the existing Markdown, diagram, math, HTML-policy, worker, CSS, streaming, and virtualization setup unless a documented 2.x break requires a change.
 4. Validate the migrated behavior and leave a rollback path.

--- a/.agents/skills/markstream-migration/SKILL.md
+++ b/.agents/skills/markstream-migration/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: markstream-migration
-description: Audit and migrate existing Markdown rendering to Markstream. Use when Codex needs to replace another renderer, classify direct vs custom vs plugin-heavy usage, preserve behavior during adoption, migrate custom renderers into scoped Markstream overrides, or decide when `nodes` streaming is worth adopting.
+description: Audit and migrate existing Markdown rendering to Markstream, or upgrade a markstream-vue 1.x integration to 2.x. Use when Codex needs to replace another renderer, classify direct vs custom vs plugin-heavy adoption, preserve behavior during adoption, migrate custom renderers into scoped Markstream overrides, decide when `nodes` streaming is worth adopting, or replace removed 1.x code-block dependencies, APIs, preview payloads, and parser types.
 ---
 
 # Markstream Migration
 
-Use this skill when a repo already renders Markdown and the task is to adopt Markstream safely.
+Use this skill when a repo already renders Markdown and the task is either to adopt Markstream safely or to upgrade an existing `markstream-vue` 1.x integration to 2.x.
 
-Read [references/adoption-checklist.md](references/adoption-checklist.md) before changing code.
+## Choose The Migration Route
 
-## Workflow
+Inspect `package.json`, the lockfile, imports, and renderer props before changing code.
+
+- If the repo already depends on `markstream-vue` 1.x, read [references/vue-1x-to-2x.md](references/vue-1x-to-2x.md) and follow **Route B**. Confirm the package dependency instead of routing only from shared names such as `MarkdownCodeBlockNode` or `InternalParseOptions`, which can also appear in other adapters.
+- Otherwise, when replacing `react-markdown`, `markdown-it`, `marked`, or another renderer with a Markstream package, read [references/adoption-checklist.md](references/adoption-checklist.md) and follow **Route A**.
+- If both apply, complete the 1.x to 2.x package and API upgrade first, then audit the separate renderer replacement as an adoption task.
+
+## Route A: Adopt Markstream From Another Renderer
 
 1. Audit the repo's current renderer usage.
    - Search for markdown renderers, plugin chains, raw HTML handling, security props, and custom renderers.
@@ -43,9 +49,31 @@ Read [references/adoption-checklist.md](references/adoption-checklist.md) before
    - Run the smallest relevant tests or build.
    - Report direct mappings, TODOs, and remaining verification work.
 
+## Route B: Upgrade markstream-vue 1.x To 2.x
+
+1. Freeze the current integration surface.
+   - Record the installed `markstream-vue` version and package-manager resolution.
+   - Find old code-block dependencies, renderer values, props, public types, runtime helpers, preview handlers, and direct parser imports.
+   - Identify the smallest build, typecheck, SSR, and code-block checks that prove the current behavior.
+2. Choose one release line.
+   - Use the coordinated beta family only after it is published and `next` resolves to that generation, or `markstream-vue@2` after stable release.
+   - Check registry versions and dist-tags before editing the manifest; repository version bumps do not prove that a package is installable.
+   - Install only the adapter used by the application. Add parser or core directly only when the application imports it directly.
+   - Keep packages on the same prerelease generation; do not mix unrelated beta versions.
+3. Apply only the required dependency and API changes from [references/vue-1x-to-2x.md](references/vue-1x-to-2x.md).
+   - Remove both former code-block runtimes and their options.
+   - Add `stream-diffs` only when enhanced code or diff blocks are required; otherwise use the plain fallback.
+   - Preserve the existing Markdown, diagram, math, HTML-policy, worker, CSS, streaming, and virtualization setup unless a documented 2.x break requires a change.
+4. Validate the migrated behavior and leave a rollback path.
+   - Check package resolution, public types, preview payload consumers, normal and diff fences, themes, responsive diff layout, and SSR or packed installs where relevant.
+   - Report the exact 1.x version or legacy dist-tag that restores the previous line.
+
 ## Default Decisions
 
 - Renderer swap first, streaming optimization second.
+- Do not treat an existing Markstream version upgrade as a renderer-adoption rewrite.
+- For 1.x to 2.x, preserve application behavior outside the documented code-block and parser changes.
+- Keep a coordinated beta family on one prerelease generation and make rollback explicit before changing dependencies.
 - Smooth streaming is an intermediate option between "just content" and "full nodes migration": it paces visible output without requiring AST control.
 - Preserve safety over feature parity when HTML or security rules are involved.
 - Prefer explicit TODOs over vague claims.
@@ -55,6 +83,7 @@ Read [references/adoption-checklist.md](references/adoption-checklist.md) before
 
 ## Useful Doc Targets
 
+- `docs/guide/migration-2-0.md`
 - `docs/guide/react-markdown-migration.md`
 - `docs/guide/react-markdown-migration-cookbook.md`
 - `docs/guide/ai-chat-streaming.md`

--- a/.agents/skills/markstream-migration/agents/openai.yaml
+++ b/.agents/skills/markstream-migration/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: Markstream Migration
   short_description: Adopt Markstream or upgrade markstream-vue 1.x to 2.x
-  default_prompt: "Use $markstream-migration to inspect this repository, choose between adopting Markstream from another renderer and upgrading markstream-vue 1.x to 2.x, then apply the matching migration checklist and validate the result."
+  default_prompt: 'Use $markstream-migration to inspect this repository, choose between adopting Markstream from another renderer and upgrading markstream-vue 1.x to 2.x, then apply the matching migration checklist and validate the result.'

--- a/.agents/skills/markstream-migration/agents/openai.yaml
+++ b/.agents/skills/markstream-migration/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: Markstream Migration
-  short_description: Audit and migrate existing Markdown rendering to Markstream
-  default_prompt: "Use $markstream-migration to audit this repository's current Markdown renderer and migrate it to the appropriate Markstream package."
+  short_description: Adopt Markstream or upgrade markstream-vue 1.x to 2.x
+  default_prompt: "Use $markstream-migration to inspect this repository, choose between adopting Markstream from another renderer and upgrading markstream-vue 1.x to 2.x, then apply the matching migration checklist and validate the result."

--- a/.agents/skills/markstream-migration/references/vue-1x-to-2x.md
+++ b/.agents/skills/markstream-migration/references/vue-1x-to-2x.md
@@ -1,0 +1,177 @@
+# markstream-vue 1.x To 2.x
+
+Use this reference only when an application already uses `markstream-vue` 1.x. It is not a Vue 2 to Vue 3 guide, and it is not a reason to replace unrelated application code.
+
+`markstream-vue` 2.x removes the Monaco and `stream-markdown` code-block runtimes. `stream-diffs` is the only optional enhanced code-block surface. Without it, fenced code renders as plain `<pre><code>`. Normal Markdown, Mermaid, KaTeX, D2, Infographic, HTML-policy, worker, CSS, streaming, and virtualization APIs remain available.
+
+## Audit Before Changing Dependencies
+
+Record the exact installed version and search the manifest, lockfile, source, tests, and build configuration for:
+
+- `stream-monaco`, `stream-markdown`, and `stream-diffs`
+- `codeRenderer`, `renderCodeBlocksAsPre`, and top-level `langs`
+- `monacoOptions`, `codeBlockMonacoOptions`, and `CodeBlockMonaco*`
+- `MarkdownCodeBlockNode`, `MarkdownCodeBlockNodeProps`, `MarkdownCodeBlockPreviewPayload`, and `ShikiCodeBlockProps`
+- `resolveMonacoLanguageId`, `getUseMonaco`, and exported `Monaco*` runtime types
+- `InternalParseOptions` and direct imports from `stream-markdown-parser`
+- preview listeners such as `@preview-code` and adapter callbacks such as `onHandleArtifactClick`
+
+Do not begin with a broad refactor. Capture the current typecheck, build, code-fence, preview, and SSR behavior so the migration has a concrete comparison.
+
+## Install The Target Release
+
+Before editing the manifest, query the package registry for the target version and dist-tags. A repository manifest can be bumped before its package is published, and `next` can still point to a 1.x prerelease during that interval.
+
+After the coordinated beta is published and `markstream-vue@next` resolves to the announced 2.x generation, install the Vue 3 adapter from `next`. After 2.x stable is published, use the maintained major:
+
+```bash
+# 2.x beta validation
+pnpm remove stream-monaco stream-markdown
+pnpm add markstream-vue@next
+
+# after 2.x stable is published
+pnpm add markstream-vue@2
+```
+
+Add `stream-diffs` only when the application needs enhanced File or Diff blocks:
+
+```bash
+pnpm add stream-diffs
+```
+
+Otherwise set `code-renderer="pre"` or `render-code-blocks-as-pre` explicitly when the application should always use the plain fallback. Adapt the commands to the repository's package manager and preserve its lockfile policy.
+
+### Coordinated beta family
+
+The following versions are the declared `2.0.0-beta.1` package-family targets. They are install instructions only after those exact versions are published and each `next` tag resolves to the matching generation. Install only the adapter used by the application, plus `stream-diffs` when enhanced code blocks are required. Install parser or core directly only when application code imports them itself.
+
+| Framework or layer | Coordinated version | Beta install |
+| --- | --- | --- |
+| Vue 3, Nuxt, or VitePress | `markstream-vue@2.0.0-beta.1` | `pnpm add markstream-vue@next stream-diffs` |
+| React or Next.js | `markstream-react@0.1.0-beta.1` | `pnpm add markstream-react@next stream-diffs` |
+| Octane | `markstream-octane@0.1.0-beta.1` | `pnpm add markstream-octane@next octane@^0.1.21 stream-diffs` |
+| Svelte 5 | `markstream-svelte@0.1.0-beta.1` | `pnpm add markstream-svelte@next svelte@^5 stream-diffs` |
+| Angular | `markstream-angular@0.1.0-beta.1` | `pnpm add markstream-angular@next stream-diffs` |
+| Vue 2 | `markstream-vue2@0.1.0-beta.1` | `pnpm add markstream-vue2@next stream-diffs` |
+| Parser only | `stream-markdown-parser@1.2.5-beta.1` | `pnpm add stream-markdown-parser@next` |
+| Streaming core only | `markstream-core@1.1.0-beta.1` | `pnpm add markstream-core@next` |
+
+Keep the package family on one prerelease generation. Verify the selected adapter's framework peers before installation: React requires both `react` and `react-dom` 18 or newer, Octane requires `octane@^0.1.21`, Svelte requires version 5, Angular requires `@angular/core` and `@angular/common` 20 or newer on the same Angular version line, and `markstream-vue2` requires Vue 2.6.14 or newer but below 3. Every Vue 2.6 consumer must install and register `@vue/composition-api`; Vue 2.7 has built-in Composition API support and must not install that plugin.
+
+## Replace Removed APIs
+
+| 1.x dependency or API | 2.x migration |
+| --- | --- |
+| `codeRenderer: 'monaco'` or `'shiki'` | Use `'stream-diffs'` for enhanced blocks or `'pre'` for the plain fallback. |
+| `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `CodeBlockMonacoLanguage` | Remove it. Fence languages are normalized by `resolveLanguageId`. |
+| `CodeBlockMonacoOptions` | Remove it. There is no public editor-options replacement. |
+| `resolveMonacoLanguageId` | `resolveLanguageId` |
+| `getUseMonaco` | `getStreamDiffsRuntime` |
+| `MarkdownCodeBlockNode` | `CodeBlockNode`, or the plain fallback. Adapter-specific `MarkdownCodeBlockNodeProps` imports, where present, become `CodeBlockNodeProps`. |
+| `ShikiCodeBlockProps` / top-level `langs` | Remove them. Keep `themes` when needed; language preload lists are no longer renderer props. |
+| `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`; update field access as described below. |
+| `monacoOptions` / `codeBlockMonacoOptions` | Remove them. There is no adapter-options replacement. |
+| `stream-monaco` / `stream-markdown` | Remove both dependencies. |
+| `stream-diffs` | Optional peer for enhanced blocks; omit it for plain `<pre><code>`. |
+
+For Vue templates, the typical renderer change is:
+
+```vue
+<!-- 1.x -->
+<MarkdownRender
+  :content="content"
+  code-renderer="monaco"
+  :code-block-monaco-options="editorOptions"
+/>
+
+<!-- 2.x -->
+<MarkdownRender
+  :content="content"
+  code-renderer="stream-diffs"
+  :is-dark="isDark"
+  :themes="['vitesse-dark', 'vitesse-light']"
+/>
+```
+
+Theme selection remains public. Low-level sizing, wrapping, diff-algorithm, and adapter CSS options are no longer renderer props.
+
+### Preview payload
+
+This payload migration applies only to code that directly used the removed `MarkdownCodeBlockNode` and its `MarkdownCodeBlockPreviewPayload`. Existing 1.x `CodeBlockNode` and `MarkdownRender` artifact handlers already used the common payload and do not need a shape rewrite.
+
+`MarkdownCodeBlockPreviewPayload` is not a field-for-field type rename. Its handler read `{ type, content, title }`. `CodeBlockNode` emits `CodeBlockPreviewPayload`:
+
+```ts
+import type { CodeBlockPreviewPayload } from 'markstream-vue'
+
+function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPreviewPayload) {
+  openArtifact({
+    id,
+    type: artifactType,
+    content: node.code,
+    title: artifactTitle,
+  })
+}
+```
+
+Update consumers to read rendered source from `node.code`. Across the coordinated adapters, the normalized artifact callback payload is `{ node, artifactType, artifactTitle, id }`. Custom React or Octane code-block components may still call their local `onPreviewCode` callback with optional `{ type, content, title }`; the adapter normalizes that into the common artifact payload and uses `content` as `node.code` when supplied.
+
+### Low-level runtime types
+
+These public runtime types follow the runtime rename. They describe the `stream-diffs` adapter boundary and do not restore removed editor options.
+
+| 1.x type | 2.x type |
+| --- | --- |
+| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
+| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
+| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
+| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
+| `MonacoHelpers` | `StreamDiffsHelpers` |
+| `MonacoModelLike` | `StreamDiffsModelLike` |
+| `MonacoModule` | `StreamDiffsModule` |
+| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
+| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+
+## Parser Types
+
+`InternalParseOptions` is removed. Use the public `ParseOptions` contract from the adapter root, or from `stream-markdown-parser` when the application directly owns parser calls:
+
+```ts
+import type { ParseOptions } from 'markstream-vue'
+
+const parseOptions: ParseOptions = {
+  reuseStableTopLevelNodes: true,
+}
+```
+
+The supported structured-reuse and timing fields are `reuseStableTopLevelNodes` and `parserMetrics`. Cursor, fragment, and stream-control fields remain internal and have no public replacement. Remove internal fields such as `__customHtmlBlockCursor`, `__disableStreamParse`, `__disableStructuredReuse`, and `__insideStrong` instead of copying them into application-owned parser options.
+
+## Verification
+
+1. Inspect the manifest and lockfile.
+   - `stream-monaco` and `stream-markdown` are absent.
+   - The selected adapter, directly imported parser or core, and lockfile resolve to one release family.
+   - `stream-diffs` is present only when enhanced code blocks are intended.
+2. Run the repository's package-manager install, typecheck, build, and focused renderer tests.
+3. Exercise plain and enhanced code fences, including normal files and diffs, in light and dark themes.
+4. Verify inline and side-by-side diff behavior at the widths used by the application.
+5. If the application migrated a direct `MarkdownCodeBlockNode` preview handler, trigger it and assert `{ node, artifactType, artifactTitle, id }`, including that the preview source is `node.code`. Confirm existing `CodeBlockNode` or `MarkdownRender` handlers retain that same shape.
+6. Run SSR and packed-install checks for Nuxt, VitePress, Next.js, or another server renderer.
+7. Recheck optional Mermaid, KaTeX, D2, Infographic, custom component, streaming, and virtualization behavior without changing their configuration unless a failure proves it is necessary.
+
+## Rollback And 1.x Maintenance
+
+Before upgrading, record the exact working 1.x version and retain the pre-migration lockfile. At the `2.0.0-beta.1` repository baseline, the last stable is `markstream-vue@1.0.9` and the preserved prerelease candidate is `markstream-vue@1.1.2-beta.3`. If validation fails, revert the dependency and source changes together; do not leave 2.x code using 1.x packages or restore only one removed runtime.
+
+Use the maintained 1.x channels when a rollback must stay on that major:
+
+| Intent | Install |
+| --- | --- |
+| Exact pre-cutover stable | `pnpm add markstream-vue@1.0.9` |
+| Exact pre-cutover prerelease | `pnpm add markstream-vue@1.1.2-beta.3` |
+| Latest maintained 1.x stable | `pnpm add markstream-vue@1` |
+| Legacy stable alias after the 2.x stable cutover | `pnpm add markstream-vue@legacy` |
+| Latest maintained 1.x prerelease after the beta cutover | `pnpm add markstream-vue@legacy-next` |
+
+Applications pinned to `^1.x` remain on the 1.x line. Do not assume that `legacy` or `legacy-next` exists before its corresponding release cutover; use an exact known-good version or `@1` before then. After the beta cutover, `next` belongs to 2.x while `latest` still belongs to 1.x. After the stable cutover, both `latest` and `next` belong to 2.x; use `@1`, `legacy`, or `legacy-next` for the maintained 1.x line.

--- a/.agents/skills/markstream-migration/references/vue-1x-to-2x.md
+++ b/.agents/skills/markstream-migration/references/vue-1x-to-2x.md
@@ -9,7 +9,7 @@ Use this reference only when an application already uses `markstream-vue` 1.x. I
 Record the exact installed version and search the manifest, lockfile, source, tests, and build configuration for:
 
 - `stream-monaco`, `stream-markdown`, and `stream-diffs`
-- `codeRenderer`, `renderCodeBlocksAsPre`, and top-level `langs`
+- `codeRenderer`, `markdownCodeRenderer`, `NodeRendererCodeRenderer`, `renderCodeBlocksAsPre`, and top-level `langs`
 - `monacoOptions`, `codeBlockMonacoOptions`, and `CodeBlockMonaco*`
 - `MarkdownCodeBlockNode`, `MarkdownCodeBlockNodeProps`, `MarkdownCodeBlockPreviewPayload`, and `ShikiCodeBlockProps`
 - `resolveMonacoLanguageId`, `getUseMonaco`, and exported `Monaco*` runtime types
@@ -39,7 +39,7 @@ Add `stream-diffs` only when the application needs enhanced File or Diff blocks:
 pnpm add stream-diffs
 ```
 
-Otherwise set `code-renderer="pre"` or `render-code-blocks-as-pre` explicitly when the application should always use the plain fallback. Adapt the commands to the repository's package manager and preserve its lockfile policy.
+Otherwise set `render-code-blocks-as-pre` when the application should always use the plain fallback. Use a scoped `setCustomComponents(customId, { code_block: MyCodeBlock })` mapping when the application owns the renderer. Adapt the commands to the repository's package manager and preserve its lockfile policy.
 
 ### Coordinated beta family
 
@@ -62,18 +62,24 @@ Keep the package family on one prerelease generation. Verify the selected adapte
 
 | 1.x dependency or API | 2.x migration |
 | --- | --- |
-| `codeRenderer: 'monaco'` or `'shiki'` | Use `'stream-diffs'` for enhanced blocks or `'pre'` for the plain fallback. |
-| `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `codeRenderer: 'monaco'`, `'shiki'`, or `'pre'` | Remove it. Enhanced blocks use `stream-diffs` automatically. Replace the old `'pre'` value with `renderCodeBlocksAsPre`; use `setCustomComponents(customId, { code_block: ... })` for a scoped custom renderer. |
+| `markdownCodeRenderer` / `NodeRendererCodeRenderer` | Remove them. Timeline and virtual-adapter callers use `renderCodeBlocksAsPre: true` only when they require the plain path. |
+| string `CodeBlockMonacoTheme` | string `CodeBlockTheme`; use `CodeBlockThemePair` for `{ dark, light }` selection. |
+| Monaco JSON theme object / `CodeBlockMonacoThemeObject` | No direct conversion. Translate it to a Shiki `ThemeRegistration`, register it with `registerCustomTheme(name, loader)` from `stream-diffs/pierre`, then pass the registered name. |
 | `CodeBlockMonacoLanguage` | Remove it. Fence languages are normalized by `resolveLanguageId`. |
-| `CodeBlockMonacoOptions` | Remove it. There is no public editor-options replacement. |
+| `CodeBlockMonacoOptions` | `CodeBlockOptions` for the supported renderer-neutral fields. |
 | `resolveMonacoLanguageId` | `resolveLanguageId` |
-| `getUseMonaco` | `getStreamDiffsRuntime` |
+| `getUseMonaco` used only for preload | `preloadCodeBlockRuntime` |
+| `getUseMonaco` used for direct runtime calls | Import the advanced API directly from `stream-diffs`; Markstream does not expose its raw runtime module. |
 | `MarkdownCodeBlockNode` | `CodeBlockNode`, or the plain fallback. Adapter-specific `MarkdownCodeBlockNodeProps` imports, where present, become `CodeBlockNodeProps`. |
 | `ShikiCodeBlockProps` / top-level `langs` | Remove them. Keep `themes` when needed; language preload lists are no longer renderer props. |
 | `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`; update field access as described below. |
-| `monacoOptions` / `codeBlockMonacoOptions` | Remove them. There is no adapter-options replacement. |
+| Direct `CodeBlockNode.monacoOptions` | `CodeBlockNode.codeBlockOptions` |
+| `MarkdownRender.codeBlockMonacoOptions` | top-level `MarkdownRender.codeBlockOptions` |
 | `stream-monaco` / `stream-markdown` | Remove both dependencies. |
 | `stream-diffs` | Optional peer for enhanced blocks; omit it for plain `<pre><code>`. |
+
+In 1.x, direct `CodeBlockNode` usage accepted `monacoOptions`; `MarkdownRender` exposed `codeBlockMonacoOptions` as the wrapper-level forwarding prop. In 2.x both entry points use the same `codeBlockOptions` name, and every coordinated adapter exposes it on direct `CodeBlockNode` plus top-level `NodeRenderer` / `MarkdownRender`. Keep header and toolbar configuration in the separate `codeBlockProps` bag.
 
 For Vue templates, the typical renderer change is:
 
@@ -88,13 +94,50 @@ For Vue templates, the typical renderer change is:
 <!-- 2.x -->
 <MarkdownRender
   :content="content"
-  code-renderer="stream-diffs"
   :is-dark="isDark"
+  :code-block-options="codeBlockOptions"
   :themes="['vitesse-dark', 'vitesse-light']"
 />
 ```
 
-Theme selection remains public. Low-level sizing, wrapping, diff-algorithm, and adapter CSS options are no longer renderer props.
+Migrate only supported fields. Host-managed typography/layout includes `fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, and `tabSize`; supported File/FileDiff fields include `disableLineNumbers`, `overflow`, highlighter limits, diff layout/folding, interactions, selection callbacks, annotations, `onController`, and `workerManager`. Theme, content/language, stream state, the single header, mount/reveal timing, and disposal remain host-owned and take precedence. If 1.x used different top and bottom padding values, choose one symmetric pixel value during migration; the 2.x option cannot preserve asymmetric padding.
+
+Map common old fields explicitly:
+
+| 1.x option | 2.x option |
+| --- | --- |
+| `MAX_HEIGHT: number` | `maxHeight: number` in CSS pixels; convert string values explicitly. |
+| `wordWrap: 'on'` / `'off'` | `overflow: 'wrap'` / `'scroll'`; choose manually for `wordWrapColumn` or `bounded`. |
+| `renderSideBySide: true` / `false` | `diffStyle: 'split'` / `'unified'` |
+| `diffUnchangedRegionStyle` | `hunkSeparators` |
+| `diffHideUnchangedRegions` | Map `false` / `{ enabled: false }` to `expandUnchanged: true`, and `true` / `{ enabled: true }` to `expandUnchanged: false`. Use `parseDiffOptions.context`, `collapsedContextThreshold`, and `expansionLineCount` for the remaining behavior; tune them because there is no field-for-field conversion. |
+
+Theme values are registered names. Direct `CodeBlockNode.theme` accepts a string or `{ dark, light }`, while `themes` is the `[dark, light]` pair. A former Monaco JSON object must first be converted to a Shiki `ThemeRegistration`; translate Monaco `rules` into Shiki `tokenColors` or `settings` before registering it:
+
+```ts
+import type { ThemeRegistration } from 'stream-diffs/pierre'
+import { registerCustomTheme } from 'stream-diffs/pierre'
+
+const themeName = 'acme-dark'
+const acmeDark: ThemeRegistration = {
+  name: themeName,
+  type: 'dark',
+  colors: {
+    'editor.background': '#0d1117',
+    'editor.foreground': '#c9d1d9',
+  },
+  tokenColors: [
+    {
+      scope: ['comment'],
+      settings: { foreground: '#8b949e', fontStyle: 'italic' },
+    },
+  ],
+}
+
+registerCustomTheme(themeName, async () => acmeDark)
+```
+
+Pass `themeName` after registration; never pass the former Monaco object directly. A generic `code_block` override applies to ordinary fences; Mermaid, D2, and Infographic use dedicated component keys and must be overridden separately when required.
 
 ### Preview payload
 
@@ -117,21 +160,9 @@ function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPrevi
 
 Update consumers to read rendered source from `node.code`. Across the coordinated adapters, the normalized artifact callback payload is `{ node, artifactType, artifactTitle, id }`. Custom React or Octane code-block components may still call their local `onPreviewCode` callback with optional `{ type, content, title }`; the adapter normalizes that into the common artifact payload and uses `content` as `node.code` when supplied.
 
-### Low-level runtime types
+### Low-level runtime access
 
-These public runtime types follow the runtime rename. They describe the `stream-diffs` adapter boundary and do not restore removed editor options.
-
-| 1.x type | 2.x type |
-| --- | --- |
-| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
-| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
-| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
-| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
-| `MonacoHelpers` | `StreamDiffsHelpers` |
-| `MonacoModelLike` | `StreamDiffsModelLike` |
-| `MonacoModule` | `StreamDiffsModule` |
-| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
-| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+Do not replace root-level `Monaco*` runtime imports with guessed `StreamDiffs*` imports from Markstream. Use `preloadCodeBlockRuntime()` when the old code only warmed the optional module. When an application intentionally owns a controller, import its functions and types directly from `stream-diffs` and own its lifecycle.
 
 ## Parser Types
 
@@ -155,6 +186,8 @@ The supported structured-reuse and timing fields are `reuseStableTopLevelNodes` 
    - `stream-diffs` is present only when enhanced code blocks are intended.
 2. Run the repository's package-manager install, typecheck, build, and focused renderer tests.
 3. Exercise plain and enhanced code fences, including normal files and diffs, in light and dark themes.
+   - Verify migrated `codeBlockOptions` on both direct and renderer-level paths.
+   - Verify custom theme names were registered; do not pass old Monaco JSON objects as `theme`.
 4. Verify inline and side-by-side diff behavior at the widths used by the application.
 5. If the application migrated a direct `MarkdownCodeBlockNode` preview handler, trigger it and assert `{ node, artifactType, artifactTitle, id }`, including that the preview source is `node.code`. Confirm existing `CodeBlockNode` or `MarkdownRender` handlers retain that same shape.
 6. Run SSR and packed-install checks for Nuxt, VitePress, Next.js, or another server renderer.

--- a/.agents/skills/markstream-nuxt/SKILL.md
+++ b/.agents/skills/markstream-nuxt/SKILL.md
@@ -16,10 +16,10 @@ Use this skill when the host app is Nuxt and SSR boundaries matter.
 4. Import `markstream-vue/index.css` from a client-safe app shell or plugin.
    - The root JS import does not inject styles; use `markstream-vue/index.css` or `markstream-vue/index.px.css` explicitly.
 5. Start with `content`, choose the renderer mode by surface, and move to `nodes` plus `final` only when the UI needs custom AST control.
-   - Use `mode="chat"` for AI chat or SSE output. It uses lightweight batches, `<pre>` code rendering by default, `fade=false`, and `max-live-nodes=0`; `smooth-streaming="auto"` paces visible output.
-   - Use `mode="docs"` for rich document surfaces. It is the default, enables larger batches, tooltips, fade, and enhanced `stream-diffs` code blocks when the peer is installed.
+   - Use `mode="chat"` for AI chat or SSE output. It uses lightweight batches, `fade=false`, and `max-live-nodes=0`; `smooth-streaming="auto"` paces visible output.
+   - Use `mode="docs"` for rich document surfaces. It is the default and enables larger batches, tooltips, and fade.
    - Use `mode="minimal"` for lightweight non-chat surfaces.
-   - Choose regular fenced-code rendering with `code-renderer="stream-diffs" | "pre"`. `stream-diffs` renders enhanced File/Diff code blocks; `pre` needs no code peer.
+   - Regular fenced code uses the built-in renderer, enhanced by `stream-diffs` when the optional peer is installed. Use `render-code-blocks-as-pre` for a forced plain path or `setCustomComponents(customId, { code_block: ... })` for a scoped application-owned renderer.
    - `typewriter` only controls the blinking cursor and defaults to `false`. Prefer `typewriter="simple"` for high-frequency chat.
    - When overriding mode defaults on a high-frequency stream, pair smooth streaming with `:fade="false"` to avoid delta fade stacking with high-commit pacing.
    - **Streaming vs recovering history**: in chat UIs the same `MarkdownRender` starts streaming and later switches to history when `final=true`.
@@ -38,6 +38,7 @@ Use this skill when the host app is Nuxt and SSR boundaries matter.
 - Avoid import-time access to browser globals from server code paths.
 - Treat the enhanced code runtime, Mermaid workers, and similar heavy peers as client-only unless the repo already has a proven SSR pattern.
 - Enhanced code blocks in every Markstream package use `stream-diffs`; do not install `stream-monaco`.
+- Use top-level `code-block-options` for supported built-in code-surface configuration. Keep theme, code/language, streaming lifecycle, header, mounting, reveal, and disposal under Markstream's control.
 - Keep `html-policy="safe"` and Mermaid strict mode unless the task is preserving trusted legacy rendering.
 - If a trusted client-only surface needs older behavior, opt out locally with `html-policy="trusted"` and `:mermaid-props="{ isStrict: false }"`, and document why that surface is trusted.
 

--- a/.agents/skills/markstream-vue/SKILL.md
+++ b/.agents/skills/markstream-vue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markstream-vue
-description: Integrate markstream-vue into a Vue 3 app. Use when Codex needs to add the Vue 3 renderer, import CSS in the right order, choose renderer, DOM, and code-block modes, choose between `content` and `nodes`, coordinate long AI timelines with `MarkstreamVirtualTimeline`, `useMarkstreamVirtualAdapter`, or `vue-virtual-scroller`, enable optional peers such as stream-diffs, Mermaid, KaTeX, D2, or Infographic, or wire scoped custom components in a non-Nuxt Vue repository.
+description: Integrate markstream-vue into a Vue 3 app. Use when Codex needs to add the Vue 3 renderer, import CSS in the right order, choose renderer and DOM modes, choose built-in, plain, or custom code-block paths, choose between `content` and `nodes`, coordinate long AI timelines with `MarkstreamVirtualTimeline`, `useMarkstreamVirtualAdapter`, or `vue-virtual-scroller`, enable optional peers such as stream-diffs, Mermaid, KaTeX, D2, or Infographic, or wire scoped custom components in a non-Nuxt Vue repository.
 ---
 
 # Markstream Vue 3
@@ -15,17 +15,17 @@ Use this skill when the host app is plain Vue 3, typically Vite-based, and not N
    - In Tailwind or UnoCSS projects, use `@import 'markstream-vue/index.css' layer(components);`.
    - The root JS import does not inject styles; use `markstream-vue/index.css` or `markstream-vue/index.px.css` explicitly.
 4. Start with `content` and choose the renderer mode by surface.
-   - Use `mode="chat"` for AI chat or SSE output. It uses lightweight batches, `<pre>` code rendering by default, `fade=false`, and `max-live-nodes=0`; `smooth-streaming="auto"` paces visible output.
-   - Use `mode="docs"` for rich document surfaces. It is the default, enables larger batches, tooltips, fade, and enhanced `stream-diffs` code blocks when the peer is installed.
+   - Use `mode="chat"` for AI chat or SSE output. It uses lightweight batches, `fade=false`, and `max-live-nodes=0`; `smooth-streaming="auto"` paces visible output.
+   - Use `mode="docs"` for rich document surfaces. It is the default and enables larger batches, tooltips, and fade.
    - Use `mode="minimal"` when the surface is lightweight but not chat.
-   - Choose regular fenced-code rendering with `code-renderer="stream-diffs" | "pre"`. `stream-diffs` renders enhanced File/Diff code blocks; `pre` needs no code peer. `render-code-blocks-as-pre=true` takes precedence.
+   - Regular fenced code uses the built-in `CodeBlockNode`, enhanced by `stream-diffs` when that optional peer is installed and otherwise falling back to `<pre><code>`. Set `render-code-blocks-as-pre=true` to force the plain path, or replace `code_block` through scoped `setCustomComponents(...)` when the app owns the renderer.
    - Use `dom-mode="minimal"` only when the surface can also disable wrapper-dependent features such as fade, batching, deferral, virtualization, typewriter, and custom components; otherwise it falls back to full DOM.
    - `typewriter` only controls the blinking cursor and defaults to `false`. Prefer `typewriter="simple"` for high-frequency chat and precise mode for complex inline cursor placement.
    - Set `:smooth-streaming="false"` to preserve raw chunk cadence; set `:smooth-streaming="true"` to force smooth pacing even on first-screen content (may cause hydration mismatch in SSR).
    - When overriding mode defaults on a high-frequency stream, pair smooth streaming with `:fade="false"` to avoid delta fade (280 ms) stacking with high-commit pacing.
    - **Streaming vs recovering history**: in chat UIs the same `MarkdownRender` starts streaming and later switches to history when `final=true`.
      - Streaming: `mode="chat"`, `smooth-streaming="auto"`, `:fade="false"`, `typewriter=true`.
-     - Recovering/completed chat history: keep `mode="chat"` on the same chat row to avoid switching code renderer or layout strategy when `final=true`; use `:smooth-streaming="false"`, `typewriter=false`, and only set `:fade="true"` when the host explicitly wants a history-entry animation.
+     - Recovering/completed chat history: keep `mode="chat"` on the same chat row to avoid switching layout strategy when `final=true`; use `:smooth-streaming="false"`, `typewriter=false`, and only set `:fade="true"` when the host explicitly wants a history-entry animation.
      - Use `mode="minimal"` for lightweight non-chat recovered content, and use `mode="docs"` only for rich document surfaces, not for finalizing an existing chat message.
    - Switch to `nodes` plus `final` only when the app needs custom AST control, worker preparsing, or structural updates beyond pacing.
    - Remember that `html-policy` now defaults to `safe`, and Mermaid strict mode is on by default through `mermaid-props`.
@@ -48,8 +48,9 @@ Use this skill when the host app is plain Vue 3, typically Vite-based, and not N
 - Prefer local component registration unless the repo already uses a shared plugin entry.
 - If a Vue 3 app already virtualizes messages, keep that outer virtualizer in charge and enable `virtual-scroll` only on large Markdown messages.
 - For `vue-virtual-scroller`, keep `sessionKey` tied to content identity (`thread:item:revision`) and `measurementKey` tied to layout identity such as width, theme, font, and density.
-- When enhanced code blocks need app-level preloading, `preloadCodeBlockRuntime` is still available to preload the runtime. For direct runtime use, `getStreamDiffsRuntime()` is exported from `markstream-vue`.
+- When enhanced code blocks need app-level preloading, use `preloadCodeBlockRuntime`. For intentional low-level controller use, import the advanced API directly from `stream-diffs`; do not depend on a raw-runtime getter from `markstream-vue`.
 - The Vue 3 enhanced code surface uses `stream-diffs` only; do not install `stream-monaco`.
+- Configure the built-in surface through top-level `code-block-options` or direct `CodeBlockNode.codeBlockOptions`. Keep header/toolbar props in `code-block-props`; Markstream retains ownership of theme, code/language, streaming lifecycle, header, mount/reveal timing, and disposal.
 - Keep `html-policy="safe"` and Mermaid strict mode unless the task is explicitly preserving trusted legacy behavior.
 - If a trusted surface needs pre-hardening behavior, opt out locally with `html-policy="trusted"` and `:mermaid-props="{ isStrict: false }"`, and call out the trust boundary in the final handoff.
 - If the host is actually Nuxt, leave SSR-specific setup to `markstream-nuxt`.

--- a/.agents/skills/markstream-vue2-cli/SKILL.md
+++ b/.agents/skills/markstream-vue2-cli/SKILL.md
@@ -16,6 +16,7 @@ Use this skill when the host app is Vue 2 on Vue CLI or another Webpack 4-style 
    - Use `createKaTeXWorkerFromCDN(...)` and `createMermaidWorkerFromCDN(...)` when workers are needed.
 5. Prefer stable code block defaults over brittle wiring.
    - In Webpack 4-era repos, `stream-diffs` (or plain `<pre>`) is the only code block runtime — there is no Monaco/`stream-monaco` fallback and no `MarkdownCodeBlockNode`.
+   - Use top-level `code-block-options` or direct `CodeBlockNode.code-block-options` for the shared renderer-neutral option contract. Keep header/toolbar props in `code-block-props`.
    - For AI chat or streaming UIs, keep `content` and use built-in smooth streaming first.
      - `smooth-streaming="auto"` is the default and activates when `typewriter=true` or `max-live-nodes <= 0`.
      - `typewriter` only controls the blinking cursor and defaults to `false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### ⚠ Breaking changes
 
-- Remove the Monaco and `stream-markdown` code-block runtimes, their peers, `MarkdownCodeBlockNode`, React / Octane `MarkdownCodeBlockNodeProps`, `ShikiCodeBlockProps`, the top-level `langs` prop, and the `CodeBlockMonaco*` public types and props.
+- Remove the Monaco and `stream-markdown` code-block runtimes, their peers, `MarkdownCodeBlockNode`, React / Octane `MarkdownCodeBlockNodeProps`, `ShikiCodeBlockProps`, the top-level `langs` prop, and Monaco-named public types and props.
 - Use `stream-diffs` as the only enhanced code-block surface; without the optional peer, code fences fall back to plain `<pre><code>` rendering.
-- Remove `codeRenderer` values `monaco` and `shiki`. `monacoOptions` and `codeBlockMonacoOptions` have no replacement.
-- Replace `CodeBlockMonacoTheme` with `CodeBlockTheme`, `resolveMonacoLanguageId` with `resolveLanguageId`, and `getUseMonaco` with `getStreamDiffsRuntime`.
-- Replace the low-level `MonacoDiffEditorViewLike`, `MonacoDiffLineChangeLike`, `MonacoDisposableLike`, `MonacoEditorViewLike`, `MonacoHelpers`, `MonacoModelLike`, `MonacoModule`, `MonacoNamespaceLike`, and `MonacoRuntimeOptions` types with their `StreamDiffs*` counterparts.
+- Remove `codeRenderer`, `markdownCodeRenderer`, and the `NodeRendererCodeRenderer` type. Enhanced code blocks use `stream-diffs` automatically; use `renderCodeBlocksAsPre` for plain `<pre><code>` output or `setCustomComponents(customId, { code_block: ... })` for a scoped custom renderer.
+- Replace direct `monacoOptions`, wrapper-level `codeBlockMonacoOptions`, and `CodeBlockMonacoOptions` with the shared `codeBlockOptions` / `CodeBlockOptions` API on direct `CodeBlockNode` and top-level `NodeRenderer` / `MarkdownRender` across Vue 3, React, Octane, Svelte, Angular, and Vue 2. `maxHeight` is a numeric pixel value, and `padding` is one symmetric numeric pixel value rather than separate top and bottom values.
+- Replace string `CodeBlockMonacoTheme` with string `CodeBlockTheme` and `{ dark, light }` theme pairs. Monaco JSON theme objects have no direct rename; register one with `registerCustomTheme` from `stream-diffs/pierre` and pass its name. `themes` is the `[dark, light]` name pair.
+- Replace `resolveMonacoLanguageId` with `resolveLanguageId`. For historical `getUseMonaco` preload usage, use `preloadCodeBlockRuntime`; import advanced controller APIs directly from `stream-diffs` instead of relying on a Markstream raw-runtime getter or copied `StreamDiffs*` types.
 - For consumers that directly used the removed `MarkdownCodeBlockNode`, replace `MarkdownCodeBlockPreviewPayload` with `CodeBlockPreviewPayload`; those handlers now receive `{ node, artifactType, artifactTitle, id }` instead of `{ type, content, title }`. Existing `CodeBlockNode` and `MarkdownRender` handlers already use the common payload.
 - Replace the parser-only `InternalParseOptions` type with the public `ParseOptions` contract.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@
 
 ### ⚠ Breaking changes
 
-- Remove the Monaco and `stream-markdown` code-block runtimes, their peers, `MarkdownCodeBlockNode`, and the `CodeBlockMonaco*` public types and props.
+- Remove the Monaco and `stream-markdown` code-block runtimes, their peers, `MarkdownCodeBlockNode`, React / Octane `MarkdownCodeBlockNodeProps`, `ShikiCodeBlockProps`, the top-level `langs` prop, and the `CodeBlockMonaco*` public types and props.
 - Use `stream-diffs` as the only enhanced code-block surface; without the optional peer, code fences fall back to plain `<pre><code>` rendering.
-- Remove `codeRenderer` values `monaco`, `shiki`, and `markdown`. `monacoOptions` and `codeBlockMonacoOptions` have no replacement.
+- Remove `codeRenderer` values `monaco` and `shiki`. `monacoOptions` and `codeBlockMonacoOptions` have no replacement.
 - Replace `CodeBlockMonacoTheme` with `CodeBlockTheme`, `resolveMonacoLanguageId` with `resolveLanguageId`, and `getUseMonaco` with `getStreamDiffsRuntime`.
+- Replace the low-level `MonacoDiffEditorViewLike`, `MonacoDiffLineChangeLike`, `MonacoDisposableLike`, `MonacoEditorViewLike`, `MonacoHelpers`, `MonacoModelLike`, `MonacoModule`, `MonacoNamespaceLike`, and `MonacoRuntimeOptions` types with their `StreamDiffs*` counterparts.
+- For consumers that directly used the removed `MarkdownCodeBlockNode`, replace `MarkdownCodeBlockPreviewPayload` with `CodeBlockPreviewPayload`; those handlers now receive `{ node, artifactType, artifactTitle, id }` instead of `{ type, content, title }`. Existing `CodeBlockNode` and `MarkdownRender` handlers already use the common payload.
 - Replace the parser-only `InternalParseOptions` type with the public `ParseOptions` contract.
 
 ### Features and reliability
 
 - Complete the parser ownership, leaf-module, reuse, lifecycle, API-snapshot, differential, and performance-gate work tracked by the 2.0 parser epic.
 - Align Vue 3, React, Octane, Svelte, Angular, and Vue 2 code-block rendering on the same `stream-diffs` handoff and plain fallback behavior.
-- Keep 1.x releases isolated on `legacy` / `legacy-next` while 2.x uses `latest` / `next`.
+- During beta validation, keep 1.x stable releases on `latest`, preserve 1.x prereleases on `legacy-next`, and use `next` for 2.x betas. After the stable cutover, use `legacy` / `legacy-next` for 1.x and `latest` / `next` for 2.x.
 
 ### Coordinated beta versions
 

--- a/README.md
+++ b/README.md
@@ -360,9 +360,11 @@ Choose the renderer mode by surface:
 ```
 
 Use `mode="minimal"` when you want the same lightweight defaults as `chat`, but prefer a neutral mode name for non-chat surfaces. Avoid combining high-frequency `smooth-streaming` with `fade`; it can turn a steady stream into repeated opacity restarts.
-For the same chat message, do not switch from `mode="chat"` to `mode="docs"` only because `final` changed. Keep the mode stable and switch pacing/animation props (`smooth-streaming`, `typewriter`, `fade`) instead; `docs` changes the default code renderer and layout strategy.
-For docs pages that do not need enhanced code blocks, set `:render-code-blocks-as-pre="true"`. If you want the rich `CodeBlockNode` UI and File/Diff rendering, install `stream-diffs`; otherwise the renderer intentionally falls back to `<pre>` rendering.
+For the same chat message, do not switch from `mode="chat"` to `mode="docs"` only because `final` changed. Keep the mode stable and switch pacing/animation props (`smooth-streaming`, `typewriter`, `fade`) instead; `docs` changes the layout strategy.
+For surfaces that do not need enhanced code blocks, set `:render-code-blocks-as-pre="true"`. If you want the rich `CodeBlockNode` UI and File/Diff rendering, install `stream-diffs`; otherwise the renderer intentionally falls back to `<pre>` rendering. To own ordinary fenced-code rendering, register a scoped `code_block` with `setCustomComponents`.
 `stream-diffs` is a framework-agnostic DOM runtime. `CodeBlockNode` owns the Vue-side decision of when to replace the streaming `<pre>` with its finalized File or FileDiff surface.
+
+Use the top-level `code-block-options` prop to configure the built-in surface; direct `CodeBlockNode` usage accepts the same `codeBlockOptions` object. `CodeBlockOptions` is shared across all six framework adapters. It covers host-managed typography/layout (`fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, `tabSize`) plus supported File/FileDiff, interaction, annotation, and callback fields. Theme, code/language, stream state, header, mounting, reveal, and disposal remain host-owned.
 
 Renderer CSS is scoped under an internal `.markstream-vue` container to minimize global style conflicts. If you render exported node components outside of `MarkdownRender`, wrap them in an element with class `markstream-vue`.
 
@@ -377,6 +379,8 @@ Prefer the unified code-block `theme` prop for new integrations. When you render
   :content="doc"
 />
 ```
+
+Theme values are registered names: direct `CodeBlockNode.theme` accepts a fixed string or `{ dark, light }`, and `themes` is the `[dark, light]` pair to load. A former Monaco JSON theme object is not renamed directly; call `registerCustomTheme` from `stream-diffs/pierre`, then pass the registered name.
 
 `code-block-props` forwards user-facing code block props only. Structural renderer keys such as `node`, `key`, `ref`, `ctx`, `renderNode`, `indexKey`, `__proto__`, `prototype`, and `constructor` are ignored.
 
@@ -664,7 +668,7 @@ If markstream-vue helps your work, you can support ongoing maintenance with one 
 - Full history: [CHANGELOG.md](./CHANGELOG.md)
 - 2.0 beta candidate:
   - After `npm view markstream-vue@next version` reports `2.0.0-beta.1`, install `markstream-vue@next` with `stream-diffs`; stable 1.x remains available through `@1`.
-  - Monaco, `stream-markdown`, and their public code-block APIs are removed.
+  - Monaco and `stream-markdown` runtimes and Monaco-named APIs are removed; supported code-block options move to `codeBlockOptions`.
   - Read [Migrating from 1.x to 2.0](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 - 1.0 launch notes:
   - Stable Vue 3 renderer API, SSR imports, CSS exports, Tailwind export, worker client exports, and safe HTML defaults.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ Other packages:
 
 ## Install markstream-vue
 
+The stable line remains 1.x. The coordinated 2.0 beta will use `next`; first verify
+that `npm view markstream-vue@next version` reports `2.0.0-beta.1`, then follow
+the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0):
+
 ```bash
-pnpm add markstream-vue
+pnpm add markstream-vue@next stream-diffs
+```
+
+During the beta, the untagged package remains on 1.x. Use `@1` when you want to
+pin the maintained 1.x line across the stable 2.0 cutover:
+
+```bash
+pnpm add markstream-vue@1
 ```
 
 ```vue
@@ -88,7 +99,9 @@ Start with the [framework overview](https://markstream.simonhe.me/frameworks) if
 
 ## Stability
 
-`markstream-vue` has a stable 1.x API contract. The current npm package may still use beta tags while the 1.0 release gate and cross-framework package family are finalized. The stable surface includes `MarkdownRender`, streaming content rendering, pre-parsed node rendering, the safe HTML policy, optional Mermaid / KaTeX / D2 / Infographic integrations, stream-diffs enhanced code blocks, virtual-scroll coordination, CSS exports, worker client subpaths, and SSR imports for Vite / Nuxt / VitePress.
+`markstream-vue` has a stable 1.x API contract. The breaking 2.0 line will be released through the npm `next` tag for validation before it can replace `latest`. It removes the Monaco and `stream-markdown` code-block runtimes and uses `stream-diffs` as the only enhanced code-block surface. See [Migrating from 1.x to 2.0](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+The stable surface includes `MarkdownRender`, streaming content rendering, pre-parsed node rendering, the safe HTML policy, optional Mermaid / KaTeX / D2 / Infographic integrations, enhanced code blocks, virtual-scroll coordination, CSS exports, worker client subpaths, and SSR imports for Vite / Nuxt / VitePress.
 
 Cross-framework renderers (`markstream-react`, `markstream-octane`, `markstream-svelte`, `markstream-angular`, `markstream-vue2`) are available and actively developed. Check each package page for API maturity, framework support, and known limitations.
 
@@ -178,6 +191,7 @@ npx skills add Simon-He95/markstream-vue
 Recommended usage:
 
 - `npx skills add Simon-He95/markstream-vue` is the primary path for Codex-compatible skill discovery because it reads `.agents/skills` directly from the GitHub repository
+- use the bundled `markstream-migration` skill when upgrading an existing Markstream 1.x application to 2.0
 - `markstream-vue@1.0` no longer exposes the `markstream-vue` CLI or any CLI `bin`; repository scripts such as `pnpm skills:list` and `pnpm prompts:list` are contributor-only helpers for cloned checkouts
 - prompts remain in the repository under `prompts/` for direct copying or future separate-package work
 
@@ -648,6 +662,10 @@ If markstream-vue helps your work, you can support ongoing maintenance with one 
 
 - Latest: [Releases](https://github.com/Simon-He95/markstream-vue/releases) — see highlights and upgrade notes.
 - Full history: [CHANGELOG.md](./CHANGELOG.md)
+- 2.0 beta candidate:
+  - After `npm view markstream-vue@next version` reports `2.0.0-beta.1`, install `markstream-vue@next` with `stream-diffs`; stable 1.x remains available through `@1`.
+  - Monaco, `stream-markdown`, and their public code-block APIs are removed.
+  - Read [Migrating from 1.x to 2.0](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 - 1.0 launch notes:
   - Stable Vue 3 renderer API, SSR imports, CSS exports, Tailwind export, worker client exports, and safe HTML defaults.
   - `markstream-vue@1.0.0`, `markstream-core@1.0.0`, and `stream-markdown-parser@1.0.0` ship together.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -332,9 +332,11 @@ createApp({
 ```
 
 当你想要和 `chat` 相同的轻量默认值，但当前页面不是聊天语义时，可以使用 `mode="minimal"`。避免把高频 `smooth-streaming` 和 `fade` 同时开启，否则稳定的流式输出可能变成反复重启的透明度动画。
-同一条聊天消息不要仅因为 `final` 变为 `true` 就从 `mode="chat"` 切到 `mode="docs"`。保持 mode 稳定，只切换 `smooth-streaming`、`typewriter`、`fade` 等节奏/动画 props；`docs` 会改变默认代码块渲染器和布局策略。
-如果文档页不需要增强代码块，建议设置 `:render-code-blocks-as-pre="true"`；如果需要富 `CodeBlockNode` UI 与 File/Diff 渲染，请安装 `stream-diffs`，否则渲染器会按设计降级为 `<pre>` 渲染。
+同一条聊天消息不要仅因为 `final` 变为 `true` 就从 `mode="chat"` 切到 `mode="docs"`。保持 mode 稳定，只切换 `smooth-streaming`、`typewriter`、`fade` 等节奏/动画 props；`docs` 会改变布局策略。
+如果某个渲染面不需要增强代码块，建议设置 `:render-code-blocks-as-pre="true"`；如果需要富 `CodeBlockNode` UI 与 File/Diff 渲染，请安装 `stream-diffs`，否则渲染器会按设计降级为 `<pre>` 渲染。如果应用要完全接管普通 fenced code，用 `setCustomComponents` 注册带作用域的 `code_block`。
 `stream-diffs` 是与框架无关的 DOM runtime；由 `CodeBlockNode` 决定何时把流式 `<pre>` 切换为最终的 File 或 FileDiff surface。
+
+使用顶层 `code-block-options` 配置内置 surface；直接使用 `CodeBlockNode` 时接收同一个 `codeBlockOptions` object。六个框架 adapter 共享 `CodeBlockOptions`。它包含宿主管理的排版/布局字段（`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`），以及受支持的 File/FileDiff、交互、annotation 与 callback 字段。主题、code/language、流式状态、header、挂载、显示与释放仍由宿主管理。
 
 渲染器的 CSS 会作用于内部 `.markstream-vue` 容器下，以尽量降低对全局的影响；如果你脱离 `MarkdownRender` 单独使用导出的节点组件，请在外层包一层带 `markstream-vue` 类名的容器。
 
@@ -349,6 +351,8 @@ createApp({
   :content="doc"
 />
 ```
+
+主题值使用已注册名称：直接 `CodeBlockNode.theme` 接收固定 string 或 `{ dark, light }`，`themes` 是要加载的 `[dark, light]` 对。旧 Monaco JSON theme object 不会直接改名；先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再传入注册名称。
 
 `code-block-props` 只会透传面向用户的代码块 props；`node`、`key`、`ref`、`ctx`、`renderNode`、`indexKey`、`__proto__`、`prototype`、`constructor` 等渲染器结构字段会被忽略。
 
@@ -622,7 +626,7 @@ setCustomComponents('docs', {
 - 完整历史：[CHANGELOG.md](./CHANGELOG.md)
 - 2.0 beta 候选版：
   - `npm view markstream-vue@next version` 返回 `2.0.0-beta.1` 后，通过 `markstream-vue@next` 安装；稳定 1.x 继续通过 `@1` 获取。
-  - Monaco、`stream-markdown` 及其公开代码块 API 已移除。
+  - Monaco、`stream-markdown` runtime 与 Monaco 命名 API 已移除；受支持的代码块配置迁移到 `codeBlockOptions`。
   - 升级前阅读 [从 1.x 迁移到 2.0](https://markstream.simonhe.me/zh/guide/migration-2-0)。
 
 ## 🧭 案例与展示

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,9 @@ Vue 包：
 
 ## 稳定性
 
-`markstream-vue` 已进入稳定的 1.x API 契约；当前 npm 包仍可能带 beta tag，用于发布门禁和跨框架家族同步。稳定面包括：`MarkdownRender`、流式内容渲染、预解析节点渲染、安全 HTML 策略、可选 Mermaid / KaTeX / D2 / Infographic 集成、`stream-diffs` 增强代码块、虚拟滚动协调、CSS 导出、worker client 子路径以及 Vite / Nuxt / VitePress 的 SSR 导入。
+`markstream-vue` 继续维护稳定的 1.x API 契约。破坏性的 2.0 版本线先通过 npm `next` 标签进行验证，不会在 beta 阶段替换 `latest`。2.0 移除 Monaco 和 `stream-markdown` 代码块 runtime，并将 `stream-diffs` 作为唯一的增强代码块表面。升级前请阅读 [从 1.x 迁移到 2.0](https://markstream.simonhe.me/zh/guide/migration-2-0)。
+
+稳定面包括：`MarkdownRender`、流式内容渲染、预解析节点渲染、安全 HTML 策略、可选 Mermaid / KaTeX / D2 / Infographic 集成、增强代码块、虚拟滚动协调、CSS 导出、worker client 子路径以及 Vite / Nuxt / VitePress 的 SSR 导入。
 
 跨框架渲染器（`markstream-react`、`markstream-octane`、`markstream-svelte`、`markstream-angular`、`markstream-vue2`）已可用并积极开发中。请查看各包文档了解 API 成熟度、框架支持和已知限制。
 
@@ -146,6 +148,7 @@ npx skills add Simon-He95/markstream-vue
 推荐这样理解：
 
 - `npx skills add Simon-He95/markstream-vue` 是最推荐的安装方式，因为它会直接读取 GitHub 仓库里的 `.agents/skills`
+- 升级现有 Markstream 1.x 应用到 2.0 时，使用内置的 `markstream-migration` skill
 - `markstream-vue@1.0` 不发布 CLI `bin`；`pnpm skills:list`、`pnpm prompts:list` 这类脚本只面向克隆仓库后的维护者
 - prompts 继续保留在仓库的 `prompts/` 目录下，供直接复制或后续拆成独立包
 
@@ -182,8 +185,16 @@ npx skills add git@github.com:Simon-He95/markstream-vue.git
 
 ### Vue / Nuxt
 
+协调发布的 2.0 beta 将使用 `next`。请先确认 `npm view markstream-vue@next version` 返回 `2.0.0-beta.1`，再执行：
+
 ```bash
-pnpm add markstream-vue
+pnpm add markstream-vue@next stream-diffs
+```
+
+从 1.x 升级前请阅读 [2.0 迁移指南](https://markstream.simonhe.me/zh/guide/migration-2-0)。beta 阶段无 tag 安装仍然保持在 1.x；如需在 2.0 stable 切换后仍锁定维护中的 1.x，请显式使用 `markstream-vue@1`。
+
+```bash
+pnpm add markstream-vue@1
 ```
 
 ```vue
@@ -609,10 +620,10 @@ setCustomComponents('docs', {
 
 - 最新版本与升级提示：[Releases](https://github.com/Simon-He95/markstream-vue/releases)
 - 完整历史：[CHANGELOG.md](./CHANGELOG.md)
-- 最新亮点（0.0.3-beta.1/beta.0）：
-  - 解析器升级到 `stream-markdown-parser@0.0.36`，修复多项解析问题。
-  - Monaco 升级，更多语言/主题，代码块对 diff 更友好。
-  - Playground 增加 HTML/SVG 预览对话框与 AST 调试视图。
+- 2.0 beta 候选版：
+  - `npm view markstream-vue@next version` 返回 `2.0.0-beta.1` 后，通过 `markstream-vue@next` 安装；稳定 1.x 继续通过 `@1` 获取。
+  - Monaco、`stream-markdown` 及其公开代码块 API 已移除。
+  - 升级前阅读 [从 1.x 迁移到 2.0](https://markstream.simonhe.me/zh/guide/migration-2-0)。
 
 ## 🧭 案例与展示
 

--- a/docs/.vitepress/twoslash/markstream-angular.d.ts
+++ b/docs/.vitepress/twoslash/markstream-angular.d.ts
@@ -1,5 +1,33 @@
 import type { BaseNode } from 'stream-markdown-parser'
 
+export type CodeBlockTheme = string
+
+export interface CodeBlockThemePair {
+  dark: string
+  light: string
+}
+
+export interface CodeBlockOptions {
+  fontSize?: number
+  lineHeight?: number
+  fontFamily?: string
+  maxHeight?: number
+  padding?: number
+  tabSize?: number
+  disableLineNumbers?: boolean
+  overflow?: 'scroll' | 'wrap'
+  diffStyle?: 'unified' | 'split'
+  expandUnchanged?: boolean
+  collapsedContextThreshold?: number
+  hunkSeparators?: 'simple' | 'metadata' | 'line-info' | 'line-info-basic'
+  lineDiffType?: 'word-alt' | 'word' | 'char' | 'none'
+  parseDiffOptions?: Record<string, unknown>
+  enableLineSelection?: boolean
+  lineAnnotations?: unknown[]
+  onController?: (controller: unknown) => void
+  workerManager?: unknown
+}
+
 export interface MarkstreamAngularComponentProps {
   content?: string
   nodes?: BaseNode[]
@@ -7,6 +35,7 @@ export interface MarkstreamAngularComponentProps {
   fade?: boolean
   isDark?: boolean
   mermaidProps?: Record<string, unknown>
+  codeBlockOptions?: CodeBlockOptions
   codeBlockProps?: Record<string, unknown>
   [key: string]: unknown
 }

--- a/docs/.vitepress/twoslash/markstream-react.d.ts
+++ b/docs/.vitepress/twoslash/markstream-react.d.ts
@@ -1,6 +1,8 @@
 import type { ComponentType, PropsWithChildren, ReactNode } from 'react'
 import type { BaseNode } from 'stream-markdown-parser'
 
+export type CodeBlockTheme = string
+
 export type RenderNodeFn = (node: BaseNode, key: string | number, ctx: RenderContext) => ReactNode
 
 export interface RenderContext {
@@ -26,6 +28,27 @@ export type StreamingComponentMap = Record<string, StreamingComponent<any>>
 export type HtmlComponent<P extends object = any> = ComponentType<PropsWithChildren<P>>
 export type HtmlComponentMap = Record<string, HtmlComponent<any>>
 
+export interface CodeBlockOptions {
+  fontSize?: number
+  lineHeight?: number
+  fontFamily?: string
+  maxHeight?: number
+  padding?: number
+  tabSize?: number
+  disableLineNumbers?: boolean
+  overflow?: 'scroll' | 'wrap'
+  diffStyle?: 'unified' | 'split'
+  expandUnchanged?: boolean
+  collapsedContextThreshold?: number
+  hunkSeparators?: 'simple' | 'metadata' | 'line-info' | 'line-info-basic'
+  lineDiffType?: 'word-alt' | 'word' | 'char' | 'none'
+  parseDiffOptions?: Record<string, unknown>
+  enableLineSelection?: boolean
+  lineAnnotations?: unknown[]
+  onController?: (controller: unknown) => void
+  workerManager?: unknown
+}
+
 export interface NodeRendererProps {
   content?: string
   nodes?: BaseNode[]
@@ -33,6 +56,7 @@ export interface NodeRendererProps {
   fade?: boolean
   isDark?: boolean
   mermaidProps?: Record<string, unknown>
+  codeBlockOptions?: CodeBlockOptions
   codeBlockProps?: Record<string, unknown>
   [key: string]: unknown
 }

--- a/docs/.vitepress/twoslash/markstream-svelte.d.ts
+++ b/docs/.vitepress/twoslash/markstream-svelte.d.ts
@@ -1,5 +1,33 @@
 import type { BaseNode } from 'stream-markdown-parser'
 
+export type CodeBlockTheme = string
+
+export interface CodeBlockThemePair {
+  dark: string
+  light: string
+}
+
+export interface CodeBlockOptions {
+  fontSize?: number
+  lineHeight?: number
+  fontFamily?: string
+  maxHeight?: number
+  padding?: number
+  tabSize?: number
+  disableLineNumbers?: boolean
+  overflow?: 'scroll' | 'wrap'
+  diffStyle?: 'unified' | 'split'
+  expandUnchanged?: boolean
+  collapsedContextThreshold?: number
+  hunkSeparators?: 'simple' | 'metadata' | 'line-info' | 'line-info-basic'
+  lineDiffType?: 'word-alt' | 'word' | 'char' | 'none'
+  parseDiffOptions?: Record<string, unknown>
+  enableLineSelection?: boolean
+  lineAnnotations?: unknown[]
+  onController?: (controller: unknown) => void
+  workerManager?: unknown
+}
+
 export interface NodeRendererProps {
   content?: string
   nodes?: BaseNode[]
@@ -7,6 +35,7 @@ export interface NodeRendererProps {
   fade?: boolean
   isDark?: boolean
   mermaidProps?: Record<string, unknown>
+  codeBlockOptions?: CodeBlockOptions
   codeBlockProps?: Record<string, unknown>
   [key: string]: unknown
 }

--- a/docs/.vitepress/twoslash/markstream-vue.d.ts
+++ b/docs/.vitepress/twoslash/markstream-vue.d.ts
@@ -3,7 +3,6 @@ import type { BaseNode } from 'stream-markdown-parser'
 import type {
   CodeBlockDiffHunkActionContext,
   CodeBlockNodeProps,
-  CodeBlockTheme,
   CustomComponents,
   D2BlockNodeProps,
   ImageNodeProps,
@@ -11,24 +10,53 @@ import type {
   MermaidBlockNodeProps,
   PreCodeNodeProps,
 } from '../../../src/exports'
-import type { NodeRendererProps } from '../../../src/types/node-renderer-props'
+import type { NodeRendererProps as SourceNodeRendererProps } from '../../../src/types/node-renderer-props'
+
+export type CodeBlockTheme = string
+
+export interface CodeBlockThemePair {
+  dark: string
+  light: string
+}
+
+export interface CodeBlockOptions {
+  fontSize?: number
+  lineHeight?: number
+  fontFamily?: string
+  maxHeight?: number
+  padding?: number
+  tabSize?: number
+  disableLineNumbers?: boolean
+  overflow?: 'scroll' | 'wrap'
+  diffStyle?: 'unified' | 'split'
+  expandUnchanged?: boolean
+  collapsedContextThreshold?: number
+  hunkSeparators?: 'simple' | 'metadata' | 'line-info' | 'line-info-basic'
+  lineDiffType?: 'word-alt' | 'word' | 'char' | 'none'
+  parseDiffOptions?: Record<string, unknown>
+  enableLineSelection?: boolean
+  lineAnnotations?: unknown[]
+  onController?: (controller: unknown) => void
+  workerManager?: unknown
+}
+
+export interface NodeRendererProps extends SourceNodeRendererProps {
+  codeBlockOptions?: CodeBlockOptions
+}
 
 export type {
   BaseNode,
   CodeBlockDiffHunkActionContext,
   CodeBlockNodeProps,
-  CodeBlockTheme,
   CustomComponents,
   D2BlockNodeProps,
   ImageNodeProps,
   MermaidBlockEvent,
   MermaidBlockNodeProps,
-  NodeRendererProps,
   PreCodeNodeProps,
 }
 
 export {
-  CodeBlockNode,
   D2BlockNode,
   ImageNode,
   MermaidBlockNode,
@@ -40,8 +68,8 @@ export {
   enableMermaid,
   getRegisteredThemes,
   getMarkdown,
-  getStreamDiffsRuntime,
   parseMarkdownToStructure,
+  preloadCodeBlockRuntime,
   preloadExtendedLanguageIcons,
   registerIconTheme,
   removeCustomComponents,
@@ -58,6 +86,7 @@ export {
   VueRendererMarkdown,
 } from '../../../src/exports'
 
+export declare const CodeBlockNode: DefineComponent<CodeBlockNodeProps & { codeBlockOptions?: CodeBlockOptions }>
 export declare const MarkdownRender: DefineComponent<NodeRendererProps>
 
 export default MarkdownRender

--- a/docs/e2e-testing-report.md
+++ b/docs/e2e-testing-report.md
@@ -70,7 +70,7 @@ pnpm lint
    - Complex nested lists with markup inside
    - Escaped bracket edge-cases
    - Streaming fence edgecases
-3. Add integration tests for rendering plugins that require DOM or workers (Mermaid, KaTeX worker, Monaco). Consider adding a browser-based test job (Playwright) for those.
+3. Add integration tests for rendering plugins that require DOM or workers (Mermaid, the KaTeX worker, and the `stream-diffs` code-block surface). Consider adding a browser-based test job (Playwright) for those.
 4. Configure CI to run snapshots or a visual regression step if the renderer's HTML output becomes more important.
 
 If you want, I can:

--- a/docs/guide/ai-chat-streaming.md
+++ b/docs/guide/ai-chat-streaming.md
@@ -21,7 +21,7 @@ If you only render static articles or docs pages, go back to [Usage & Streaming]
 | Need | Packages | Best for |
 | --- | --- | --- |
 | Text-only or lightweight chat UI | `markstream-vue` | Basic Markdown, lists, links, blockquotes |
-| Plain (SSR-friendly) code blocks | `markstream-vue` (`code-renderer="pre"`) | Lower bundle budgets, SSR-friendly transcripts |
+| Plain (SSR-friendly) code blocks | `markstream-vue` (`render-code-blocks-as-pre`) | Lower bundle budgets, SSR-friendly transcripts |
 | Rich code interactions | `markstream-vue stream-diffs` | Copy, preview, syntax highlighting, and File/Diff surfaces |
 | Diagrams or math in chat output | `markstream-vue mermaid katex` | Mermaid fences and KaTeX formulas |
 
@@ -244,8 +244,9 @@ For long mixed timelines, prefer the built-in virtual timeline. Its default `sti
 
 ### Better code blocks
 
-- Want a lighter docs-style look: use `code-renderer="pre"` on `CodeBlockNode` for plain `<pre>` output
-- Want richer preview/diff controls: use `code-renderer="stream-diffs"` on `CodeBlockNode`
+- Want a lighter surface: set `render-code-blocks-as-pre` on `MarkdownRender` for plain `<pre>` output.
+- Want richer preview/diff controls: install `stream-diffs`; the built-in `CodeBlockNode` uses it automatically.
+- Want an application-owned renderer: register a scoped `code_block` with `setCustomComponents`. Mermaid, D2, and Infographic use their own component keys.
 
 See [Renderer & Node Components](/guide/components) for the trade-offs.
 

--- a/docs/guide/angular-installation.md
+++ b/docs/guide/angular-installation.md
@@ -43,7 +43,7 @@ Install only the heavy features you need:
 | D2 diagrams | `@terrastruct/d2` |
 | AntV infographic blocks | `@antv/infographic` |
 
-Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Code and diff options use `stream-diffs` built-in defaults, and theming is controlled through `darkTheme` / `lightTheme` / `themes`.
+Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Direct `CodeBlockNode` props and top-level renderer props both accept `codeBlockOptions`; registered theme names use `theme` and the `[dark, light]` `themes` pair.
 
 Quick install:
 

--- a/docs/guide/code-block-node.md
+++ b/docs/guide/code-block-node.md
@@ -19,23 +19,22 @@ keywords:
 Refer to `src/types/component-props.ts` for full signature. Key props:
 - `node` — code_block node (required)
 - `loading`, `stream`, `isShowPreview`
-- Code/diff options are not configurable per block in 2.0; the enhanced surface uses the `stream-diffs` built-in defaults. Theming is done through `theme` / `darkTheme` / `lightTheme` / `themes`.
+- `codeBlockOptions` — renderer-neutral typography, layout, File/FileDiff, interaction, annotation, and callback options. The same prop is also available at the `NodeRenderer` / `MarkdownRender` top level.
+- `theme` — a registered string name or `{ dark, light }`; `themes` is the `[dark, light]` name pair to load.
 - Header controls: `showHeader`, `showCollapseButton`, `showCopyButton`, `showExpandButton`, `showPreviewButton`, `showFontSizeButtons`, `showTooltips`
 - HTML preview sandbox: `htmlPreviewAllowScripts` defaults to `false`, and `htmlPreviewSandbox` lets you override the iframe sandbox tokens directly
 
 Built-in inline HTML preview uses `sandbox=""` by default so untrusted preview documents do not run scripts or inherit the host origin. `htmlPreviewSandbox` takes precedence over `htmlPreviewAllowScripts`; passing `htmlPreviewSandbox=""` keeps the iframe fully sandboxed, omitting `htmlPreviewSandbox` leaves `htmlPreviewAllowScripts` in control, and invalid non-string overrides such as `null` fall back to the safe default. Only opt into `htmlPreviewAllowScripts` for trusted demos, and avoid combining `allow-scripts` with `allow-same-origin` for untrusted preview content.
 
-Default diff UX in enhanced mode:
+Default finalized diff UX when no `codeBlockOptions` override is supplied:
 
-- `diffHideUnchangedRegions: { enabled: true, contextLineCount: 2, minimumLineCount: 4, revealLineCount: 5 }`
-- `diffLineStyle: 'background'`
-- `diffAppearance: 'auto'`
-- `diffUnchangedRegionStyle: 'line-info'`
-- `diffHunkActionsOnHover: true`
-- `diffHunkHoverHideDelayMs: 160`
+- `diffStyle: 'split'`
+- `expandUnchanged: false`
+- `collapsedContextThreshold: 5`
+- `hunkSeparators: 'line-info'`
+- `parseDiffOptions: { context: 2 }`
 
-These are the `stream-diffs` built-in defaults; in 2.0 there is no per-block override prop.
-When `diffAppearance: 'auto'` is used, `CodeBlockNode` resolves it to the current light/dark surface before passing the options to its `stream-diffs` adapter.
+The same folding options apply to the fallback and finalized surface; streaming state does not override the consumer's `expandUnchanged` choice. Theme, content/language, header, mount/reveal timing, and disposal remain host-owned even when `codeBlockOptions` is present.
 
 Diff blocks also show `- / +` line counts in the built-in header.
 
@@ -108,6 +107,36 @@ function runSnippet() {}
 </template>
 ```
 
+### Configure the code surface
+
+```vue
+<script setup lang="ts">
+import type { CodeBlockNodeProps, CodeBlockOptions } from 'markstream-vue'
+import { CodeBlockNode } from 'markstream-vue'
+
+const node = {
+  type: 'code_block',
+  language: 'ts',
+  code: 'const answer = 42',
+  raw: 'const answer = 42',
+} satisfies CodeBlockNodeProps['node']
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  lineHeight: 20,
+  overflow: 'wrap',
+  disableLineNumbers: true,
+  enableLineSelection: true,
+}
+</script>
+
+<template>
+  <CodeBlockNode :node="node" :code-block-options="codeBlockOptions" />
+</template>
+```
+
+`fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, and `tabSize` are host-managed so the fallback and finalized surface share geometry. Other supported fields are forwarded to `stream-diffs`. Use the separate component props for header and toolbar controls.
+
 ### Custom loading placeholder
 
 ```vue twoslash
@@ -163,8 +192,7 @@ const themes = [
     </button>
     <MarkdownRender
       :is-dark="isDark"
-      code-block-dark-theme="vitesse-dark"
-      code-block-light-theme="vitesse-light"
+      :code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"
       :themes="themes"
       :content="content"
     />
@@ -208,8 +236,7 @@ const themes = [
 <template>
   <MarkdownRender
     :is-dark="isDark"
-    code-block-dark-theme="vitesse-dark"
-    code-block-light-theme="vitesse-light"
+    :code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"
     :themes="themes"
     :content="content"
   />
@@ -226,14 +253,11 @@ The `theme` prop accepts either a fixed theme or a light/dark pair:
 
 <!-- Fixed theme (ignores isDark) -->
 <CodeBlockNode theme="monokai" />
-
-<!-- Theme object (fixed, ignores isDark) -->
-<CodeBlockNode :theme="{ name: 'my-theme', colors: { ... } }" />
 ```
 
-When using a `{ light, dark }` pair, the component automatically switches based on the `isDark` prop.
+When using a `{ dark, light }` pair, the component automatically switches based on the `isDark` prop.
 
-The `themes` prop accepts exactly a `[dark, light]` pair.
+The `themes` prop accepts exactly a `[dark, light]` pair. A former Monaco JSON theme object is not a valid `theme` value in 2.0; use `registerCustomTheme` from `stream-diffs/pierre`, then pass its registered name.
 
 > **Backward compatibility:** `darkTheme` / `lightTheme` props still work but are deprecated. Prefer the unified `theme` prop.
 
@@ -242,8 +266,8 @@ The `themes` prop accepts exactly a `[dark, light]` pair.
 | Prop | Direct CodeBlockNode | Via MarkdownRender |
 |------|---------------------|-------------------|
 | `isDark` | Passed directly to `<CodeBlockNode :is-dark="isDark" />` | Passed via `<MarkdownRender :is-dark="isDark" />` and automatically forwarded |
-| Theme | `:theme="{ light: 'vitesse-light', dark: 'vitesse-dark' }"` | `:code-block-dark-theme="'vitesse-dark'"` `:code-block-light-theme="'vitesse-light'"` (legacy) |
-| Dark/light themes | `:themes="['vitesse-dark', 'vitesse-light']"` | `:themes="['vitesse-dark', 'vitesse-light']"` |
+| Theme | `:theme="{ dark: 'vitesse-dark', light: 'vitesse-light' }"` | `:code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"` |
+| Themes pair | `:themes="['vitesse-dark', 'vitesse-light']"` | `:themes="['vitesse-dark', 'vitesse-light']"` |
 
 ## Notes
 - The CodeBlock header API is documented in `docs/guide/codeblock-header.md` (examples for replacing header and custom loading placeholder).

--- a/docs/guide/code-block-runtime-internals.md
+++ b/docs/guide/code-block-runtime-internals.md
@@ -13,7 +13,7 @@ This legacy route describes how markstream-vue connects `CodeBlockNode` to the f
 
 ## Loading contract
 
-`getStreamDiffsRuntime()` is the loader export (renamed from the historical `getUseMonaco` in 2.0). It dynamically imports `stream-diffs`, not `stream-diffs/vue`. The returned adapter exposes the small editor-compatible surface that `CodeBlockNode` needs: create, update, theme, measure, and dispose.
+Markstream uses an internal cached loader that dynamically imports `stream-diffs`, not `stream-diffs/vue`. The adapter exposes only the small surface that `CodeBlockNode` needs: create, update, theme, measure, and dispose. The raw loader/module is intentionally not part of Markstream's public API.
 
 ```text
 CodeBlockNode                 markstream-vue runtime                stream-diffs
@@ -47,6 +47,8 @@ import { preloadCodeBlockRuntime } from 'markstream-vue'
 
 void preloadCodeBlockRuntime()
 ```
+
+This is the public replacement when historical `getUseMonaco` usage only warmed the code-block runtime. Advanced code that intentionally owns a controller should import the API and types directly from `stream-diffs` instead of depending on Markstream's internal adapter.
 
 ## Themes
 

--- a/docs/guide/code-block-runtime.md
+++ b/docs/guide/code-block-runtime.md
@@ -4,12 +4,12 @@ description: How the optional stream-diffs runtime powers CodeBlockNode with min
 keywords:
   - code block runtime
   - stream-diffs runtime
-  - monaco compatibility
+  - runtime preload
   - code editor surface
 ---
 # Code Block Runtime
 
-This page documents the optional `stream-diffs` runtime used by `CodeBlockNode`. In 2.0 the previous Monaco-based options API and the `stream-monaco` fallback were removed: `stream-diffs` is the only enhanced code block surface, and code/diff behavior uses its built-in defaults.
+This page documents the optional `stream-diffs` runtime used by `CodeBlockNode`. In 2.0 the `stream-monaco` fallback is removed and `stream-diffs` is the only enhanced code-block surface. Supported configuration is exposed through the renderer-neutral `CodeBlockOptions` API.
 
 ## Install
 
@@ -50,9 +50,22 @@ Completion, visibility, and unmount are `CodeBlockNode` concerns. They are not `
 
 ## Theming
 
-Use the `theme` / `darkTheme` / `lightTheme` / `themes` props for light/dark themes. `CodeBlockNode` sends theme changes to its mounted surface without recreating the Vue component.
+Use `theme` with either a registered string name or `{ dark, light }`. The `themes` prop is the `[dark, light]` name pair available to the runtime. `CodeBlockNode` sends theme changes to its mounted surface without recreating the Vue component.
 
-The former `monacoOptions` / `codeBlockMonacoOptions` props are removed in 2.0 with no replacement; code and diff options fall back to the `stream-diffs` built-in defaults.
+Monaco JSON theme objects are not renamed into the 2.0 API. Use `registerCustomTheme` from `stream-diffs/pierre`, then pass the registered name.
+
+## Options handoff
+
+Direct `CodeBlockNode` usage and the top-level `NodeRenderer` / `MarkdownRender` API both accept `codeBlockOptions`. The same `CodeBlockOptions` contract is available across Vue 3, React, Octane, Svelte, Angular, and Vue 2.
+
+The supported surface includes:
+
+- host-managed typography and layout: `fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, and `tabSize`;
+- File options such as `disableLineNumbers`, `overflow`, highlighting limits, and virtualization/highlighter controls;
+- FileDiff layout, indicators, unchanged-region folding, and line-diff controls;
+- line/token interactions, selection callbacks, annotations, `onController`, and `workerManager`.
+
+Markstream applies the host-managed fields to both the streaming `<pre>` and finalized surface, then forwards the remaining supported fields to `stream-diffs`. Theme, language/content, streaming state, the single header, mount/reveal timing, and disposal remain host-owned and take precedence over conflicting runtime values.
 
 ## Optional preload
 
@@ -68,4 +81,4 @@ This only warms the optional module. It does not create a surface, finalize a st
 
 ## Diff interactions
 
-Diff blocks keep the same adapter boundary. The enhanced diff surface (folding, unchanged-region handling, inline vs side-by-side layout) is driven by `stream-diffs` built-in defaults; there is no per-block diff options prop in 2.0.
+Diff blocks keep the same adapter boundary. The enhanced diff surface uses `stream-diffs` defaults unless the corresponding `codeBlockOptions` fields are supplied. For example, `diffStyle`, `expandUnchanged`, `collapsedContextThreshold`, `hunkSeparators`, `lineDiffType`, and `parseDiffOptions` configure layout and folding.

--- a/docs/guide/code-blocks.md
+++ b/docs/guide/code-blocks.md
@@ -1,11 +1,11 @@
 ---
 title: Code Block Rendering
-description: How markstream-vue renders code blocks — enhanced diff surface, Shiki highlighting, or plain pre/code fallback depending on installed peers.
+description: How markstream-vue renders code blocks with the optional stream-diffs File/FileDiff surface or the plain pre/code fallback.
 keywords:
   - code block rendering
   - streaming code blocks
-  - shiki highlighting
-  - markdown code renderer
+  - stream-diffs
+  - code block options
 ---
 # Code Block Rendering
 
@@ -34,7 +34,32 @@ npm i stream-diffs
 
 ### Configuration
 
-The enhanced `stream-diffs` surface does not expose a per-block options prop. Code and diff options use the `stream-diffs` built-in defaults, so no `monaco-options`-style configuration is needed. Theming is handled through the `theme` / `darkTheme` / `lightTheme` / `themes` props (see `CodeBlockTheme`).
+Use the renderer-neutral `codeBlockOptions` prop on either `MarkdownRender` / `NodeRenderer` or a directly mounted `CodeBlockNode`. The same public `CodeBlockOptions` type is exported by all six framework adapters.
+
+```vue
+<script setup lang="ts">
+import type { CodeBlockOptions } from 'markstream-vue'
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  expandUnchanged: false,
+  enableLineSelection: true,
+}
+</script>
+
+<template>
+  <MarkdownRender
+    :content="content"
+    :code-block-options="codeBlockOptions"
+  />
+</template>
+```
+
+Typography/layout fields (`fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, `tabSize`) are coordinated by Markstream so the streaming fallback and finalized surface match. Supported File/FileDiff fields include `disableLineNumbers`, `overflow`, highlighter limits, diff layout/folding, interactions, selection callbacks, annotations, `onController`, and `workerManager`. Theme, language/content, streaming state, header, mounting, reveal, and disposal stay host-owned and take precedence.
+
+Themes are registered string names. Direct `CodeBlockNode.theme` accepts a string or `{ dark, light }`, while `themes` is the `[dark, light]` pair to load. A former Monaco JSON theme object has no direct rename: use `registerCustomTheme` from `stream-diffs/pierre`, then pass its name.
 
 See [/guide/code-block-runtime](/guide/code-block-runtime) for the full runtime behavior, diff interactions, and optional preload.
 
@@ -82,6 +107,9 @@ const node = {
 </script>
 
 <template>
-  <CodeBlockNode :node="node" />
+  <CodeBlockNode
+    :node="node"
+    :code-block-options="{ overflow: 'wrap', disableLineNumbers: true }"
+  />
 </template>
 ```

--- a/docs/guide/component-overrides.md
+++ b/docs/guide/component-overrides.md
@@ -167,7 +167,7 @@ Every custom renderer receives the basics:
 
 The renderer also forwards feature-specific props:
 
-- regular code block overrides receive `stream`, `theme`, `darkTheme`, `lightTheme`, `themes`, `minWidth`, `maxWidth`, and anything passed through `codeBlockProps` (`theme` is the recommended field; `darkTheme` / `lightTheme` remain for compatibility)
+- regular code block overrides receive `stream`, `theme`, `darkTheme`, `lightTheme`, `themes`, `minWidth`, `maxWidth`, the top-level `codeBlockOptions` object, and anything passed through `codeBlockProps` (`theme` is the recommended child prop; `darkTheme` / `lightTheme` remain for compatibility)
 - Mermaid, D2, and infographic overrides receive the corresponding `mermaidProps`, `d2Props`, or `infographicProps`
 - link and list overrides inherit tooltip and typewriter-related bindings from the parent renderer
 

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -213,7 +213,7 @@ setCustomComponents('docs', {
 - **Peer**: `stream-diffs`
 - **Common gotcha**: the enhanced surface waits for the block to finish streaming and enter the viewport
 
-Reach for this when the code block itself is part of the product experience. `stream-diffs` is framework-agnostic; Vue mount and unmount decisions stay in `CodeBlockNode`. Code and diff options use the `stream-diffs` built-in defaults.
+Reach for this when the code block itself is part of the product experience. `stream-diffs` is framework-agnostic; Vue mount and unmount decisions stay in `CodeBlockNode`. Configure supported code and diff behavior through direct or renderer-level `codeBlockOptions`.
 
 Deep dive: [CodeBlockNode](/guide/code-block-node), [Code Block Runtime](/guide/code-block-runtime)
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -1,11 +1,11 @@
 ---
 title: Features
-description: Capability overview of markstream-vue covering progressive Mermaid and D2, streaming diffs, Monaco code rendering, and parse hooks.
+description: Capability overview of markstream-vue covering progressive Mermaid and D2, stream-diffs code rendering, and parse hooks.
 keywords:
   - markdown features
   - progressive mermaid
   - streaming diff code blocks
-  - monaco code rendering
+  - stream-diffs code rendering
   - parse hooks
 ---
 # Features

--- a/docs/guide/migration-2-0.md
+++ b/docs/guide/migration-2-0.md
@@ -14,10 +14,13 @@ keywords:
 
 ## Install
 
-Install the beta from `next`. After the stable release, `@2` selects the maintained 2.x line:
+The live documentation may be deployed before the beta reaches npm. Check the `next` tag first, and run the beta install only when it returns `2.0.0-beta.1`. After the stable release, `@2` selects the maintained 2.x line:
 
 ```bash
-# 2.0 beta validation
+# Continue only when this prints 2.0.0-beta.1
+npm view markstream-vue@next version
+
+# 2.0 beta validation, after the check above passes
 pnpm add markstream-vue@next stream-diffs
 
 # after 2.0 stable is published
@@ -26,15 +29,44 @@ pnpm add markstream-vue@2 stream-diffs
 
 Without `stream-diffs`, code fences render as a plain `<pre><code>` fallback. You can request that path explicitly with `render-code-blocks-as-pre`.
 
+### Coordinated beta family
+
+The same code-block migration applies to every framework adapter in the coordinated beta. The packages publish independently, so checking `markstream-vue@next` does not prove that another adapter is ready. Before running a row below, query that row's package and confirm that it exactly matches the listed beta version:
+
+```bash
+# Replace this name with the package from the row you use.
+PACKAGE=markstream-react
+npm view "$PACKAGE@next" version
+```
+
+Install the adapter you use from `next`; install parser or core directly only when your application imports them itself.
+
+| Framework or layer | Beta version | Beta install |
+| --- | --- | --- |
+| Vue 3 / Nuxt / VitePress | `markstream-vue@2.0.0-beta.1` | `pnpm add markstream-vue@next stream-diffs` |
+| React / Next.js | `markstream-react@0.1.0-beta.1` | `pnpm add markstream-react@next stream-diffs` |
+| Octane | `markstream-octane@0.1.0-beta.1` | `pnpm add markstream-octane@next octane@^0.1.21 stream-diffs` |
+| Svelte 5 | `markstream-svelte@0.1.0-beta.1` | `pnpm add markstream-svelte@next svelte@^5 stream-diffs` |
+| Angular | `markstream-angular@0.1.0-beta.1` | `pnpm add markstream-angular@next stream-diffs` |
+| Vue 2 | `markstream-vue2@0.1.0-beta.1` | `pnpm add markstream-vue2@next stream-diffs` |
+| Parser only | `stream-markdown-parser@1.2.5-beta.1` | `pnpm add stream-markdown-parser@next` |
+| Streaming core only | `markstream-core@1.1.0-beta.1` | `pnpm add markstream-core@next` |
+
+Keep existing framework peers compatible instead of upgrading only part of a framework. React requires both `react` and `react-dom` 18 or newer. Keep all Angular packages on one version line. Vue 2.6 users must also install and register `@vue/composition-api`; Vue 2.7 users must not install that plugin.
+
 ## Breaking code-block changes
 
 | 1.x API or dependency | 2.0 migration |
 | --- | --- |
-| `codeRenderer: 'monaco'`, `'shiki'`, or `'markdown'` | Use `codeRenderer: 'stream-diffs'` to keep enhanced blocks, or `'pre'` for the plain fallback. |
+| `codeRenderer: 'monaco'` or `'shiki'` | Use `codeRenderer: 'stream-diffs'` to keep enhanced blocks, or `'pre'` for the plain fallback. |
 | `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `CodeBlockMonacoLanguage` | Remove it. Language identifiers now come from the code fence and are normalized by `resolveLanguageId`. |
+| `CodeBlockMonacoOptions` | Remove it. There is no public editor-options replacement. |
 | `resolveMonacoLanguageId` | `resolveLanguageId` |
 | `getUseMonaco` | `getStreamDiffsRuntime` |
-| `MarkdownCodeBlockNode` | `CodeBlockNode`, or the plain `pre` fallback |
+| `MarkdownCodeBlockNode` and the React / Octane `MarkdownCodeBlockNodeProps` export | `CodeBlockNode` / `CodeBlockNodeProps`, or the plain `pre` fallback |
+| `ShikiCodeBlockProps` / top-level `langs` | Remove them. Keep `themes` when needed; language preload lists are no longer renderer props. |
+| `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`; update the handler shape as shown below. |
 | `monacoOptions` / `codeBlockMonacoOptions` | Remove them. There is no adapter-options replacement. |
 | `stream-monaco` / `stream-markdown` | Remove both dependencies. |
 | `stream-diffs` | Optional peer for enhanced code blocks. |
@@ -45,7 +77,7 @@ Before:
 <MarkdownRender
   :content="content"
   code-renderer="monaco"
-  :monaco-options="editorOptions"
+  :code-block-monaco-options="editorOptions"
 />
 ```
 
@@ -62,12 +94,50 @@ After:
 
 Theme selection remains public. Low-level editor sizing, wrapping, diff-algorithm, and adapter CSS options are no longer renderer props.
 
+### Preview event payload
+
+`MarkdownCodeBlockPreviewPayload` is not a type-only rename. A handler attached to the removed `MarkdownCodeBlockNode` previously received the rendered content directly:
+
+```ts
+import type { MarkdownCodeBlockPreviewPayload } from 'markstream-vue'
+
+function handlePreview({ type, content, title }: MarkdownCodeBlockPreviewPayload) {
+  openArtifact({ type, content, title })
+}
+```
+
+`CodeBlockNode` now emits `CodeBlockPreviewPayload`. Read the source from `node.code` and use the explicit artifact fields:
+
+```ts
+import type { CodeBlockPreviewPayload } from 'markstream-vue'
+
+function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPreviewPayload) {
+  openArtifact({ id, type: artifactType, content: node.code, title: artifactTitle })
+}
+```
+
+### Low-level runtime type renames
+
+These root exports follow the runtime rename. They describe the `stream-diffs` adapter surface; they do not restore the removed renderer options.
+
+| 1.x type | 2.0 type |
+| --- | --- |
+| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
+| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
+| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
+| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
+| `MonacoHelpers` | `StreamDiffsHelpers` |
+| `MonacoModelLike` | `StreamDiffsModelLike` |
+| `MonacoModule` | `StreamDiffsModule` |
+| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
+| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+
 ## Parser types
 
 Use `ParseOptions` for public parser configuration. `InternalParseOptions` is removed. The supported structured-reuse and timing fields are `reuseStableTopLevelNodes` and `parserMetrics`; cursor, fragment, and stream-control fields remain internal.
 
 ```ts
-import type { ParseOptions } from 'stream-markdown-parser'
+import type { ParseOptions } from 'markstream-vue'
 
 const parseOptions: ParseOptions = {
   reuseStableTopLevelNodes: true,
@@ -78,14 +148,13 @@ const parseOptions: ParseOptions = {
 
 The `1.x` branch remains available for critical bug and security fixes. Fixes that apply to both lines land on the current line first and are cherry-picked to `1.x`; fixes tied to removed 1.x code stay on that branch. No 1.x end-of-life date is set here; it will be announced separately.
 
-| Install intent | Command or dist-tag |
-| --- | --- |
-| Current stable major | `pnpm add markstream-vue` or `@latest` |
-| Current prerelease | `pnpm add markstream-vue@next` |
-| Latest maintained 1.x stable | `pnpm add markstream-vue@1`; `@legacy` is also available after the stable 2.0 cutover |
-| Latest maintained 1.x prerelease | `pnpm add markstream-vue@legacy-next` after the first 2.x beta cutover |
+| Release phase | `latest` | `next` | Maintained 1.x channels |
+| --- | --- | --- | --- |
+| Before the 2.x beta cutover | 1.x stable | 1.x prerelease | `markstream-vue@1` or an exact version |
+| After beta, before stable | 1.x stable | 2.x beta | `markstream-vue@1` for stable; `markstream-vue@legacy-next` for prereleases |
+| After the 2.x stable cutover | 2.x stable | 2.x prerelease | `markstream-vue@1` or `@legacy` for stable; `@legacy-next` for prereleases |
 
-Applications already pinned to `^1.x` stay on the 1.x line. The release workflow routes later 1.x publications to the legacy tags so they cannot move `latest` or `next` back from 2.x.
+Applications already pinned to `^1.x` stay on the 1.x line. The beta cutover moves only the prerelease channel; 1.x stable patches can continue updating `latest` until the stable 2.x cutover. After stable 2.x takes `latest`, subsequent 1.x stable releases go to `legacy`.
 
 ## Verification checklist
 

--- a/docs/guide/migration-2-0.md
+++ b/docs/guide/migration-2-0.md
@@ -58,18 +58,24 @@ Keep existing framework peers compatible instead of upgrading only part of a fra
 
 | 1.x API or dependency | 2.0 migration |
 | --- | --- |
-| `codeRenderer: 'monaco'` or `'shiki'` | Use `codeRenderer: 'stream-diffs'` to keep enhanced blocks, or `'pre'` for the plain fallback. |
-| `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `codeRenderer: 'monaco'`, `'shiki'`, or `'pre'` | Remove it. Enhanced blocks use `stream-diffs` automatically. Replace the old `'pre'` value with `renderCodeBlocksAsPre`; use `setCustomComponents(customId, { code_block: ... })` for a scoped custom renderer. |
+| `markdownCodeRenderer` / `NodeRendererCodeRenderer` | Remove them. Timeline and virtual-adapter callers that require plain output should set `renderCodeBlocksAsPre: true`; the enhanced path needs no selector. |
+| `CodeBlockMonacoTheme` string | `CodeBlockTheme` string. A light/dark selection can use `CodeBlockThemePair` (`{ dark, light }`). |
+| Monaco JSON theme object / `CodeBlockMonacoThemeObject` | No direct conversion. Translate it to a Shiki `ThemeRegistration`, register it with `registerCustomTheme(name, loader)` from `stream-diffs/pierre`, then pass the registered name. |
 | `CodeBlockMonacoLanguage` | Remove it. Language identifiers now come from the code fence and are normalized by `resolveLanguageId`. |
-| `CodeBlockMonacoOptions` | Remove it. There is no public editor-options replacement. |
+| `CodeBlockMonacoOptions` | `CodeBlockOptions` for the supported renderer-neutral fields. |
 | `resolveMonacoLanguageId` | `resolveLanguageId` |
-| `getUseMonaco` | `getStreamDiffsRuntime` |
+| `getUseMonaco` used only for preload | `preloadCodeBlockRuntime` |
+| `getUseMonaco` used to call the runtime directly | Import the advanced API from `stream-diffs`; Markstream does not expose its raw runtime module. |
 | `MarkdownCodeBlockNode` and the React / Octane `MarkdownCodeBlockNodeProps` export | `CodeBlockNode` / `CodeBlockNodeProps`, or the plain `pre` fallback |
 | `ShikiCodeBlockProps` / top-level `langs` | Remove them. Keep `themes` when needed; language preload lists are no longer renderer props. |
 | `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`; update the handler shape as shown below. |
-| `monacoOptions` / `codeBlockMonacoOptions` | Remove them. There is no adapter-options replacement. |
+| Direct `CodeBlockNode.monacoOptions` | `CodeBlockNode.codeBlockOptions` |
+| `MarkdownRender.codeBlockMonacoOptions` | Top-level `MarkdownRender.codeBlockOptions` |
 | `stream-monaco` / `stream-markdown` | Remove both dependencies. |
 | `stream-diffs` | Optional peer for enhanced code blocks. |
+
+In 1.x, a directly mounted `CodeBlockNode` accepted `monacoOptions`, while `MarkdownRender` exposed `codeBlockMonacoOptions` to forward that configuration. In 2.0 both entry points use the same renderer-neutral name: `codeBlockOptions`. Every coordinated adapter exposes it on its direct `CodeBlockNode` and as a top-level `NodeRenderer` / `MarkdownRender` prop. `codeBlockProps` remains the separate bag for component chrome such as header and toolbar controls.
 
 Before:
 
@@ -86,13 +92,50 @@ After:
 ```vue
 <MarkdownRender
   :content="content"
-  code-renderer="stream-diffs"
   :is-dark="isDark"
+  :code-block-options="codeBlockOptions"
   :themes="['vitesse-dark', 'vitesse-light']"
 />
 ```
 
-Theme selection remains public. Low-level editor sizing, wrapping, diff-algorithm, and adapter CSS options are no longer renderer props.
+`CodeBlockOptions` includes host-managed typography and layout (`fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, `tabSize`) plus supported `stream-diffs` options such as `disableLineNumbers`, `overflow`, highlighting limits, diff layout and folding, line/token interactions, annotations, selection callbacks, `onController`, and `workerManager`. Markstream still owns theme selection, language and streamed content, its single header, mounting/reveal timing, and disposal; conflicting raw runtime keys cannot override those host responsibilities. If 1.x used different top and bottom padding values, choose one symmetric pixel value during migration; 2.0 cannot preserve asymmetric padding through `codeBlockOptions`.
+
+Common option migrations are not field-for-field renames:
+
+| 1.x option | 2.0 option |
+| --- | --- |
+| `MAX_HEIGHT: number` | `maxHeight: number` in CSS pixels. Convert string values explicitly. |
+| `wordWrap: 'on'` / `'off'` | `overflow: 'wrap'` / `'scroll'`. Choose one of those behaviors manually for `wordWrapColumn` or `bounded`. |
+| `renderSideBySide: true` / `false` | `diffStyle: 'split'` / `'unified'` |
+| `diffUnchangedRegionStyle` | `hunkSeparators` |
+| `diffHideUnchangedRegions` | There is no single replacement object. Map `false` / `{ enabled: false }` to `expandUnchanged: true`, and `true` / `{ enabled: true }` to `expandUnchanged: false`. Use `parseDiffOptions.context` for surrounding context, `collapsedContextThreshold` for when a region collapses, and `expansionLineCount` for reveal size. Tune the thresholds because the old and new algorithms are not identical. |
+
+Theme values are names, not Monaco theme JSON. Direct `CodeBlockNode.theme` accepts a fixed string or `{ dark, light }`; `themes` is the `[dark, light]` name pair used for loading. Convert an old Monaco theme to Shiki's theme format before registering it; in particular, Monaco `rules` are not Shiki token rules and must be translated to `tokenColors` or `settings`:
+
+```ts
+import type { ThemeRegistration } from 'stream-diffs/pierre'
+import { registerCustomTheme } from 'stream-diffs/pierre'
+
+const themeName = 'acme-dark'
+const acmeDark: ThemeRegistration = {
+  name: themeName,
+  type: 'dark',
+  colors: {
+    'editor.background': '#0d1117',
+    'editor.foreground': '#c9d1d9',
+  },
+  tokenColors: [
+    {
+      scope: ['comment'],
+      settings: { foreground: '#8b949e', fontStyle: 'italic' },
+    },
+  ],
+}
+
+registerCustomTheme(themeName, async () => acmeDark)
+```
+
+Pass `themeName` after registration. Do not pass the former Monaco object directly. The built-in `CodeBlockNode` is automatic; use a scoped `setCustomComponents(customId, { code_block: MyCodeBlock })` mapping when the application owns the renderer. Mermaid, D2, and Infographic fences use their dedicated component keys and must be overridden separately when needed.
 
 ### Preview event payload
 
@@ -116,21 +159,9 @@ function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPrevi
 }
 ```
 
-### Low-level runtime type renames
+### Low-level runtime access
 
-These root exports follow the runtime rename. They describe the `stream-diffs` adapter surface; they do not restore the removed renderer options.
-
-| 1.x type | 2.0 type |
-| --- | --- |
-| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
-| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
-| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
-| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
-| `MonacoHelpers` | `StreamDiffsHelpers` |
-| `MonacoModelLike` | `StreamDiffsModelLike` |
-| `MonacoModule` | `StreamDiffsModule` |
-| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
-| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+The old root-level `Monaco*` runtime types and `getUseMonaco` are not renamed into a second public copy of the `stream-diffs` API. Use `preloadCodeBlockRuntime()` when the application only needs to warm Markstream's optional code-block module. Advanced applications that intentionally own a runtime controller should import its functions and types directly from `stream-diffs` and manage that controller's lifecycle themselves.
 
 ## Parser types
 
@@ -158,7 +189,8 @@ Applications already pinned to `^1.x` stay on the 1.x line. The beta cutover mov
 
 ## Verification checklist
 
-- Remove `stream-monaco`, `stream-markdown`, and removed code-block props.
+- Remove `stream-monaco`, `stream-markdown`, and the old code-block prop names.
+- Rename supported `monacoOptions` / `codeBlockMonacoOptions` fields to `codeBlockOptions` and review unsupported Monaco-only fields instead of copying them blindly.
 - Add `stream-diffs` if enhanced code blocks are required.
 - Exercise normal and diff fences in light and dark themes.
 - Verify inline and side-by-side diffs at the widths used by your application.

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -36,7 +36,6 @@ Experimental/internal props: `indexKey`, `renderAsFragment`, `debugPerformance`,
 | `html-policy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | Controls `html_block` / `html_inline` rendering. `safe` blocks active/embed/form tags, `escape` shows literal HTML text, and `trusted` keeps the older broad HTML behavior while still removing scripts and unsafe attrs. |
 | `mode` | `'docs' \| 'chat' \| 'minimal'` | `'docs'` | Preset renderer tuning. Use `chat` for AI/SSE output, `docs` for rich document surfaces, and `minimal` for lightweight non-chat surfaces. |
 | `dom-mode` | `'full' \| 'minimal'` | `'full'` | Best-effort DOM structure mode. `minimal` skips per-node `.node-slot` / `.node-content` wrappers only when wrappers are not needed; it falls back to `full` for fade, batching, deferral, virtualization, host virtual-scroll, typewriter, or custom components. Disable those features explicitly when you need stable minimal output. |
-| `code-renderer` | `'pre' \| 'stream-diffs'` | Mode-dependent | Selects the regular fenced-code renderer. `docs` mode defaults to the enhanced `stream-diffs` surface; `chat` and `minimal` default to plain `<pre><code>`. `render-code-blocks-as-pre=true` takes precedence. |
 | `custom-markdown-it` | `(md: MarkdownIt) => MarkdownIt` | – | Customize the internal MarkdownIt instance (add plugins, tweak options). |
 | `debug-performance` | `boolean` | `false` | Logs parse/render timing, virtualization stats, and `parse(stream)` details such as `streamMode` / `streamDelta` (dev only). |
 | `typewriter` | `boolean \| 'simple' \| 'precise'` | `false` | Shows the blinking typewriter cursor while streamed content grows. `true` / `'precise'` uses Range-based precise positioning; `'simple'` uses a lightweight CSS cursor. |
@@ -168,7 +167,7 @@ Use `html-policy="escape"` when you want literal HTML text to stay visible inste
 
 | Flag | Default | What it does |
 | ---- | ------- | ------------ |
-| `render-code-blocks-as-pre` | `false` | Render non‑Mermaid/Infographic/D2 `code_block` nodes as `<pre><code>` (uses `PreCodeNode`). Mermaid/infographic/D2 blocks still route to their dedicated nodes unless you override them via `setCustomComponents`. |
+| `render-code-blocks-as-pre` | `false` | Force the built-in fenced-code path to `<pre><code>` (uses `PreCodeNode`). Scoped language or `code_block` overrides registered with `setCustomComponents` keep priority. |
 | `code-block-stream` | `true` | Stream code blocks as content arrives. Disable to keep the enhanced surface in a loading state until the final chunk lands—useful when incomplete code causes parser hiccups. |
 | `viewport-priority` | `true` | Defers heavy work (code blocks, Mermaid, D2, KaTeX) when elements are offscreen. Turn off if you need deterministic renders for PDF/print pipelines. |
 | `defer-nodes-until-visible` | `true` | When enabled, heavy nodes can render as placeholders until they approach the viewport (non-virtualized mode only). |
@@ -195,15 +194,23 @@ These props are forwarded to `CodeBlockNode` (but **not** to Mermaid/D2/Infograp
 
 - `code-block-dark-theme`, `code-block-light-theme`
 - `code-block-min-width`, `code-block-max-width`
+- `code-block-options` (`CodeBlockOptions`, forwarded from the renderer to ordinary `CodeBlockNode` instances and supported by direct `CodeBlockNode` usage under the same name)
 - `code-block-props` (extra code-block props such as `showHeader`, `showFontSizeButtons`, `showTooltips`, `htmlPreviewAllowScripts`, and `htmlPreviewSandbox`, plus custom forwarded keys that are not structural renderer keys like `node`, `key`, `ref`, `ctx`, `renderNode`, `indexKey`, `__proto__`, `prototype`, or `constructor`)
-- `themes` (theme list forwarded to the `stream-diffs` adapter when present)
+- `themes` (the `[dark, light]` registered theme-name pair)
 
-Code and diff options are not configurable per block in 2.0; the enhanced `CodeBlockNode` uses the `stream-diffs` built-in defaults. `htmlPreviewAllowScripts` and `htmlPreviewSandbox` only affect the built-in `CodeBlockNode` inline HTML iframe preview; they do not affect `previewCode` event handlers or external artifact renderers.
+`code-block-options` and `code-block-props` serve different layers. Use `code-block-options` for host-managed typography/layout (`fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, `tabSize`) and supported File/FileDiff runtime fields. Use `code-block-props` for the component shell and toolbar. Theme, code/language, stream state, the single header, mount/reveal timing, and disposal remain host-owned and override conflicting runtime values. `htmlPreviewAllowScripts` and `htmlPreviewSandbox` only affect the built-in `CodeBlockNode` inline HTML iframe preview; they do not affect `previewCode` event handlers or external artifact renderers.
 
 `code-block-props` is also strongly typed through the renderer props surface, so you can reuse it without falling back to `any`:
 
 ```ts twoslash
-import type { NodeRendererProps } from 'markstream-vue'
+import type { CodeBlockOptions, NodeRendererProps } from 'markstream-vue'
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  enableLineSelection: true,
+}
 
 const codeBlockProps: NonNullable<NodeRendererProps['codeBlockProps']> = {
   showHeader: false,
@@ -212,6 +219,8 @@ const codeBlockProps: NonNullable<NodeRendererProps['codeBlockProps']> = {
   htmlPreviewAllowScripts: false,
 }
 ```
+
+Pass both at the renderer top level: `:code-block-options="codeBlockOptions"` and `:code-block-props="codeBlockProps"`. A directly mounted `CodeBlockNode` accepts the same `codeBlockOptions` object. Direct `CodeBlockNode.theme` accepts a registered string name or `{ dark, light }`; register old Monaco JSON theme objects with `registerCustomTheme` from `stream-diffs/pierre`, then reference the registered name.
 
 ## Diagram node props forwarded from `MarkdownRender`
 

--- a/docs/guide/react-components.md
+++ b/docs/guide/react-components.md
@@ -71,15 +71,16 @@ The primary component for rendering markdown content in React.
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `codeBlockDarkTheme` | `CodeBlockTheme` | Dark theme object forwarded to every `CodeBlockNode` |
-| `codeBlockLightTheme` | `CodeBlockTheme` | Light theme object forwarded to every `CodeBlockNode` |
+| `codeBlockDarkTheme` | `CodeBlockTheme` | Registered dark theme name forwarded to every `CodeBlockNode` |
+| `codeBlockLightTheme` | `CodeBlockTheme` | Registered light theme name forwarded to every `CodeBlockNode` |
 | `codeBlockMinWidth` | `string \| number` | Min width forwarded to `CodeBlockNode` |
 | `codeBlockMaxWidth` | `string \| number` | Max width forwarded to `CodeBlockNode` |
+| `codeBlockOptions` | `CodeBlockOptions` | Renderer-neutral typography/layout and supported File/FileDiff options forwarded to every ordinary `CodeBlockNode` |
 | `codeBlockProps` | `NodeRendererCodeBlockProps` | Extra props forwarded to every `CodeBlockNode` |
 | `mermaidProps` | `Partial<Omit<MermaidBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to Mermaid fences and custom `mermaid` renderers |
 | `d2Props` | `Partial<Omit<D2BlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to D2 fences and custom `d2` renderers |
 | `infographicProps` | `Partial<Omit<InfographicBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to infographic fences and custom `infographic` renderers |
-| `themes` | `CodeBlockTheme[]` | Theme list forwarded to `CodeBlockNode` |
+| `themes` | `readonly [CodeBlockTheme, CodeBlockTheme]` | Registered `[dark, light]` theme-name pair forwarded to `CodeBlockNode` |
 
 #### Heavy renderer prop forwarding
 
@@ -116,7 +117,9 @@ Trusted compatibility example:
 />
 ```
 
-`NodeRendererCodeBlockProps` follows the public `CodeBlockNode` prop surface except for `node`, so you get completion for flags like `showHeader`, `showFontSizeButtons`, and `showTooltips` without dropping to `any`.
+`CodeBlockOptions` is a separate top-level prop shared by direct `CodeBlockNode` and `NodeRenderer`. It includes host-managed `fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, and `tabSize`, plus supported `stream-diffs` File/FileDiff, interaction, annotation, and callback fields. Theme, code/language, streaming state, header, mount/reveal timing, and disposal remain host-owned.
+
+`NodeRendererCodeBlockProps` follows the public component-shell surface except for `node` and `codeBlockOptions`, so you get completion for flags like `showHeader`, `showFontSizeButtons`, and `showTooltips` without dropping to `any`.
 
 ```tsx
 import type { NodeRendererCodeBlockProps } from 'markstream-react'
@@ -228,7 +231,7 @@ This API split fixes discoverability and typing around the two component contrac
 
 ### CodeBlockNode
 
-Feature-rich code blocks enhanced by the optional `stream-diffs` runtime (falls back to a plain `<pre>` when the peer is not installed). Code and diff options use `stream-diffs` built-in defaults.
+Feature-rich code blocks enhanced by the optional `stream-diffs` runtime (falls back to a plain `<pre>` when the peer is not installed). Direct and renderer-level configuration uses `codeBlockOptions`.
 
 ```tsx
 import { CodeBlockNode } from 'markstream-react'

--- a/docs/guide/react-installation.md
+++ b/docs/guide/react-installation.md
@@ -40,7 +40,7 @@ markstream-react supports various features through optional peer dependencies. I
 | D2 Diagrams | `@terrastruct/d2` | `pnpm add @terrastruct/d2` |
 | Math Rendering (KaTeX) | `katex` | `pnpm add katex` |
 
-Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Code and diff options use `stream-diffs` built-in defaults, and theming is controlled through `darkTheme` / `lightTheme` / `themes`.
+Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Direct `CodeBlockNode` and top-level `MarkdownRender` both accept `codeBlockOptions`; registered theme names use `darkTheme` / `lightTheme`, with `themes` as the `[dark, light]` preload pair.
 
 ## Optional: off-thread workers in Vite / Vite-compatible bundlers
 
@@ -109,7 +109,7 @@ Requires `stream-diffs`:
 pnpm add stream-diffs
 ```
 
-`stream-diffs` powers the enhanced `CodeBlockNode` runtime with built-in defaults for code and diff options. When it is not installed, code blocks fall back to a plain `<pre>`. You can override the `code_block` renderer via `setCustomComponents` for custom behavior:
+`stream-diffs` powers the enhanced `CodeBlockNode` runtime. Configure its supported surface through `codeBlockOptions`; when it is not installed, code blocks fall back to a plain `<pre>`. You can override the `code_block` renderer via `setCustomComponents` for custom behavior:
 
 ```tsx
 import { setCustomComponents } from 'markstream-react'
@@ -120,13 +120,14 @@ setCustomComponents({
       node={node}
       isDark={isDark}
       stream={ctx?.codeBlockStream}
+      codeBlockOptions={ctx?.codeBlockOptions}
       {...(ctx?.codeBlockProps || {})}
     />
   ),
 })
 ```
 
-Theming is controlled through the `darkTheme` / `lightTheme` / `themes` props.
+Theme values are registered string names. Use `darkTheme` / `lightTheme` for direct `CodeBlockNode` and `themes` for the `[dark, light]` preload pair; register former JSON theme objects with `registerCustomTheme` from `stream-diffs/pierre` and pass the resulting name.
 
 #### Mermaid Diagrams
 

--- a/docs/guide/react-markdown-migration.md
+++ b/docs/guide/react-markdown-migration.md
@@ -235,7 +235,7 @@ To use the enhanced code block runtime, install the optional peer:
 pnpm add stream-diffs
 ```
 
-Theming is controlled through `darkTheme` / `lightTheme` / `themes`, and code/diff options use `stream-diffs` built-in defaults.
+Use registered theme names (`themes` is the `[dark, light]` pair), and pass supported code/diff configuration through top-level `codeBlockOptions`.
 
 ## Migrating plugin logic
 

--- a/docs/guide/react-quick-start.md
+++ b/docs/guide/react-quick-start.md
@@ -147,7 +147,7 @@ Install the optional peer:
 pnpm add stream-diffs
 ```
 
-Enhanced code blocks (the `CodeBlockNode` runtime) use `stream-diffs` built-in defaults for code and diff options, with theming via `darkTheme` / `lightTheme` / `themes`. When `stream-diffs` is not installed, code blocks fall back to a plain `<pre>`.
+Enhanced code blocks use `stream-diffs` defaults and accept the shared `CodeBlockOptions` contract through direct `CodeBlockNode.codeBlockOptions` or top-level `MarkdownRender.codeBlockOptions`. Themes are registered names; `themes` is the `[dark, light]` pair. When `stream-diffs` is not installed, code blocks fall back to a plain `<pre>`.
 
 ```tsx
 import MarkdownRender from 'markstream-react'

--- a/docs/guide/roadmap-2-0.md
+++ b/docs/guide/roadmap-2-0.md
@@ -20,7 +20,7 @@ Tracked in [issue #615](https://github.com/Simon-He95/markstream-vue/issues/615)
 
 - [x] Remove `monacoOptions` / `codeBlockMonacoOptions` and all `CodeBlockMonaco*` params/APIs (no replacement; diff options fall back to stream-diffs built-in defaults)
 - [x] Delete the `stream-markdown` `MarkdownCodeBlockNode` component and its styles
-- [x] Rename `codeRenderer` value `'monaco'` → `'stream-diffs'`; drop the `'shiki'` / `'markdown'` renderer kinds
+- [x] Rename `codeRenderer` value `'monaco'` → `'stream-diffs'`; drop the `'shiki'` renderer kind
 - [x] Rename public identifiers to drop Monaco naming (`CodeBlockTheme`, `resolveLanguageId`, `getStreamDiffsRuntime`)
 - [x] Migrate vue2 / react / svelte / angular / octane to stream-diffs only
 - [x] Update tests and snapshots; full suite green (313 files / 2684 tests)
@@ -47,7 +47,15 @@ Get the breaking release through the normal release gates before publishing.
 - [x] Reconcile `check:peer-deps` for workspace-root optional peers
 - [x] Prepare coordinated `2.0.0-beta.1` package versions, release notes, and the [2.0 migration guide](/guide/migration-2-0); publish the beta before promoting the same matrix to stable versions
 
-Release-operator cutover (requires npm maintainer credentials): before the first beta, preserve the current prerelease with `npm dist-tag add markstream-vue@1.1.2-beta.3 legacy-next`. Before stable 2.0, preserve the current stable with `npm dist-tag add markstream-vue@1.0.9 legacy`. `release:family:preflight` checks every candidate dist-tag before any package is published and fails with the required command if an alias is missing.
+### Release-operator handoff
+
+These registry operations require npm maintainer credentials and remain incomplete until the corresponding publication is verified:
+
+- [ ] Before the first beta, preserve the current prerelease with `npm dist-tag add markstream-vue@1.1.2-beta.3 legacy-next`.
+- [ ] Run `pnpm release:family:preflight`, publish the coordinated beta family, and verify real installs of the published packages.
+- [ ] Before stable 2.0, read `npm view markstream-vue@latest version`, verify that it is still a 1.x version, and run the exact `npm dist-tag add` command printed by `release:family:preflight` for that live version.
+
+`release:family:preflight` checks every candidate dist-tag before any package is published and fails with the required command if an alias is missing.
 
 ## Goal 4: Runtime visual verification
 

--- a/docs/guide/roadmap-2-0.md
+++ b/docs/guide/roadmap-2-0.md
@@ -18,10 +18,10 @@ The 2.0 headline breaking change: the Monaco-based code block API and the Shiki-
 
 Tracked in [issue #615](https://github.com/Simon-He95/markstream-vue/issues/615) and merged into the `2.0.0` integration branch by [PR #619](https://github.com/Simon-He95/markstream-vue/pull/619).
 
-- [x] Remove `monacoOptions` / `codeBlockMonacoOptions` and all `CodeBlockMonaco*` params/APIs (no replacement; diff options fall back to stream-diffs built-in defaults)
+- [x] Replace `monacoOptions` / `codeBlockMonacoOptions` with the shared `codeBlockOptions` / `CodeBlockOptions` contract across all six adapters; remove Monaco-only public types
 - [x] Delete the `stream-markdown` `MarkdownCodeBlockNode` component and its styles
-- [x] Rename `codeRenderer` value `'monaco'` → `'stream-diffs'`; drop the `'shiki'` renderer kind
-- [x] Rename public identifiers to drop Monaco naming (`CodeBlockTheme`, `resolveLanguageId`, `getStreamDiffsRuntime`)
+- [x] Remove `codeRenderer`, `markdownCodeRenderer`, and `NodeRendererCodeRenderer`; use `stream-diffs` automatically, `renderCodeBlocksAsPre` for plain output, and scoped custom components for replacement renderers
+- [x] Use renderer-neutral public identifiers (`CodeBlockTheme`, `CodeBlockThemePair`, `CodeBlockOptions`, `resolveLanguageId`, `preloadCodeBlockRuntime`) without exposing the raw runtime module
 - [x] Migrate vue2 / react / svelte / angular / octane to stream-diffs only
 - [x] Update tests and snapshots; full suite green (313 files / 2684 tests)
 - [x] Clean playgrounds (deps, vite config, sandbox pages)

--- a/docs/guide/vue2-components.md
+++ b/docs/guide/vue2-components.md
@@ -18,6 +18,7 @@ markstream-vue2 provides the same powerful components as markstream-vue, but bui
 ```ts
 import type {
   CodeBlockNodeProps,
+  CodeBlockOptions,
   D2BlockNodeProps,
   InfographicBlockNodeProps,
   MermaidBlockNodeProps,
@@ -86,15 +87,16 @@ The primary component for rendering markdown content in Vue 2.
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `code-block-dark-theme` | `any` | Dark theme object forwarded to every `CodeBlockNode` |
-| `code-block-light-theme` | `any` | Light theme object forwarded to every `CodeBlockNode` |
+| `code-block-dark-theme` | `CodeBlockTheme` | Registered dark theme name forwarded to every `CodeBlockNode` |
+| `code-block-light-theme` | `CodeBlockTheme` | Registered light theme name forwarded to every `CodeBlockNode` |
 | `code-block-min-width` | `string \| number` | Min width forwarded to `CodeBlockNode` |
 | `code-block-max-width` | `string \| number` | Max width forwarded to `CodeBlockNode` |
+| `code-block-options` | `CodeBlockOptions` | Typography/layout and supported File/FileDiff options forwarded to every ordinary `CodeBlockNode` |
 | `code-block-props` | `Record<string, any>` | Extra props forwarded to every `CodeBlockNode` |
 | `mermaid-props` | `Partial<Omit<MermaidBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to Mermaid fences and custom `mermaid` renderers |
 | `d2-props` | `Partial<Omit<D2BlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to D2 fences and custom `d2` renderers |
 | `infographic-props` | `Partial<Omit<InfographicBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | Extra props forwarded to infographic fences and custom `infographic` renderers |
-| `themes` | `string[]` | Theme list forwarded to `CodeBlockNode` |
+| `themes` | `readonly [string, string]` | Registered `[dark, light]` theme-name pair forwarded to `CodeBlockNode` |
 
 #### Heavy renderer prop forwarding
 
@@ -166,7 +168,7 @@ export default {
 
 ### CodeBlockNode
 
-Feature-rich code blocks enhanced by the optional `stream-diffs` runtime (falls back to a plain `<pre>` when the peer is not installed). Code and diff options use `stream-diffs` built-in defaults.
+Feature-rich code blocks enhanced by the optional `stream-diffs` runtime (falls back to a plain `<pre>` when the peer is not installed). Both direct `CodeBlockNode` and top-level `MarkdownRender` usage accept `codeBlockOptions`.
 
 ```vue
 <script>
@@ -181,6 +183,11 @@ export default {
         language: 'typescript',
         code: 'const greeting: string = "Hello"',
         raw: 'const greeting: string = "Hello"'
+      },
+      codeBlockOptions: {
+        overflow: 'wrap',
+        diffStyle: 'unified',
+        enableLineSelection: true
       }
     }
   },
@@ -199,6 +206,7 @@ export default {
   <div class="markstream-vue">
     <CodeBlockNode
       :node="codeNode"
+      :code-block-options="codeBlockOptions"
       :stream="true"
       @copy="handleCopy"
       @preview-code="handlePreviewCode"
@@ -206,6 +214,8 @@ export default {
   </div>
 </template>
 ```
+
+Markstream coordinates `fontSize`, `lineHeight`, `fontFamily`, numeric-pixel `maxHeight`, numeric-pixel symmetric `padding`, and `tabSize` across the fallback and finalized surface. It forwards the other supported File/FileDiff fields while retaining ownership of theme, content/language, streaming state, header, mounting, reveal, and disposal.
 
 ## Math Components
 

--- a/docs/guide/vue2-installation.md
+++ b/docs/guide/vue2-installation.md
@@ -189,7 +189,7 @@ markstream-vue2 supports various features through optional peer dependencies. In
 | D2 Diagrams | `@terrastruct/d2` | `pnpm add @terrastruct/d2` |
 | Math Rendering (KaTeX) | `katex` | `pnpm add katex` |
 
-Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Code and diff options use `stream-diffs` built-in defaults, and theming is controlled through `darkTheme` / `lightTheme` / `themes`.
+Enhanced code blocks use the optional `stream-diffs` peer. When it is not installed, a plain `<pre>` is rendered instead. Direct `CodeBlockNode` and top-level `MarkdownRender` both accept `code-block-options`; themes are registered names and `themes` is the `[dark, light]` pair.
 
 ## Vue 2.6.x Setup
 
@@ -290,9 +290,9 @@ if (mermaidWorker)
 
 If you want to keep using subpath imports like `markstream-vue2/index.css`, add `resolve.alias` mappings in `vue.config.js` (see `playground-vue2-cli/vue.config.js`).
 
-### Code blocks: prefer the `stream-diffs` override
+### Code blocks: install `stream-diffs` for the enhanced surface
 
-The enhanced code block runtime (`stream-diffs`) is the only code block renderer in markstream-vue2. It falls back to a plain `<pre>` when the optional peer is not installed. For Webpack 4, `stream-diffs` is the recommended (and only) code block runtime — there is no Monaco fallback.
+The enhanced code block runtime (`stream-diffs`) is the only code block renderer in markstream-vue2. It falls back to a plain `<pre>` when the optional peer is not installed. For Webpack 4, it remains the only enhanced runtime; there is no Monaco fallback.
 
 1) Install the optional peer:
 
@@ -381,7 +381,7 @@ Requires `stream-diffs`:
 pnpm add stream-diffs
 ```
 
-`stream-diffs` powers the enhanced `CodeBlockNode` runtime with built-in defaults for code and diff options. When it is not installed, code blocks fall back to a plain `<pre>`. You can override the `code_block` renderer via `setCustomComponents` for custom behavior:
+`stream-diffs` powers the enhanced `CodeBlockNode` runtime. Configure supported code/diff behavior through `code-block-options`. When it is not installed, code blocks fall back to a plain `<pre>`. You can override the `code_block` renderer via `setCustomComponents` for custom behavior:
 
 ```js
 import { setCustomComponents } from 'markstream-vue2'

--- a/docs/guide/vue2-quick-start.md
+++ b/docs/guide/vue2-quick-start.md
@@ -183,7 +183,7 @@ Install the optional peer:
 pnpm add stream-diffs
 ```
 
-Enhanced code blocks (the `CodeBlockNode` runtime) use `stream-diffs` built-in defaults for code and diff options, with theming via `darkTheme` / `lightTheme` / `themes`. When `stream-diffs` is not installed, code blocks fall back to a plain `<pre>`.
+Enhanced code blocks accept the shared `CodeBlockOptions` contract through direct `CodeBlockNode.codeBlockOptions` or top-level `MarkdownRender.codeBlockOptions`. Themes are registered names and `themes` is the `[dark, light]` pair. When `stream-diffs` is not installed, code blocks fall back to a plain `<pre>`.
 
 ```vue
 <script>

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -171,16 +171,19 @@ Use these as “answer skeletons”: quick steps + minimal repro questions + whe
 - Steps:
   - `CodeBlockNode` is the only code block renderer, enhanced via `stream-diffs` (diff tracking, code/render options)
   - For app-level preloading, call `preloadCodeBlockRuntime()` from `markstream-vue`
-  - Set `code-renderer` to `'pre'` (plain) or `'stream-diffs'` (enhanced); no extra peer is required
-- Ask: “Any console errors? Which `code-renderer` value are you using?”
+  - Install `stream-diffs` for the enhanced surface; without it the built-in renderer falls back to `<pre><code>`
+  - Pass supported options through top-level or direct `codeBlockOptions`; keep header/toolbar settings in `codeBlockProps`
+  - Use numeric CSS pixels for `maxHeight` and the single symmetric `padding` value
+  - Set `render-code-blocks-as-pre` to force the plain path, or replace `code_block` through scoped `setCustomComponents(...)`
+- Ask: “Any console errors? Is `stream-diffs` installed? Are you forcing the plain path or using a custom `code_block`?”
 - Docs: `docs/guide/code-block-runtime.md`, `docs/guide/components.md`
 
 ### Prefer lightweight code blocks (no diffs)
 
 - Signals: “SSR friendly”, “reduce bundle”
 - Steps:
-  - Use `code-renderer="pre"` for plain `<pre>` code blocks (no diff tracking)
-  - Use `code-renderer="stream-diffs"` on `CodeBlockNode` when you want diff tracking
+  - Use `render-code-blocks-as-pre` for plain `<pre>` code blocks (no diff tracking)
+  - Install `stream-diffs` when the built-in `CodeBlockNode` should provide diff tracking
 - Ask: “Need diff tracking or just plain code?”
 - Docs: `docs/guide/code-blocks.md`, `docs/guide/components.md`
 

--- a/docs/llms.zh-CN.md
+++ b/docs/llms.zh-CN.md
@@ -171,16 +171,19 @@
 - 步骤：
   - `CodeBlockNode` 是唯一的代码块渲染器，通过 `stream-diffs` 增强（diff 追踪、code/render 选项）
   - 如果应用层要提前预热，调用 `markstream-vue` 的 `preloadCodeBlockRuntime()`
-  - 设置 `code-renderer` 为 `'pre'`（纯文本）或 `'stream-diffs'`（增强）；无需额外 peer
-- 最小追问： “控制台是否有报错？你用的 `code-renderer` 值是什么？”
+  - 安装 `stream-diffs` 获得增强 surface；未安装时内置 renderer 会回退 `<pre><code>`
+  - 受支持选项通过顶层或直接 `codeBlockOptions` 传入；header/toolbar 设置留在 `codeBlockProps`
+  - `maxHeight` 与单个上下对称 `padding` 都使用 number 类型的 px 数值
+  - 设置 `render-code-blocks-as-pre` 强制普通路径，或通过带作用域的 `setCustomComponents(...)` 替换 `code_block`
+- 最小追问： “控制台是否有报错？是否安装 `stream-diffs`？是否强制普通路径或使用了自定义 `code_block`？”
 - 文档：`docs/guide/code-block-runtime.md`, `docs/guide/components.md`
 
 ### 想要轻量代码块（不装 diff）
 
 - 表述： “SSR 友好”, “减包体”
 - 步骤：
-  - 用 `code-renderer="pre"` 输出纯 `<pre>` 代码块（无 diff 追踪）
-  - 需要 diff 追踪时用 `code-renderer="stream-diffs"` 的 `CodeBlockNode`
+  - 用 `render-code-blocks-as-pre` 输出纯 `<pre>` 代码块（无 diff 追踪）
+  - 需要内置 `CodeBlockNode` 提供 diff 追踪时安装 `stream-diffs`
 - 最小追问： “需要 diff 追踪还是纯文本就行？”
 - 文档：`docs/guide/code-blocks.md`, `docs/guide/components.md`
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -199,9 +199,10 @@ pnpm add markstream-angular@next
 
 ### From markstream-vue 1.x to 2.0
 1. Replace Monaco and stream-markdown code blocks with stream-diffs, or use the plain pre fallback.
-2. Remove monacoOptions, codeBlockMonacoOptions, stream-monaco, and stream-markdown.
-3. Use the renamed code-block helpers and the public ParseOptions contract.
-4. Full guide: https://markstream.simonhe.me/guide/migration-2-0
+2. Rename supported monacoOptions / codeBlockMonacoOptions fields to the shared codeBlockOptions / CodeBlockOptions API; maxHeight and symmetric padding are numeric pixel values. Remove stream-monaco and stream-markdown.
+3. Theme values are registered names: use a string or { dark, light }, keep themes as [dark, light], and register former JSON themes with registerCustomTheme from stream-diffs/pierre.
+4. Use preloadCodeBlockRuntime for preload-only code; import advanced controllers directly from stream-diffs. Use the public ParseOptions contract.
+5. Full guide: https://markstream.simonhe.me/guide/migration-2-0
 
 ### From react-markdown to markstream-react
 1. Replace import: react-markdown -> markstream-react.

--- a/docs/public/llms-full.zh-CN.txt
+++ b/docs/public/llms-full.zh-CN.txt
@@ -199,9 +199,10 @@ pnpm add markstream-angular@next
 
 ### 从 markstream-vue 1.x 迁移到 2.0
 1. 用 stream-diffs 替换 Monaco 与 stream-markdown 代码块，或使用普通 pre 回退。
-2. 删除 monacoOptions、codeBlockMonacoOptions、stream-monaco 与 stream-markdown。
-3. 使用重命名后的代码块 helper 与公开 ParseOptions 约定。
-4. 完整指南：https://markstream.simonhe.me/zh/guide/migration-2-0
+2. 把受支持的 monacoOptions / codeBlockMonacoOptions 字段改为共享 codeBlockOptions / CodeBlockOptions；maxHeight 与上下对称 padding 都是 number 类型且单位为 px。删除 stream-monaco 与 stream-markdown。
+3. 主题值使用已注册名称：传 string 或 { dark, light }，themes 保持 [dark, light]；旧 JSON 主题用 stream-diffs/pierre 的 registerCustomTheme 注册。
+4. 只需预热时使用 preloadCodeBlockRuntime；高级 controller 直接从 stream-diffs 导入。Parser 使用公开 ParseOptions 约定。
+5. 完整指南：https://markstream.simonhe.me/zh/guide/migration-2-0
 
 ### 从 react-markdown 迁移到 markstream-react
 1. 替换导入：react-markdown -> markstream-react。

--- a/docs/use-cases/streaming-code-blocks.md
+++ b/docs/use-cases/streaming-code-blocks.md
@@ -68,7 +68,7 @@ For an enhanced code block surface (syntax highlighting plus diff interactions),
 pnpm add stream-diffs
 ```
 
-When `stream-diffs` is installed, `CodeBlockNode` mounts a File or FileDiff surface once the fence completes and enters the viewport. Code and diff options use the `stream-diffs` built-in defaults. When `stream-diffs` is absent, the block falls back to a plain `<pre><code>` representation.
+When `stream-diffs` is installed, `CodeBlockNode` mounts a File or FileDiff surface once the fence completes and enters the viewport. Supported configuration comes from direct or renderer-level `codeBlockOptions`. When `stream-diffs` is absent, the block falls back to a plain `<pre><code>` representation.
 
 For mobile WebViews or conservative bundles, use plain `pre` rendering:
 

--- a/docs/zh/e2e-testing-report.md
+++ b/docs/zh/e2e-testing-report.md
@@ -81,7 +81,7 @@ pnpm lint
    - 深度嵌套列表中混合标记
    - 转义括号等特殊场景
    - 流式代码围栏的异常输入
-3. 为需要 DOM 或 Worker 的插件（Mermaid、KaTeX、Monaco）补充集成测试，并考虑在 CI 中加入基于 Playwright 的浏览器流程。
+3. 为需要 DOM 或 Worker 的插件（Mermaid、KaTeX worker 与 `stream-diffs` 代码块 surface）补充集成测试，并考虑在 CI 中加入基于 Playwright 的浏览器流程。
 
 如果需要，我可以：
 1. 立即扩充快照的元信息。

--- a/docs/zh/guide/ai-chat-streaming.md
+++ b/docs/zh/guide/ai-chat-streaming.md
@@ -19,7 +19,7 @@ keywords:
 | 需求 | 安装包 | 适合场景 |
 | --- | --- | --- |
 | 纯文本或轻量聊天界面 | `markstream-vue` | 基础 Markdown、列表、链接、引用 |
-| 纯文本（SSR 友好）代码块 | `markstream-vue`（`code-renderer="pre"`） | 较小 bundle、SSR 友好聊天记录 |
+| 纯文本（SSR 友好）代码块 | `markstream-vue`（`render-code-blocks-as-pre`） | 较小 bundle、SSR 友好聊天记录 |
 | 更强的代码交互 | `markstream-vue stream-diffs` | 复制、预览、语法高亮和 File/Diff surface |
 | 聊天内容里有图表或公式 | `markstream-vue mermaid katex` | Mermaid 图表和 KaTeX 公式 |
 
@@ -242,8 +242,9 @@ onBeforeUnmount(() => {
 
 ### 更好的代码块
 
-- 想要更轻的文档风格：在 `CodeBlockNode` 上用 `code-renderer="pre"`，输出纯 `<pre>`
-- 想要更强的预览 / diff / 交互：在 `CodeBlockNode` 上用 `code-renderer="stream-diffs"`
+- 想要更轻的 surface：在 `MarkdownRender` 上设置 `render-code-blocks-as-pre`，输出纯 `<pre>`。
+- 想要更强的预览 / diff / 交互：安装 `stream-diffs`，内置 `CodeBlockNode` 会自动使用。
+- 想使用应用自有 renderer：用 `setCustomComponents` 注册带作用域的 `code_block`。Mermaid、D2 与 Infographic 使用各自的组件 key。
 
 具体差异看 [渲染器与节点组件](/zh/guide/components)。
 

--- a/docs/zh/guide/angular-installation.md
+++ b/docs/zh/guide/angular-installation.md
@@ -43,7 +43,7 @@ import 'katex/dist/katex.min.css'
 | D2 图表 | `@terrastruct/d2` |
 | AntV infographic block | `@antv/infographic` |
 
-增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。代码与 diff 选项使用 `stream-diffs` 内置默认值，主题通过 `darkTheme` / `lightTheme` / `themes` 控制。
+增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。直接 `CodeBlockNode` props 与顶层 renderer props 都接收 `codeBlockOptions`；主题使用已注册名称和 `[dark, light]` `themes` 对。
 
 一次性安装：
 

--- a/docs/zh/guide/code-block-node.md
+++ b/docs/zh/guide/code-block-node.md
@@ -22,23 +22,22 @@ keywords:
 
 - `node` — code_block 节点（必需）
 - `loading`、`stream`、`isShowPreview`
-- 2.0 不再支持按块（per-block）配置 code/diff 选项，增强 surface 使用 `stream-diffs` 内置默认值。主题通过 `theme` / `darkTheme` / `lightTheme` / `themes` 设置。
+- `codeBlockOptions` — 与 renderer 无关的排版、布局、File/FileDiff、交互、annotation 与 callback 配置；`NodeRenderer` / `MarkdownRender` 顶层也提供同名 prop。
+- `theme` — 已注册的 string 名称或 `{ dark, light }`；`themes` 是要加载的 `[dark, light]` 名称对。
 - 头部控制：`showHeader`、`showCollapseButton`、`showCopyButton`、`showExpandButton`、`showPreviewButton`、`showFontSizeButtons`、`showTooltips`
 - HTML preview sandbox：`htmlPreviewAllowScripts` 默认 `false`，`htmlPreviewSandbox` 可直接覆盖 iframe sandbox token
 
 内置 inline HTML preview 默认使用 `sandbox=""`，因此不可信预览文档不会默认执行脚本，也不会继承宿主页面 origin。`htmlPreviewSandbox` 的优先级高于 `htmlPreviewAllowScripts`；传入 `htmlPreviewSandbox=""` 会保留完整 sandbox，不传 `htmlPreviewSandbox` 时由 `htmlPreviewAllowScripts` 控制，而 `null` 这类无效非 string override 会回退到安全默认值。只有在可信 demo 场景下才建议显式开启 `htmlPreviewAllowScripts`；对于不可信预览内容，不要把 `allow-scripts` 和 `allow-same-origin` 组合在一起。
 
-增强 diff 模式下的默认行为：
+未提供 `codeBlockOptions` override 时，最终 enhanced diff 的默认行为：
 
-- `diffHideUnchangedRegions: { enabled: true, contextLineCount: 2, minimumLineCount: 4, revealLineCount: 5 }`
-- `diffLineStyle: 'background'`
-- `diffAppearance: 'auto'`
-- `diffUnchangedRegionStyle: 'line-info'`
-- `diffHunkActionsOnHover: true`
-- `diffHunkHoverHideDelayMs: 160`
+- `diffStyle: 'split'`
+- `expandUnchanged: false`
+- `collapsedContextThreshold: 5`
+- `hunkSeparators: 'line-info'`
+- `parseDiffOptions: { context: 2 }`
 
-这些是 `stream-diffs` 的内置默认值；2.0 不再提供按块覆盖的 prop。
-当使用 `diffAppearance: 'auto'` 时，`CodeBlockNode` 会先根据当前明暗外观解析成实际的 light/dark，再传给自身的 `stream-diffs` adapter。
+fallback 与最终 surface 使用同一组折叠配置；流式状态不会覆盖用户设置的 `expandUnchanged`。即使提供 `codeBlockOptions`，主题、内容/语言、header、挂载/显示时机与释放仍由宿主管理。
 
 Diff 代码块的内置 header 现在也会显示 `- / +` 行数统计。
 
@@ -114,6 +113,36 @@ function runSnippet() {}
 </template>
 ```
 
+### 配置代码 surface
+
+```vue
+<script setup lang="ts">
+import type { CodeBlockNodeProps, CodeBlockOptions } from 'markstream-vue'
+import { CodeBlockNode } from 'markstream-vue'
+
+const node = {
+  type: 'code_block',
+  language: 'ts',
+  code: 'const answer = 42',
+  raw: 'const answer = 42',
+} satisfies CodeBlockNodeProps['node']
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  lineHeight: 20,
+  overflow: 'wrap',
+  disableLineNumbers: true,
+  enableLineSelection: true,
+}
+</script>
+
+<template>
+  <CodeBlockNode :node="node" :code-block-options="codeBlockOptions" />
+</template>
+```
+
+`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding` 与 `tabSize` 由宿主管理，以确保 fallback 与最终 surface 的几何一致。其余受支持字段传给 `stream-diffs`；header 与 toolbar 继续使用独立的组件 props。
+
 ### 自定义加载占位符
 
 ```vue twoslash
@@ -169,8 +198,7 @@ const themes = [
     </button>
     <MarkdownRender
       :is-dark="isDark"
-      code-block-dark-theme="vitesse-dark"
-      code-block-light-theme="vitesse-light"
+      :code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"
       :themes="themes"
       :content="content"
     />
@@ -214,8 +242,7 @@ const themes = [
 <template>
   <MarkdownRender
     :is-dark="isDark"
-    code-block-dark-theme="vitesse-dark"
-    code-block-light-theme="vitesse-light"
+    :code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"
     :themes="themes"
     :content="content"
   />
@@ -232,14 +259,11 @@ const themes = [
 
 <!-- 固定主题（忽略 isDark） -->
 <CodeBlockNode theme="monokai" />
-
-<!-- 主题对象（固定，忽略 isDark） -->
-<CodeBlockNode :theme="{ name: 'my-theme', colors: { ... } }" />
 ```
 
-使用 `{ light, dark }` 配对时，组件根据 `isDark` prop 自动切换。
+使用 `{ dark, light }` 配对时，组件根据 `isDark` prop 自动切换。
 
-`themes` prop 只接受一个 `[深色, 浅色]` 二元主题对。
+`themes` prop 只接受一个 `[深色, 浅色]` 二元主题对。旧 Monaco JSON theme object 在 2.0 中不是有效的 `theme` 值；先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再传入注册名称。
 
 > **向后兼容：** `darkTheme` / `lightTheme` props 仍然可用但已废弃。推荐使用统一的 `theme` prop。
 
@@ -248,8 +272,8 @@ const themes = [
 | Prop | 直接使用 CodeBlockNode | 通过 MarkdownRender |
 |------|---------------------|-------------------|
 | `isDark` | 直接传给 `<CodeBlockNode :is-dark="isDark" />` | 通过 `<MarkdownRender :is-dark="isDark" />` 传入并自动转发 |
-| 主题 | `:theme="{ light: 'vitesse-light', dark: 'vitesse-dark' }"` | `:code-block-dark-theme="'vitesse-dark'"` `:code-block-light-theme="'vitesse-light'"` (兼容) |
-| 深色/浅色主题对 | `:themes="['vitesse-dark', 'vitesse-light']"` | `:themes="['vitesse-dark', 'vitesse-light']"` |
+| 主题 | `:theme="{ dark: 'vitesse-dark', light: 'vitesse-light' }"` | `:code-block-props="{ theme: { dark: 'vitesse-dark', light: 'vitesse-light' } }"` |
+| 主题对 | `:themes="['vitesse-dark', 'vitesse-light']"` | `:themes="['vitesse-dark', 'vitesse-light']"` |
 
 ## 注意事项
 

--- a/docs/zh/guide/code-block-runtime-internals.md
+++ b/docs/zh/guide/code-block-runtime-internals.md
@@ -13,7 +13,7 @@ keywords:
 
 ## 加载 contract
 
-`getStreamDiffsRuntime()` 是 loader 导出名（2.0 从历史名称 `getUseMonaco` 重命名而来）。它动态导入的是 `stream-diffs`，不是 `stream-diffs/vue`。返回的 adapter 只提供 `CodeBlockNode` 需要的 editor-compatible 能力：创建、更新、主题、测量和释放。
+Markstream 使用内部缓存 loader 动态导入 `stream-diffs`，而不是 `stream-diffs/vue`。adapter 只提供 `CodeBlockNode` 所需的少量能力：创建、更新、主题、测量与释放。原始 loader/module 刻意不属于 Markstream 公开 API。
 
 ```text
 CodeBlockNode                 markstream-vue runtime                stream-diffs
@@ -47,6 +47,8 @@ import { preloadCodeBlockRuntime } from 'markstream-vue'
 
 void preloadCodeBlockRuntime()
 ```
+
+历史 `getUseMonaco` 只是用于预热代码块 runtime 时，公开替代项就是这个函数。确实要自行管理 controller 的高级代码应直接从 `stream-diffs` 导入 API 与类型，不要依赖 Markstream 的内部 adapter。
 
 ## 主题
 

--- a/docs/zh/guide/code-block-runtime.md
+++ b/docs/zh/guide/code-block-runtime.md
@@ -4,12 +4,12 @@ description: 说明 markstream-vue 的代码块 Runtime，介绍 CodeBlockNode �
 keywords:
   - 代码块 Runtime
   - stream-diffs
-  - Monaco
+  - runtime 预热
 ---
 
 # 代码块 Runtime
 
-本页说明 `CodeBlockNode` 使用的可选 `stream-diffs` runtime。2.0 移除了旧的 Monaco 选项 API 与 `stream-monaco` 回退：`stream-diffs` 是唯一增强型代码块 surface，代码与 diff 行为使用其内置默认值。
+本页说明 `CodeBlockNode` 使用的可选 `stream-diffs` runtime。2.0 移除了 `stream-monaco` 回退，`stream-diffs` 是唯一增强型代码块 surface；受支持的配置统一通过与 renderer 无关的 `CodeBlockOptions` API 暴露。
 
 ## 安装
 
@@ -50,9 +50,22 @@ CodeBlockNode                          controller + DOM surface
 
 ## 主题
 
-明暗主题请使用 `theme` / `darkTheme` / `lightTheme` / `themes` props。`CodeBlockNode` 会把主题变化传给已挂载的 surface，不会重建 Vue 组件。
+`theme` 可传已注册的 string 名称或 `{ dark, light }`；`themes` 是 runtime 可用的 `[dark, light]` 名称对。`CodeBlockNode` 会把主题变化传给已挂载的 surface，不会重建 Vue 组件。
 
-2.0 已移除 `monacoOptions` / `codeBlockMonacoOptions` props，且无替代方案；代码与 diff 选项回退到 `stream-diffs` 内置默认值。
+Monaco JSON theme object 不会在 2.0 中直接改名。自定义主题需先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再传入注册名称。
+
+## Options 透传
+
+直接使用 `CodeBlockNode`，或通过顶层 `NodeRenderer` / `MarkdownRender`，都可以传 `codeBlockOptions`。Vue 3、React、Octane、Svelte、Angular 与 Vue 2 使用同一套 `CodeBlockOptions` 约定。
+
+受支持的 surface 包括：
+
+- 宿主管理的排版与布局：`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`；
+- File 配置，例如 `disableLineNumbers`、`overflow`、高亮长度限制，以及虚拟化/高亮器控制；
+- FileDiff 布局、indicator、未变化区域折叠与 line diff 控制；
+- line/token 交互、selection callback、annotation、`onController` 与 `workerManager`。
+
+Markstream 会把宿主管理字段同时应用到流式 `<pre>` 与最终 surface，再把其余受支持字段传给 `stream-diffs`。主题、语言/内容、流式状态、唯一 header、挂载/显示时机与释放仍由宿主管理，优先于冲突的 runtime 值。
 
 ## 可选预热
 
@@ -68,4 +81,4 @@ void preloadCodeBlockRuntime()
 
 ## Diff 交互
 
-diff block 使用相同的适配边界。增强 diff surface（折叠、未变化区域处理、inline/side-by-side 布局）由 `stream-diffs` 内置默认值驱动；2.0 不再提供按代码块配置的 diff options prop。
+diff block 使用相同的适配边界。未提供对应 `codeBlockOptions` 时，增强 diff surface 使用 `stream-diffs` 默认值；可通过 `diffStyle`、`expandUnchanged`、`collapsedContextThreshold`、`hunkSeparators`、`lineDiffType` 与 `parseDiffOptions` 配置布局和折叠。

--- a/docs/zh/guide/code-blocks.md
+++ b/docs/zh/guide/code-blocks.md
@@ -34,7 +34,32 @@ npm i stream-diffs
 
 ### 配置
 
-增强的 `stream-diffs` surface 不暴露按块（per-block）的 options prop。代码与 diff 选项使用 `stream-diffs` 内置默认值，因此不再需要 `monaco-options` 风格的配置。主题通过 `theme` / `darkTheme` / `lightTheme` / `themes` props 设置（见 `CodeBlockTheme`）。
+可以在 `MarkdownRender` / `NodeRenderer` 顶层或直接挂载的 `CodeBlockNode` 上使用与 renderer 无关的 `codeBlockOptions`。六个框架 adapter 都导出相同的 `CodeBlockOptions` 公开类型。
+
+```vue
+<script setup lang="ts">
+import type { CodeBlockOptions } from 'markstream-vue'
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  expandUnchanged: false,
+  enableLineSelection: true,
+}
+</script>
+
+<template>
+  <MarkdownRender
+    :content="content"
+    :code-block-options="codeBlockOptions"
+  />
+</template>
+```
+
+排版/布局字段（`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`）由 Markstream 协调，确保流式 fallback 与最终 surface 一致。受支持的 File/FileDiff 字段包括 `disableLineNumbers`、`overflow`、高亮限制、diff 布局/折叠、交互、selection callback、annotation、`onController` 与 `workerManager`。主题、语言/内容、流式状态、header、挂载、显示和释放仍由宿主管理，并具有更高优先级。
+
+主题使用已注册的 string 名称。直接 `CodeBlockNode.theme` 接收 string 或 `{ dark, light }`，`themes` 是要加载的 `[dark, light]` 对。旧 Monaco JSON theme object 没有直接改名：先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再传入注册名称。
 
 完整运行时行为、diff 交互与可选预热见 [/zh/guide/code-block-runtime](/zh/guide/code-block-runtime)。
 
@@ -82,6 +107,9 @@ const node = {
 </script>
 
 <template>
-  <CodeBlockNode :node="node" />
+  <CodeBlockNode
+    :node="node"
+    :code-block-options="{ overflow: 'wrap', disableLineNumbers: true }"
+  />
 </template>
 ```

--- a/docs/zh/guide/component-overrides.md
+++ b/docs/zh/guide/component-overrides.md
@@ -164,7 +164,7 @@ setCustomComponents('docs', {
 
 另外，渲染器还会按节点类型继续透传一些能力相关 props：
 
-- 普通代码块会拿到 `stream`、`theme`、`darkTheme`、`lightTheme`、`themes`、`minWidth`、`maxWidth`，以及你传给 `codeBlockProps` 的内容（新的推荐字段是 `theme`；`darkTheme` / `lightTheme` 继续保留作兼容）
+- 普通代码块会拿到 `stream`、`theme`、`darkTheme`、`lightTheme`、`themes`、`minWidth`、`maxWidth`、顶层 `codeBlockOptions` object，以及你传给 `codeBlockProps` 的内容（推荐的子组件主题字段是 `theme`；`darkTheme` / `lightTheme` 继续保留作兼容）
 - Mermaid、D2、Infographic 会分别拿到对应的 `mermaidProps`、`d2Props`、`infographicProps`
 - link 和 list 会继承 tooltip / typewriter 相关的上层配置
 

--- a/docs/zh/guide/components.md
+++ b/docs/zh/guide/components.md
@@ -211,7 +211,7 @@ setCustomComponents('docs', {
 - **同伴依赖**：`stream-diffs`
 - **常见问题**：增强 surface 会等待代码块结束流式输出并进入视口
 
-如果代码块本身就是产品体验的一部分，用它最合适。`stream-diffs` 与框架无关，Vue 的 mount/unmount 决策保留在 `CodeBlockNode`。代码与 diff 选项使用 `stream-diffs` 内置默认值。
+如果代码块本身就是产品体验的一部分，用它最合适。`stream-diffs` 与框架无关，Vue 的 mount/unmount 决策保留在 `CodeBlockNode`。受支持的 code/diff 行为通过直接或 renderer 顶层 `codeBlockOptions` 配置。
 
 深入页面： [CodeBlockNode](/zh/guide/code-block-node)、[Code Block Runtime](/zh/guide/code-block-runtime)
 

--- a/docs/zh/guide/e2e-testing-report.md
+++ b/docs/zh/guide/e2e-testing-report.md
@@ -64,7 +64,7 @@ pnpm lint
    - 深度嵌套列表中混合标记
    - 转义括号等特殊场景
    - 流式代码围栏的异常输入
-3. 为需要 DOM 或 Worker 的插件（Mermaid、KaTeX、Monaco）补充集成测试，并考虑在 CI 中加入基于 Playwright 的浏览器流程。
+3. 为需要 DOM 或 Worker 的插件（Mermaid、KaTeX worker 与 `stream-diffs` 代码块 surface）补充集成测试，并考虑在 CI 中加入基于 Playwright 的浏览器流程。
 
 如果需要，我可以：
 1. 立即扩充快照的元信息。

--- a/docs/zh/guide/migration-2-0.md
+++ b/docs/zh/guide/migration-2-0.md
@@ -14,10 +14,13 @@ keywords:
 
 ## 安装
 
-Beta 阶段从 `next` 安装；稳定版发布后，`@2` 会选择持续维护的 2.x 版本线：
+线上文档可能先于 beta 发布到 npm。请先检查 `next` tag，只有返回 `2.0.0-beta.1` 时才执行 beta 安装；稳定版发布后，`@2` 会选择持续维护的 2.x 版本线：
 
 ```bash
-# 验证 2.0 beta
+# 仅当这里输出 2.0.0-beta.1 时继续
+npm view markstream-vue@next version
+
+# 上述检查通过后验证 2.0 beta
 pnpm add markstream-vue@next stream-diffs
 
 # 2.0 stable 发布后
@@ -26,15 +29,44 @@ pnpm add markstream-vue@2 stream-diffs
 
 未安装 `stream-diffs` 时，代码 fence 回退为普通 `<pre><code>`。也可以通过 `render-code-blocks-as-pre` 显式使用该路径。
 
+### 协调发布的 beta 家族
+
+协调 beta 中的所有框架 adapter 都适用同一套代码块迁移规则。各包独立发布，因此 `markstream-vue@next` 检查通过并不代表其他 adapter 已就绪。执行下表某一行前，请查询该行对应的包，并确认结果与表中的 beta 版本完全一致：
+
+```bash
+# 把这里的包名替换为你实际使用的那一行。
+PACKAGE=markstream-react
+npm view "$PACKAGE@next" version
+```
+
+请从 `next` 安装你使用的 adapter；只有应用自身直接导入 parser 或 core 时，才需要单独安装它们。
+
+| 框架或层 | Beta 版本 | Beta 安装命令 |
+| --- | --- | --- |
+| Vue 3 / Nuxt / VitePress | `markstream-vue@2.0.0-beta.1` | `pnpm add markstream-vue@next stream-diffs` |
+| React / Next.js | `markstream-react@0.1.0-beta.1` | `pnpm add markstream-react@next stream-diffs` |
+| Octane | `markstream-octane@0.1.0-beta.1` | `pnpm add markstream-octane@next octane@^0.1.21 stream-diffs` |
+| Svelte 5 | `markstream-svelte@0.1.0-beta.1` | `pnpm add markstream-svelte@next svelte@^5 stream-diffs` |
+| Angular | `markstream-angular@0.1.0-beta.1` | `pnpm add markstream-angular@next stream-diffs` |
+| Vue 2 | `markstream-vue2@0.1.0-beta.1` | `pnpm add markstream-vue2@next stream-diffs` |
+| 仅 parser | `stream-markdown-parser@1.2.5-beta.1` | `pnpm add stream-markdown-parser@next` |
+| 仅流式 core | `markstream-core@1.1.0-beta.1` | `pnpm add markstream-core@next` |
+
+请保持宿主框架 peer 兼容，不要只升级框架的一部分。React 同时要求 `react` 与 `react-dom` 18 或更高版本；所有 Angular 包必须保持在同一版本线。Vue 2.6 用户还必须安装并注册 `@vue/composition-api`，Vue 2.7 用户则不应安装该插件。
+
 ## 代码块破坏性变更
 
 | 1.x API 或依赖 | 2.0 迁移方式 |
 | --- | --- |
-| `codeRenderer: 'monaco'`、`'shiki'` 或 `'markdown'` | 要保留增强代码块时改为 `codeRenderer: 'stream-diffs'`；普通回退使用 `'pre'`。 |
+| `codeRenderer: 'monaco'` 或 `'shiki'` | 要保留增强代码块时改为 `codeRenderer: 'stream-diffs'`；普通回退使用 `'pre'`。 |
 | `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `CodeBlockMonacoLanguage` | 删除。语言标识改为读取 code fence，并由 `resolveLanguageId` 规范化。 |
+| `CodeBlockMonacoOptions` | 删除；不提供公开的编辑器选项替代项。 |
 | `resolveMonacoLanguageId` | `resolveLanguageId` |
 | `getUseMonaco` | `getStreamDiffsRuntime` |
-| `MarkdownCodeBlockNode` | `CodeBlockNode`，或普通 `pre` 回退 |
+| `MarkdownCodeBlockNode` 与 React / Octane 导出的 `MarkdownCodeBlockNodeProps` | `CodeBlockNode` / `CodeBlockNodeProps`，或普通 `pre` 回退 |
+| `ShikiCodeBlockProps` / 顶层 `langs` | 删除。需要时继续使用 `themes`；语言预加载列表不再是 renderer prop。 |
+| `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`；按下方示例更新 handler 结构。 |
 | `monacoOptions` / `codeBlockMonacoOptions` | 删除；没有 adapter options 替代项。 |
 | `stream-monaco` / `stream-markdown` | 删除两个依赖。 |
 | `stream-diffs` | 增强代码块的可选 peer。 |
@@ -45,7 +77,7 @@ pnpm add markstream-vue@2 stream-diffs
 <MarkdownRender
   :content="content"
   code-renderer="monaco"
-  :monaco-options="editorOptions"
+  :code-block-monaco-options="editorOptions"
 />
 ```
 
@@ -62,12 +94,50 @@ pnpm add markstream-vue@2 stream-diffs
 
 主题选择仍是公开 API。底层编辑器尺寸、换行、diff 算法与 adapter CSS 选项不再是 renderer props。
 
+### Preview 事件 payload
+
+`MarkdownCodeBlockPreviewPayload` 不只是类型改名。绑定到已移除 `MarkdownCodeBlockNode` 的 handler 以前会直接收到渲染内容：
+
+```ts
+import type { MarkdownCodeBlockPreviewPayload } from 'markstream-vue'
+
+function handlePreview({ type, content, title }: MarkdownCodeBlockPreviewPayload) {
+  openArtifact({ type, content, title })
+}
+```
+
+`CodeBlockNode` 现在发出 `CodeBlockPreviewPayload`。源内容从 `node.code` 读取，并使用明确的 artifact 字段：
+
+```ts
+import type { CodeBlockPreviewPayload } from 'markstream-vue'
+
+function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPreviewPayload) {
+  openArtifact({ id, type: artifactType, content: node.code, title: artifactTitle })
+}
+```
+
+### 底层 runtime 类型重命名
+
+以下包根导出随 runtime 一起重命名。它们描述 `stream-diffs` adapter surface，不会恢复已移除的 renderer options。
+
+| 1.x 类型 | 2.0 类型 |
+| --- | --- |
+| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
+| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
+| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
+| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
+| `MonacoHelpers` | `StreamDiffsHelpers` |
+| `MonacoModelLike` | `StreamDiffsModelLike` |
+| `MonacoModule` | `StreamDiffsModule` |
+| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
+| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+
 ## Parser 类型
 
 公开 parser 配置统一使用 `ParseOptions`。`InternalParseOptions` 已移除。结构复用与计时字段分别是 `reuseStableTopLevelNodes` 和 `parserMetrics`；cursor、fragment 与 stream-control 字段保持内部实现。
 
 ```ts
-import type { ParseOptions } from 'stream-markdown-parser'
+import type { ParseOptions } from 'markstream-vue'
 
 const parseOptions: ParseOptions = {
   reuseStableTopLevelNodes: true,
@@ -78,14 +148,13 @@ const parseOptions: ParseOptions = {
 
 `1.x` 分支继续接收关键 bug 与安全修复。同时适用于两条版本线的修复会先进入当前版本线，再 cherry-pick 到 `1.x`；只涉及已移除 1.x 代码的修复留在维护分支。本页不设定 1.x EOL 日期，后续会单独公告。
 
-| 安装目标 | 命令或 dist-tag |
-| --- | --- |
-| 当前稳定大版本 | `pnpm add markstream-vue` 或 `@latest` |
-| 当前预发布版本 | `pnpm add markstream-vue@next` |
-| 最新维护中的 1.x 稳定版 | `pnpm add markstream-vue@1`；2.0 stable 切换后也可使用 `@legacy` |
-| 最新维护中的 1.x 预发布版 | 首个 2.x beta 切换后使用 `pnpm add markstream-vue@legacy-next` |
+| 发布阶段 | `latest` | `next` | 维护中的 1.x 通道 |
+| --- | --- | --- | --- |
+| 2.x beta 切换前 | 1.x stable | 1.x prerelease | `markstream-vue@1` 或精确版本 |
+| beta 后、stable 前 | 1.x stable | 2.x beta | 稳定版使用 `markstream-vue@1`；预发布使用 `markstream-vue@legacy-next` |
+| 2.x stable 切换后 | 2.x stable | 2.x prerelease | 稳定版使用 `markstream-vue@1` 或 `@legacy`；预发布使用 `@legacy-next` |
 
-已经锁定 `^1.x` 的应用会留在 1.x。发布 workflow 会把后续 1.x 版本路由到 legacy 标签，避免 `latest` 或 `next` 从 2.x 被指回 1.x。
+已经锁定 `^1.x` 的应用会留在 1.x。beta 切换只移动预发布通道；在 2.x stable 接管 `latest` 前，1.x stable patch 仍可继续更新 `latest`。stable 切换完成后，后续 1.x stable 发布才会进入 `legacy`。
 
 ## 验证清单
 

--- a/docs/zh/guide/migration-2-0.md
+++ b/docs/zh/guide/migration-2-0.md
@@ -58,18 +58,24 @@ npm view "$PACKAGE@next" version
 
 | 1.x API 或依赖 | 2.0 迁移方式 |
 | --- | --- |
-| `codeRenderer: 'monaco'` 或 `'shiki'` | 要保留增强代码块时改为 `codeRenderer: 'stream-diffs'`；普通回退使用 `'pre'`。 |
-| `CodeBlockMonacoTheme` / `CodeBlockMonacoThemeObject` | `CodeBlockTheme` / `CodeBlockThemeObject` |
+| `codeRenderer: 'monaco'`、`'shiki'` 或 `'pre'` | 删除。增强代码块会自动使用 `stream-diffs`；原 `'pre'` 值改用 `renderCodeBlocksAsPre`，带作用域的自定义渲染器使用 `setCustomComponents(customId, { code_block: ... })`。 |
+| `markdownCodeRenderer` / `NodeRendererCodeRenderer` | 删除。Timeline 与 virtual adapter 只有在需要普通输出时才设置 `renderCodeBlocksAsPre: true`；增强路径无需 selector。 |
+| string 形式的 `CodeBlockMonacoTheme` | string 形式的 `CodeBlockTheme`；明暗选择可用 `CodeBlockThemePair`（`{ dark, light }`）。 |
+| Monaco JSON theme object / `CodeBlockMonacoThemeObject` | 不能直接转换。先改成 Shiki `ThemeRegistration`，再用 `stream-diffs/pierre` 的 `registerCustomTheme(name, loader)` 注册，最后传入注册名称。 |
 | `CodeBlockMonacoLanguage` | 删除。语言标识改为读取 code fence，并由 `resolveLanguageId` 规范化。 |
-| `CodeBlockMonacoOptions` | 删除；不提供公开的编辑器选项替代项。 |
+| `CodeBlockMonacoOptions` | 对于受支持且与 renderer 无关的字段，改为 `CodeBlockOptions`。 |
 | `resolveMonacoLanguageId` | `resolveLanguageId` |
-| `getUseMonaco` | `getStreamDiffsRuntime` |
+| 只用于预热的 `getUseMonaco` | `preloadCodeBlockRuntime` |
+| 用于直接调用 runtime 的 `getUseMonaco` | 从 `stream-diffs` 导入高级 API；Markstream 不公开原始 runtime module。 |
 | `MarkdownCodeBlockNode` 与 React / Octane 导出的 `MarkdownCodeBlockNodeProps` | `CodeBlockNode` / `CodeBlockNodeProps`，或普通 `pre` 回退 |
 | `ShikiCodeBlockProps` / 顶层 `langs` | 删除。需要时继续使用 `themes`；语言预加载列表不再是 renderer prop。 |
 | `MarkdownCodeBlockPreviewPayload` | `CodeBlockPreviewPayload`；按下方示例更新 handler 结构。 |
-| `monacoOptions` / `codeBlockMonacoOptions` | 删除；没有 adapter options 替代项。 |
+| 直接 `CodeBlockNode.monacoOptions` | `CodeBlockNode.codeBlockOptions` |
+| `MarkdownRender.codeBlockMonacoOptions` | 顶层 `MarkdownRender.codeBlockOptions` |
 | `stream-monaco` / `stream-markdown` | 删除两个依赖。 |
 | `stream-diffs` | 增强代码块的可选 peer。 |
+
+1.x 里，直接挂载的 `CodeBlockNode` 接收 `monacoOptions`，而 `MarkdownRender` 用 `codeBlockMonacoOptions` 向下透传这些配置。2.0 的两个入口统一使用与 renderer 无关的 `codeBlockOptions`。协调发布的每个 adapter 都在直接 `CodeBlockNode` 以及顶层 `NodeRenderer` / `MarkdownRender` 上公开该字段。`codeBlockProps` 仍是另一组组件外壳配置，例如 header 与 toolbar 控制。
 
 迁移前：
 
@@ -86,13 +92,50 @@ npm view "$PACKAGE@next" version
 ```vue
 <MarkdownRender
   :content="content"
-  code-renderer="stream-diffs"
   :is-dark="isDark"
+  :code-block-options="codeBlockOptions"
   :themes="['vitesse-dark', 'vitesse-light']"
 />
 ```
 
-主题选择仍是公开 API。底层编辑器尺寸、换行、diff 算法与 adapter CSS 选项不再是 renderer props。
+`CodeBlockOptions` 包含由宿主协调的排版与布局字段（`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`），以及受支持的 `stream-diffs` 配置，例如 `disableLineNumbers`、`overflow`、高亮限制、diff 布局和折叠、line/token 交互、annotation、selection callback、`onController` 与 `workerManager`。主题选择、语言与流式内容、唯一 header、挂载/显示时机和释放仍由 Markstream 管理；冲突的原始 runtime key 不能覆盖这些宿主职责。如果 1.x 使用不同的上下 padding，迁移时需选择一个统一的 px 数值；2.0 无法通过 `codeBlockOptions` 保留不对称 padding。
+
+常见配置不是简单的字段改名：
+
+| 1.x 配置 | 2.0 配置 |
+| --- | --- |
+| `MAX_HEIGHT: number` | 单位为 CSS px 的 `maxHeight: number`。string 值需要显式换算。 |
+| `wordWrap: 'on'` / `'off'` | `overflow: 'wrap'` / `'scroll'`。`wordWrapColumn` 或 `bounded` 需要人工选择其中一种行为。 |
+| `renderSideBySide: true` / `false` | `diffStyle: 'split'` / `'unified'` |
+| `diffUnchangedRegionStyle` | `hunkSeparators` |
+| `diffHideUnchangedRegions` | 没有单个对象可直接替换。把 `false` / `{ enabled: false }` 改成 `expandUnchanged: true`，把 `true` / `{ enabled: true }` 改成 `expandUnchanged: false`。用 `parseDiffOptions.context` 控制上下文、`collapsedContextThreshold` 控制何时折叠、`expansionLineCount` 控制每次展开行数。新旧算法并不相同，需要重新调节阈值。 |
+
+主题值是名称，而不是 Monaco theme JSON。直接 `CodeBlockNode.theme` 接收固定 string 或 `{ dark, light }`，`themes` 是用于加载的 `[dark, light]` 名称对。注册前必须先把旧 Monaco theme 转为 Shiki theme 格式；尤其不能直接复用 Monaco `rules`，需要改成 Shiki `tokenColors` 或 `settings`：
+
+```ts
+import type { ThemeRegistration } from 'stream-diffs/pierre'
+import { registerCustomTheme } from 'stream-diffs/pierre'
+
+const themeName = 'acme-dark'
+const acmeDark: ThemeRegistration = {
+  name: themeName,
+  type: 'dark',
+  colors: {
+    'editor.background': '#0d1117',
+    'editor.foreground': '#c9d1d9',
+  },
+  tokenColors: [
+    {
+      scope: ['comment'],
+      settings: { foreground: '#8b949e', fontStyle: 'italic' },
+    },
+  ],
+}
+
+registerCustomTheme(themeName, async () => acmeDark)
+```
+
+注册后传入 `themeName`，不要直接传旧 Monaco 对象。内置 `CodeBlockNode` 会自动启用；应用自有 renderer 时使用带作用域的 `setCustomComponents(customId, { code_block: MyCodeBlock })`。Mermaid、D2 与 Infographic fence 使用各自的专用组件 key，需要时应分别覆盖。
 
 ### Preview 事件 payload
 
@@ -116,21 +159,9 @@ function handlePreview({ node, artifactType, artifactTitle, id }: CodeBlockPrevi
 }
 ```
 
-### 底层 runtime 类型重命名
+### 底层 runtime 访问
 
-以下包根导出随 runtime 一起重命名。它们描述 `stream-diffs` adapter surface，不会恢复已移除的 renderer options。
-
-| 1.x 类型 | 2.0 类型 |
-| --- | --- |
-| `MonacoDiffEditorViewLike` | `StreamDiffsDiffEditorViewLike` |
-| `MonacoDiffLineChangeLike` | `StreamDiffsDiffLineChangeLike` |
-| `MonacoDisposableLike` | `StreamDiffsDisposableLike` |
-| `MonacoEditorViewLike` | `StreamDiffsEditorViewLike` |
-| `MonacoHelpers` | `StreamDiffsHelpers` |
-| `MonacoModelLike` | `StreamDiffsModelLike` |
-| `MonacoModule` | `StreamDiffsModule` |
-| `MonacoNamespaceLike` | `StreamDiffsNamespaceLike` |
-| `MonacoRuntimeOptions` | `StreamDiffsRuntimeOptions` |
+旧的根级 `Monaco*` runtime 类型与 `getUseMonaco` 不会改名为另一份公开的 `stream-diffs` API。应用只需预热 Markstream 的可选代码块 module 时使用 `preloadCodeBlockRuntime()`。确实要自行管理 runtime controller 的高级应用，应直接从 `stream-diffs` 导入函数与类型，并自行负责该 controller 的生命周期。
 
 ## Parser 类型
 
@@ -158,7 +189,8 @@ const parseOptions: ParseOptions = {
 
 ## 验证清单
 
-- 删除 `stream-monaco`、`stream-markdown` 与已移除的代码块 props。
+- 删除 `stream-monaco`、`stream-markdown` 与旧代码块 prop 名称。
+- 把受支持的 `monacoOptions` / `codeBlockMonacoOptions` 字段改为 `codeBlockOptions`，Monaco-only 字段需逐项审查，不要直接复制。
 - 需要增强代码块时安装 `stream-diffs`。
 - 在明暗主题中验证普通与 diff fence。
 - 在应用实际宽度下验证 inline 与 side-by-side diff。

--- a/docs/zh/guide/props.md
+++ b/docs/zh/guide/props.md
@@ -26,7 +26,6 @@ keywords:
 | `html-policy` | `'safe' \| 'escape' \| 'trusted'` | `'safe'` | 控制 `html_block` / `html_inline` 渲染。`safe` 会阻断 active/embed/form 类标签，`escape` 按文本显示 HTML，`trusted` 保留旧的宽 HTML 行为但仍移除脚本和危险属性。 |
 | `mode` | `'docs' \| 'chat' \| 'minimal'` | `'docs'` | 按场景选择预设调优。AI/SSE 输出用 `chat`，富文档页面用 `docs`，非聊天的轻量场景用 `minimal`。 |
 | `dom-mode` | `'full' \| 'minimal'` | `'full'` | 尽力减少 DOM 结构。`minimal` 只会在不需要 per-node `.node-slot` / `.node-content` 包装时跳过它们；遇到 fade、批量渲染、视口延迟、虚拟化、宿主 virtual-scroll、typewriter 或自定义组件时会回退到 `full`。如需稳定 minimal 输出，请显式关闭这些能力。 |
-| `code-renderer` | `'pre' \| 'stream-diffs'` | 随 mode 变化 | 选择普通 fenced code block 的渲染器。`docs` 默认使用增强的 `stream-diffs` surface；`chat` 和 `minimal` 默认使用纯 `<pre><code>`。`render-code-blocks-as-pre=true` 优先级更高。 |
 | `custom-markdown-it` | `(md: MarkdownIt) => MarkdownIt` | – | 自定义内部 MarkdownIt 实例（加插件、改配置）。 |
 | `debug-performance` | `boolean` | `false` | 打印解析/渲染耗时、虚拟化统计，以及 `parse(stream)` 的 `streamMode` / `streamDelta` 等信息（仅 dev）。 |
 | `typewriter` | `boolean \| 'simple' \| 'precise'` | `false` | 流式内容增长时显示闪烁打字光标。`true` / `'precise'` 使用基于 Range 的精确定位；`'simple'` 使用轻量 CSS 光标。 |
@@ -158,7 +157,7 @@ flowchart TD
 
 | Flag | 默认值 | 功能 |
 | ---- | ------ | ---- |
-| `render-code-blocks-as-pre` | `false` | 将非 Mermaid/Infographic/D2 的 `code_block` 渲染为 `<pre><code>`（使用 `PreCodeNode`）。Mermaid/infographic/D2 仍会路由到各自组件，除非用 `setCustomComponents` 覆盖。 |
+| `render-code-blocks-as-pre` | `false` | 强制内置 fenced-code 路径使用 `<pre><code>`（`PreCodeNode`）。通过 `setCustomComponents` 注册的带作用域语言或 `code_block` 覆盖仍然优先。 |
 | `code-block-stream` | `true` | 启用流式代码块更新；关闭后会保持加载态直到完整文本就绪，避免中间态解析产生问题。 |
 | `viewport-priority` | `true` | 优先渲染视窗内的代码块/Mermaid/D2/KaTeX 等重节点，延迟离屏渲染以提升交互体验。 |
 | `defer-nodes-until-visible` | `true` | 启用后，重节点在接近视口前可先渲染为占位（仅在非虚拟化模式生效）。 |
@@ -185,15 +184,23 @@ flowchart TD
 
 - `code-block-dark-theme`, `code-block-light-theme`
 - `code-block-min-width`, `code-block-max-width`
+- `code-block-options`（`CodeBlockOptions`，从 renderer 顶层传给普通 `CodeBlockNode`；直接使用 `CodeBlockNode` 时也用同名 prop）
 - `code-block-props`（额外代码块 props，例如 `showHeader`、`showFontSizeButtons`、`showTooltips`、`htmlPreviewAllowScripts`、`htmlPreviewSandbox`，同时保留不是渲染器结构字段的自定义透传字段；`node`、`key`、`ref`、`ctx`、`renderNode`、`indexKey`、`__proto__`、`prototype`、`constructor` 不会透传）
-- `themes`（在安装 `stream-diffs` 时，会转发给其 adapter 的主题系统）
+- `themes`（已注册主题名称组成的 `[dark, light]` 对）
 
-2.0 不再支持按块配置 code/diff 选项，增强版 `CodeBlockNode` 使用 `stream-diffs` 内置默认值。`htmlPreviewAllowScripts` 和 `htmlPreviewSandbox` 只影响内置 `CodeBlockNode` 的 inline HTML iframe preview；它们不会影响 `previewCode` 事件处理器，也不会影响外部 artifact renderer。
+`code-block-options` 与 `code-block-props` 分属不同层。排版/布局（`fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`）及受支持的 File/FileDiff runtime 字段使用 `code-block-options`；组件 shell 与 toolbar 使用 `code-block-props`。主题、code/language、流式状态、唯一 header、挂载/显示时机与释放由宿主管理，会覆盖冲突的 runtime 值。`htmlPreviewAllowScripts` 和 `htmlPreviewSandbox` 只影响内置 `CodeBlockNode` 的 inline HTML iframe preview；它们不会影响 `previewCode` 事件处理器，也不会影响外部 artifact renderer。
 
 `code-block-props` 也可以直接走渲染器公开类型，不需要再退回 `any`：
 
 ```ts twoslash
-import type { NodeRendererProps } from 'markstream-vue'
+import type { CodeBlockOptions, NodeRendererProps } from 'markstream-vue'
+
+const codeBlockOptions: CodeBlockOptions = {
+  fontSize: 13,
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  enableLineSelection: true,
+}
 
 const codeBlockProps: NonNullable<NodeRendererProps['codeBlockProps']> = {
   showHeader: false,
@@ -202,6 +209,8 @@ const codeBlockProps: NonNullable<NodeRendererProps['codeBlockProps']> = {
   htmlPreviewAllowScripts: false,
 }
 ```
+
+两者都从 renderer 顶层传入：`:code-block-options="codeBlockOptions"` 与 `:code-block-props="codeBlockProps"`。直接挂载的 `CodeBlockNode` 接收相同的 `codeBlockOptions` object。直接 `CodeBlockNode.theme` 接收已注册的 string 名称或 `{ dark, light }`；旧 Monaco JSON theme object 需先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再通过注册名称引用。
 
 ## 图表节点全局下发参数
 

--- a/docs/zh/guide/react-components.md
+++ b/docs/zh/guide/react-components.md
@@ -71,15 +71,16 @@ markstream-react 提供与 markstream-vue 相同强大的组件，但专为 Reac
 
 | 属性 | 类型 | 描述 |
 |------|------|-------------|
-| `codeBlockDarkTheme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的深色主题 |
-| `codeBlockLightTheme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的浅色主题 |
+| `codeBlockDarkTheme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的已注册深色主题名称 |
+| `codeBlockLightTheme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的已注册浅色主题名称 |
 | `codeBlockMinWidth` | `string \| number` | 转发到 `CodeBlockNode` 的最小宽度 |
 | `codeBlockMaxWidth` | `string \| number` | 转发到 `CodeBlockNode` 的最大宽度 |
+| `codeBlockOptions` | `CodeBlockOptions` | 转发到每个普通 `CodeBlockNode` 的中性排版/布局与受支持 File/FileDiff 选项 |
 | `codeBlockProps` | `NodeRendererCodeBlockProps` | 额外转发到每个 `CodeBlockNode` 的 props |
 | `mermaidProps` | `Partial<Omit<MermaidBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 Mermaid 围栏和自定义 `mermaid` 渲染器的 props |
 | `d2Props` | `Partial<Omit<D2BlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 D2 围栏和自定义 `d2` 渲染器的 props |
 | `infographicProps` | `Partial<Omit<InfographicBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 infographic 围栏和自定义 `infographic` 渲染器的 props |
-| `themes` | `CodeBlockTheme[]` | 转发到 `CodeBlockNode` 的主题列表 |
+| `themes` | `readonly [CodeBlockTheme, CodeBlockTheme]` | 转发到 `CodeBlockNode` 的已注册 `[dark, light]` 主题名称对 |
 
 #### 重型渲染器 props 透传
 
@@ -116,7 +117,9 @@ markstream-react 提供与 markstream-vue 相同强大的组件，但专为 Reac
 />
 ```
 
-`NodeRendererCodeBlockProps` 会跟随公开的 `CodeBlockNode` props 结构（去掉 `node`），所以像 `showHeader`、`showFontSizeButtons`、`showTooltips` 这类字段都能直接获得补全，而不需要退回 `any`。
+`CodeBlockOptions` 是直接 `CodeBlockNode` 与 `NodeRenderer` 共享的独立顶层 prop。它包含宿主管理的 `fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding`、`tabSize`，以及受支持的 `stream-diffs` File/FileDiff、交互、annotation 与 callback 字段。主题、code/language、流式状态、header、挂载/显示时机与释放仍由宿主管理。
+
+`NodeRendererCodeBlockProps` 跟随公开的组件 shell props 结构（去掉 `node` 与 `codeBlockOptions`），所以像 `showHeader`、`showFontSizeButtons`、`showTooltips` 这类字段都能直接获得补全，而不需要退回 `any`。
 
 ```tsx
 import type { NodeRendererCodeBlockProps } from 'markstream-react'
@@ -228,7 +231,7 @@ function App({ content, isDone }: { content: string, isDone: boolean }) {
 
 ### CodeBlockNode
 
-功能丰富的代码块，由可选的对等依赖 `stream-diffs` 增强（未安装时会回退渲染普通 `<pre>`）。代码与 diff 选项使用 `stream-diffs` 内置默认值。
+功能丰富的代码块，由可选的对等依赖 `stream-diffs` 增强（未安装时会回退渲染普通 `<pre>`）。直接与 renderer 顶层配置都使用 `codeBlockOptions`。
 
 ```tsx
 import { CodeBlockNode } from 'markstream-react'

--- a/docs/zh/guide/react-installation.md
+++ b/docs/zh/guide/react-installation.md
@@ -1,6 +1,6 @@
 ---
 title: React 安装
-description: 在 React 应用中安装 markstream-react，介绍通过 pnpm、npm 与 yarn 的安装方式，以及 Shiki 等可选 peer 依赖的配置。
+description: 在 React 应用中安装 markstream-react，介绍通过 pnpm、npm 与 yarn 的安装方式，以及 stream-diffs 等可选 peer 依赖的配置。
 keywords:
   - React 安装
   - markstream-react
@@ -40,7 +40,7 @@ markstream-react 通过可选的对等依赖支持各种功能。只安装你需
 | D2 图表 | `@terrastruct/d2` | `pnpm add @terrastruct/d2` |
 | 数学公式渲染（KaTeX） | `katex` | `pnpm add katex` |
 
-增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。代码与 diff 选项使用 `stream-diffs` 内置默认值，主题通过 `darkTheme` / `lightTheme` / `themes` 控制。
+增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。直接 `CodeBlockNode` 与顶层 `MarkdownRender` 都接收 `codeBlockOptions`；已注册的主题名称通过 `darkTheme` / `lightTheme` 传入，`themes` 是用于预加载的 `[dark, light]` 对。
 
 ## 可选：在 Vite / Vite 兼容打包器中启用线程外 Worker
 
@@ -109,7 +109,7 @@ npm install stream-diffs mermaid @terrastruct/d2 katex
 pnpm add stream-diffs
 ```
 
-`stream-diffs` 为增强的 `CodeBlockNode` 运行时提供代码与 diff 的默认配置。未安装时会回退渲染普通 `<pre>`。需要自定义行为时，可通过 `setCustomComponents` 覆盖 `code_block` 渲染器：
+`stream-diffs` 提供增强 `CodeBlockNode` runtime。受支持的配置使用 `codeBlockOptions`；未安装时会回退渲染普通 `<pre>`。需要自定义行为时，可通过 `setCustomComponents` 覆盖 `code_block` 渲染器：
 
 ```tsx
 import { setCustomComponents } from 'markstream-react'
@@ -120,13 +120,14 @@ setCustomComponents({
       node={node}
       isDark={isDark}
       stream={ctx?.codeBlockStream}
+      codeBlockOptions={ctx?.codeBlockOptions}
       {...(ctx?.codeBlockProps || {})}
     />
   ),
 })
 ```
 
-主题通过 `darkTheme` / `lightTheme` / `themes` 属性控制。
+主题值是已注册的 string 名称。直接 `CodeBlockNode` 使用 `darkTheme` / `lightTheme`，`themes` 是用于预加载的 `[dark, light]` 对；旧 JSON theme object 需先调用 `stream-diffs/pierre` 的 `registerCustomTheme`，再传入注册名称。
 
 #### Mermaid 图表
 

--- a/docs/zh/guide/react-markdown-migration.md
+++ b/docs/zh/guide/react-markdown-migration.md
@@ -232,7 +232,7 @@ export function Article({ markdown }: { markdown: string }) {
 pnpm add stream-diffs
 ```
 
-主题通过 `darkTheme` / `lightTheme` / `themes` 控制，代码与 diff 选项使用 `stream-diffs` 内置默认值。
+主题使用已注册名称（`themes` 是 `[dark, light]` 对），受支持的 code/diff 配置通过顶层 `codeBlockOptions` 传入。
 
 ## 迁移插件逻辑
 

--- a/docs/zh/guide/react-quick-start.md
+++ b/docs/zh/guide/react-quick-start.md
@@ -147,7 +147,7 @@ export default function MarkdownPage() {
 pnpm add stream-diffs
 ```
 
-增强代码块（`CodeBlockNode` 运行时）使用 `stream-diffs` 内置的代码与 diff 默认配置，主题通过 `darkTheme` / `lightTheme` / `themes` 控制。未安装 `stream-diffs` 时，代码块会回退渲染普通 `<pre>`。
+增强代码块默认使用 `stream-diffs` 配置，并通过直接 `CodeBlockNode.codeBlockOptions` 或顶层 `MarkdownRender.codeBlockOptions` 接收共享 `CodeBlockOptions`。主题使用已注册名称，`themes` 是 `[dark, light]` 对。未安装 `stream-diffs` 时，代码块会回退渲染普通 `<pre>`。
 
 ```tsx
 import MarkdownRender from 'markstream-react'

--- a/docs/zh/guide/roadmap-2-0.md
+++ b/docs/zh/guide/roadmap-2-0.md
@@ -19,7 +19,7 @@ keywords:
 
 - [x] 移除 `monacoOptions` / `codeBlockMonacoOptions` 与全部 `CodeBlockMonaco*` 参数/API（无替代；diff 选项回退 stream-diffs 内置默认值）
 - [x] 删除 `stream-markdown` 的 `MarkdownCodeBlockNode` 组件及其样式
-- [x] `codeRenderer` 取值 `'monaco'` → `'stream-diffs'`；删除 `'shiki'` / `'markdown'` 渲染器类型
+- [x] `codeRenderer` 取值 `'monaco'` → `'stream-diffs'`；删除 `'shiki'` 渲染器类型
 - [x] 公共标识符去 Monaco 命名（`CodeBlockTheme`、`resolveLanguageId`、`getStreamDiffsRuntime`）
 - [x] vue2 / react / svelte / angular / octane 迁移到仅 stream-diffs
 - [x] 更新测试与快照；全量测试通过（313 文件 / 2684 用例）
@@ -46,7 +46,15 @@ keywords:
 - [x] 收敛 `check:peer-deps` 工作区根目录可选 peer
 - [x] 准备协调一致的 `2.0.0-beta.1` 包版本、release notes 与 [2.0 迁移指南](/zh/guide/migration-2-0)；先发布 beta 完成验证，再将同一版本矩阵提升到稳定版
 
-发布维护者切换步骤（需要 npm maintainer 权限）：首个 beta 前先运行 `npm dist-tag add markstream-vue@1.1.2-beta.3 legacy-next` 保留当前预发布；2.0 stable 前运行 `npm dist-tag add markstream-vue@1.0.9 legacy` 保留当前稳定版。`release:family:preflight` 会在发布任何包之前检查全部候选 dist-tag；别名缺失时会给出所需命令并失败关闭。
+### 发布维护者交接
+
+以下 registry 操作需要 npm maintainer 权限；在对应发布完成验证前保持未完成状态：
+
+- [ ] 首个 beta 前运行 `npm dist-tag add markstream-vue@1.1.2-beta.3 legacy-next`，保留当前预发布。
+- [ ] 运行 `pnpm release:family:preflight`，发布协调 beta 家族，并对已发布包完成真实安装验证。
+- [ ] 2.0 stable 前先读取 `npm view markstream-vue@latest version`，确认它仍是 1.x，再执行 `release:family:preflight` 针对该实时版本输出的准确 `npm dist-tag add` 命令。
+
+`release:family:preflight` 会在发布任何包之前检查全部候选 dist-tag；别名缺失时会给出所需命令并失败关闭。
 
 ## 目标 4：运行时视觉验证
 

--- a/docs/zh/guide/roadmap-2-0.md
+++ b/docs/zh/guide/roadmap-2-0.md
@@ -17,10 +17,10 @@ keywords:
 
 跟踪于 [issue #615](https://github.com/Simon-He95/markstream-vue/issues/615)，并已通过 [PR #619](https://github.com/Simon-He95/markstream-vue/pull/619) 合入 `2.0.0` 集成分支。
 
-- [x] 移除 `monacoOptions` / `codeBlockMonacoOptions` 与全部 `CodeBlockMonaco*` 参数/API（无替代；diff 选项回退 stream-diffs 内置默认值）
+- [x] 在六个 adapter 中统一用 `codeBlockOptions` / `CodeBlockOptions` 替换 `monacoOptions` / `codeBlockMonacoOptions`，并移除 Monaco-only 公开类型
 - [x] 删除 `stream-markdown` 的 `MarkdownCodeBlockNode` 组件及其样式
-- [x] `codeRenderer` 取值 `'monaco'` → `'stream-diffs'`；删除 `'shiki'` 渲染器类型
-- [x] 公共标识符去 Monaco 命名（`CodeBlockTheme`、`resolveLanguageId`、`getStreamDiffsRuntime`）
+- [x] 删除 `codeRenderer`、`markdownCodeRenderer` 与 `NodeRendererCodeRenderer`；自动使用 `stream-diffs`，普通输出用 `renderCodeBlocksAsPre`，自定义 renderer 用带作用域的组件覆盖
+- [x] 使用与 renderer 无关的公开标识符（`CodeBlockTheme`、`CodeBlockThemePair`、`CodeBlockOptions`、`resolveLanguageId`、`preloadCodeBlockRuntime`），不公开原始 runtime module
 - [x] vue2 / react / svelte / angular / octane 迁移到仅 stream-diffs
 - [x] 更新测试与快照；全量测试通过（313 文件 / 2684 用例）
 - [x] 清理 playground（依赖、vite 配置、sandbox 页面）

--- a/docs/zh/guide/vue2-components.md
+++ b/docs/zh/guide/vue2-components.md
@@ -18,6 +18,7 @@ markstream-vue2 提供与 markstream-vue 相同强大的组件，但专为 Vue 2
 ```ts
 import type {
   CodeBlockNodeProps,
+  CodeBlockOptions,
   D2BlockNodeProps,
   InfographicBlockNodeProps,
   MermaidBlockNodeProps,
@@ -85,15 +86,16 @@ import type { CodeBlockNode } from 'stream-markdown-parser'
 
 | 属性 | 类型 | 描述 |
 |------|------|-------------|
-| `code-block-dark-theme` | `any` | 转发到每个 `CodeBlockNode` 的深色主题 |
-| `code-block-light-theme` | `any` | 转发到每个 `CodeBlockNode` 的浅色主题 |
+| `code-block-dark-theme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的已注册深色主题名称 |
+| `code-block-light-theme` | `CodeBlockTheme` | 转发到每个 `CodeBlockNode` 的已注册浅色主题名称 |
 | `code-block-min-width` | `string \| number` | 转发到 `CodeBlockNode` 的最小宽度 |
 | `code-block-max-width` | `string \| number` | 转发到 `CodeBlockNode` 的最大宽度 |
+| `code-block-options` | `CodeBlockOptions` | 转发到每个普通 `CodeBlockNode` 的排版/布局与受支持 File/FileDiff 选项 |
 | `code-block-props` | `Record<string, any>` | 额外转发到每个 `CodeBlockNode` 的 props |
 | `mermaid-props` | `Partial<Omit<MermaidBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 Mermaid 围栏和自定义 `mermaid` 渲染器的 props |
 | `d2-props` | `Partial<Omit<D2BlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 D2 围栏和自定义 `d2` 渲染器的 props |
 | `infographic-props` | `Partial<Omit<InfographicBlockNodeProps, 'node' \| 'loading' \| 'isDark'>>` | 额外转发到 infographic 围栏和自定义 `infographic` 渲染器的 props |
-| `themes` | `string[]` | 转发到 `CodeBlockNode` 的主题列表 |
+| `themes` | `readonly [string, string]` | 转发到 `CodeBlockNode` 的已注册 `[dark, light]` 主题名称对 |
 
 #### 重型渲染器 props 透传
 
@@ -154,7 +156,7 @@ export default {
 
 ### CodeBlockNode
 
-功能丰富的代码块，由可选的对等依赖 `stream-diffs` 增强（未安装时会回退渲染普通 `<pre>`）。代码与 diff 选项使用 `stream-diffs` 内置默认值。
+功能丰富的代码块，由可选的对等依赖 `stream-diffs` 增强（未安装时会回退渲染普通 `<pre>`）。直接 `CodeBlockNode` 与顶层 `MarkdownRender` 都接收 `codeBlockOptions`。
 
 ```vue
 <script>
@@ -169,6 +171,11 @@ export default {
         language: 'typescript',
         code: 'const greeting: string = "Hello"',
         raw: 'const greeting: string = "Hello"'
+      },
+      codeBlockOptions: {
+        overflow: 'wrap',
+        diffStyle: 'unified',
+        enableLineSelection: true
       }
     }
   },
@@ -187,6 +194,7 @@ export default {
   <div class="markstream-vue">
     <CodeBlockNode
       :node="codeNode"
+      :code-block-options="codeBlockOptions"
       :stream="true"
       @copy="handleCopy"
       @preview-code="handlePreviewCode"
@@ -194,6 +202,8 @@ export default {
   </div>
 </template>
 ```
+
+Markstream 会在 fallback 与最终 surface 之间协调 `fontSize`、`lineHeight`、`fontFamily`、number 类型且单位为 px 的 `maxHeight`、number 类型且单位为 px 的上下对称 `padding` 与 `tabSize`，并转发其他受支持的 File/FileDiff 字段。主题、内容/语言、流式状态、header、挂载、显示与释放仍由宿主管理。
 
 ## 数学组件
 

--- a/docs/zh/guide/vue2-installation.md
+++ b/docs/zh/guide/vue2-installation.md
@@ -189,7 +189,7 @@ markstream-vue2 通过可选的对等依赖支持各种功能。只安装你需�
 | D2 图表 | `@terrastruct/d2` | `pnpm add @terrastruct/d2` |
 | 数学公式渲染（KaTeX） | `katex` | `pnpm add katex` |
 
-增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。代码与 diff 选项使用 `stream-diffs` 内置默认值，主题通过 `darkTheme` / `lightTheme` / `themes` 控制。
+增强代码块使用可选的对等依赖 `stream-diffs`。未安装时会回退渲染普通 `<pre>`。直接 `CodeBlockNode` 与顶层 `MarkdownRender` 都接收 `code-block-options`；主题使用已注册名称，`themes` 是 `[dark, light]` 对。
 
 ## Vue 2.6.x 设置
 
@@ -290,9 +290,9 @@ if (mermaidWorker)
 
 如果你希望继续使用 `markstream-vue2/index.css` 这类导入路径，需要在 `vue.config.js` 里做 `resolve.alias` 映射（见 `playground-vue2-cli/vue.config.js`）。
 
-### 代码块：推荐用 `stream-diffs` 覆盖
+### 代码块：安装 `stream-diffs` 启用增强 surface
 
-增强代码块运行时（`stream-diffs`）是 markstream-vue2 中唯一的代码块渲染器。未安装该可选对等依赖时，会回退渲染普通 `<pre>`。对于 Webpack 4，`stream-diffs` 是推荐（也是唯一）的代码块运行时——没有 Monaco 回退。
+增强代码块运行时（`stream-diffs`）是 markstream-vue2 中唯一的代码块渲染器。未安装该可选对等依赖时，会回退渲染普通 `<pre>`。对于 Webpack 4，它仍然是唯一的增强 runtime；不存在 Monaco 回退。
 
 1) 安装可选对等依赖：
 

--- a/docs/zh/use-cases/incomplete-markdown-renderer.md
+++ b/docs/zh/use-cases/incomplete-markdown-renderer.md
@@ -63,7 +63,7 @@ async function appendChunk(chunk: string) {
 
 ### 未闭合代码 fence
 
-Markstream 让未闭合 fence 保持可读，而不是把文档其余部分当作最终的高亮代码来处理。当闭合 fence 到达时，代码块渲染器可以根据你的设置升级为 Monaco、Shiki 或普通 `pre` 块。
+Markstream 让未闭合 fence 保持可读，而不是把文档其余部分当作最终的高亮代码来处理。当闭合 fence 到达时，代码块渲染器会根据安装情况切换为增强的 `stream-diffs` surface 或普通 `pre` 块。
 
 ### 部分表格
 

--- a/docs/zh/use-cases/index.md
+++ b/docs/zh/use-cases/index.md
@@ -20,7 +20,7 @@ Markstream 专为 Markdown 逐块到达的场景而设计。以下是最常见�
 - [AI 聊天流式 Markdown](/zh/use-cases/ai-chat-streaming) — 在 Vue、React、Svelte 和 Angular 中渲染 LLM token 流
 - [SSE 与 WebSocket 流式渲染](/zh/use-cases/sse-websocket) — 处理 Server-Sent Events 和 WebSocket 的 Markdown 输出
 - [未闭合 Markdown 渲染器](/zh/use-cases/incomplete-markdown-renderer) — 在回复仍处于流式阶段时，保持未闭合 fence、部分表格、数学公式和 HTML 稳定
-- [流式代码块](/zh/use-cases/streaming-code-blocks) — 为逐 token 到达的代码 fence 选择 Monaco、Shiki 或普通 `pre` 渲染
+- [流式代码块](/zh/use-cases/streaming-code-blocks) — 用增强的 `stream-diffs` surface 或普通 `pre` 回退渲染逐 token 到达的代码 fence
 
 ## 渐进式重型块
 

--- a/docs/zh/use-cases/long-ai-responses.md
+++ b/docs/zh/use-cases/long-ai-responses.md
@@ -14,7 +14,7 @@ faq:
     answer: 当回复经常超过数十 KB、包含大量块，或导致滚动和布局工作变得明显时，请启用虚拟化。
   - question: 单条长消息必须使用 virtual-scroll 吗？
     answer: 通常不需要。先使用节点级虚拟化；virtual-scroll 用于协调多条消息的外层时间线虚拟化器。
-  - question: 离屏的 Mermaid 或 Monaco 块仍会立即渲染吗？
+  - question: 离屏的 Mermaid 或增强代码块仍会立即渲染吗？
     answer: 当启用视口优先级和 defer-until-visible 路径时不会。重型块可以保持空闲，直到接近视口为止。
 ---
 # 长 AI 回答渲染与虚拟化
@@ -52,7 +52,7 @@ Markstream 使用视口感知渲染来约束 live DOM 节点的数量：
 
 ## 视口感知的重型块
 
-Mermaid 图、Monaco 代码块和其他重型块在屏幕外时保持空闲：
+Mermaid 图、增强代码块和其他重型块在屏幕外时保持空闲：
 
 ```vue
 <MarkdownRender

--- a/docs/zh/use-cases/streaming-code-blocks.md
+++ b/docs/zh/use-cases/streaming-code-blocks.md
@@ -67,7 +67,7 @@ defineProps<{
 pnpm add stream-diffs
 ```
 
-安装后，`CodeBlockNode` 会在 fence 足够完整并进入视口时挂载 File 或 FileDiff 表面。代码与 diff 选项使用 `stream-diffs` 的内置默认值。未安装该 peer 时会自动回退为普通 `<pre><code>`。
+安装后，`CodeBlockNode` 会在 fence 足够完整并进入视口时挂载 File 或 FileDiff 表面。受支持的配置来自直接或 renderer 顶层 `codeBlockOptions`。未安装该 peer 时会自动回退为普通 `<pre><code>`。
 
 对于移动端 WebView 或保守的包体，请使用普通 `pre` 渲染：
 

--- a/packages/markstream-angular/README.md
+++ b/packages/markstream-angular/README.md
@@ -2,7 +2,7 @@
 
 Angular 20+ standalone component for streaming Markdown: AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown states, long documents, Mermaid, KaTeX, streaming code blocks, D2, infographic blocks, custom HTML tags, and cross-framework playground parity.
 
-The coordinated 2.0 family beta will use `markstream-angular@next`. Before installing, verify that `npm view markstream-angular@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+The coordinated 2.0 family beta will use `markstream-angular@next`. Before installing, verify that `npm view markstream-angular@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 
 ```bash
 pnpm add markstream-angular@next stream-diffs
@@ -70,12 +70,17 @@ class CodeBlockComponent {
     darkTheme: 'vitesse-dark',
     lightTheme: 'vitesse-light',
     themes: ['vitesse-dark', 'vitesse-light'],
+    codeBlockOptions: {
+      overflow: 'wrap',
+      diffStyle: 'unified',
+      enableLineSelection: true,
+    },
     stream: true,
   }
 }
 ```
 
-Component state and themes go through the `props` input: `isDark`, `darkTheme` / `lightTheme` / `themes`, `loading`, `stream`. Code and diff options use the `stream-diffs` built-in defaults and are not configurable per block.
+Direct component state goes through the `props` input. Both direct `CodeBlockNode` props and top-level `MarkstreamAngularComponent` props accept `codeBlockOptions`; it covers host-managed typography/layout and supported File/FileDiff, interaction, annotation, and callback fields. `maxHeight` and the single symmetric `padding` value use numeric CSS pixels. Use `codeBlockProps` for header/toolbar controls. Theme values are registered names and `themes` is the `[dark, light]` pair. An old Monaco JSON theme is not accepted directly: first convert it to a Shiki `ThemeRegistration`, then call `registerCustomTheme(name, loader)` from `stream-diffs/pierre`; see the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0).
 
 ## Quick Start
 

--- a/packages/markstream-angular/README.md
+++ b/packages/markstream-angular/README.md
@@ -2,6 +2,14 @@
 
 Angular 20+ standalone component for streaming Markdown: AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown states, long documents, Mermaid, KaTeX, streaming code blocks, D2, infographic blocks, custom HTML tags, and cross-framework playground parity.
 
+The coordinated 2.0 family beta will use `markstream-angular@next`. Before installing, verify that `npm view markstream-angular@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+```bash
+pnpm add markstream-angular@next stream-diffs
+```
+
+Run this in an existing Angular 20+ application. Keep `@angular/core`, `@angular/common`, the compiler, and platform packages on the same Angular version line.
+
 ## When to use it
 
 Use `markstream-angular` when Markdown streams from an LLM, SSE, or WebSocket into an Angular 20+ standalone app.
@@ -14,7 +22,7 @@ This package is currently alpha. Treat it as a streaming Markdown integration su
 ## Install
 
 ```bash
-pnpm add markstream-angular @angular/core @angular/common
+pnpm add markstream-angular
 ```
 
 Optional peer dependencies:

--- a/packages/markstream-octane/README.md
+++ b/packages/markstream-octane/README.md
@@ -4,6 +4,12 @@ Native Octane streaming Markdown renderer for AI chat, SSE/WebSocket output, inc
 
 `markstream-octane` is compiled with the Octane compiler and runs on the Octane client and server runtimes. It does not require a React root or React compatibility layer. The published package contains precompiled JavaScript, declarations, styles, and workers, so consumers do not need to compile TSRX from `node_modules`.
 
+The coordinated 2.0 family beta will use `markstream-octane@next`. Before installing, verify that `npm view markstream-octane@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+```bash
+pnpm add markstream-octane@next octane@^0.1.21 stream-diffs
+```
+
 ## Install
 
 ```bash

--- a/packages/markstream-octane/README.md
+++ b/packages/markstream-octane/README.md
@@ -4,7 +4,7 @@ Native Octane streaming Markdown renderer for AI chat, SSE/WebSocket output, inc
 
 `markstream-octane` is compiled with the Octane compiler and runs on the Octane client and server runtimes. It does not require a React root or React compatibility layer. The published package contains precompiled JavaScript, declarations, styles, and workers, so consumers do not need to compile TSRX from `node_modules`.
 
-The coordinated 2.0 family beta will use `markstream-octane@next`. Before installing, verify that `npm view markstream-octane@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+The coordinated 2.0 family beta will use `markstream-octane@next`. Before installing, verify that `npm view markstream-octane@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 
 ```bash
 pnpm add markstream-octane@next octane@^0.1.21 stream-diffs
@@ -27,6 +27,8 @@ Optional renderer features are peer dependencies. Install only the features used
 | KaTeX math | `katex` |
 | D2 diagrams | `@terrastruct/d2` |
 | Infographic blocks | `@antv/infographic` |
+
+Enhanced code blocks resolve to `stream-diffs` automatically. Direct `CodeBlockNode` and top-level `NodeRenderer` both accept the shared `codeBlockOptions` / `CodeBlockOptions` contract; `maxHeight` and the single symmetric `padding` value use numeric CSS pixels. Use `codeBlockProps` for header and toolbar controls. Markstream keeps theme, code/language, streaming state, header, mounting, reveal, and disposal host-owned. Themes are registered names and `themes` is the `[dark, light]` pair. An old Monaco JSON theme is not accepted directly: first convert it to a Shiki `ThemeRegistration`, then call `registerCustomTheme(name, loader)` from `stream-diffs/pierre`; see the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0).
 
 ## Compiler setup
 

--- a/packages/markstream-react/README.md
+++ b/packages/markstream-react/README.md
@@ -4,6 +4,14 @@ React/Next.js streaming Markdown renderer for AI chat, SSE/WebSocket output, lon
 
 `markstream-react` is the React renderer in the Markstream family. It renders raw Markdown strings with `content`, and it can also accept pre-parsed `nodes` when a worker or store already owns parsing.
 
+The coordinated 2.0 family beta will use `markstream-react@next`. Before installing, verify that `npm view markstream-react@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+```bash
+pnpm add markstream-react@next stream-diffs
+```
+
+This beta requires both `react` and `react-dom` 18 or newer.
+
 ## Install
 
 ```bash

--- a/packages/markstream-react/README.md
+++ b/packages/markstream-react/README.md
@@ -4,7 +4,7 @@ React/Next.js streaming Markdown renderer for AI chat, SSE/WebSocket output, lon
 
 `markstream-react` is the React renderer in the Markstream family. It renders raw Markdown strings with `content`, and it can also accept pre-parsed `nodes` when a worker or store already owns parsing.
 
-The coordinated 2.0 family beta will use `markstream-react@next`. Before installing, verify that `npm view markstream-react@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+The coordinated 2.0 family beta will use `markstream-react@next`. Before installing, verify that `npm view markstream-react@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 
 ```bash
 pnpm add markstream-react@next stream-diffs
@@ -149,7 +149,7 @@ import 'katex/dist/katex.min.css'
 
 ## Enhanced Code Blocks
 
-Code blocks use `stream-diffs` across all Markstream packages: `stream-diffs` is preferred (smaller runtime, no `monaco-editor`), and a plain `<pre>` is rendered when it is not installed.
+`stream-diffs` powers enhanced code blocks across all Markstream packages (smaller runtime, no `monaco-editor`); a plain `<pre>` is rendered when it is not installed.
 
 Install the runtime:
 
@@ -160,6 +160,7 @@ pnpm add stream-diffs
 `CodeBlockNode` renders a single code block with the header, toolbar, and a `stream-diffs` File / FileDiff surface. Use it directly for one-off blocks, or let `MarkdownRender` resolve it automatically for code blocks in your Markdown:
 
 ```tsx
+import type { CodeBlockOptions } from 'markstream-react'
 import { CodeBlockNode } from 'markstream-react'
 
 const node = {
@@ -169,12 +170,18 @@ const node = {
   raw: 'const answer = 42',
 }
 
+const codeBlockOptions: CodeBlockOptions = {
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  enableLineSelection: true,
+}
+
 export function CodeBlock() {
-  return <CodeBlockNode node={node} isDark showLineNumbers showHeader />
+  return <CodeBlockNode node={node} codeBlockOptions={codeBlockOptions} isDark showHeader />
 }
 ```
 
-Component-level options: `isDark` / `darkTheme` / `lightTheme` for theming, `showLineNumbers`, `showHeader`, and `stream` / `loading` for streaming states.
+Direct `CodeBlockNode` and top-level `MarkdownRender` both accept `codeBlockOptions`. The shared `CodeBlockOptions` type covers host-managed typography/layout plus supported File/FileDiff, interaction, annotation, and callback fields; `maxHeight` and the single symmetric `padding` value use numeric CSS pixels. Keep header/toolbar controls in `codeBlockProps`. Theme values are registered names: use `darkTheme` / `lightTheme` for the active names and `themes` for the `[dark, light]` pair to preload. An old Monaco JSON theme is not accepted directly: first convert it to a Shiki `ThemeRegistration`, then call `registerCustomTheme(name, loader)` from `stream-diffs/pierre`; see the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0).
 
 ## Tailwind
 

--- a/packages/markstream-svelte/README.md
+++ b/packages/markstream-svelte/README.md
@@ -2,7 +2,7 @@
 
 Svelte 5 streaming Markdown renderer for AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown states, long documents, custom components, Mermaid, KaTeX, stream-diffs code blocks, D2, and Infographic.
 
-The coordinated 2.0 family beta will use `markstream-svelte@next`. Before installing, verify that `npm view markstream-svelte@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+The coordinated 2.0 family beta will use `markstream-svelte@next`. Before installing, verify that `npm view markstream-svelte@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 
 ```bash
 pnpm add markstream-svelte@next svelte@^5 stream-diffs
@@ -44,6 +44,7 @@ pnpm add katex mermaid stream-diffs @terrastruct/d2 @antv/infographic
 
 ```svelte
 <script lang="ts">
+  import type { CodeBlockOptions } from 'markstream-svelte'
   import { CodeBlockNode } from 'markstream-svelte'
 
   const node = {
@@ -52,12 +53,18 @@ pnpm add katex mermaid stream-diffs @terrastruct/d2 @antv/infographic
     code: 'const answer = 42',
     raw: 'const answer = 42',
   }
+
+  const codeBlockOptions: CodeBlockOptions = {
+    overflow: 'wrap',
+    diffStyle: 'unified',
+    enableLineSelection: true,
+  }
 </script>
 
-<CodeBlockNode {node} isDark showLineNumbers showHeader />
+<CodeBlockNode {node} {codeBlockOptions} isDark showHeader />
 ```
 
-Component-level options: `isDark`, `showLineNumbers` (default `true`), `showHeader`. When `stream-diffs` is not installed, the block renders as a plain `<pre>`.
+Direct `CodeBlockNode` and top-level `MarkdownRender` both accept `codeBlockOptions`. It covers host-managed typography/layout and supported File/FileDiff, interaction, annotation, and callback fields; `maxHeight` and the single symmetric `padding` value use numeric CSS pixels. Use `codeBlockProps` for header/toolbar controls. Theme values are registered names and `themes` is the `[dark, light]` pair. An old Monaco JSON theme is not accepted directly: first convert it to a Shiki `ThemeRegistration`, then call `registerCustomTheme(name, loader)` from `stream-diffs/pierre`; see the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0). When `stream-diffs` is not installed, the block renders as a plain `<pre>`.
 
 ## Basic Usage
 

--- a/packages/markstream-svelte/README.md
+++ b/packages/markstream-svelte/README.md
@@ -1,6 +1,12 @@
 # markstream-svelte
 
-Svelte 5 streaming Markdown renderer for AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown states, long documents, custom components, Mermaid, KaTeX, Monaco, D2, and Infographic.
+Svelte 5 streaming Markdown renderer for AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown states, long documents, custom components, Mermaid, KaTeX, stream-diffs code blocks, D2, and Infographic.
+
+The coordinated 2.0 family beta will use `markstream-svelte@next`. Before installing, verify that `npm view markstream-svelte@next version` reports `0.1.0-beta.1`. It removes the former Monaco code-block API in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+```bash
+pnpm add markstream-svelte@next svelte@^5 stream-diffs
+```
 
 ## When to use it
 

--- a/packages/markstream-vue2/README.md
+++ b/packages/markstream-vue2/README.md
@@ -7,7 +7,7 @@ Vue 2.6 / 2.7 compatibility renderer for legacy Vue 2 apps that need streaming M
 
 For Vue 3 or new Vue/Nuxt projects, use `markstream-vue` instead.
 
-The coordinated 2.0 family beta will use `markstream-vue2@next`. Before installing, verify that `npm view markstream-vue2@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+The coordinated 2.0 family beta will use `markstream-vue2@next`. Before installing, verify that `npm view markstream-vue2@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
 
 ```bash
 # Vue 2.7
@@ -197,7 +197,7 @@ Notes:
 
 ## Enhanced Code Blocks
 
-Code blocks use `stream-diffs` across all Markstream packages: `stream-diffs` is preferred (smaller runtime, no `monaco-editor`), and a plain `<pre>` is rendered when it is not installed.
+`stream-diffs` powers enhanced code blocks across all Markstream packages (smaller runtime, no `monaco-editor`); a plain `<pre>` is rendered when it is not installed.
 
 Install the runtime:
 
@@ -209,8 +209,15 @@ pnpm add stream-diffs
 
 ```vue
 <script lang="ts">
+import type { CodeBlockOptions } from 'markstream-vue2'
 import { CodeBlockNode } from 'markstream-vue2'
 import Vue from 'vue'
+
+const codeBlockOptions: CodeBlockOptions = {
+  overflow: 'wrap',
+  diffStyle: 'unified',
+  enableLineSelection: true,
+}
 
 export default Vue.extend({
   components: { CodeBlockNode },
@@ -222,17 +229,18 @@ export default Vue.extend({
         code: 'const answer = 42',
         raw: 'const answer = 42',
       },
+      codeBlockOptions,
     }
   },
 })
 </script>
 
 <template>
-  <CodeBlockNode :node="node" is-dark show-line-numbers show-header />
+  <CodeBlockNode :node="node" :code-block-options="codeBlockOptions" is-dark show-header />
 </template>
 ```
 
-Component props (kebab-case in templates): `is-dark`, `show-line-numbers`, `show-header`. Vue 2.6 apps need `@vue/composition-api`; see the Webpack 4 notes above if you use Vue CLI 4.
+Direct `CodeBlockNode` and top-level `MarkdownRender` both accept `code-block-options`. The shared `CodeBlockOptions` type covers host-managed typography/layout plus supported File/FileDiff, interaction, annotation, and callback fields; `maxHeight` and the single symmetric `padding` value use numeric CSS pixels. Use `code-block-props` for header/toolbar controls. Theme values are registered names and `themes` is the `[dark, light]` pair. An old Monaco JSON theme is not accepted directly: first convert it to a Shiki `ThemeRegistration`, then call `registerCustomTheme(name, loader)` from `stream-diffs/pierre`; see the [coordinated 2.0 family migration guide](https://markstream.simonhe.me/guide/migration-2-0). Vue 2.6 apps need `@vue/composition-api`; see the Webpack 4 notes above if you use Vue CLI 4.
 
 ## Language-specific code block overrides
 
@@ -376,7 +384,7 @@ module.exports = {
 ## Notes
 
 - The Vue 2 package is a compatibility port for legacy Vue 2 apps and mirrors the Vue 3 renderer feature set where practical (virtualization, streaming code blocks, stream-diffs, Mermaid, KaTeX, tooltip singleton).
-- Optional peers are still required for those features (`stream-diffs` for the recommended enhanced code blocks, `mermaid`, `katex`, etc.).
+- Optional peers are still required for those features (`stream-diffs` for enhanced code blocks, `mermaid`, `katex`, etc.).
 - Custom node components are supported via `setCustomComponents` from `markstream-vue2`.
 - If you only render short static Markdown, a smaller Vue 2 Markdown component may be a simpler fit.
 

--- a/packages/markstream-vue2/README.md
+++ b/packages/markstream-vue2/README.md
@@ -7,6 +7,16 @@ Vue 2.6 / 2.7 compatibility renderer for legacy Vue 2 apps that need streaming M
 
 For Vue 3 or new Vue/Nuxt projects, use `markstream-vue` instead.
 
+The coordinated 2.0 family beta will use `markstream-vue2@next`. Before installing, verify that `npm view markstream-vue2@next version` reports `0.1.0-beta.1`. It removes the Monaco and Shiki code-block APIs in favor of `stream-diffs`; read the [1.x to 2.0 migration guide](https://markstream.simonhe.me/guide/migration-2-0) before upgrading.
+
+```bash
+# Vue 2.7
+pnpm add markstream-vue2@next stream-diffs
+
+# Vue 2.6 (also register the plugin with Vue.use)
+pnpm add markstream-vue2@next stream-diffs @vue/composition-api
+```
+
 ## Install
 
 ```bash

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -636,9 +636,10 @@ ${renderFeatureMatrix()}
 
 ### From markstream-vue 1.x to 2.0
 1. Replace Monaco and stream-markdown code blocks with stream-diffs, or use the plain pre fallback.
-2. Remove monacoOptions, codeBlockMonacoOptions, stream-monaco, and stream-markdown.
-3. Use the renamed code-block helpers and the public ParseOptions contract.
-4. Full guide: ${docsSiteUrl}/guide/migration-2-0
+2. Rename supported monacoOptions / codeBlockMonacoOptions fields to the shared codeBlockOptions / CodeBlockOptions API; maxHeight and symmetric padding are numeric pixel values. Remove stream-monaco and stream-markdown.
+3. Theme values are registered names: use a string or { dark, light }, keep themes as [dark, light], and register former JSON themes with registerCustomTheme from stream-diffs/pierre.
+4. Use preloadCodeBlockRuntime for preload-only code; import advanced controllers directly from stream-diffs. Use the public ParseOptions contract.
+5. Full guide: ${docsSiteUrl}/guide/migration-2-0
 
 ### From react-markdown to markstream-react
 1. Replace import: react-markdown -> markstream-react.
@@ -788,9 +789,10 @@ ${renderChineseFeatureMatrix()}
 
 ### 从 markstream-vue 1.x 迁移到 2.0
 1. 用 stream-diffs 替换 Monaco 与 stream-markdown 代码块，或使用普通 pre 回退。
-2. 删除 monacoOptions、codeBlockMonacoOptions、stream-monaco 与 stream-markdown。
-3. 使用重命名后的代码块 helper 与公开 ParseOptions 约定。
-4. 完整指南：${docsSiteUrl}/zh/guide/migration-2-0
+2. 把受支持的 monacoOptions / codeBlockMonacoOptions 字段改为共享 codeBlockOptions / CodeBlockOptions；maxHeight 与上下对称 padding 都是 number 类型且单位为 px。删除 stream-monaco 与 stream-markdown。
+3. 主题值使用已注册名称：传 string 或 { dark, light }，themes 保持 [dark, light]；旧 JSON 主题用 stream-diffs/pierre 的 registerCustomTheme 注册。
+4. 只需预热时使用 preloadCodeBlockRuntime；高级 controller 直接从 stream-diffs 导入。Parser 使用公开 ParseOptions 约定。
+5. 完整指南：${docsSiteUrl}/zh/guide/migration-2-0
 
 ### 从 react-markdown 迁移到 markstream-react
 1. 替换导入：react-markdown -> markstream-react。


### PR DESCRIPTION
## Summary

- complete the English and Chinese 1.x to 2.0 breaking-change guide
- document the coordinated eight-package beta, per-package registry gates, and staged npm channels
- extend the migration skill with a self-contained Vue 1.x upgrade route
- add beta and migration guidance to the root and adapter package READMEs
- keep the npm operator handoff visibly incomplete until publication is verified

## Validation

- `pnpm release:family:dry-run`
- `pnpm test:api:strict`
- `pnpm docs:build:ci`
- `pnpm docs:build`
- `pnpm docs:check-llms`
- `pnpm docs:check-zh`
- `pnpm docs:seo:source`
- `pnpm skills:list`
- `git diff --check`

Relates to #618 and #625.