### PR TITLE
fix(mermaid): fit oversized diagrams to preview viewport on 1.x

### DIFF
--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -1032,9 +1032,9 @@ function updateContainerHeight(newContainerWidth?: number, options?: { force?: b
     const newHeight = effectiveWidth * aspectRatio
     const resolvedHeight = maxHeight == null ? newHeight : Math.min(newHeight, maxHeight)
     const previewHeight = Math.max(resolvedHeight, resolveEstimatedPreviewHeight())
-    contentHeight.value = `${Math.max(newHeight, previewHeight)}px`
     if (!freezePreviewHeight && !hasExternalPreviewHeightEstimate())
       containerHeight.value = `${previewHeight}px`
+    contentHeight.value = containerHeight.value
   }
 }
 
@@ -1530,9 +1530,9 @@ async function initMermaid(request = createMermaidRenderRequest()) {
       const bindFunctions = res?.bindFunctions ?? null
       lastMermaidBindFunctions = bindFunctions
       bindMermaidInteractions(rendered.bindTarget)
+      safeRaf(() => updateContainerHeight())
       // Successful full render clears Partial preview state
       if (!hasRenderedOnce.value && !isThemeRendering.value) {
-        safeRaf(() => updateContainerHeight())
         hasRenderedOnce.value = true
         savedTransformState.value = {
           zoom: zoom.value,
@@ -2673,7 +2673,12 @@ const computedButtonStyle = 'mermaid-action-btn p-[var(--ms-action-btn-padding)]
 ._mermaid :deep(svg) {
   width: 100%;
   height: auto;
+  max-height: 100%;
   display: block;
+}
+
+.fullscreen ._mermaid :deep(svg) {
+  max-height: none;
 }
 
 .fullscreen {

--- a/test/mermaid-max-height.test.ts
+++ b/test/mermaid-max-height.test.ts
@@ -43,7 +43,7 @@ describe('mermaid block max height', () => {
   it('caps preview height unless maxHeight is none', async () => {
     const capped = await renderWithMaxHeight('500px')
     expect(capped.container.style.height).toBe('500px')
-    expect(capped.content.style.height).toBe('2000px')
+    expect(capped.content.style.height).toBe('500px')
     capped.wrapper.unmount()
 
     const uncapped = await renderWithMaxHeight('none')
@@ -86,21 +86,22 @@ describe('mermaid block max height', () => {
     await nextTick()
 
     expect(container.style.height).toBe('360px')
-    expect(content.style.height).toBe('2000px')
+    expect(content.style.height).toBe('360px')
 
     await wrapper.setProps({ loading: false })
     setupState.updateContainerHeight(undefined, { force: true })
     await nextTick()
 
     expect(container.style.height).toBe('360px')
+    expect(content.style.height).toBe('360px')
     wrapper.unmount()
   })
 
-  it('sizes capped preview content to the full SVG height', async () => {
+  it('sizes capped preview content to the preview height', async () => {
     const { wrapper } = await renderWithMaxHeight('500px')
     const content = wrapper.get('div._mermaid').element as HTMLElement
 
-    expect(content.style.height).toBe('2000px')
+    expect(content.style.height).toBe('500px')
 
     wrapper.unmount()
   })
@@ -114,7 +115,7 @@ describe('mermaid block max height', () => {
     await nextTick()
 
     const modalContent = document.body.querySelector<HTMLElement>('[data-mermaid-modal-clone="1"] ._mermaid')
-    expect(modalContent?.style.height).toBe('2000px')
+    expect(modalContent?.style.height).toBe('500px')
     expect(modalContent?.style.contain).toBe('none')
     expect(modalContent?.style.contentVisibility).toBe('visible')
 
@@ -131,6 +132,7 @@ describe('mermaid block max height', () => {
           raw: '```mermaid\ngraph LR\nA-->B\n```',
         },
         loading: false,
+        maxHeight: 'none',
       },
       attachTo: document.body,
     })


### PR DESCRIPTION
## Summary

- keep Mermaid content height aligned with the actual preview viewport
- apply SVG max-height through the scoped deep selector so runtime-inserted SVGs are fitted
- preserve uncapped fullscreen rendering
- remeasure height after every successful full render commit

Backport of the Mermaid viewport fix from #676 for the 1.x release line.

Related: #675

## Verification

- `pnpm exec vitest --run test/mermaid*.test.ts test/security/mermaid-block-sanitizer.test.ts` (53 tests)
- `pnpm typecheck`
- `pnpm exec eslint src/components/MermaidBlockNode/MermaidBlockNode.vue test/mermaid-max-height.test.ts`