### PR TITLE
fix(release): attach renderer family migration notes

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -39,9 +39,19 @@ jobs:
             PRERELEASE=true
           fi
 
+          FAMILY_BREAKING=false
+          case "${PKG}" in
+            markstream-react|markstream-octane|markstream-svelte|markstream-angular|markstream-vue2)
+              case "${VERSION}" in
+                0.1.0|0.1.0-*) FAMILY_BREAKING=true ;;
+              esac
+              ;;
+          esac
+
           echo "pkg=${PKG}" >> "${GITHUB_OUTPUT}"
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "prerelease=${PRERELEASE}" >> "${GITHUB_OUTPUT}"
+          echo "family_breaking=${FAMILY_BREAKING}" >> "${GITHUB_OUTPUT}"
           echo "name=[${PKG}] ${VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout (for changelog body)
@@ -199,8 +209,26 @@ jobs:
           prerelease: ${{ steps.meta.outputs.prerelease }}
           generate_release_notes: true
 
+      - name: Create GitHub Release (0.1.0 renderer family)
+        if: ${{ steps.meta.outputs.family_breaking == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ steps.meta.outputs.name }}
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          generate_release_notes: true
+          body: |
+            ## Breaking changes in the Markstream 2.0 renderer family
+
+            - Monaco and `stream-markdown` integrations, renderer selection, and their public configuration are removed.
+            - `stream-diffs` is the only built-in enhanced code-block runtime; without it, code fences use the plain `<pre><code>` fallback.
+            - These `0.1.0` adapter releases are not API-compatible with the prior `0.0.x` line.
+
+            Migration guide: https://markstream.simonhe.me/guide/migration-2-0
+          append_body: true
+
       - name: Create GitHub Release (other packages)
-        if: ${{ steps.meta.outputs.pkg != 'markstream-vue' }}
+        if: ${{ steps.meta.outputs.pkg != 'markstream-vue' && steps.meta.outputs.family_breaking != 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}

--- a/test/release-gates.test.ts
+++ b/test/release-gates.test.ts
@@ -166,6 +166,38 @@ describe('release dependency gates', () => {
     expect(publishIndex).toBeGreaterThan(packedGateIndex)
   })
 
+  it('adds fixed breaking notes only to the 0.1.0 renderer family releases', () => {
+    const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/release-stable.yml'), 'utf8')
+    const rendererPackages = 'markstream-react|markstream-octane|markstream-svelte|markstream-angular|markstream-vue2'
+    const pkgVariable = '$' + '{PKG}'
+    const versionVariable = '$' + '{VERSION}'
+    const familyBreakingVariable = '$' + '{FAMILY_BREAKING}'
+    const githubOutputVariable = '$' + '{GITHUB_OUTPUT}'
+    const actionsExpression = '$' + '{{'
+    const familyGate = workflow.slice(
+      workflow.indexOf('FAMILY_BREAKING=false'),
+      workflow.indexOf(`echo "pkg=${pkgVariable}"`),
+    )
+    const familyRelease = workflow.slice(
+      workflow.indexOf('- name: Create GitHub Release (0.1.0 renderer family)'),
+      workflow.indexOf('- name: Create GitHub Release (other packages)'),
+    )
+
+    expect(familyGate).toContain(`case "${pkgVariable}" in\n            ${rendererPackages})`)
+    expect(familyGate).toContain(`case "${versionVariable}" in\n                0.1.0|0.1.0-*) FAMILY_BREAKING=true ;;`)
+    expect(familyGate.match(/FAMILY_BREAKING=true/g)).toHaveLength(1)
+    expect(familyGate).not.toContain('stream-markdown-parser')
+    expect(familyGate).not.toContain('markstream-core')
+    expect(workflow).toContain(`echo "family_breaking=${familyBreakingVariable}" >> "${githubOutputVariable}"`)
+
+    expect(familyRelease).toContain(`if: ${actionsExpression} steps.meta.outputs.family_breaking == 'true' }}`)
+    expect(familyRelease).toContain('## Breaking changes in the Markstream 2.0 renderer family')
+    expect(familyRelease).toContain('https://markstream.simonhe.me/guide/migration-2-0')
+    expect(familyRelease).toContain('generate_release_notes: true')
+    expect(familyRelease).toContain('append_body: true')
+    expect(workflow).toContain(`if: ${actionsExpression} steps.meta.outputs.pkg != 'markstream-vue' && steps.meta.outputs.family_breaking != 'true' }}`)
+  })
+
   it('binds the 1.0 benchmark report to the release version and commit', () => {
     const script = readFileSync(resolve(process.cwd(), 'scripts/benchmark-1-0.mjs'), 'utf8')
 


### PR DESCRIPTION
## Summary

- identify the five `0.1.0` renderer adapter release lines as part of the coordinated Markstream 2.0 family
- prepend a fixed breaking-change notice and migration link to their GitHub Releases while retaining generated notes
- leave parser, core, `markstream-vue`, and later adapter versions on their existing release paths

This keeps the independently versioned adapters at `0.1.0` while making their public API break explicit; it does not relabel them as `2.0.0` packages.

## Verification

- `pnpm exec vitest --run test/release-gates.test.ts` (29 tests)
- positive/negative tag-routing matrix for all affected/unaffected package-version combinations
- workflow YAML parse
- ESLint
- `git diff --check`
