### PR TITLE
docs: clarify adapter theme APIs

### DIFF
--- a/docs/guide/migration-2-0.md
+++ b/docs/guide/migration-2-0.md
@@ -110,7 +110,7 @@ Common option migrations are not field-for-field renames:
 | `diffUnchangedRegionStyle` | `hunkSeparators` |
 | `diffHideUnchangedRegions` | There is no single replacement object. Map `false` / `{ enabled: false }` to `expandUnchanged: true`, and `true` / `{ enabled: true }` to `expandUnchanged: false`. Use `parseDiffOptions.context` for surrounding context, `collapsedContextThreshold` for when a region collapses, and `expansionLineCount` for reveal size. Tune the thresholds because the old and new algorithms are not identical. |
 
-Theme values are names, not Monaco theme JSON. Direct `CodeBlockNode.theme` accepts a fixed string or `{ dark, light }`; `themes` is the `[dark, light]` name pair used for loading. Convert an old Monaco theme to Shiki's theme format before registering it; in particular, Monaco `rules` are not Shiki token rules and must be translated to `tokenColors` or `settings`:
+Theme values are names, not Monaco theme JSON. In Vue 3, Svelte, Angular, and Vue 2, `CodeBlockNode.theme` accepts a fixed string or `{ dark, light }`. React and Octane use `darkTheme` / `lightTheme` for the active names. In every adapter, `themes` is the `[dark, light]` name pair used for loading. Convert an old Monaco theme to Shiki's theme format before registering it; in particular, Monaco `rules` are not Shiki token rules and must be translated to `tokenColors` or `settings`:
 
 ```ts
 import type { ThemeRegistration } from 'stream-diffs/pierre'

--- a/docs/zh/guide/migration-2-0.md
+++ b/docs/zh/guide/migration-2-0.md
@@ -110,7 +110,7 @@ npm view "$PACKAGE@next" version
 | `diffUnchangedRegionStyle` | `hunkSeparators` |
 | `diffHideUnchangedRegions` | 没有单个对象可直接替换。把 `false` / `{ enabled: false }` 改成 `expandUnchanged: true`，把 `true` / `{ enabled: true }` 改成 `expandUnchanged: false`。用 `parseDiffOptions.context` 控制上下文、`collapsedContextThreshold` 控制何时折叠、`expansionLineCount` 控制每次展开行数。新旧算法并不相同，需要重新调节阈值。 |
 
-主题值是名称，而不是 Monaco theme JSON。直接 `CodeBlockNode.theme` 接收固定 string 或 `{ dark, light }`，`themes` 是用于加载的 `[dark, light]` 名称对。注册前必须先把旧 Monaco theme 转为 Shiki theme 格式；尤其不能直接复用 Monaco `rules`，需要改成 Shiki `tokenColors` 或 `settings`：
+主题值是名称，而不是 Monaco theme JSON。在 Vue 3、Svelte、Angular 和 Vue 2 中，`CodeBlockNode.theme` 接收固定 string 或 `{ dark, light }`；React 和 Octane 则通过 `darkTheme` / `lightTheme` 指定当前主题名称。所有 adapter 的 `themes` 都是用于加载的 `[dark, light]` 名称对。注册前必须先把旧 Monaco theme 转为 Shiki theme 格式；尤其不能直接复用 Monaco `rules`，需要改成 Shiki `tokenColors` 或 `settings`：
 
 ```ts
 import type { ThemeRegistration } from 'stream-diffs/pierre'


### PR DESCRIPTION
## Summary
- clarify which adapters expose the unified `theme` prop
- document React and Octane's existing `darkTheme` / `lightTheme` API
- keep the shared `[dark, light]` `themes` tuple contract explicit

## Validation
- `pnpm docs:check-zh`
- `pnpm docs:llms:check`
- `git diff --check origin/2.0.0...HEAD`