### PR TITLE
fix(2.0): preserve Mermaid strict label line breaks

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -52,7 +52,7 @@ const DOMPURIFY_CONFIG = {
   USE_PROFILES: { svg: true },
   FORBID_TAGS: ['script'],
   FORBID_ATTR: [/^on/i],
-  ADD_TAGS: ['style'],
+  ADD_TAGS: ['style', 'br'],
   ADD_ATTR: ['style'],
   SAFE_FOR_TEMPLATES: true,
 } as const
@@ -66,6 +66,7 @@ const mermaidInitConfig = computed(() => ({
   startOnLoad: false,
   securityLevel: mermaidSecurityLevel.value,
   dompurifyConfig: mermaidSecurityLevel.value === 'strict' ? DOMPURIFY_CONFIG : undefined,
+  htmlLabels: mermaidSecurityLevel.value === 'strict' ? false : undefined,
   flowchart: mermaidSecurityLevel.value === 'strict' ? { htmlLabels: false } : undefined,
 }))
 
@@ -263,8 +264,10 @@ function getCodeWithTheme(theme: 'light' | 'dark', code = baseFixedCode.value) {
   const baseCode = code
   const themeValue = theme === 'dark' ? 'dark' : 'default'
   const initConfig: Record<string, unknown> = { theme: themeValue }
-  if (mermaidSecurityLevel.value === 'strict')
+  if (mermaidSecurityLevel.value === 'strict') {
+    initConfig.htmlLabels = false
     initConfig.flowchart = { htmlLabels: false }
+  }
   const themeConfig = `%%{init: ${JSON.stringify(initConfig)}}%%\n`
   if (baseCode.trim().startsWith('%%{')) {
     return baseCode
@@ -675,8 +678,10 @@ function onCopyHover(e: Event) {
 function applyThemeTo(code: string, theme: 'light' | 'dark') {
   const themeValue = theme === 'dark' ? 'dark' : 'default'
   const initConfig: Record<string, unknown> = { theme: themeValue }
-  if (mermaidSecurityLevel.value === 'strict')
+  if (mermaidSecurityLevel.value === 'strict') {
+    initConfig.htmlLabels = false
     initConfig.flowchart = { htmlLabels: false }
+  }
   const themeConfig = `%%{init: ${JSON.stringify(initConfig)}}%%\n`
   const trimmed = code.trimStart()
   if (trimmed.startsWith('%%{'))

--- a/test/mermaid-static-performance.test.ts
+++ b/test/mermaid-static-performance.test.ts
@@ -108,10 +108,15 @@ describe('mermaid static render performance', () => {
     await flushVueUpdates()
 
     expect(fakeMermaid.render).toHaveBeenCalledTimes(1)
+    expect(fakeMermaid.render.mock.calls[0]?.[1]).toContain('"htmlLabels":false')
     expect(fakeMermaid.render.mock.calls[0]?.[1]).toContain('"flowchart":{"htmlLabels":false}')
     expect(fakeMermaid.initialize).toHaveBeenCalledWith(expect.objectContaining({
       securityLevel: 'strict',
+      htmlLabels: false,
       flowchart: { htmlLabels: false },
+      dompurifyConfig: expect.objectContaining({
+        ADD_TAGS: ['style', 'br'],
+      }),
     }))
     expect(canParseOffthread).not.toHaveBeenCalled()
     expect(findPrefixOffthread).not.toHaveBeenCalled()

--- a/test/mermaid-strict-line-break.test.ts
+++ b/test/mermaid-strict-line-break.test.ts
@@ -1,0 +1,116 @@
+import { mount } from '@vue/test-utils'
+import { sanitizeMermaidSvg } from 'stream-markdown-parser'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+async function flushVueUpdates() {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('mermaid strict line breaks', () => {
+  it('preserves br labels as safe SVG text lines', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+
+    const initialize = vi.fn()
+    const render = vi.fn(async () => ({
+      svg: '<svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>',
+    }))
+    const fakeMermaid = { initialize, render }
+
+    vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+      canParseOffthread: vi.fn(async () => true),
+      findPrefixOffthread: vi.fn(async () => null),
+      terminateWorker: vi.fn(),
+    }))
+    vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+      getMermaid: vi.fn(async () => fakeMermaid),
+      isMermaidEnabled: vi.fn(() => true),
+    }))
+
+    const code = 'graph TD\nrootCause4["温度梯度与能量<br/>梯级利用设计缺失"]'
+    const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+    const wrapper = mount(MermaidBlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'mermaid',
+          code,
+          raw: code,
+        },
+        loading: false,
+      },
+    })
+
+    await flushVueUpdates()
+    ;(wrapper.vm as any).mermaidAvailable = true
+    ;(wrapper.vm as any).showSource = false
+    ;(wrapper.vm as any).viewportReady = true
+    await flushVueUpdates()
+    await vi.advanceTimersByTimeAsync(5000)
+    await flushVueUpdates()
+
+    const initConfig = initialize.mock.calls[0]?.[0]
+    const renderedCode = render.mock.calls[0]?.[1]
+    expect(initConfig).toEqual(expect.objectContaining({
+      securityLevel: 'strict',
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+      dompurifyConfig: expect.objectContaining({
+        ADD_TAGS: ['style', 'br'],
+      }),
+    }))
+    expect(renderedCode).toContain('"htmlLabels":false')
+
+    wrapper.unmount()
+    vi.useRealTimers()
+
+    const getBBox = Object.getOwnPropertyDescriptor(SVGElement.prototype, 'getBBox')
+    const getComputedTextLength = Object.getOwnPropertyDescriptor(SVGElement.prototype, 'getComputedTextLength')
+    const getSubStringLength = Object.getOwnPropertyDescriptor(SVGElement.prototype, 'getSubStringLength')
+    Object.defineProperties(SVGElement.prototype, {
+      getBBox: { configurable: true, value: () => ({ x: 0, y: 0, width: 100, height: 20 }) },
+      getComputedTextLength: { configurable: true, value: () => 100 },
+      getSubStringLength: { configurable: true, value: (_start: number, length: number) => length * 8 },
+    })
+
+    try {
+      const actualMermaid = (await vi.importActual<typeof import('mermaid')>('mermaid')).default
+      actualMermaid.initialize(initConfig)
+      const result = await actualMermaid.render('issue-663', renderedCode)
+      const safeSvg = sanitizeMermaidSvg(result.svg)
+
+      expect(safeSvg).toBeTruthy()
+      expect(safeSvg).not.toContain('<foreignObject')
+      const parsed = new DOMParser().parseFromString(safeSvg!, 'image/svg+xml')
+      const label = Array.from(parsed.querySelectorAll('text'))
+        .find(node => node.textContent === '温度梯度与能量梯级利用设计缺失')
+      const lines = Array.from(label?.children ?? [])
+        .filter(node => node.tagName.toLowerCase() === 'tspan')
+        .map(node => node.textContent)
+      expect(lines).toEqual(['温度梯度与能量', '梯级利用设计缺失'])
+    }
+    finally {
+      if (getBBox)
+        Object.defineProperty(SVGElement.prototype, 'getBBox', getBBox)
+      else
+        delete (SVGElement.prototype as any).getBBox
+      if (getComputedTextLength)
+        Object.defineProperty(SVGElement.prototype, 'getComputedTextLength', getComputedTextLength)
+      else
+        delete (SVGElement.prototype as any).getComputedTextLength
+      if (getSubStringLength)
+        Object.defineProperty(SVGElement.prototype, 'getSubStringLength', getSubStringLength)
+      else
+        delete (SVGElement.prototype as any).getSubStringLength
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Port the Mermaid strict-mode `<br/>` label fix from #664 to the `2.0.0` branch.
Related to #663.

## Changes

- allow the inert `br` tag through Mermaid's internal DOMPurify pass
- set both global and flowchart `htmlLabels: false` so Mermaid emits native SVG text lines
- include the real Mermaid render-and-sanitize regression test

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [x] Shareable repro link is included in #663

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test -- --run` (322 files, 2788 tests)
- [x] Build: `pnpm build` (library + CSS)
