### PR TITLE
fix(code-block): align split diff fallback divider and collapsed pill with highlight surface

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -3968,7 +3968,6 @@ onUnmounted(() => {
   --markstream-diff-panel-bg-soft: var(--code-bg);
   --markstream-diff-panel-bg-strong: var(--code-bg);
   --markstream-diff-panel-border: hsl(var(--ms-border) / 0.3);
-  --markstream-diff-pane-divider: hsl(var(--ms-border) / 0.42);
   --markstream-diff-gutter-bg: transparent;
   --markstream-diff-gutter-guide: hsl(var(--ms-border) / 0.72);
   --markstream-diff-gutter-gap: 8px;
@@ -4023,7 +4022,6 @@ onUnmounted(() => {
   --markstream-diff-panel-bg-soft: #121212;
   --markstream-diff-panel-bg-strong: #121212;
   --markstream-diff-panel-border: hsl(var(--ms-border) / 0.3);
-  --markstream-diff-pane-divider: hsl(var(--ms-border) / 0.34);
   --markstream-diff-gutter-bg: linear-gradient(
     180deg,
     hsl(0 0% 7% / 0.94) 0%,

--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -558,39 +558,51 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
 }
 
 .markstream-vue pre.markstream-pre--diff-preview .markstream-pre__diff-pane--modified {
-  --markstream-pre-diff-pane-divider-width: 1px;
   --markstream-pre-diff-line-number-gap-to-code: var(--markstream-pre-diff-code-gap);
   --markstream-pre-diff-line-number-left: 0px;
-  box-shadow: inset 1px 0 var(--markstream-diff-pane-divider, hsl(var(--ms-border)));
-}
-
-.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified {
-  --markstream-pre-diff-line-number-left: calc(
-    0px
-    + var(--markstream-pre-diff-pane-divider-width)
-  );
-}
-
-.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified .markstream-pre__diff-rail {
-  left: var(--markstream-pre-diff-pane-divider-width);
-}
-
-.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified .markstream-pre__diff-line {
-  padding-left: calc(
-    var(--markstream-pre-diff-code-left)
-    + var(--markstream-pre-diff-pane-divider-width)
-  );
-}
-
-.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified .markstream-pre__diff-line::before {
-  left: calc(
-    var(--markstream-pre-diff-code-fill-left)
-    + var(--markstream-pre-diff-pane-divider-width)
-  );
-}
-
-.markstream-vue pre.markstream-pre--diff-preview.markstream-pre--diff-inline .markstream-pre__diff-pane--modified {
+  /* The finalized highlight surface separates its split columns with a clean
+     background gap (pierre's 1ch line paddings plus background-colored column
+     borders), not a colored 1px divider line. Keep the pre fallback visually
+     identical: drop the divider so the middle between the two columns reads
+     as a 2ch white gap. */
   box-shadow: none;
+}
+
+/* Match the finalized highlight surface's 2ch white split divider: pierre's
+   split lines carry 1ch inline padding on each side of the code content. The
+   left pane mirrors the text's 1ch right padding toward the seam; the right
+   pane already spaces its text 1ch past the line-number gutter
+   (`--markstream-pre-diff-line-number-gap-to-code`), so no extra left padding
+   is added there — adding one would push the right column's content one `ch`
+   away from the line numbers compared with the highlight surface. */
+.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--original .markstream-pre__diff-line:not(.markstream-pre__diff-line--collapsed) .markstream-pre__diff-content {
+  padding-right: 1ch;
+}
+
+/* Split view: the collapsed "N unmodified lines" pill must read as ONE
+   continuous pill spanning both columns (pierre's split separators meet at the
+   middle divider). The left pane extends its pill flush to its right edge and
+   the right pane starts flush at its own left edge, so the two halves abut
+   exactly at the column seam; the inner corners are squared so there is no
+   notch where they meet. */
+.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--original .markstream-pre__diff-line--collapsed::before {
+  right: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified .markstream-pre__diff-line--collapsed::before {
+  left: 0px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+/* The modified (right) pane's collapsed row is only the empty half of the
+   continuous pill — the finalized surface renders the "N unmodified lines"
+   widget once on the original side. Hide the duplicated chevron/icon so the
+   right half stays clean (matches the highlight surface). */
+.markstream-vue pre.markstream-pre--diff-preview:not(.markstream-pre--diff-inline) .markstream-pre__diff-pane--modified .markstream-pre__diff-line--collapsed > .markstream-pre__diff-collapsed-icon {
+  display: none;
 }
 
 .markstream-vue pre.markstream-pre--diff-preview .markstream-pre__diff-line {


### PR DESCRIPTION
## 概述

streaming 场景下 two-column diff 的 pre fallback 与最终 highlight 表面不一致。本次修复使 pre 2列模式与 highlight 逐项对齐。

## 问题

| 项 | pre（修复前） | highlight（目标） |
|---|---|---|
| 中间分割 | 1px 彩色分割线 | 2ch 白色分割 |
| "N unmodified lines" pill | 被中间切开成两半 + 右列重复 chevron | 横跨两列的连续一条，只在左侧显示 widget |
| 右列"行号→代码"距离 | 2ch（偏大 1ch） | 1ch |

右列代码内容在 pre 中比 highlight 偏右约 1ch（几 px），导致 pre→highlight 切换时右列内容向左移动；行号位置不变。

## 改动

- **`src/components/PreCodeNode/PreCodeNode.vue`**
  - 去掉 modified pane 的彩色 `box-shadow` 分割线及整套 `--markstream-pre-diff-pane-divider-width` 偏移规则
  - 中间改为 2ch 白色分割：左 pane 代码内容 `padding-right: 1ch` + 右 pane 已有 1ch 行号间隙（不再额外加左 padding，避免右列偏移）
  - split 模式下 collapsed pill 左右两半在列缝处精确相接（内侧圆角置 0），形成连续一条
  - 隐藏右 pane 重复的 chevron
- **`src/components/CodeBlockNode/CodeBlockNode.vue`**
  - 删除已失效的 `--markstream-diff-pane-divider` 变量（light/dark）

## 验证

- Playground 直接挂载 PreCodeBlock（wrap + scroll 两种模式）像素级验证：pill 连续、中间无彩色分割线、右列"行号→代码"= 1ch
- 相关测试 8 个文件 116 个全部通过（含 pre-code-node-diff-preview、diff-code-block-fallback-height、vue2/react editor-lock 等）
- `pnpm lint`、`pnpm typecheck` 通过
