### PR TITLE
fix: correct tag-package script path in 1.x parser release

### DIFF
--- a/scripts/release-parser.mjs
+++ b/scripts/release-parser.mjs
@@ -201,7 +201,7 @@ function main() {
   run('npm', ['publish', '--access', 'public', '--tag', EXPECTED_DIST_TAG], PARSER_DIR, { stdio: 'inherit' })
 
   log(`push git tag ${PACKAGE_NAME}@${p.target}`)
-  run('node', ['../scripts/tag-package.mjs', '--package-json', 'package.json', '--push'], PARSER_DIR, { stdio: 'inherit' })
+  run('node', ['../../scripts/tag-package.mjs', '--package-json', 'package.json', '--push'], PARSER_DIR, { stdio: 'inherit' })
 
   if (!args.parserOnly) {
     log('release:family — publish all downstream markstream packages on this branch')


### PR DESCRIPTION
Port the tag-path fix (../../scripts/tag-package.mjs, called from packages/markdown-parser) to the 1.x edition. Without it, the tag push step fails with MODULE_NOT_FOUND: packages/scripts/tag-package.mjs.