### PR TITLE
fix: stabilize infographic streaming fallbacks

### DIFF
--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -6,7 +6,7 @@ Markstream is a family of streaming Markdown renderers for AI applications. This
 
 ### markstream-vue
 - Package name: markstream-vue
-- Version: 2.0.1-beta.0
+- Version: 2.0.1-beta.1
 - Maturity label: stable
 - Framework/runtime: Vue 3, Nuxt 3, VitePress
 - Description: Vue/Nuxt streaming Markdown renderer for AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown, long documents, Mermaid, KaTeX, and stream-diffs powered code blocks.

--- a/docs/public/llms-full.zh-CN.txt
+++ b/docs/public/llms-full.zh-CN.txt
@@ -6,7 +6,7 @@ Markstream 是面向 AI 应用的多框架流式 Markdown 渲染器家族。本�
 
 ### markstream-vue
 - 包名：markstream-vue
-- 版本：2.0.1-beta.0
+- 版本：2.0.1-beta.1
 - 成熟度标签：稳定
 - 框架/运行时：Vue 3、Nuxt 3、VitePress
 - 描述：Vue/Nuxt streaming Markdown renderer for AI chat, LLM token streams, SSE/WebSocket output, incomplete Markdown, long documents, Mermaid, KaTeX, and stream-diffs powered code blocks.

--- a/packages/markstream-angular/src/components/InfographicBlockNode/InfographicBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/InfographicBlockNode/InfographicBlockNode.component.ts
@@ -118,7 +118,9 @@ import {
           #previewHost
           class="infographic-render"
           [style.minHeight]="resolvedContainerMinHeight"
-        ></div>
+        >
+          <pre *ngIf="!svgMarkup && !error" class="markstream-angular-enhanced-block__source infographic-pending-source"><code translate="no">{{ code }}</code></pre>
+        </div>
 
         <pre *ngIf="showSource" class="markstream-angular-enhanced-block__source"><code translate="no">{{ code }}</code></pre>
 
@@ -177,6 +179,7 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
   private viewReady = false
   private destroyed = false
   private renderToken = 0
+  private renderScheduled = false
   private copyTimer: number | null = null
   private infographicInstance: any = null
 
@@ -282,19 +285,20 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
 
   ngAfterViewInit() {
     this.viewReady = true
-    queueMicrotask(() => void this.renderInfographic())
+    this.scheduleInfographicRender()
   }
 
   ngOnChanges() {
     if (!this.viewReady)
       return
     this.containerMinHeight = ''
-    queueMicrotask(() => void this.renderInfographic())
+    this.scheduleInfographicRender()
   }
 
   ngOnDestroy() {
     this.destroyed = true
     this.renderToken += 1
+    this.renderScheduled = false
     if (this.copyTimer != null && typeof window !== 'undefined')
       window.clearTimeout(this.copyTimer)
     this.destroyInfographic()
@@ -361,7 +365,7 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
   toggleCollapsed() {
     this.collapsed = !this.collapsed
     if (!this.collapsed)
-      queueMicrotask(() => void this.renderInfographic())
+      this.scheduleInfographicRender()
     this.cdr.markForCheck()
   }
 
@@ -373,6 +377,17 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
   resetZoom() {
     this.zoom = 1
     this.cdr.markForCheck()
+  }
+
+  private scheduleInfographicRender() {
+    if (this.destroyed || this.renderScheduled)
+      return
+    this.renderScheduled = true
+    queueMicrotask(() => {
+      this.renderScheduled = false
+      if (!this.destroyed)
+        void this.renderInfographic()
+    })
   }
 
   private async renderInfographic() {
@@ -395,16 +410,17 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
       this.renderToken += 1
       this.rendering = true
       this.error = ''
-      this.svgMarkup = ''
-      clearElement(host)
       this.cdr.markForCheck()
       return
     }
 
+    const final = !this.resolvedLoading
     const token = ++this.renderToken
     this.rendering = true
     this.error = ''
     this.cdr.markForCheck()
+    let nextInstance: any = null
+    let previousChildren: ChildNode[] | null = null
 
     try {
       const InfographicClass = await getInfographic()
@@ -413,19 +429,49 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
       if (this.destroyed || token !== this.renderToken)
         return
 
-      this.destroyInfographic()
-      clearElement(host)
-      const instance = new InfographicClass({
+      previousChildren = Array.from(host.childNodes)
+      nextInstance = new InfographicClass({
         container: host,
         width: '100%',
         height: '100%',
       })
-      this.infographicInstance = instance
-      instance.render(source)
+      let renderErrorMessage = ''
+      let renderCompleted = false
+      nextInstance.on?.('error', (error: unknown) => {
+        const errors = Array.isArray(error) ? error : [error]
+        renderErrorMessage = errors
+          .map((item) => {
+            if (item instanceof Error)
+              return item.message
+            if (typeof item === 'string')
+              return item
+            if (item && typeof item === 'object' && 'message' in item)
+              return String((item as { message?: unknown }).message ?? '')
+            return String(item ?? '')
+          })
+          .filter(Boolean)
+          .join('; ')
+      })
+      nextInstance.on?.('rendered', () => {
+        renderCompleted = true
+      })
+      nextInstance.render(source)
+      if (renderErrorMessage)
+        throw new Error(renderErrorMessage)
+      const nextChildren = Array.from(host.childNodes)
+      const replacedChildren = nextChildren.length > 0 && (
+        nextChildren.length !== previousChildren.length
+        || nextChildren.some((child, index) => child !== previousChildren?.[index])
+      )
+      if (!renderCompleted && !replacedChildren)
+        throw new Error('Infographic render returned empty output.')
 
       if (this.destroyed || token !== this.renderToken)
         return
 
+      this.infographicInstance?.destroy?.()
+      this.infographicInstance = nextInstance
+      nextInstance = null
       const svg = host.querySelector('svg')
       this.svgMarkup = svg ? svg.outerHTML : ''
       const measuredHeight = host.scrollHeight
@@ -436,13 +482,21 @@ export class InfographicBlockNodeComponent implements AfterViewInit, OnChanges, 
     catch (error) {
       if (this.destroyed || token !== this.renderToken)
         return
-      this.destroyInfographic()
-      this.svgMarkup = ''
-      this.showSource = true
-      this.error = error instanceof Error ? error.message : 'Failed to render infographic.'
-      clearElement(host)
+      nextInstance?.destroy?.()
+      nextInstance = null
+      if (final && !this.resolvedLoading && source === this.code.trim()) {
+        this.destroyInfographic()
+        this.svgMarkup = ''
+        this.showSource = true
+        this.error = error instanceof Error ? error.message : 'Failed to render infographic.'
+        clearElement(host)
+      }
+      else if (previousChildren) {
+        host.replaceChildren(...previousChildren)
+      }
     }
     finally {
+      nextInstance?.destroy?.()
       if (token === this.renderToken) {
         this.rendering = false
         this.cdr.markForCheck()

--- a/packages/markstream-angular/src/index.css
+++ b/packages/markstream-angular/src/index.css
@@ -1505,7 +1505,15 @@ body > div[id^="dmermaid-"] {
 }
 
 .markstream-angular .infographic-render {
+  position: relative;
   width: 100%;
   min-height: 320px;
   overflow: auto;
+}
+
+.markstream-angular .infographic-pending-source {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  margin: 0;
 }

--- a/packages/markstream-octane/src/components/InfographicBlockNode/InfographicBlockNode.tsrx
+++ b/packages/markstream-octane/src/components/InfographicBlockNode/InfographicBlockNode.tsrx
@@ -68,6 +68,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
   }, [baseCode, maxPreviewHeight, props.estimatedPreviewHeightPx])
   const [containerHeight, setContainerHeight] = useState(`${estimatedPreviewHeight}px`)
   const [hasPreview, setHasPreview] = useState(false)
+  const [hasRenderError, setHasRenderError] = useState(false)
 
   // Zoom
   const [zoom, setZoom] = useState(1)
@@ -81,6 +82,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
   const modalCloneWrapperRef = useRef<HTMLElement | null>(null)
   const dragStartRef = useRef({ x: 0, y: 0 })
   const instanceRef = useRef<any>(null)
+  const renderGenerationRef = useRef(0)
   const registerViewport = useViewportPriority()
 
   const resolveContainerHeight = useCallback((actualHeight: number) => {
@@ -131,29 +133,61 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
     if (!containerRef.current)
       return
     const el = containerRef.current
+    const source = baseCode
+    const final = props.loading === false
+    const generation = ++renderGenerationRef.current
+    let nextInstance: any = null
+    let previousChildren: ChildNode[] | null = null
 
     try {
       const InfographicClass = await getInfographic()
-      if (!InfographicClass) {
-        console.warn('Infographic library failed to load.')
+      if (generation !== renderGenerationRef.current || el !== containerRef.current)
         return
-      }
+      if (!InfographicClass)
+        throw new Error('Infographic library failed to load.')
 
-      if (instanceRef.current) {
-        instanceRef.current.destroy?.()
-        instanceRef.current = null
-      }
-
-      el.innerHTML = ''
-
-      const instance = new InfographicClass({
+      previousChildren = Array.from(el.childNodes)
+      nextInstance = new InfographicClass({
         container: el,
         width: '100%',
         height: '100%',
       })
-      instanceRef.current = instance
-      instance.render(baseCode)
+      let renderErrorMessage = ''
+      let renderCompleted = false
+      nextInstance.on?.('error', (error: unknown) => {
+        const errors = Array.isArray(error) ? error : [error]
+        renderErrorMessage = errors
+          .map((item) => {
+            if (item instanceof Error)
+              return item.message
+            if (typeof item === 'string')
+              return item
+            if (item && typeof item === 'object' && 'message' in item)
+              return String((item as { message?: unknown }).message ?? '')
+            return String(item ?? '')
+          })
+          .filter(Boolean)
+          .join('; ')
+      })
+      nextInstance.on?.('rendered', () => {
+        renderCompleted = true
+      })
+      nextInstance.render(source)
+      if (renderErrorMessage)
+        throw new Error(renderErrorMessage)
+      const nextChildren = Array.from(el.childNodes)
+      const replacedChildren = nextChildren.length > 0 && (
+        nextChildren.length !== previousChildren.length
+        || nextChildren.some((child, index) => child !== previousChildren?.[index])
+      )
+      if (!renderCompleted && !replacedChildren)
+        throw new Error('Infographic render returned empty output.')
+
+      instanceRef.current?.destroy?.()
+      instanceRef.current = nextInstance
+      nextInstance = null
       setHasPreview(true)
+      setHasRenderError(false)
 
       // Update height
       setTimeout(() => {
@@ -161,11 +195,26 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
       }, 0)
     }
     catch (error) {
-      console.error('Failed to render infographic:', error)
-      setHasPreview(false)
-      el.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+      if (generation !== renderGenerationRef.current || el !== containerRef.current)
+        return
+      nextInstance?.destroy?.()
+      nextInstance = null
+      if (final && props.loading === false && source === baseCode) {
+        console.error('Failed to render infographic:', error)
+        instanceRef.current?.destroy?.()
+        instanceRef.current = null
+        setHasPreview(false)
+        setHasRenderError(true)
+        el.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+      }
+      else if (previousChildren) {
+        el.replaceChildren(...previousChildren)
+      }
     }
-  }, [baseCode, updateContainerHeight, viewportReady])
+    finally {
+      nextInstance?.destroy?.()
+    }
+  }, [baseCode, props.loading, updateContainerHeight, viewportReady])
 
   useEffect(() => {
     const el = viewportTargetRef.current
@@ -191,6 +240,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
 
   useEffect(() => {
     return () => {
+      renderGenerationRef.current += 1
       if (instanceRef.current) {
         instanceRef.current.destroy?.()
         instanceRef.current = null
@@ -312,7 +362,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
       <div
         ref={viewportTargetRef}
         data-markstream-infographic="1"
-        data-markstream-mode={showSource ? 'source' : hasPreview ? 'preview' : 'pending'}
+        data-markstream-mode={showSource ? 'source' : hasRenderError ? 'error' : hasPreview ? 'preview' : 'pending'}
         className={clsx('my-4 rounded-lg border overflow-hidden shadow-sm', props.isDark ? 'border-gray-700/30' : 'border-gray-200', { 'is-rendering': props.loading })}
       >
         {props.showHeader && (
@@ -470,6 +520,9 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
                       onTouchMove={onMouseMove}
                       onTouchEnd={stopDrag}
                     >
+                      {!hasPreview && !hasRenderError && (
+                        <pre className={clsx('absolute inset-0 overflow-auto p-4 text-left text-sm font-mono whitespace-pre-wrap', props.isDark ? 'text-gray-300' : 'text-gray-700')}>{baseCode}</pre>
+                      )}
                       <div className={clsx('absolute inset-0 cursor-grab', isDragging && 'cursor-grabbing')} style={{ transform: `translate(${translate.x}px, ${translate.y}px) scale(${zoom})` }}>
                         <div ref={containerRef} className="w-full text-center flex items-center justify-center min-h-full" />
                       </div>

--- a/packages/markstream-octane/tests/client/infographic.test.ts
+++ b/packages/markstream-octane/tests/client/infographic.test.ts
@@ -1,0 +1,84 @@
+import { cleanup, render, waitFor } from '@octanejs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InfographicBlockNode } from '../../src/components/InfographicBlockNode/InfographicBlockNode.tsrx'
+
+const mockState = vi.hoisted(() => ({ sources: [] as string[] }))
+
+vi.mock('../../src/components/InfographicBlockNode/infographic', () => ({
+  getInfographic: vi.fn(async () => class FakeInfographic {
+    private container: HTMLElement
+    private errorHandler?: (error: unknown) => void
+    private renderedHandler?: () => void
+
+    constructor(options: { container: HTMLElement }) {
+      this.container = options.container
+    }
+
+    on(event: string, handler: (payload?: unknown) => void) {
+      if (event === 'error')
+        this.errorHandler = handler
+      if (event === 'rendered')
+        this.renderedHandler = handler
+    }
+
+    render(source: string) {
+      mockState.sources.push(source)
+      if (source.includes('invalid')) {
+        this.container.replaceChildren(document.createTextNode('partial'))
+        this.errorHandler?.(new Error('Incomplete streaming options'))
+        return
+      }
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('data-preview', source)
+      this.container.replaceChildren(svg)
+      this.renderedHandler?.()
+    }
+
+    destroy() {}
+  }),
+}))
+
+function node(code: string) {
+  return {
+    type: 'code_block' as const,
+    language: 'infographic',
+    code,
+    raw: `\`\`\`infographic\n${code}\n\`\`\``,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  mockState.sources = []
+  document.body.innerHTML = ''
+})
+
+describe('markstream-octane infographic streaming errors', () => {
+  it('keeps the latest successful preview until a newer render succeeds or the stream finishes', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const view = render(InfographicBlockNode, {
+      props: { node: node('first'), loading: true, showHeader: false },
+    })
+    await waitFor(() => expect(mockState.sources).toContain('first'))
+
+    view.rerender({
+      props: { node: node('second'), loading: true, showHeader: false },
+    })
+    await waitFor(() => expect(mockState.sources).toContain('second'))
+    const secondPreview = view.container.querySelector('svg[data-preview="second"]')
+    expect(secondPreview).not.toBeNull()
+
+    view.rerender({
+      props: { node: node('invalid intermediate'), loading: true, showHeader: false },
+    })
+    await waitFor(() => expect(mockState.sources).toContain('invalid intermediate'))
+    expect(view.container.querySelector('svg[data-preview="second"]')).toBe(secondPreview)
+    expect(view.container.querySelector('[data-markstream-infographic]')?.getAttribute('data-markstream-mode')).toBe('preview')
+
+    view.rerender({
+      props: { node: node('invalid final'), loading: false, showHeader: false },
+    })
+    await waitFor(() => expect(view.container.textContent).toContain('Failed to render infographic: Incomplete streaming options'))
+    expect(view.container.querySelector('[data-markstream-infographic]')?.getAttribute('data-markstream-mode')).toBe('error')
+  })
+})

--- a/packages/markstream-react/src/components/InfographicBlockNode/InfographicBlockNode.tsx
+++ b/packages/markstream-react/src/components/InfographicBlockNode/InfographicBlockNode.tsx
@@ -67,6 +67,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
   }, [baseCode, maxPreviewHeight, props.estimatedPreviewHeightPx])
   const [containerHeight, setContainerHeight] = useState(`${estimatedPreviewHeight}px`)
   const [hasPreview, setHasPreview] = useState(false)
+  const [hasRenderError, setHasRenderError] = useState(false)
 
   // Zoom
   const [zoom, setZoom] = useState(1)
@@ -80,6 +81,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
   const modalCloneWrapperRef = useRef<HTMLElement | null>(null)
   const dragStartRef = useRef({ x: 0, y: 0 })
   const instanceRef = useRef<any>(null)
+  const renderGenerationRef = useRef(0)
   const registerViewport = useViewportPriority()
 
   const resolveContainerHeight = useCallback((actualHeight: number) => {
@@ -130,29 +132,61 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
     if (!containerRef.current)
       return
     const el = containerRef.current
+    const source = baseCode
+    const final = props.loading === false
+    const generation = ++renderGenerationRef.current
+    let nextInstance: any = null
+    let previousChildren: ChildNode[] | null = null
 
     try {
       const InfographicClass = await getInfographic()
-      if (!InfographicClass) {
-        console.warn('Infographic library failed to load.')
+      if (generation !== renderGenerationRef.current || el !== containerRef.current)
         return
-      }
+      if (!InfographicClass)
+        throw new Error('Infographic library failed to load.')
 
-      if (instanceRef.current) {
-        instanceRef.current.destroy?.()
-        instanceRef.current = null
-      }
-
-      el.innerHTML = ''
-
-      const instance = new InfographicClass({
+      previousChildren = Array.from(el.childNodes)
+      nextInstance = new InfographicClass({
         container: el,
         width: '100%',
         height: '100%',
       })
-      instanceRef.current = instance
-      instance.render(baseCode)
+      let renderErrorMessage = ''
+      let renderCompleted = false
+      nextInstance.on?.('error', (error: unknown) => {
+        const errors = Array.isArray(error) ? error : [error]
+        renderErrorMessage = errors
+          .map((item) => {
+            if (item instanceof Error)
+              return item.message
+            if (typeof item === 'string')
+              return item
+            if (item && typeof item === 'object' && 'message' in item)
+              return String((item as { message?: unknown }).message ?? '')
+            return String(item ?? '')
+          })
+          .filter(Boolean)
+          .join('; ')
+      })
+      nextInstance.on?.('rendered', () => {
+        renderCompleted = true
+      })
+      nextInstance.render(source)
+      if (renderErrorMessage)
+        throw new Error(renderErrorMessage)
+      const nextChildren = Array.from(el.childNodes)
+      const replacedChildren = nextChildren.length > 0 && (
+        nextChildren.length !== previousChildren.length
+        || nextChildren.some((child, index) => child !== previousChildren?.[index])
+      )
+      if (!renderCompleted && !replacedChildren)
+        throw new Error('Infographic render returned empty output.')
+
+      instanceRef.current?.destroy?.()
+      instanceRef.current = nextInstance
+      nextInstance = null
       setHasPreview(true)
+      setHasRenderError(false)
 
       // Update height
       setTimeout(() => {
@@ -160,11 +194,26 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
       }, 0)
     }
     catch (error) {
-      console.error('Failed to render infographic:', error)
-      setHasPreview(false)
-      el.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+      if (generation !== renderGenerationRef.current || el !== containerRef.current)
+        return
+      nextInstance?.destroy?.()
+      nextInstance = null
+      if (final && props.loading === false && source === baseCode) {
+        console.error('Failed to render infographic:', error)
+        instanceRef.current?.destroy?.()
+        instanceRef.current = null
+        setHasPreview(false)
+        setHasRenderError(true)
+        el.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+      }
+      else if (previousChildren) {
+        el.replaceChildren(...previousChildren)
+      }
     }
-  }, [baseCode, updateContainerHeight, viewportReady])
+    finally {
+      nextInstance?.destroy?.()
+    }
+  }, [baseCode, props.loading, updateContainerHeight, viewportReady])
 
   useEffect(() => {
     const el = viewportTargetRef.current
@@ -190,6 +239,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
 
   useEffect(() => {
     return () => {
+      renderGenerationRef.current += 1
       if (instanceRef.current) {
         instanceRef.current.destroy?.()
         instanceRef.current = null
@@ -311,7 +361,7 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
       <div
         ref={viewportTargetRef}
         data-markstream-infographic="1"
-        data-markstream-mode={showSource ? 'source' : hasPreview ? 'preview' : 'pending'}
+        data-markstream-mode={showSource ? 'source' : hasRenderError ? 'error' : hasPreview ? 'preview' : 'pending'}
         className={clsx('my-4 rounded-lg border overflow-hidden shadow-sm', props.isDark ? 'border-gray-700/30' : 'border-gray-200', { 'is-rendering': props.loading })}
       >
         {props.showHeader && (
@@ -469,6 +519,9 @@ export function InfographicBlockNode(rawProps: InfographicBlockNodeProps & Infog
                       onTouchMove={onMouseMove}
                       onTouchEnd={stopDrag}
                     >
+                      {!hasPreview && !hasRenderError && (
+                        <pre className={clsx('absolute inset-0 overflow-auto p-4 text-left text-sm font-mono whitespace-pre-wrap', props.isDark ? 'text-gray-300' : 'text-gray-700')}>{baseCode}</pre>
+                      )}
                       <div className={clsx('absolute inset-0 cursor-grab', isDragging && 'cursor-grabbing')} style={{ transform: `translate(${translate.x}px, ${translate.y}px) scale(${zoom})` }}>
                         <div ref={containerRef} className="w-full text-center flex items-center justify-center min-h-full" />
                       </div>

--- a/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
+++ b/packages/markstream-svelte/src/components/InfographicBlockNode.svelte
@@ -55,6 +55,8 @@
   let rendering = $state(false)
   let rerenderQueued = $state(false)
   let rerenderForce = $state(false)
+  let renderScheduled = $state(false)
+  let renderScheduledForce = $state(false)
   let hasPreview = $state(false)
   let copied = $state(false)
   let collapsed = $state(false)
@@ -111,7 +113,16 @@
   function queueInfographicRender(force = false) {
     if (!mounted || !renderHost || collapsed || showSource || !source.trim())
       return
-    void tick().then(() => renderInfographic(force))
+    renderScheduledForce = renderScheduledForce || force
+    if (renderScheduled)
+      return
+    renderScheduled = true
+    void tick().then(() => {
+      renderScheduled = false
+      const forceNext = renderScheduledForce
+      renderScheduledForce = false
+      return renderInfographic(forceNext)
+    })
   }
 
   async function renderInfographic(force = false) {
@@ -128,7 +139,9 @@
       return
     }
 
-    const signature = `${source}\n${resolvedIsDark}\n${final}\n${progressivePreview}`
+    const renderSource = source
+    const renderFinal = final
+    const signature = `${renderSource}\n${resolvedIsDark}\n${renderFinal}\n${progressivePreview}`
     if (!force && signature === lastCompletedRenderSignature && hasPreview)
       return
     if (!force && signature === lastSuppressedErrorSignature)
@@ -148,6 +161,8 @@
     rendering = true
     if (shouldShowError)
       renderError = ''
+    let nextInstance: any = null
+    let previousChildren: ChildNode[] | null = null
 
     try {
       const InfographicClass = await getInfographic()
@@ -155,17 +170,22 @@
         return
       if (!InfographicClass)
         throw new Error('Infographic renderer is not available.')
+      const currentSignature = `${source}\n${resolvedIsDark}\n${final}\n${progressivePreview}`
+      const canRender = signature === currentSignature
+        || (!renderFinal && resolvedLoading && source.startsWith(renderSource))
+      if (!canRender)
+        return
 
-      destroyInstance()
-      clearElement(renderHost)
-      instance = new InfographicClass({
+      previousChildren = Array.from(renderHost.childNodes)
+      nextInstance = new InfographicClass({
         container: renderHost,
         width: '100%',
         height: '100%',
       })
 
       let renderErrorMessage = ''
-      instance.on?.('error', (error: unknown) => {
+      let renderCompleted = false
+      nextInstance.on?.('error', (error: unknown) => {
         const errors = Array.isArray(error) ? error : [error]
         renderErrorMessage = errors
           .map((item) => {
@@ -180,15 +200,24 @@
           .filter(Boolean)
           .join('; ')
       })
+      nextInstance.on?.('rendered', () => {
+        renderCompleted = true
+      })
 
-      instance.render(source)
+      nextInstance.render(renderSource)
       if (renderErrorMessage)
         throw new Error(renderErrorMessage)
-      await tick()
-      if (!mounted || token !== renderToken || collapsed || showSource || !renderHost)
-        return
-      if (!renderHost.querySelector('svg') && !renderHost.childElementCount)
+      const nextChildren = Array.from(renderHost.childNodes)
+      const replacedChildren = nextChildren.length > 0 && (
+        nextChildren.length !== previousChildren.length
+        || nextChildren.some((child, index) => child !== previousChildren?.[index])
+      )
+      if (!renderCompleted && !replacedChildren)
         throw new Error('Infographic render returned empty output.')
+
+      instance?.destroy?.()
+      instance = nextInstance
+      nextInstance = null
       hasPreview = true
       renderError = ''
       lastCompletedRenderSignature = signature
@@ -196,8 +225,11 @@
     }
     catch (error) {
       if (token === renderToken) {
+        nextInstance?.destroy?.()
+        nextInstance = null
         lastCompletedRenderSignature = ''
-        if (shouldShowError) {
+        const currentSignature = `${source}\n${resolvedIsDark}\n${final}\n${progressivePreview}`
+        if (shouldShowError && signature === currentSignature) {
           lastSuppressedErrorSignature = ''
           destroyInstance()
           clearElement(renderHost)
@@ -205,11 +237,15 @@
           renderError = error instanceof Error ? error.message : String(error)
         }
         else {
-          lastSuppressedErrorSignature = signature
+          if (previousChildren && renderHost)
+            renderHost.replaceChildren(...previousChildren)
+          if (signature === currentSignature)
+            lastSuppressedErrorSignature = signature
         }
       }
     }
     finally {
+      nextInstance?.destroy?.()
       if (token === renderToken) {
         rendering = false
         activeRenderSignature = ''
@@ -239,6 +275,8 @@
     rendering = false
     rerenderQueued = false
     rerenderForce = false
+    renderScheduled = false
+    renderScheduledForce = false
     hasPreview = false
     renderError = ''
     activeRenderSignature = ''
@@ -417,6 +455,9 @@
             </div>
           {/if}
           <div class="infographic-render" style={previewStyle}>
+            {#if !hasPreview && !renderError}
+              <pre class="infographic-source-code infographic-pending-source"><code>{source}</code></pre>
+            {/if}
             <div bind:this={renderHost} style={transformStyle}></div>
             {#if renderError}
               <p class="d2-error">{renderError}</p>

--- a/packages/markstream-svelte/src/index.css
+++ b/packages/markstream-svelte/src/index.css
@@ -2121,6 +2121,15 @@ body > div[id^="dmermaid-"] {
   text-align: center;
 }
 
+.markstream-svelte .infographic-pending-source {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: auto;
+  padding: var(--ms-inset-panel-body);
+  text-align: left;
+}
+
 .markstream-svelte .infographic-render > div {
   transition: transform 120ms ease;
 }

--- a/packages/markstream-vue2/src/components/InfographicBlockNode/InfographicBlockNode.vue
+++ b/packages/markstream-vue2/src/components/InfographicBlockNode/InfographicBlockNode.vue
@@ -50,6 +50,8 @@ const isModalOpen = ref(false)
 const modalContent = ref<HTMLElement>()
 const modalCloneWrapper = ref<HTMLElement | null>(null)
 const baseCode = computed(() => props.node.code)
+const hasPreview = ref(false)
+const hasRenderError = ref(false)
 const maxPreviewHeight = computed(() => {
   if (!props.maxHeight || props.maxHeight === 'none')
     return null
@@ -323,59 +325,161 @@ function stopDrag() {
 }
 
 let infographicInstance: any | null = null
+let renderInFlight = false
+let rerenderQueued = false
+let rerenderForce = false
+let renderScheduled = false
+let renderScheduledForce = false
+let lastCompletedRenderSignature = ''
+let unmounted = false
+let renderGeneration = 0
 
-async function renderInfographic() {
-  if (!infographicContainer.value)
+async function renderInfographic(force = false) {
+  if (unmounted || !infographicContainer.value)
     return
+  if (renderInFlight) {
+    rerenderQueued = true
+    rerenderForce = rerenderForce || force
+    return
+  }
+  const signature = baseCode.value
+  if (!force && signature === lastCompletedRenderSignature && hasPreview.value)
+    return
+
+  const source = baseCode.value
+  const final = props.loading === false
+  const generation = ++renderGeneration
+  renderInFlight = true
+  let nextInfographicInstance: any | null = null
+  let previousChildren: ChildNode[] | null = null
 
   try {
     const InfographicClass = await getInfographic()
-    if (!InfographicClass) {
-      console.warn('Infographic library failed to load.')
+    if (unmounted || generation !== renderGeneration)
       return
-    }
+    if (!InfographicClass)
+      throw new Error('Infographic library failed to load.')
+    const container = infographicContainer.value
+    if (!container)
+      return
 
-    // Clear previous instance
-    if (infographicInstance) {
-      infographicInstance.destroy?.()
-      infographicInstance = null
-    }
+    const stillStreaming = props.loading === true
+    const canRender = signature === baseCode.value
+      || (!final && stillStreaming && baseCode.value.startsWith(source))
+    if (!canRender)
+      return
 
-    // Clear container
-    infographicContainer.value.innerHTML = ''
-
-    // Create new instance
-    infographicInstance = new InfographicClass({
-      container: infographicContainer.value,
+    previousChildren = Array.from(container.childNodes)
+    nextInfographicInstance = new InfographicClass({
+      container,
       width: '100%',
       height: '100%',
     })
 
-    // Render the syntax
-    infographicInstance.render(baseCode.value)
+    let renderErrorMessage = ''
+    let renderCompleted = false
+    nextInfographicInstance.on?.('error', (error: unknown) => {
+      const errors = Array.isArray(error) ? error : [error]
+      renderErrorMessage = errors
+        .map((item) => {
+          if (item instanceof Error)
+            return item.message
+          if (typeof item === 'string')
+            return item
+          if (item && typeof item === 'object' && 'message' in item)
+            return String((item as { message?: unknown }).message ?? '')
+          return String(item ?? '')
+        })
+        .filter(Boolean)
+        .join('; ')
+    })
+    nextInfographicInstance.on?.('rendered', () => {
+      renderCompleted = true
+    })
+    nextInfographicInstance.render(source)
+    if (renderErrorMessage)
+      throw new Error(renderErrorMessage)
+    const nextChildren = Array.from(container.childNodes)
+    const replacedChildren = nextChildren.length > 0 && (
+      nextChildren.length !== previousChildren.length
+      || nextChildren.some((child, index) => child !== previousChildren?.[index])
+    )
+    if (!renderCompleted && !replacedChildren)
+      throw new Error('Infographic render returned empty output.')
 
-    // Update container height after render
+    infographicInstance?.destroy?.()
+    infographicInstance = nextInfographicInstance
+    nextInfographicInstance = null
+    hasPreview.value = true
+    hasRenderError.value = false
+    lastCompletedRenderSignature = signature
+
     nextTick(() => {
-      updateContainerHeight()
+      if (!unmounted && generation === renderGeneration)
+        updateContainerHeight()
     })
   }
   catch (error) {
-    console.error('Failed to render infographic:', error)
-    if (infographicContainer.value) {
-      infographicContainer.value.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+    if (unmounted || generation !== renderGeneration)
+      return
+    nextInfographicInstance?.destroy?.()
+    nextInfographicInstance = null
+    if (final && props.loading === false && signature === baseCode.value) {
+      console.error('Failed to render infographic:', error)
+      infographicInstance?.destroy?.()
+      infographicInstance = null
+      hasPreview.value = false
+      hasRenderError.value = true
+      lastCompletedRenderSignature = ''
+      if (infographicContainer.value) {
+        infographicContainer.value.innerHTML = `<div class="text-red-500 p-4">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
+      }
+    }
+    else if (previousChildren && infographicContainer.value) {
+      infographicContainer.value.replaceChildren(...previousChildren)
     }
   }
+  finally {
+    nextInfographicInstance?.destroy?.()
+    renderInFlight = false
+    if (!unmounted && generation === renderGeneration && rerenderQueued) {
+      const forceNext = rerenderForce
+      rerenderQueued = false
+      rerenderForce = false
+      queueInfographicRender(forceNext)
+    }
+  }
+}
+
+function queueInfographicRender(force = false) {
+  if (unmounted || showSource.value || isCollapsed.value)
+    return
+  renderScheduledForce = renderScheduledForce || force
+  if (renderScheduled)
+    return
+  renderScheduled = true
+  nextTick(() => {
+    renderScheduled = false
+    const forceNext = renderScheduledForce
+    renderScheduledForce = false
+    if (!unmounted)
+      void renderInfographic(forceNext)
+  })
 }
 
 // Watch for code changes
 watch(
   () => baseCode.value,
   () => {
-    if (!showSource.value && !isCollapsed.value) {
-      nextTick(() => {
-        renderInfographic()
-      })
-    }
+    queueInfographicRender(true)
+  },
+)
+
+watch(
+  () => props.loading,
+  (loading, prev) => {
+    if (prev && !loading)
+      queueInfographicRender(true)
   },
 )
 
@@ -383,11 +487,8 @@ watch(
 watch(
   () => showSource.value,
   (isSource) => {
-    if (!isSource && !isCollapsed.value) {
-      nextTick(() => {
-        renderInfographic()
-      })
-    }
+    if (!isSource)
+      queueInfographicRender(true)
   },
 )
 
@@ -395,34 +496,29 @@ watch(
 watch(
   () => isCollapsed.value,
   (collapsed) => {
-    if (!collapsed && !showSource.value) {
-      nextTick(() => {
-        renderInfographic()
-      })
-    }
+    if (!collapsed)
+      queueInfographicRender()
   },
 )
 
 watch(
   () => props.maxHeight,
   () => {
-    if (!showSource.value && !isCollapsed.value) {
-      nextTick(() => {
-        renderInfographic()
-      })
-    }
+    nextTick(updateContainerHeight)
   },
 )
 
 onMounted(() => {
-  if (!showSource.value && !isCollapsed.value) {
-    nextTick(() => {
-      renderInfographic()
-    })
-  }
+  queueInfographicRender()
 })
 
 onBeforeUnmount(() => {
+  unmounted = true
+  renderGeneration += 1
+  rerenderQueued = false
+  rerenderForce = false
+  renderScheduled = false
+  renderScheduledForce = false
   if (infographicInstance) {
     infographicInstance.destroy?.()
     infographicInstance = null
@@ -461,7 +557,7 @@ watch(
 <template>
   <div
     data-markstream-infographic="1"
-    :data-markstream-mode="showSource ? 'source' : infographicInstance ? 'preview' : 'pending'"
+    :data-markstream-mode="showSource ? 'source' : hasRenderError ? 'error' : hasPreview ? 'preview' : 'pending'"
     class="my-4 rounded-lg border overflow-hidden shadow-sm"
     :class="[
       props.isDark ? 'border-gray-700/30' : 'border-gray-200',
@@ -636,6 +732,10 @@ watch(
           @touchmove.passive="onDrag"
           @touchend.passive="stopDrag"
         >
+          <pre
+            v-if="!hasPreview && !hasRenderError"
+            class="absolute inset-0 overflow-auto p-4 text-left text-sm font-mono whitespace-pre-wrap"
+          >{{ baseCode }}</pre>
           <div
             class="absolute inset-0 cursor-grab"
             :class="{ 'cursor-grabbing': isDragging }"

--- a/src/components/InfographicBlockNode/InfographicBlockNode.vue
+++ b/src/components/InfographicBlockNode/InfographicBlockNode.vue
@@ -411,6 +411,8 @@ let infographicInstance: any | null = null
 let renderInFlight = false
 let rerenderQueued = false
 let rerenderForce = false
+let renderScheduled = false
+let renderScheduledForce = false
 let lastCompletedRenderSignature = ''
 let unmounted = false
 let renderGeneration = 0
@@ -433,45 +435,40 @@ async function renderInfographic(force = false) {
   if (!force && signature === lastCompletedRenderSignature && hasPreview.value)
     return
 
+  const source = baseCode.value
   const final = props.loading === false
   const generation = ++renderGeneration
   renderInFlight = true
   markLifecyclePending()
-  const previousHtml = infographicContainer.value.innerHTML
-  const previousHasPreview = hasPreview.value
-  const previousHasRenderError = hasRenderError.value
-  hasRenderError.value = false
+  let nextInfographicInstance: any | null = null
+  let previousChildren: ChildNode[] | null = null
 
   try {
     const InfographicClass = await getInfographic()
     if (!isCurrentRender(generation))
       return
-    if (!InfographicClass) {
-      console.warn('Infographic library failed to load.')
-      return
-    }
+    if (!InfographicClass)
+      throw new Error('Infographic library failed to load.')
     const container = infographicContainer.value
     if (!container)
       return
 
-    // Clear previous instance
-    if (infographicInstance) {
-      infographicInstance.destroy?.()
-      infographicInstance = null
-    }
+    const stillStreaming = props.loading === true
+    const canRender = signature === renderSignature.value
+      || (!final && stillStreaming && baseCode.value.startsWith(source))
+    if (!canRender)
+      return
 
-    // Clear container
-    container.innerHTML = ''
-
-    // Create new instance
-    infographicInstance = new InfographicClass({
+    previousChildren = Array.from(container.childNodes)
+    nextInfographicInstance = new InfographicClass({
       container,
       width: '100%',
       height: '100%',
     })
 
     let renderErrorMessage = ''
-    infographicInstance.on?.('error', (error: unknown) => {
+    let renderCompleted = false
+    nextInfographicInstance.on?.('error', (error: unknown) => {
       const errors = Array.isArray(error) ? error : [error]
       renderErrorMessage = errors
         .map((item) => {
@@ -486,13 +483,25 @@ async function renderInfographic(force = false) {
         .filter(Boolean)
         .join('; ')
     })
+    nextInfographicInstance.on?.('rendered', () => {
+      renderCompleted = true
+    })
 
     // Render the syntax
-    infographicInstance.render(baseCode.value)
+    nextInfographicInstance.render(source)
     if (renderErrorMessage)
       throw new Error(renderErrorMessage)
-    if (!container.childNodes.length)
+    const nextChildren = Array.from(container.childNodes)
+    const replacedChildren = nextChildren.length > 0 && (
+      nextChildren.length !== previousChildren.length
+      || nextChildren.some((child, index) => child !== previousChildren?.[index])
+    )
+    if (!renderCompleted && !replacedChildren)
       throw new Error('Infographic render returned empty output.')
+
+    infographicInstance?.destroy?.()
+    infographicInstance = nextInfographicInstance
+    nextInfographicInstance = null
     hasPreview.value = true
     hasRenderError.value = false
     lastCompletedRenderSignature = signature
@@ -506,8 +515,12 @@ async function renderInfographic(force = false) {
   catch (error) {
     if (!isCurrentRender(generation))
       return
+    nextInfographicInstance?.destroy?.()
+    nextInfographicInstance = null
     if (final && props.loading === false && signature === renderSignature.value) {
       console.error('Failed to render infographic:', error)
+      infographicInstance?.destroy?.()
+      infographicInstance = null
       hasPreview.value = false
       hasRenderError.value = true
       lastCompletedRenderSignature = ''
@@ -515,15 +528,12 @@ async function renderInfographic(force = false) {
         infographicContainer.value.innerHTML = `<div style="padding: var(--ms-inset-panel-body); color: hsl(var(--ms-destructive))">Failed to render infographic: ${error instanceof Error ? error.message : 'Unknown error'}</div>`
       }
     }
-    else {
-      hasPreview.value = previousHasPreview
-      hasRenderError.value = previousHasRenderError
-      if (previousHasPreview && infographicContainer.value) {
-        infographicContainer.value.innerHTML = previousHtml
-      }
+    else if (previousChildren && infographicContainer.value) {
+      infographicContainer.value.replaceChildren(...previousChildren)
     }
   }
   finally {
+    nextInfographicInstance?.destroy?.()
     renderInFlight = false
     if (isCurrentRender(generation)) {
       if (rerenderQueued) {
@@ -544,9 +554,16 @@ async function renderInfographic(force = false) {
 function queueInfographicRender(force = false) {
   if (unmounted || !viewportReady.value || showSource.value || isCollapsed.value)
     return
+  renderScheduledForce = renderScheduledForce || force
+  if (renderScheduled)
+    return
+  renderScheduled = true
   nextTick(() => {
+    renderScheduled = false
+    const forceNext = renderScheduledForce
+    renderScheduledForce = false
     if (!unmounted)
-      void renderInfographic(force)
+      void renderInfographic(forceNext)
   })
 }
 
@@ -621,6 +638,8 @@ onBeforeUnmount(() => {
   renderGeneration += 1
   rerenderQueued = false
   rerenderForce = false
+  renderScheduled = false
+  renderScheduledForce = false
   viewportHandle.value?.destroy()
   viewportHandle.value = null
   clearLifecyclePending()

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5230,10 +5230,10 @@ const InfographicBlockNodeInnerAsync = defineAsyncComponent({
     }
     catch (e) {
       console.warn(
-        '[markstream-vue] Failed to load InfographicBlockNode. Falling back to preformatted code rendering. To enable Infographic rendering, install "@antv/infographic" and configure setInfographicLoader with a dynamic loader.',
+        '[markstream-vue] Failed to load InfographicBlockNode. Showing the Infographic source fallback. To enable Infographic rendering, install "@antv/infographic" and configure setInfographicLoader with a dynamic loader.',
         e,
       )
-      return PreCodeNode
+      return InfographicBlockNodeLoading
     }
   },
   loadingComponent: InfographicBlockNodeLoading,

--- a/test/infographic-loading-fallback.test.ts
+++ b/test/infographic-loading-fallback.test.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { flushAll } from './setup/flush-all'
+
+afterEach(() => {
+  vi.doUnmock('../src/components/InfographicBlockNode')
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('infographic async loading fallback', () => {
+  it('keeps the Infographic shell when the component chunk fails to load', async () => {
+    vi.doMock('../src/components/InfographicBlockNode', () => {
+      throw new Error('chunk failed')
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const MarkdownRender = (await import('../src/components/NodeRenderer')).default
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: `\`\`\`infographic
+infographic list-row-simple-horizontal-arrow
+data
+  items
+    - label: Step 1
+      desc: Start
+\`\`\``,
+        final: true,
+        batchRendering: false,
+        viewportPriority: false,
+      },
+    })
+
+    await flushAll()
+
+    const fallback = wrapper.get('[data-markstream-infographic="1"]')
+    expect(fallback.attributes('data-markstream-mode')).toBe('pending')
+    expect(fallback.get('.infographic-block-header').text()).toContain('Infographic')
+    expect(fallback.get('.infographic-pending-source').text()).toContain('list-row-simple-horizontal-arrow')
+
+    wrapper.unmount()
+  })
+})

--- a/test/infographic-streaming-error.test.ts
+++ b/test/infographic-streaming-error.test.ts
@@ -95,6 +95,72 @@ describe('infographicBlockNode streaming errors', () => {
     wrapper.unmount()
   })
 
+  it('keeps the last successful preview across intermediate failures and commits the final result', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+    const previousPreviewVisibleDuringFailure = vi.fn()
+    let wrapper: ReturnType<typeof mount>
+
+    class StatefulInfographic {
+      private container: HTMLElement
+      private errorHandler?: (error: unknown) => void
+
+      constructor(options: { container: HTMLElement }) {
+        this.container = options.container
+      }
+
+      on(event: string, handler: (error: unknown) => void) {
+        if (event === 'error')
+          this.errorHandler = handler
+      }
+
+      render(source: string) {
+        if (source.includes('invalid')) {
+          previousPreviewVisibleDuringFailure(wrapper.find('svg[data-preview="second"]').exists())
+          this.errorHandler?.(new Error('Incomplete streaming options'))
+          return
+        }
+        const preview = source.includes('second') ? 'second' : 'first'
+        this.container.innerHTML = `<svg data-preview="${preview}"></svg>`
+      }
+
+      destroy() {}
+    }
+
+    setInfographicLoader(() => StatefulInfographic)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    wrapper = mount(InfographicBlockNode as any, {
+      props: {
+        node: createNode('first'),
+        loading: true,
+      },
+    })
+    await flushAll()
+    expect(wrapper.find('svg[data-preview="first"]').exists()).toBe(true)
+
+    await wrapper.setProps({ node: createNode('second') })
+    await flushAll()
+    expect(wrapper.find('svg[data-preview="second"]').exists()).toBe(true)
+
+    await wrapper.setProps({ node: createNode('invalid intermediate') })
+    await flushAll()
+    expect(previousPreviewVisibleDuringFailure).toHaveBeenLastCalledWith(true)
+    expect(wrapper.attributes('data-markstream-mode')).toBe('preview')
+    expect(wrapper.find('svg[data-preview="second"]').exists()).toBe(true)
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    await wrapper.setProps({
+      node: createNode('invalid final'),
+      loading: false,
+    })
+    await flushAll()
+    expect(wrapper.attributes('data-markstream-mode')).toBe('error')
+    expect(wrapper.find('.infographic-preview svg').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Failed to render infographic: Incomplete streaming options')
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
   it('does not report an in-flight streaming failure after loading settles', async () => {
     vi.stubGlobal('IntersectionObserver', undefined as any)
 
@@ -214,9 +280,9 @@ describe('infographicBlockNode streaming errors', () => {
           this.errorHandler = handler
       }
 
-      render() {
+      render(source: string) {
         renderCount++
-        if (renderCount === 1) {
+        if (source === 'first') {
           this.errorHandler?.(new Error('Stale final source'))
           return
         }
@@ -241,7 +307,7 @@ describe('infographicBlockNode streaming errors', () => {
     resolveLoader?.(SourceRaceInfographic)
     await flushAll()
 
-    expect(renderCount).toBe(2)
+    expect(renderCount).toBe(1)
     expect(errorSpy).not.toHaveBeenCalled()
     expect(wrapper.text()).not.toContain('Failed to render infographic')
     expect(wrapper.find('svg[data-infographic="latest"]').exists()).toBe(true)

--- a/test/react-heavy-node-viewport-priority.test.tsx
+++ b/test/react-heavy-node-viewport-priority.test.tsx
@@ -166,9 +166,17 @@ describe('markstream-react heavy-node viewport priority', () => {
     const render = vi.fn()
     vi.doMock('../packages/markstream-react/src/components/InfographicBlockNode/infographic', () => ({
       getInfographic: vi.fn(async () => class FakeInfographic {
-        constructor(_options: any) {}
+        private container: HTMLElement
 
-        render = render
+        constructor(options: { container: HTMLElement }) {
+          this.container = options.container
+        }
+
+        render = (source: string) => {
+          render(source)
+          this.container.innerHTML = '<svg data-infographic="1"></svg>'
+        }
+
         destroy() {}
       }),
     }))

--- a/test/react-infographic-streaming-error.test.tsx
+++ b/test/react-infographic-streaming-error.test.tsx
@@ -1,0 +1,96 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function node(code: string) {
+  return {
+    type: 'code_block',
+    language: 'infographic',
+    code,
+    raw: `\`\`\`infographic\n${code}\n\`\`\``,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = false
+})
+
+describe('markstream-react infographic streaming errors', () => {
+  it('keeps the latest successful preview until a newer render succeeds or the stream finishes', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined as any)
+    ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    class FakeInfographic {
+      private container: HTMLElement
+      private errorHandler?: (error: unknown) => void
+      private renderedHandler?: () => void
+
+      constructor(options: { container: HTMLElement }) {
+        this.container = options.container
+      }
+
+      on(event: string, handler: (payload?: unknown) => void) {
+        if (event === 'error')
+          this.errorHandler = handler
+        if (event === 'rendered')
+          this.renderedHandler = handler
+      }
+
+      render(source: string) {
+        if (source.includes('invalid')) {
+          this.container.replaceChildren(document.createTextNode('partial'))
+          this.errorHandler?.(new Error('Incomplete streaming options'))
+          return
+        }
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+        svg.setAttribute('data-preview', source)
+        this.container.replaceChildren(svg)
+        this.renderedHandler?.()
+      }
+
+      destroy() {}
+    }
+
+    vi.doMock('../packages/markstream-react/src/components/InfographicBlockNode/infographic', () => ({
+      getInfographic: vi.fn(async () => FakeInfographic),
+    }))
+
+    const { InfographicBlockNode } = await import('../packages/markstream-react/src/components/InfographicBlockNode/InfographicBlockNode')
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const render = async (code: string, loading: boolean) => {
+      await act(async () => {
+        root.render(<InfographicBlockNode node={node(code) as any} loading={loading} showHeader={false} />)
+      })
+      await flushReact()
+    }
+
+    await render('first', true)
+    await render('second', true)
+    const secondPreview = host.querySelector('svg[data-preview="second"]')
+    expect(secondPreview).not.toBeNull()
+
+    await render('invalid intermediate', true)
+    expect(host.querySelector('svg[data-preview="second"]')).toBe(secondPreview)
+    expect(host.querySelector('[data-markstream-infographic]')?.getAttribute('data-markstream-mode')).toBe('preview')
+
+    await render('invalid final', false)
+    expect(host.textContent).toContain('Failed to render infographic: Incomplete streaming options')
+    expect(host.querySelector('[data-markstream-infographic]')?.getAttribute('data-markstream-mode')).toBe('error')
+
+    await act(async () => root.unmount())
+  })
+})


### PR DESCRIPTION
## Summary

- keep the Infographic shell and styled raw source fallback while the renderer loads
- preserve the latest successful preview when an intermediate streaming frame fails
- commit every successful intermediate frame and converge on final success or error
- apply the same atomic render behavior to Vue 3, Vue 2, React, Octane, Angular, and Svelte
- rely on `@antv/infographic` internal completeness check and atomic DOM replacement instead of a second parse or offscreen DOM render
- coalesce same-tick source/loading updates to avoid duplicate rendering
- add React and Octane regression coverage for success → success → intermediate failure → final failure
- sync generated LLM docs with the current package version required by CI

## Verification

- `pnpm exec vitest run` — 334 files, 2955 tests passed
- `pnpm --filter markstream-octane test:client` — 7 files, 42 tests passed
- React, Octane, Angular, and Svelte package typechecks passed
- `pnpm --filter markstream-vue2 build` passed, including DTS and dist validation
- `pnpm lint` passed
- playground actual `@antv/infographic` preview check