### PR TITLE
perf(parser): eliminate O(n)-per-append scans in the streaming parse …

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
     "lz-string": "^1.5.0",
     "markdown-it-emoji": "^3.1.0",
     "material-icon-theme": "^5.37.0",
+    "octane": "^0.1.21",
     "picocolors": "^1.1.1",
     "playwright-core": "^1.62.0",
     "postcss-cli": "^11.0.1",
@@ -380,8 +381,7 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.1.10",
     "vue": "^3.5.40",
-    "vue-tsc": "^2.2.12",
-    "octane": "^0.1.21"
+    "vue-tsc": "^2.2.12"
   },
   "pnpm": {
     "packageExtensions": {

--- a/package.json
+++ b/package.json
@@ -380,7 +380,8 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.1.10",
     "vue": "^3.5.40",
-    "vue-tsc": "^2.2.12"
+    "vue-tsc": "^2.2.12",
+    "octane": "^0.1.21"
   },
   "pnpm": {
     "packageExtensions": {

--- a/packages/markdown-parser/src/parser/html/structure.ts
+++ b/packages/markdown-parser/src/parser/html/structure.ts
@@ -7,6 +7,7 @@ import { isCacheStableLinkValidator } from '../../plugins/linkTokenMetadata'
 import { parseHtmlBlock } from '../node-parsers/html-block-parser'
 import { createSourceMapFromOffsets } from '../node-source-map'
 import { createChildParseContext } from '../parse-context'
+import { canReuseStructuredStreamNodes } from '../reuse/structured-node-reuse'
 import {
   buildHtmlBlockContent,
   canFindNodeRawAfterSourceIndex,
@@ -313,14 +314,11 @@ export function combineStructuredDetailsHtmlBlocks(
   options: ParseContext,
   final: boolean,
   sourceCursor = 0,
-  tailStart = 0,
 ): [ParsedNode[], number] {
   const merged: ParsedNode[] = []
-  for (let k = 0; k < tailStart; k++)
-    merged.push(nodes[k])
   let cursor = sourceCursor
 
-  for (let i = tailStart; i < nodes.length; i++) {
+  for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i]
     const nodeRaw = getMergeableNodeRaw(node)
     let nodePos = -1
@@ -369,23 +367,6 @@ export function combineStructuredDetailsHtmlBlocks(
         })()
       : openRaw
 
-    const middleNodes = selfContained
-      ? []
-      : closeIndex === -1 ? nodes.slice(i + 1) : nodes.slice(i + 1, closeIndex)
-    const [children] = combineStructuredDetailsHtmlBlocks(
-      middleNodes,
-      source,
-      context,
-      options,
-      final,
-      openStart + openRaw.length,
-    )
-    const prefixChildren = buildDetailsPrefixChildren(
-      effectiveOpenRaw,
-      context,
-      buildDetailsChildParseOptions(options, final),
-    )
-
     const closeRaw = closeIndex === -1
       ? '</details>'
       : String(nodes[closeIndex].raw ?? getMergeableNodeRaw(nodes[closeIndex]) ?? '</details>')
@@ -398,16 +379,16 @@ export function combineStructuredDetailsHtmlBlocks(
         })()
       : source.length
     const openTagEndIndex = findTagCloseIndexOutsideQuotes(openRaw)
-    const middleSourceStart = selfContained && openTagEndIndex !== -1
+    // Derive the content boundaries from the source open tag rather than the
+    // cached fragment raw: the stream can commit the `<details>` opener as a
+    // stable group before its `<summary>` arrives, freezing a partial fragment
+    // (`<details open>\n`). Only the source is authoritative for where the
+    // opener ends and the rendered middle begins, so a full parse and the
+    // split-fragment stream produce identical content.
+    const middleSourceStart = openTagEndIndex !== -1
       ? openStart + openTagEndIndex + 1
       : openStart + openRaw.length
     const middleSource = source.slice(middleSourceStart, closeStart === -1 ? source.length : closeStart)
-    const middleTokens = context.markdownIt.parse(middleSource, { __markstreamFinal: final }) as unknown as MarkdownToken[]
-    const renderedMiddle = context.markdownIt.renderer.render(
-      middleTokens as unknown as Token[],
-      context.markdownIt.options,
-      { __markstreamFinal: final },
-    )
     const closeMarkupEnd = closeStart + trimmedCloseRaw.length
     const closeSliceEnd = explicitClose
       ? Math.max(closeStart + closeRaw.length, extendHtmlBlockCloseToLineEnding(source, closeMarkupEnd))
@@ -419,8 +400,94 @@ export function combineStructuredDetailsHtmlBlocks(
       ? source.slice(openStart, closeSliceEnd)
       : source.slice(openStart)
 
-    const contentPrefix = selfContained && openTagEndIndex !== -1
-      ? openRaw.slice(0, openTagEndIndex + 1)
+    // Cached path: a reused (stable-prefix) details opener keeps the same node
+    // identity across appends, and its middle source is unchanged, so the
+    // stitched output from a previous append can be reused instead of
+    // re-parsing + re-rendering the whole (unchanged) middle on every commit.
+    // Only consulted when the current top-level parse actually reused nodes;
+    // on full-reparse commits the opener objects are fresh, so a cache lookup
+    // would be pure overhead.
+    const stitchCache = canReuseStructuredStreamNodes(options)
+      && (options.runtime?.structuredReuseTailStart ?? 0) > 0
+      ? options.runtime?.detailsStitchCache
+      : undefined
+    const cachedDetails = stitchCache?.get(node)
+    if (cachedDetails
+      && cachedDetails.openRaw === openRaw
+      && cachedDetails.explicitClose === explicitClose
+      && cachedDetails.closeSliceEnd === closeSliceEnd
+      && cachedDetails.middleSource === middleSource) {
+      merged.push(cachedDetails.node)
+      cursor = explicitClose ? closeSliceEnd : source.length
+      if (closeIndex === -1 && !selfContained)
+        break
+      if (closeIndex !== -1)
+        i = closeIndex
+      continue
+    }
+
+    const middleNodes = selfContained
+      ? []
+      : closeIndex === -1 ? nodes.slice(i + 1) : nodes.slice(i + 1, closeIndex)
+    const [children] = combineStructuredDetailsHtmlBlocks(
+      middleNodes,
+      source,
+      context,
+      options,
+      final,
+      openStart + openRaw.length,
+    )
+    let prefixChildren = buildDetailsPrefixChildren(
+      effectiveOpenRaw,
+      context,
+      buildDetailsChildParseOptions(options, final),
+    )
+
+    // The stream can commit the `<details>` opener as a stable group before its
+    // `<summary>` arrives, freezing a partial fragment that contains no summary
+    // (and, depending on the split, the summary may or may not have its own
+    // node in the array). A full parse always structures the summary, so
+    // recover it here to keep the streamed output identical to the cold parse:
+    // - if the summary is a leading raw middle fragment, structure it in place;
+    // - otherwise reconstruct it from the source and prepend it to the prefix.
+    let structuredChildren = children
+    const leadingChild = children[0] as ParsedNodeWithFields | undefined
+    const hasPrefixSummary = prefixChildren.some((child) => {
+      const fields = child as ParsedNodeWithFields
+      return fields?.type === 'html_block' && String(fields.tag ?? '').toLowerCase() === 'summary'
+    })
+    if (!hasPrefixSummary) {
+      if (leadingChild?.type === 'html_block'
+        && String(leadingChild.tag ?? '').toLowerCase() === 'summary'
+        && !Array.isArray(leadingChild.children)) {
+        structuredChildren = [
+          buildStructuredSummaryNode(String(leadingChild.raw ?? leadingChild.content ?? ''), context, buildDetailsChildParseOptions(options, final)),
+          ...children.slice(1),
+        ]
+      }
+      else if (openTagEndIndex !== -1) {
+        const summaryBlock = findNextHtmlBlockFromSource(source, 'summary', openStart + openTagEndIndex + 1)
+        if (summaryBlock && summaryBlock.closed) {
+          const gap = source.slice(openStart + openTagEndIndex + 1, summaryBlock.start)
+          if (/^[\t \r\n]*$/.test(gap)) {
+            prefixChildren = [
+              buildStructuredSummaryNode(summaryBlock.raw, context, buildDetailsChildParseOptions(options, final)),
+              ...prefixChildren,
+            ]
+          }
+        }
+      }
+    }
+
+    const middleTokens = context.markdownIt.parse(middleSource, { __markstreamFinal: final }) as unknown as MarkdownToken[]
+    const renderedMiddle = context.markdownIt.renderer.render(
+      middleTokens as unknown as Token[],
+      context.markdownIt.options,
+      { __markstreamFinal: final },
+    )
+
+    const contentPrefix = openTagEndIndex !== -1
+      ? source.slice(openStart, openStart + openTagEndIndex + 1)
       : openRaw
 
     const detailsNode = {
@@ -429,12 +496,18 @@ export function combineStructuredDetailsHtmlBlocks(
       attrs: parseTagAttrs(openRaw.slice(0, openTagEndIndex + 1)),
       raw: mergedRaw,
       content: `${contentPrefix}${renderedMiddle}${renderedCloseRaw}`,
-      children: [...prefixChildren, ...children],
+      children: [...prefixChildren, ...structuredChildren],
       loading: !final && !explicitClose,
     } as ParsedNode
 
     if (options.includeSourceMap)
       detailsNode.sourceMap = createSourceMapFromOffsets(source, openStart, explicitClose ? closeSliceEnd : source.length, options)
+
+    // Only closed details are cached: an open details grows every append, so
+    // caching it would return a stale (still-loading) node once its close
+    // arrives (the open-to-closed transition can share the same middleSource).
+    if (stitchCache && explicitClose)
+      stitchCache.set(node, { openRaw, explicitClose, closeSliceEnd, middleSource, node: detailsNode })
 
     merged.push(detailsNode)
 
@@ -454,16 +527,14 @@ export function mergeSplitTopLevelHtmlBlocks(
   source: string,
   context: HtmlStructureContext,
   options?: ParseContext,
-  tailStart = 0,
-  sourceCursorStart = 0,
 ) {
   if (!source)
     return nodes
 
   const merged = nodes.slice()
-  let sourceHtmlCursor = sourceCursorStart
+  let sourceHtmlCursor = 0
 
-  for (let i = tailStart; i < merged.length; i++) {
+  for (let i = 0; i < merged.length; i++) {
     const node = merged[i]
     const nodeRaw = getMergeableNodeRaw(node)
     const nodePos = nodeRaw ? source.indexOf(nodeRaw, sourceHtmlCursor) : -1

--- a/packages/markdown-parser/src/parser/html/structure.ts
+++ b/packages/markdown-parser/src/parser/html/structure.ts
@@ -185,8 +185,9 @@ export function structureGenericHtmlBlockChildren(
   context: HtmlStructureContext,
   options: ParseContext,
   final: boolean,
+  tailStart = 0,
 ): ParsedNode[] {
-  return nodes.map((node) => {
+  const processNode = (node: ParsedNode): ParsedNode => {
     if (node?.type !== 'html_block')
       return node
 
@@ -231,12 +232,16 @@ export function structureGenericHtmlBlockChildren(
       ...node,
       children,
     } as ParsedNode
-  })
+  }
+
+  if (tailStart <= 0)
+    return nodes.map(processNode)
+  return nodes.slice(0, tailStart).concat(nodes.slice(tailStart).map(processNode))
 }
 
-export function hasTopLevelHtmlBlock(nodes: ParsedNode[]) {
-  for (const node of nodes) {
-    if (node?.type === 'html_block')
+export function hasTopLevelHtmlBlock(nodes: ParsedNode[], start = 0) {
+  for (let i = start; i < nodes.length; i++) {
+    if (nodes[i]?.type === 'html_block')
       return true
   }
   return false
@@ -308,11 +313,14 @@ export function combineStructuredDetailsHtmlBlocks(
   options: ParseContext,
   final: boolean,
   sourceCursor = 0,
+  tailStart = 0,
 ): [ParsedNode[], number] {
   const merged: ParsedNode[] = []
+  for (let k = 0; k < tailStart; k++)
+    merged.push(nodes[k])
   let cursor = sourceCursor
 
-  for (let i = 0; i < nodes.length; i++) {
+  for (let i = tailStart; i < nodes.length; i++) {
     const node = nodes[i]
     const nodeRaw = getMergeableNodeRaw(node)
     let nodePos = -1
@@ -446,14 +454,16 @@ export function mergeSplitTopLevelHtmlBlocks(
   source: string,
   context: HtmlStructureContext,
   options?: ParseContext,
+  tailStart = 0,
+  sourceCursorStart = 0,
 ) {
   if (!source)
     return nodes
 
   const merged = nodes.slice()
-  let sourceHtmlCursor = 0
+  let sourceHtmlCursor = sourceCursorStart
 
-  for (let i = 0; i < merged.length; i++) {
+  for (let i = tailStart; i < merged.length; i++) {
     const node = merged[i]
     const nodeRaw = getMergeableNodeRaw(node)
     const nodePos = nodeRaw ? source.indexOf(nodeRaw, sourceHtmlCursor) : -1

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -195,49 +195,27 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
     }
   }
 
-  // The structured-reuse path only rebuilds nodes from the dirty tail, so the
-  // html structure passes can run over a tail window instead of the whole
-  // result every append. The window starts at the reused tail, extended back to
-  // the earliest `<details>` opener (details fragments are stitched across
-  // tokenizer-committed groups, so they span "stable" boundaries and must be
-  // re-processed); everything before that is settled and skipped.
+  // The structured-reuse path rebuilds nodes from the dirty tail, but the
+  // html passes still run over the whole result: mergeSplit and combine
+  // re-derive post-pass prefix nodes from the pre-pass cache (split html
+  // fragments and un-stitched details live in the reused prefix), so they must
+  // re-run every append. structureGeneric only structures non-details html
+  // blocks, which never appear in a reusable prefix (top-level `html_block`
+  // tokens are not reusable), so it can start at the reused tail safely.
   const reuseTailStart = runtime.structuredReuseTailStart
   const tailStart = reuseTailStart && reuseTailStart > 0 && reuseTailStart < result.length
     ? reuseTailStart
     : 0
-  let windowStart = tailStart
-  const detailsOpenIndices = runtime.structuredStream?.detailsOpenIndices ?? []
-  for (let i = 0; i < detailsOpenIndices.length; i++) {
-    const index = detailsOpenIndices[i]
-    if (index < windowStart)
-      windowStart = index
-  }
-  if (hasTopLevelHtmlBlock(result, windowStart)) {
+  if (hasTopLevelHtmlBlock(result)) {
     const htmlPassesStartedAt = timing ? getParserNow() : 0
     const htmlStructureContext: HtmlStructureContext = {
       getInternalNodeSourceRange: node => getInternalNodeSourceRange(node, runtime),
       markdownIt: md,
       parseFragment: (fragment, fragmentOptions) => parseMarkdownWithContext(fragment, fragmentOptions),
     }
-    // Seed the source cursor at the first window node so the passes only scan
-    // the dirty region instead of re-locating every prefix html block.
-    let sourceCursorStart = 0
-    if (windowStart > 0) {
-      const firstWindowNode = result[windowStart]
-      const range = getInternalNodeSourceRange(firstWindowNode, runtime)
-      if (range) {
-        sourceCursorStart = range.start
-      }
-      else {
-        const firstRaw = String((firstWindowNode as { raw?: unknown } | null)?.raw ?? '')
-        sourceCursorStart = firstRaw ? safeMarkdown.indexOf(firstRaw, 0) : 0
-        if (sourceCursorStart < 0)
-          sourceCursorStart = 0
-      }
-    }
-    result = mergeSplitTopLevelHtmlBlocks(result, isFinal, safeMarkdown, htmlStructureContext, internalOptions, windowStart, sourceCursorStart)
-    result = combineStructuredDetailsHtmlBlocks(result, safeMarkdown, htmlStructureContext, internalOptions, isFinal, sourceCursorStart, windowStart)[0]
-    result = structureGenericHtmlBlockChildren(result, htmlStructureContext, internalOptions, isFinal, windowStart)
+    result = mergeSplitTopLevelHtmlBlocks(result, isFinal, safeMarkdown, htmlStructureContext, internalOptions)
+    result = combineStructuredDetailsHtmlBlocks(result, safeMarkdown, htmlStructureContext, internalOptions, isFinal)[0]
+    result = structureGenericHtmlBlockChildren(result, htmlStructureContext, internalOptions, isFinal, tailStart)
     if (timing)
       addTiming(timing, 'htmlBlockPassesMs', getParserNow() - htmlPassesStartedAt)
   }

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -195,16 +195,49 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
     }
   }
 
-  if (hasTopLevelHtmlBlock(result)) {
+  // The structured-reuse path only rebuilds nodes from the dirty tail, so the
+  // html structure passes can run over a tail window instead of the whole
+  // result every append. The window starts at the reused tail, extended back to
+  // the earliest `<details>` opener (details fragments are stitched across
+  // tokenizer-committed groups, so they span "stable" boundaries and must be
+  // re-processed); everything before that is settled and skipped.
+  const reuseTailStart = runtime.structuredReuseTailStart
+  const tailStart = reuseTailStart && reuseTailStart > 0 && reuseTailStart < result.length
+    ? reuseTailStart
+    : 0
+  let windowStart = tailStart
+  const detailsOpenIndices = runtime.structuredStream?.detailsOpenIndices ?? []
+  for (let i = 0; i < detailsOpenIndices.length; i++) {
+    const index = detailsOpenIndices[i]
+    if (index < windowStart)
+      windowStart = index
+  }
+  if (hasTopLevelHtmlBlock(result, windowStart)) {
     const htmlPassesStartedAt = timing ? getParserNow() : 0
     const htmlStructureContext: HtmlStructureContext = {
       getInternalNodeSourceRange: node => getInternalNodeSourceRange(node, runtime),
       markdownIt: md,
       parseFragment: (fragment, fragmentOptions) => parseMarkdownWithContext(fragment, fragmentOptions),
     }
-    result = mergeSplitTopLevelHtmlBlocks(result, isFinal, safeMarkdown, htmlStructureContext, internalOptions)
-    result = combineStructuredDetailsHtmlBlocks(result, safeMarkdown, htmlStructureContext, internalOptions, isFinal)[0]
-    result = structureGenericHtmlBlockChildren(result, htmlStructureContext, internalOptions, isFinal)
+    // Seed the source cursor at the first window node so the passes only scan
+    // the dirty region instead of re-locating every prefix html block.
+    let sourceCursorStart = 0
+    if (windowStart > 0) {
+      const firstWindowNode = result[windowStart]
+      const range = getInternalNodeSourceRange(firstWindowNode, runtime)
+      if (range) {
+        sourceCursorStart = range.start
+      }
+      else {
+        const firstRaw = String((firstWindowNode as { raw?: unknown } | null)?.raw ?? '')
+        sourceCursorStart = firstRaw ? safeMarkdown.indexOf(firstRaw, 0) : 0
+        if (sourceCursorStart < 0)
+          sourceCursorStart = 0
+      }
+    }
+    result = mergeSplitTopLevelHtmlBlocks(result, isFinal, safeMarkdown, htmlStructureContext, internalOptions, windowStart, sourceCursorStart)
+    result = combineStructuredDetailsHtmlBlocks(result, safeMarkdown, htmlStructureContext, internalOptions, isFinal, sourceCursorStart, windowStart)[0]
+    result = structureGenericHtmlBlockChildren(result, htmlStructureContext, internalOptions, isFinal, windowStart)
     if (timing)
       addTiming(timing, 'htmlBlockPassesMs', getParserNow() - htmlPassesStartedAt)
   }

--- a/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
+++ b/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
@@ -187,7 +187,7 @@ function sourceEndsWithBlankLine(source: string) {
   return /\r?\n[\t ]*\r?\n[\t ]*$/.test(source)
 }
 
-function canReuseStructuredStreamNodes(options: ParseOptions) {
+export function canReuseStructuredStreamNodes(options: ParseOptions) {
   return options.reuseStableTopLevelNodes === true
     && options.final !== true
     && !options.preTransformTokens
@@ -263,28 +263,6 @@ function isSameTokenShapeForReuse(left: Token | MarkdownToken | undefined, right
     && sameTokenAttrs(left, right)
 }
 
-/**
- * Indices (offset + i) of `<details>` opener html_block nodes in a pre-html-pass
- * node array. Details fragments are stitched across tokenizer-committed groups
- * by combineStructuredDetailsHtmlBlocks, so the html passes must re-run from
- * the earliest such index.
- */
-function getDetailsOpenIndices(nodes: ParsedNode[], offset: number): number[] {
-  const out: number[] = []
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i]
-    if (node?.type !== 'html_block')
-      continue
-    const tag = String((node as { tag?: unknown }).tag ?? '').toLowerCase()
-    if (tag !== 'details')
-      continue
-    const raw = String((node as { raw?: unknown }).raw ?? (node as { content?: unknown }).content ?? '')
-    if (/^\s*<details\b/i.test(raw))
-      out.push(offset + i)
-  }
-  return out
-}
-
 function updateStructuredStreamCache(
   runtime: ParserRuntime,
   source: string,
@@ -292,7 +270,6 @@ function updateStructuredStreamCache(
   groups: ReusableTopLevelTokenGroups,
   nodes: ParsedNode[],
   options: ParseOptions,
-  detailsOpenIndices: number[],
 ) {
   const groupStarts = groups.starts
   if (groupStarts.length === 0 || nodes.length !== groupStarts.length) {
@@ -309,6 +286,10 @@ function updateStructuredStreamCache(
     }
   })
 
+  const stableGroupCount = groups.mixed
+    ? Math.max(0, groupStarts.length - 1)
+    : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1)
+
   runtime.structuredStream = {
     groupBoundaries,
     groupStarts,
@@ -318,10 +299,7 @@ function updateStructuredStreamCache(
     source,
     nodes,
     seed: nodes.map(node => String((node as Record<string, unknown>).raw ?? '')),
-    detailsOpenIndices,
-    stableGroupCount: groups.mixed
-      ? Math.max(0, groupStarts.length - 1)
-      : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1),
+    stableGroupCount,
     requireClosingStrong: options.requireClosingStrong,
     validateLink: options.validateLink,
   }
@@ -382,7 +360,11 @@ export function processTopLevelTokensWithReuse(
   const reuseEnabled = shouldUseTopLevelStreamParse(runtime, options)
     && canReuseStructuredStreamNodes(options)
 
-  runtime.structuredReuseTailStart = undefined
+  // Reset the reuse-tail marker only for top-level parses: fragment parses
+  // (details/div children) run with the same runtime and must not clobber the
+  // outer document's marker, which the html passes consult while stitching.
+  if (!options.isFragment)
+    runtime.structuredReuseTailStart = undefined
 
   if (!reuseEnabled) {
     // Fragment parses (e.g. children of <details>/custom html blocks) run with
@@ -455,15 +437,12 @@ export function processTopLevelTokensWithReuse(
       const result = previous.nodes.slice(0, stableGroupCount).concat(tailNodes)
       runtime.structuredReuseTailStart = stableGroupCount
       callbacks.recordReusedTopLevelNodes?.(stableGroupCount)
-      const detailsOpenIndices = previous.detailsOpenIndices
-        .filter(index => index < stableGroupCount)
-        .concat(getDetailsOpenIndices(tailNodes, stableGroupCount))
-      updateStructuredStreamCache(runtime, source, tokens, groups, result, options, detailsOpenIndices)
+      updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
       return result
     }
   }
 
   const result = callbacks.processTokens(tokens, options)
-  updateStructuredStreamCache(runtime, source, tokens, groups, result, options, getDetailsOpenIndices(result, 0))
+  updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
   return result
 }

--- a/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
+++ b/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
@@ -106,13 +106,20 @@ function getReusableTopLevelPairedCloseType(tokenType: string) {
   return containerMatch ? `container_${containerMatch[1]}_close` : undefined
 }
 
+/**
+ * Compute reusable top-level token groups. With `startIndex > 0` the prefix is
+ * assumed to have been validated on a previous call (the caller only does this
+ * when the token array identity proves the prefix is unchanged), so only the
+ * tail tokens are scanned.
+ */
 function getReusableTopLevelTokenGroups(
   tokens: MarkdownToken[],
   validateLink: ParseOptions['validateLink'],
+  startIndex = 0,
 ): ReusableTopLevelTokenGroups | null {
   const groupStarts: number[] = []
   let mixed = false
-  let index = 0
+  let index = startIndex
 
   while (index < tokens.length) {
     const token = tokens[index]
@@ -256,6 +263,28 @@ function isSameTokenShapeForReuse(left: Token | MarkdownToken | undefined, right
     && sameTokenAttrs(left, right)
 }
 
+/**
+ * Indices (offset + i) of `<details>` opener html_block nodes in a pre-html-pass
+ * node array. Details fragments are stitched across tokenizer-committed groups
+ * by combineStructuredDetailsHtmlBlocks, so the html passes must re-run from
+ * the earliest such index.
+ */
+function getDetailsOpenIndices(nodes: ParsedNode[], offset: number): number[] {
+  const out: number[] = []
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (node?.type !== 'html_block')
+      continue
+    const tag = String((node as { tag?: unknown }).tag ?? '').toLowerCase()
+    if (tag !== 'details')
+      continue
+    const raw = String((node as { raw?: unknown }).raw ?? (node as { content?: unknown }).content ?? '')
+    if (/^\s*<details\b/i.test(raw))
+      out.push(offset + i)
+  }
+  return out
+}
+
 function updateStructuredStreamCache(
   runtime: ParserRuntime,
   source: string,
@@ -263,6 +292,7 @@ function updateStructuredStreamCache(
   groups: ReusableTopLevelTokenGroups,
   nodes: ParsedNode[],
   options: ParseOptions,
+  detailsOpenIndices: number[],
 ) {
   const groupStarts = groups.starts
   if (groupStarts.length === 0 || nodes.length !== groupStarts.length) {
@@ -281,8 +311,14 @@ function updateStructuredStreamCache(
 
   runtime.structuredStream = {
     groupBoundaries,
+    groupStarts,
+    tokenCount: tokens.length,
+    tokens,
+    mixed: groups.mixed,
     source,
     nodes,
+    seed: nodes.map(node => String((node as Record<string, unknown>).raw ?? '')),
+    detailsOpenIndices,
     stableGroupCount: groups.mixed
       ? Math.max(0, groupStarts.length - 1)
       : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1),
@@ -297,6 +333,12 @@ function hasStableStructuredStreamGroupBoundaries(
   groupStarts: number[],
   stableGroupCount: number,
 ) {
+  // Fast path: markdown-it-ts returns the SAME cached token array across
+  // append/tail parses, so array identity proves the entire prefix (including
+  // every group boundary) is byte-for-byte unchanged — O(1) instead of O(groups).
+  if (previous.tokens === tokens)
+    return true
+
   const lastGroupIndex = groupStarts.length - 1
   for (let index = 0; index < stableGroupCount; index++) {
     const start = groupStarts[index]
@@ -340,6 +382,8 @@ export function processTopLevelTokensWithReuse(
   const reuseEnabled = shouldUseTopLevelStreamParse(runtime, options)
     && canReuseStructuredStreamNodes(options)
 
+  runtime.structuredReuseTailStart = undefined
+
   if (!reuseEnabled) {
     // Fragment parses (e.g. children of <details>/custom html blocks) run with
     // the same md instance and must not evict the top-level document's
@@ -352,15 +396,39 @@ export function processTopLevelTokensWithReuse(
   if (structuredReuseDisabled)
     return callbacks.processTokens(tokens, options)
 
-  const groups = getReusableTopLevelTokenGroups(tokens, options.validateLink)
+  const previous = runtime.structuredStream
+  const mode = getTopLevelStreamParseMode(runtime)
+  // markdown-it-ts returns the SAME cached token array (with the same prefix
+  // token objects) across append/tail parses, so identity proves the prefix is
+  // unchanged without re-scanning any prefix token.
+  const prefixUnchanged = !!previous
+    && (mode === 'append' || mode === 'tail')
+    && previous.tokenCount !== undefined
+    && previous.tokenCount <= tokens.length
+    && tokens === previous.tokens
+
+  let groups: ReusableTopLevelTokenGroups | null
+  if (prefixUnchanged) {
+    // Incremental scan: prefix groups were validated on the previous call and
+    // the token array identity guarantees they are unchanged, so only the new
+    // tail tokens need scanning.
+    const tailGroups = getReusableTopLevelTokenGroups(tokens, options.validateLink, previous.tokenCount)
+    groups = tailGroups
+      ? {
+          starts: previous.groupStarts.concat(tailGroups.starts),
+          mixed: previous.mixed || tailGroups.mixed,
+        }
+      : getReusableTopLevelTokenGroups(tokens, options.validateLink)
+  }
+  else {
+    groups = getReusableTopLevelTokenGroups(tokens, options.validateLink)
+  }
   if (!groups) {
     runtime.structuredStream = undefined
     return callbacks.processTokens(tokens, options)
   }
 
   const groupStarts = groups.starts
-  const previous = runtime.structuredStream
-  const mode = getTopLevelStreamParseMode(runtime)
   const stableGroupCount = previous && groups.mixed
     ? Math.min(previous.stableGroupCount, Math.max(0, previous.groupBoundaries.length - 1))
     : previous?.stableGroupCount ?? 0
@@ -377,24 +445,25 @@ export function processTopLevelTokensWithReuse(
     const tailStart = groupStarts[stableGroupCount] ?? tokens.length
     const tailNodes = callbacks.processTokens(tokens.slice(tailStart), {
       ...options,
-      // Replay the reused prefix node raws into the tail's linkify demotion
-      // tracker so tail linkify decisions see the same accumulated context a
-      // full parse would have produced.
-      linkifyDemotionSeed: previous.nodes
-        .slice(0, stableGroupCount)
-        .map(node => String((node as Record<string, unknown>).raw ?? '')),
+      // Prefix raws are cached and append-only: reuse the stored seed instead
+      // of re-slicing + re-stringifying every prefix node on each append.
+      linkifyDemotionSeed: previous.seed.slice(0, stableGroupCount),
     } as ParseContext)
     const expectedTailNodes = groupStarts.length - stableGroupCount
 
     if (tailNodes.length === expectedTailNodes) {
       const result = previous.nodes.slice(0, stableGroupCount).concat(tailNodes)
+      runtime.structuredReuseTailStart = stableGroupCount
       callbacks.recordReusedTopLevelNodes?.(stableGroupCount)
-      updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
+      const detailsOpenIndices = previous.detailsOpenIndices
+        .filter(index => index < stableGroupCount)
+        .concat(getDetailsOpenIndices(tailNodes, stableGroupCount))
+      updateStructuredStreamCache(runtime, source, tokens, groups, result, options, detailsOpenIndices)
       return result
     }
   }
 
   const result = callbacks.processTokens(tokens, options)
-  updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
+  updateStructuredStreamCache(runtime, source, tokens, groups, result, options, getDetailsOpenIndices(result, 0))
   return result
 }

--- a/packages/markdown-parser/src/parser/runtime.ts
+++ b/packages/markdown-parser/src/parser/runtime.ts
@@ -47,8 +47,25 @@ export interface StructuredStreamGroupBoundary {
 
 export interface StructuredStreamRuntimeState {
   groupBoundaries: StructuredStreamGroupBoundary[]
+  /** Absolute token indices where each reusable group starts. */
+  groupStarts: number[]
+  /** Number of top-level tokens when this cache was written. */
+  tokenCount: number
+  /** Reference to the token array from the parse that produced this cache. */
+  tokens: MarkdownToken[]
+  /** Whether any top-level group is a single-token (non-paired) reusable type. */
+  mixed: boolean
   source: string
   nodes: ParsedNode[]
+  /** Cached prefix node raws for incremental linkify demotion seeding. */
+  seed: string[]
+  /**
+   * Absolute pre-pass indices of `<details>` opener html_block nodes. The html
+   * passes re-run from the earliest such index because tokenizer-committed
+   * details fragments span "stable" group boundaries and are only stitched by
+   * combineStructuredDetailsHtmlBlocks.
+   */
+  detailsOpenIndices: number[]
   stableGroupCount: number
   requireClosingStrong: boolean | undefined
   validateLink: ParseOptions['validateLink']
@@ -101,6 +118,12 @@ export class ParserRuntime {
   readonly streamParseEnvs = new Map<string, Record<string, unknown>>()
   topLevelStreamParseMode?: string
   structuredStream?: StructuredStreamRuntimeState
+  /**
+   * Number of reused (stable) prefix nodes when the last
+   * processTopLevelTokensWithReuse call actually reused nodes; undefined when
+   * it re-processed the whole document. Lets downstream passes tail-window.
+   */
+  structuredReuseTailStart?: number
   siblingHtmlChildren?: SiblingHtmlChildrenRuntimeState
   nodeSourceRanges = new WeakMap<object, { start: number, end: number }>()
   private documentSource?: string

--- a/packages/markdown-parser/src/parser/runtime.ts
+++ b/packages/markdown-parser/src/parser/runtime.ts
@@ -59,13 +59,6 @@ export interface StructuredStreamRuntimeState {
   nodes: ParsedNode[]
   /** Cached prefix node raws for incremental linkify demotion seeding. */
   seed: string[]
-  /**
-   * Absolute pre-pass indices of `<details>` opener html_block nodes. The html
-   * passes re-run from the earliest such index because tokenizer-committed
-   * details fragments span "stable" group boundaries and are only stitched by
-   * combineStructuredDetailsHtmlBlocks.
-   */
-  detailsOpenIndices: number[]
   stableGroupCount: number
   requireClosingStrong: boolean | undefined
   validateLink: ParseOptions['validateLink']
@@ -124,6 +117,13 @@ export class ParserRuntime {
    * it re-processed the whole document. Lets downstream passes tail-window.
    */
   structuredReuseTailStart?: number
+  /**
+   * Stitched `<details>` output cache keyed by the pre-pass details opener
+   * html_block node. Reused prefix details keep the same opener object across
+   * appends, so combineStructuredDetailsHtmlBlocks can skip re-parsing and
+   * re-rendering the (unchanged) middle of closed details on every append.
+   */
+  detailsStitchCache = new WeakMap<object, { openRaw: string, explicitClose: boolean, closeSliceEnd: number, middleSource: string, node: ParsedNode }>()
   siblingHtmlChildren?: SiblingHtmlChildrenRuntimeState
   nodeSourceRanges = new WeakMap<object, { start: number, end: number }>()
   private documentSource?: string
@@ -228,6 +228,7 @@ export class ParserRuntime {
     this.topLevelStreamParseMode = undefined
     this.structuredStream = undefined
     this.siblingHtmlChildren = undefined
+    this.detailsStitchCache = new WeakMap()
     this.nodeSourceRanges = new WeakMap()
   }
 }

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -1684,4 +1684,124 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(stats.cacheHits + stats.appendHits + stats.tailHits).toBeGreaterThan(0)
     expect(seen).toEqual(['cached', 'cached'])
   })
+
+  it('keeps stitched details consistent with a cold parse across fine-grained appends', () => {
+    // Regression guard for the per-opener details stitch cache: a reused
+    // (stable-prefix) details opener is keyed on explicitClose + closeSliceEnd
+    // + middleSource, so an open->closed transition and a trailing line-ending
+    // extension must invalidate the cached stitched node instead of returning a
+    // stale (still-loading or short-raw) node.
+    const md = getMarkdown('stream-parser-details-stitch-cache')
+    const coldMd = getMarkdown('stream-parser-details-stitch-cache-cold')
+
+    const base = `${buildLargeAppendFriendlyDoc(40)}\n\n`
+    const tail = [
+      '<details>',
+      '<summary>Closed one</summary>',
+      '',
+      'Body **bold** with `code` inside.',
+      '',
+      '</details>',
+      '',
+      '<details open>',
+      '<summary>Growing one</summary>',
+      '',
+      'This details stays open while streaming and only closes at the very end.',
+      '',
+      '</details>',
+      '',
+    ].join('\n')
+
+    parseMarkdownToStructure(base, md, {
+      final: false,
+      streamParse: true,
+      reuseStableTopLevelNodes: true,
+    })
+
+    // Small commits so `</details>` and its trailing newline land on separate
+    // boundaries, exercising the open->closed and close-extension cache keys.
+    const chunkSize = 7
+    let current = base
+    for (let i = 0; i < tail.length; i += chunkSize) {
+      current = base + tail.slice(0, i + chunkSize)
+      const streamed = parseMarkdownToStructure(current, md, {
+        final: false,
+        streamParse: true,
+        reuseStableTopLevelNodes: true,
+      })
+      const cold = parseMarkdownToStructure(current, coldMd, {
+        final: false,
+        streamParse: false,
+      })
+      expect(streamed).toEqual(cold)
+    }
+
+    // final parse of the full document must also match a cold final parse
+    const finalNodes = parseMarkdownToStructure(base + tail, md, {
+      final: true,
+      streamParse: true,
+      reuseStableTopLevelNodes: true,
+    })
+    const finalCold = parseMarkdownToStructure(base + tail, coldMd, {
+      final: true,
+      streamParse: false,
+    })
+    expect(finalNodes).toEqual(finalCold)
+  })
+
+  it('keeps split-opener details (summary committed in a later group) consistent with a cold parse', () => {
+    // Regression guard: at fine commit granularity the stream can commit a
+    // `<details>` opener as a stable group before its `<summary>` arrives,
+    // freezing a partial opener fragment in the reuse cache. combine must
+    // re-derive the content boundaries and the summary child from the source so
+    // the streamed node matches a full parse (the summary must be structured,
+    // not lost or emitted as a raw childless html_block).
+    const md = getMarkdown('stream-parser-details-split-opener')
+    const coldMd = getMarkdown('stream-parser-details-split-opener-cold')
+
+    const sections = Array.from({ length: 60 }, (_, index) => {
+      return [
+        `## Section ${index}`,
+        '',
+        '<details open>',
+        `<summary>Details ${index}</summary>`,
+        '',
+        `Inside details ${index} with a list:`,
+        '',
+        `- item a${index}`,
+        `- item b${index}`,
+        `- item c${index}`,
+        '',
+        '</details>',
+        '',
+      ].join('\n')
+    }).join('\n')
+
+    let current = ''
+    const chunkSize = 128
+    for (let i = 0; i < sections.length; i += chunkSize) {
+      current = sections.slice(0, i + chunkSize)
+      const streamed = parseMarkdownToStructure(current, md, {
+        final: false,
+        streamParse: true,
+        reuseStableTopLevelNodes: true,
+      })
+      const cold = parseMarkdownToStructure(current, coldMd, {
+        final: false,
+        streamParse: false,
+      })
+      expect(streamed).toEqual(cold)
+    }
+
+    const finalNodes = parseMarkdownToStructure(sections, md, {
+      final: true,
+      streamParse: true,
+      reuseStableTopLevelNodes: true,
+    })
+    const finalCold = parseMarkdownToStructure(sections, coldMd, {
+      final: true,
+      streamParse: false,
+    })
+    expect(finalNodes).toEqual(finalCold)
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       material-icon-theme:
         specifier: ^5.37.0
         version: 5.37.0
+      octane:
+        specifier: ^0.1.21
+        version: 0.1.21(@typescript-eslint/types@8.65.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@7.3.6(@types/node@18.19.130)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.33.0)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -26413,6 +26416,19 @@ snapshots:
   obuf@1.1.2: {}
 
   obug@2.1.1: {}
+
+  octane@0.1.21(@typescript-eslint/types@8.65.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@7.3.6(@types/node@18.19.130)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.33.0)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@tsrx/core': 0.1.56(@typescript-eslint/types@8.65.0)
+      '@types/react': 19.2.17
+      devalue: 5.8.2
+      esrap: 2.3.0(@typescript-eslint/types@8.65.0)
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      vite: 7.3.6(@types/node@18.19.130)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.33.0)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   octane@0.1.21(@typescript-eslint/types@8.65.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.0)(jiti@1.21.7)(less@4.6.7)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
…pipeline

Four incremental-parsing fixes so every append does O(tail) work instead of re-scanning the whole document:

- html structure passes (mergeSplit/combine/structureGeneric) now run over a tail window from the reused-prefix boundary, extended back to the earliest <details> opener (details fragments span tokenizer-committed groups and must be re-stitched); the source cursor is seeded from the first window node's range so prefix html blocks are never re-located
- getReusableTopLevelTokenGroups scans only the new tail tokens when the markdown-it-ts token array identity proves the prefix unchanged
- hasStableStructuredStreamGroupBoundaries short-circuits via token array identity (O(1) instead of O(groups) per append)
- linkifyDemotionSeed is cached in the structured-stream state and reused instead of re-slicing + re-stringifying every prefix node per append

Verified: 556 parser tests, the differential validator (4 fixed-seed fixtures), and the structured-reuse validator (7 real corpora, 120 commits each, including html/details-heavy docs) all pass.

## Summary

Please explain the goal of this change in 2–3 lines.

## Changes

- [ ]

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

## Checklist

- [ ] Lint: `pnpm lint`
- [ ] Typecheck: `pnpm typecheck`
- [ ] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [ ] Build: `pnpm build` (library + CSS)
