### PR TITLE
fix(parser): prevent streaming fence prefix jitter

### DIFF
--- a/docs/use-cases/streaming-code-blocks.md
+++ b/docs/use-cases/streaming-code-blocks.md
@@ -101,6 +101,16 @@ For mobile WebViews or conservative bundles, use plain `pre` rendering:
 - Diff fences with added and removed lines
 - Code followed by tables, Mermaid, or math before the close fence arrives
 
+A marker-only line at the streaming tail is ambiguous until more input arrives. For example, the first one or two backticks of a three-backtick closing fence must stay pending instead of entering the rendered code content:
+
+```text
+code line                         code line
+code line                         code line
+` or ``                  ->       (pending tail hidden)
+```
+
+If a non-marker character or another line arrives, the pending text is released as literal code. When `final` is true, EOF is authoritative and literal marker-only content is preserved. This rule belongs to the parser output contract so plain `pre` and every framework adapter receive the same stable `code_block.code` value.
+
 ## Performance notes
 
 - Batch token updates before rendering; do not commit every byte from an SSE or WebSocket stream.

--- a/docs/zh/use-cases/streaming-code-blocks.md
+++ b/docs/zh/use-cases/streaming-code-blocks.md
@@ -101,6 +101,16 @@ setCustomComponents('chat-code-blocks', {
 - 含新增和删除行的 diff fence
 - 在闭合 fence 到达之前，代码后跟着表格、Mermaid 或数学公式
 
+流式尾部仅由 marker 组成的独占行，在更多输入到达前具有歧义。例如，三反引号闭合 fence 的前一个或两个反引号必须保持 pending，不能进入已渲染的代码内容：
+
+```text
+代码行                           代码行
+代码行                           代码行
+` 或 ``                 ->       （隐藏 pending 尾部）
+```
+
+如果随后到达非 marker 字符或新的一行，pending 文本会作为字面代码恢复。当 `final` 为 true 时，EOF 具有最终决定权，必须保留字面意义的 marker-only 内容。这条规则属于 parser 输出 contract，因此 plain `pre` 和所有 framework adapter 都会收到相同且稳定的 `code_block.code`。
+
 ## 性能说明
 
 - 在渲染前批处理 token 更新；不要提交 SSE 或 WebSocket 流中的每个字节。

--- a/packages/markdown-parser/src/parser/inline-parsers/fence-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/fence-parser.ts
@@ -1,9 +1,11 @@
 import type { CodeBlockNode, MarkdownToken } from '../../types'
 
-// A trailing line made of the fence's own marker character that is long
-// enough to be a valid closing fence for it.
-function TRAILING_OWN_FENCE_LINE_RE(marker: string, minLen: number) {
-  return new RegExp(`\r?\n[ \\t]*${marker}{${minLen},}[ \\t]*$`)
+// A trailing line made only of the fence's own marker character is
+// ambiguous while streaming: one or two backticks may be the prefix of a
+// three-backtick closing fence. Withhold that line until the parser can prove
+// whether it is a close or literal code so the prefix does not flash in <pre>.
+function TRAILING_OWN_FENCE_CANDIDATE_LINE_RE(marker: string) {
+  return new RegExp(`(?:^|\\r\\n|\\n|\\r) {0,3}${marker}+[ \\t]*$`)
 }
 
 // Unified diff metadata/header line prefixes to skip when splitting a diff
@@ -121,22 +123,19 @@ export function parseFenceToken(token: MarkdownToken): CodeBlockNode {
       })()
     : info
 
-  // Defensive sanitization: sometimes a closing fence line (e.g. ``` or ``)
-  // can accidentally end up inside `token.content` (for example when
-  // the parser/mapping is confused during streaming). This cleanup is ONLY
-  // valid for the streaming/unclosed case, and ONLY when the trailing line
-  // could actually be the fence's own closing marker (same character, at
-  // least as long as the opening run). A closed fence carries authoritative
-  // content and must never be altered: a nested fence inside a 4-backtick
-  // outer block legitimately ends with a ``` line, and a ``` fence whose
-  // code ends in a backtick-only line keeps it.
+  // In an unclosed streaming fence, a trailing marker-only source line is
+  // ambiguous until another character arrives. It may be literal code, but it
+  // is also the prefix of the closing fence. Do not expose that pending prefix
+  // through `node.code`; otherwise the pre fallback paints ` / `` and removes
+  // it one frame later when the closing run becomes complete. A closed or
+  // final fence carries authoritative content and must never be altered, so a
+  // shorter nested fence inside a longer outer fence remains valid code.
   let content = String(token.content ?? '')
   if (!closed && token.markup) {
     const marker = token.markup[0]
-    const minLen = token.markup.length
-    const trailingFenceLineRe = TRAILING_OWN_FENCE_LINE_RE(marker, minLen)
-    if (trailingFenceLineRe.test(content))
-      content = content.replace(trailingFenceLineRe, '')
+    const trailingFenceCandidateLineRe = TRAILING_OWN_FENCE_CANDIDATE_LINE_RE(marker)
+    if (trailingFenceCandidateLineRe.test(content))
+      content = content.replace(trailingFenceCandidateLineRe, '')
   }
 
   if (diff) {

--- a/packages/markdown-parser/test/fence-streamcontent-regression.test.ts
+++ b/packages/markdown-parser/test/fence-streamcontent-regression.test.ts
@@ -133,6 +133,184 @@ describe('parseMarkdownToStructure - fence regression', () => {
     expect(String(codeNode.code)).toContain('step += 1')
   })
 
+  it('withholds a closing-fence prefix and releases it when streaming proves it is literal', () => {
+    const streamingOptions = {
+      final: false,
+      streamParse: true,
+      reuseStableTopLevelNodes: true,
+    }
+
+    for (const fence of ['```', '~~~']) {
+      const marker = fence[0]
+      const body = `${fence}python\nprint("ok")\n`
+      const closingMd = getMarkdown(`closing-fence-prefix-${marker}`)
+
+      for (const prefix of [marker, marker.repeat(2)]) {
+        const codeNode = findFirstCodeBlock(parseMarkdownToStructure(
+          `${body}${prefix}`,
+          closingMd,
+          streamingOptions,
+        ) as any[])
+        expect(codeNode?.loading).toBe(true)
+        expect(codeNode?.code).toBe('print("ok")')
+      }
+
+      const closed = findFirstCodeBlock(parseMarkdownToStructure(
+        `${body}${fence}`,
+        closingMd,
+        streamingOptions,
+      ) as any[])
+      expect(closed?.loading).toBe(false)
+      expect(closed?.code).toBe('print("ok")\n')
+
+      const literalValueMd = getMarkdown(`literal-fence-value-${marker}`)
+      parseMarkdownToStructure(`${body}${marker}`, literalValueMd, streamingOptions)
+      const literalValue = findFirstCodeBlock(parseMarkdownToStructure(
+        `${body}${marker}value`,
+        literalValueMd,
+        streamingOptions,
+      ) as any[])
+      expect(literalValue?.code).toBe(`print("ok")\n${marker}value`)
+
+      const literalLineMd = getMarkdown(`literal-fence-line-${marker}`)
+      parseMarkdownToStructure(`${body}${marker}`, literalLineMd, streamingOptions)
+      const literalLine = findFirstCodeBlock(parseMarkdownToStructure(
+        `${body}${marker}\nnext`,
+        literalLineMd,
+        streamingOptions,
+      ) as any[])
+      expect(literalLine?.code).toBe(`print("ok")\n${marker}\nnext`)
+
+      const finalLiteral = findFirstCodeBlock(parseMarkdownToStructure(
+        `${body}${marker}`,
+        getMarkdown(`final-fence-tail-${marker}`),
+        { final: true, streamParse: false },
+      ) as any[])
+      expect(finalLiteral?.loading).toBe(false)
+      expect(finalLiteral?.code).toBe(`print("ok")\n${marker}`)
+    }
+  })
+
+  it('uses the opening fence length to resolve a four-backtick stream', () => {
+    const fence = '````'
+    const marker = fence[0]
+    const body = `${fence}python\nprint("ok")\n`
+    const options = { final: false, streamParse: true, reuseStableTopLevelNodes: true }
+    const closingMd = getMarkdown('four-backtick-closing-prefix')
+
+    for (let length = 1; length < fence.length; length++) {
+      const codeNode = findFirstCodeBlock(parseMarkdownToStructure(
+        `${body}${marker.repeat(length)}`,
+        closingMd,
+        options,
+      ) as any[])
+      expect(codeNode?.loading).toBe(true)
+      expect(codeNode?.code).toBe('print("ok")')
+    }
+
+    const closed = findFirstCodeBlock(parseMarkdownToStructure(
+      `${body}${fence}`,
+      closingMd,
+      options,
+    ) as any[])
+    expect(closed?.loading).toBe(false)
+    expect(closed?.code).toBe('print("ok")\n')
+
+    const nestedMd = getMarkdown('four-backtick-literal-nested-fence')
+    parseMarkdownToStructure(`${body}${marker.repeat(3)}`, nestedMd, options)
+    const releasedNestedFence = findFirstCodeBlock(parseMarkdownToStructure(
+      `${body}${marker.repeat(3)}\nnext\n${fence}`,
+      nestedMd,
+      options,
+    ) as any[])
+    expect(releasedNestedFence?.loading).toBe(false)
+    expect(releasedNestedFence?.code).toBe('print("ok")\n```\nnext\n')
+
+    const finalLiteral = findFirstCodeBlock(parseMarkdownToStructure(
+      `${body}${marker.repeat(3)}`,
+      getMarkdown('four-backtick-final-literal'),
+      { final: true, streamParse: false },
+    ) as any[])
+    expect(finalLiteral?.code).toBe('print("ok")\n```')
+  })
+
+  it('handles empty, CRLF, and indented streaming fence prefixes', () => {
+    const options = { final: false, streamParse: true, reuseStableTopLevelNodes: true }
+    const emptyBody = '```js\n'
+    const emptyMd = getMarkdown('empty-closing-fence-prefix')
+
+    for (const prefix of ['`', '``']) {
+      const codeNode = findFirstCodeBlock(parseMarkdownToStructure(
+        `${emptyBody}${prefix}`,
+        emptyMd,
+        options,
+      ) as any[])
+      expect(codeNode?.code).toBe('')
+    }
+
+    const emptyClosed = findFirstCodeBlock(parseMarkdownToStructure(
+      `${emptyBody}\`\`\``,
+      emptyMd,
+      options,
+    ) as any[])
+    expect(emptyClosed?.loading).toBe(false)
+    expect(emptyClosed?.code).toBe('')
+
+    const crlfBody = '```js\r\ncode\r\n'
+    const crlfMd = getMarkdown('crlf-closing-fence-prefix')
+    const crlfPending = findFirstCodeBlock(parseMarkdownToStructure(
+      `${crlfBody}\``,
+      crlfMd,
+      options,
+    ) as any[])
+    expect(crlfPending?.code).toBe('code')
+
+    const crlfLiteral = findFirstCodeBlock(parseMarkdownToStructure(
+      `${crlfBody}\`value`,
+      crlfMd,
+      options,
+    ) as any[])
+    expect(crlfLiteral?.code).toBe('code\n`value')
+
+    const indentedCandidate = findFirstCodeBlock(parseMarkdownToStructure(
+      '```js\ncode\n   ``',
+      getMarkdown('indented-closing-fence-prefix'),
+      { final: false, streamParse: false },
+    ) as any[])
+    expect(indentedCandidate?.code).toBe('code')
+
+    const indentedLiteral = findFirstCodeBlock(parseMarkdownToStructure(
+      '```js\ncode\n    ``',
+      getMarkdown('indented-literal-fence-tail'),
+      { final: false, streamParse: false },
+    ) as any[])
+    expect(indentedLiteral?.code).toBe('code\n    ``')
+  })
+
+  it('applies the same pending-tail contract before diff splitting', () => {
+    const body = '```diff js\n-old\n+new\n'
+    const options = { final: false, streamParse: true, reuseStableTopLevelNodes: true }
+    const md = getMarkdown('diff-closing-fence-prefix')
+    const pending = findFirstCodeBlock(parseMarkdownToStructure(
+      `${body}\``,
+      md,
+      options,
+    ) as any[])
+
+    expect(pending?.raw).toBe('-old\n+new')
+    expect(pending?.originalCode).toBe('old')
+    expect(pending?.updatedCode).toBe('new')
+
+    const literal = findFirstCodeBlock(parseMarkdownToStructure(
+      `${body}\`value`,
+      md,
+      options,
+    ) as any[])
+    expect(literal?.raw).toBe('-old\n+new\n`value')
+    expect(literal?.originalCode).toBe('old\n`value')
+    expect(literal?.updatedCode).toBe('new\n`value')
+  })
+
   it('still strips dangling html-like tail outside fences', () => {
     const md = getMarkdown('fence-regression')
     const nodes = parseMarkdownToStructure('Hello\\n<think', md)

--- a/scripts/smoke-octane-packed-package.mjs
+++ b/scripts/smoke-octane-packed-package.mjs
@@ -80,7 +80,7 @@ try {
       'react-dom': '^19.2.0',
     },
     devDependencies: {
-      '@tsrx/core': '^0.1.56',
+      '@tsrx/core': '0.1.56',
       '@tsrx/typescript-plugin': '^0.3.118',
       'typescript': '^5.9.3',
       'vite': '^8.0.16',

--- a/test/e2e/node-renderer.e2e.test.ts
+++ b/test/e2e/node-renderer.e2e.test.ts
@@ -642,6 +642,37 @@ After`,
     }, 20000)
   }
 
+  it('does not paint a partial closing fence in the streaming pre', async () => {
+    const body = '```python\nprint("ok")\n'
+    const marker = String.fromCharCode(96)
+    const wrapper = await mountMarkdown(`${body}${marker}`, {
+      batchRendering: false,
+      deferNodesUntilVisible: false,
+      fade: false,
+      final: false,
+      nodeVirtual: false,
+      renderCodeBlocksAsPre: true,
+      viewportPriority: false,
+    })
+
+    try {
+      const renderedCode = () => wrapper.get('pre[data-markstream-pre="1"] code').element.textContent
+
+      expect(renderedCode()).toBe('print("ok")')
+
+      await wrapper.setProps({ content: `${body}${marker.repeat(2)}` })
+      await flushAll()
+      expect(renderedCode()).toBe('print("ok")')
+
+      await wrapper.setProps({ content: `${body}${marker.repeat(3)}` })
+      await flushAll()
+      expect(renderedCode()).toBe('print("ok")')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
   it('resizes table columns from header drag handles', async () => {
     const wrapper = await mountMarkdown('| Name | Role |\n| --- | --- |\n| Alice | Developer |')
     try {

--- a/test/fence-trailing-backtick.test.ts
+++ b/test/fence-trailing-backtick.test.ts
@@ -49,7 +49,7 @@ describe('fence parser trailing fence cleanup', () => {
     expect((node as any).code).toBe('a\n```')
   })
 
-  it('does not strip a shorter marker run than the opening fence', () => {
+  it('withholds a shorter marker run until a longer opening fence is resolved', () => {
     const token: any = {
       type: 'fence',
       info: 'text',
@@ -58,8 +58,12 @@ describe('fence parser trailing fence cleanup', () => {
       map: [0, 3],
       meta: { closed: false },
     }
-    const node = parseFenceToken(token as any)
-    expect((node as any).code).toBe('```\nline\n```')
+    const pendingNode = parseFenceToken(token as any)
+    expect((pendingNode as any).code).toBe('```\nline')
+
+    token.meta.closed = true
+    const finalNode = parseFenceToken(token as any)
+    expect((finalNode as any).code).toBe('```\nline\n```')
   })
 
   it('keeps legitimate content that contains backticks not on their own line', () => {


### PR DESCRIPTION
## Summary

- withhold trailing marker-only lines from unclosed streaming fenced code blocks
- release the pending text when later input proves it is literal code
- preserve authoritative content for closed and final fences
- document the parser output contract in English and Chinese streaming guides

## Root cause

While a closing fence arrived incrementally, markdown-it exposed the trailing `` ` `` / `` `` `` prefix through the fence token content. The parser copied that prefix into `node.code`, so renderers displayed it briefly inside `<pre>` until the third marker closed the fence.

Keeping the fix in `@markstream/markdown-parser` applies the same stable output contract to every renderer.

## Verification

- `pnpm test` — 320 files, 2801 tests passed
- `pnpm --dir packages/markdown-parser test:run` — 55 files, 516 tests passed
- `pnpm exec vitest --run test/e2e/node-renderer.e2e.test.ts test/fence-trailing-backtick.test.ts test/parse-final-mode.test.ts test/plugins/fence-streaming.test.ts` — 63 tests passed
- root `vue-tsc --noEmit`
- parser `tsc --noEmit`
- ESLint on all changed source/test files
- `git diff origin/1.x...HEAD --check`

Backport of #687 to the 1.x maintenance branch.
