### PR TITLE
fix(code-block): stop settled diff repainting during streams

### DIFF
--- a/docs/zh/guide/showcase.md
+++ b/docs/zh/guide/showcase.md
@@ -1,3 +1,11 @@
+---
+title: Showcase（占位）
+description: markstream 流式 Markdown 渲染器的示例与场景演示占位页，覆盖流式对话、长文档、代码评审、图表、自定义组件与安全复现流程，等待与英文版同步。
+keywords:
+  - markstream showcase
+  - 流式 markdown 演示
+---
+
 # Showcase（中文占位）
 
 > 原文节选（仅供翻译参考）：

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -1962,7 +1962,8 @@ const listBindings = computed(() => ({
   ...(typeof props.showTooltips === 'boolean' ? { showTooltips: props.showTooltips } : {}),
 }))
 const legacyRenderedItems = computed(() => {
-  return legacyNodeItems.value.map((node, index) => {
+  return legacyNodeItems.value.map((item, index) => {
+    const node = getCodeBlockRenderNode(item, index)
     const language = getCodeBlockLanguage(node)
     let resolvedNode = node
     let component = getNodeComponent(node, language)
@@ -2108,6 +2109,8 @@ function getCodeBlockRenderNode(node: ParsedNode, index: number) {
     codeBlockNode.raw,
     codeBlockNode.startLine,
     codeBlockNode.endLine,
+    codeBlockNode.sourceMap?.startLine,
+    codeBlockNode.sourceMap?.endLine,
   ] as const
 
   const cached = codeBlockRenderCache[index]

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -517,7 +517,14 @@ const nodeVisibilityState = reactive<Record<number, boolean>>({})
 const nodeVisibilityHandles = new Map<number, VisibilityHandle>()
 const nodeVisibilityFallbackTimers = new Map<number, number>()
 const nodeSlotElements = new Map<number, HTMLElement | null>()
-const codeBlockRenderCache = new Map<number, { signature: string, node: ParsedNode }>()
+const codeBlockRenderCache: Array<{ signature: readonly unknown[], node: ParsedNode } | undefined> = []
+watch(
+  () => parsedNodes.value.length,
+  (length) => {
+    if (codeBlockRenderCache.length > length)
+      codeBlockRenderCache.length = length
+  },
+)
 const nodeSlotVersion = ref(0)
 const sortedNodeSlots = computed(() => {
   // Track a manual version so we only rebuild when slots change.
@@ -2085,26 +2092,30 @@ const renderedItems = computed(() => {
 })
 
 function getCodeBlockRenderNode(node: ParsedNode, index: number) {
-  if (node.type !== 'code_block')
+  if (node.type !== 'code_block') {
+    codeBlockRenderCache[index] = undefined
     return node
+  }
 
   const codeBlockNode = node as any
   const signature = [
-    String(codeBlockNode.language ?? ''),
-    String(codeBlockNode.loading ?? ''),
-    String(codeBlockNode.diff ?? ''),
-    String(codeBlockNode.code ?? ''),
-    String(codeBlockNode.originalCode ?? ''),
-    String(codeBlockNode.updatedCode ?? ''),
-    String(codeBlockNode.raw ?? ''),
-  ].join('\u0000')
+    codeBlockNode.language,
+    codeBlockNode.loading,
+    codeBlockNode.diff,
+    codeBlockNode.code,
+    codeBlockNode.originalCode,
+    codeBlockNode.updatedCode,
+    codeBlockNode.raw,
+    codeBlockNode.startLine,
+    codeBlockNode.endLine,
+  ] as const
 
-  const cached = codeBlockRenderCache.get(index)
-  if (cached && cached.signature === signature)
+  const cached = codeBlockRenderCache[index]
+  if (cached && signature.every((value, signatureIndex) => value === cached.signature[signatureIndex]))
     return cached.node
 
   const cloned = { ...codeBlockNode } as ParsedNode
-  codeBlockRenderCache.set(index, { signature, node: cloned })
+  codeBlockRenderCache[index] = { signature, node: cloned }
   return cloned
 }
 

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -517,7 +517,7 @@ const nodeVisibilityState = reactive<Record<number, boolean>>({})
 const nodeVisibilityHandles = new Map<number, VisibilityHandle>()
 const nodeVisibilityFallbackTimers = new Map<number, number>()
 const nodeSlotElements = new Map<number, HTMLElement | null>()
-const codeBlockRenderCache = new WeakMap<object, { signature: string, node: ParsedNode }>()
+const codeBlockRenderCache = new Map<number, { signature: string, node: ParsedNode }>()
 const nodeSlotVersion = ref(0)
 const sortedNodeSlots = computed(() => {
   // Track a manual version so we only rebuild when slots change.
@@ -2023,7 +2023,7 @@ const legacyStructuredContentMode = computed(() => {
 })
 const renderedItems = computed(() => {
   return visibleNodes.value.map((item) => {
-    let node = getCodeBlockRenderNode(item.node)
+    let node = getCodeBlockRenderNode(item.node, item.index)
     const language = getCodeBlockLanguage(node)
     let component = getNodeComponent(node, language)
 
@@ -2084,7 +2084,7 @@ const renderedItems = computed(() => {
   })
 })
 
-function getCodeBlockRenderNode(node: ParsedNode) {
+function getCodeBlockRenderNode(node: ParsedNode, index: number) {
   if (node.type !== 'code_block')
     return node
 
@@ -2099,12 +2099,12 @@ function getCodeBlockRenderNode(node: ParsedNode) {
     String(codeBlockNode.raw ?? ''),
   ].join('\u0000')
 
-  const cached = codeBlockRenderCache.get(codeBlockNode)
+  const cached = codeBlockRenderCache.get(index)
   if (cached && cached.signature === signature)
     return cached.node
 
   const cloned = { ...codeBlockNode } as ParsedNode
-  codeBlockRenderCache.set(codeBlockNode, { signature, node: cloned })
+  codeBlockRenderCache.set(index, { signature, node: cloned })
   return cloned
 }
 

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -2921,6 +2921,7 @@ async function runEditorCreation(el: HTMLElement) {
   clearInlineFoldProxies()
   resetEditorHost(el)
   syncStreamDiffsRuntimeOptions()
+  await syncStreamDiffsWorkerTheme(resolveWorkerPoolTheme())
   if (isUnmounted)
     return
 
@@ -2976,10 +2977,6 @@ async function runEditorCreation(el: HTMLElement) {
   }
 
   syncFallbackFontMetricsFromEditor()
-
-  // stream-diffs keeps its theme on each mounted surface. Apply the requested
-  // theme after this surface exists so the initial frame matches props.isDark.
-  await themeUpdate()
 
   if (!isExpanded.value && !isCollapsed.value)
     syncEditorHostHeight(false)

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -102,6 +102,7 @@ const editorRuntimeCreated = ref(false)
 const editorMounted = ref(false)
 const runtimeReady = ref(false)
 let isUnmounted = false
+let pendingThemeUpdate = false
 let expandRafId: number | null = null
 let deferredHeightSyncRafId: number | null = null
 let deferredHeightSyncFollowUpRafId: number | null = null
@@ -2903,6 +2904,7 @@ async function runEditorCreation(el: HTMLElement) {
   if (!createEditor || isUnmounted)
     return
 
+  pendingThemeUpdate = false
   const creationKind = desiredEditorKind.value
   diffEditorCreatedWhileStreaming = false
   editorCreationFailed.value = false
@@ -2977,6 +2979,13 @@ async function runEditorCreation(el: HTMLElement) {
   }
 
   syncFallbackFontMetricsFromEditor()
+
+  if (pendingThemeUpdate) {
+    pendingThemeUpdate = false
+    await themeUpdate()
+    if (isUnmounted)
+      return
+  }
 
   if (!isExpanded.value && !isCollapsed.value)
     syncEditorHostHeight(false)
@@ -3557,10 +3566,17 @@ watch(
 
 watch(
   () => [resolveRequestedTheme(), effectiveDiffAppearance.value, runtimeReady.value, editorCreated.value, viewportReady.value] as const,
-  ([theme], previous) => {
-    if (!runtimeReady.value || !editorMounted.value || !viewportReady.value)
+  ([theme, appearance], previous) => {
+    if (!runtimeReady.value || !viewportReady.value)
       return
     const sameRequestedTheme = previous != null && isSameRequestedTheme(theme, previous[0])
+    const appearanceChanged = previous != null && appearance !== previous[1]
+    if (!editorMounted.value) {
+      if (!sameRequestedTheme || appearanceChanged)
+        pendingThemeUpdate = true
+      return
+    }
+    pendingThemeUpdate = false
     void themeUpdate({ appearanceOnly: sameRequestedTheme })
   },
   { flush: 'post' },

--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -2980,7 +2980,7 @@ async function runEditorCreation(el: HTMLElement) {
 
   syncFallbackFontMetricsFromEditor()
 
-  if (pendingThemeUpdate) {
+  while (pendingThemeUpdate) {
     pendingThemeUpdate = false
     await themeUpdate()
     if (isUnmounted)

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -105,6 +105,8 @@ type RuntimeCodeBlockNode = ParsedNode & {
   originalCode?: string
   updatedCode?: string
   raw?: string
+  startLine?: number
+  endLine?: number
 }
 type RuntimeHtmlNode = ParsedNode & {
   type: 'html_block' | 'html_inline'
@@ -896,7 +898,14 @@ const nodeSlotElements = new Map<number, HTMLElement | null>()
 const nodeContentResizeObserverTargets = new Map<number, HTMLElement>()
 const nodeContentResizeObserverIndexes = new WeakMap<Element, number>()
 let nodeContentResizeObserver: ResizeObserver | null = null
-const codeBlockRenderCache = new Map<number, { signature: string, node: ParsedNode }>()
+const codeBlockRenderCache: Array<{ signature: readonly unknown[], node: ParsedNode } | undefined> = []
+watch(
+  () => parsedNodes.value.length,
+  (length) => {
+    if (codeBlockRenderCache.length > length)
+      codeBlockRenderCache.length = length
+  },
+)
 // Height signatures per node index, stored in a flat array so stale-range
 // scans can start at the parser's dirty start instead of walking the whole
 // measured set on every streaming commit. `undefined` = no signature yet.
@@ -5404,26 +5413,30 @@ const tableBindings = computed(() => ({
 }))
 
 function getCodeBlockRenderNode(node: ParsedNode, index: number) {
-  if (node.type !== 'code_block')
+  if (node.type !== 'code_block') {
+    codeBlockRenderCache[index] = undefined
     return node
+  }
 
   const codeBlockNode = node as RuntimeCodeBlockNode
   const signature = [
-    String(codeBlockNode.language ?? ''),
-    String(codeBlockNode.loading ?? ''),
-    String(codeBlockNode.diff ?? ''),
-    String(codeBlockNode.code ?? ''),
-    String(codeBlockNode.originalCode ?? ''),
-    String(codeBlockNode.updatedCode ?? ''),
-    String(codeBlockNode.raw ?? ''),
-  ].join('\u0000')
+    codeBlockNode.language,
+    codeBlockNode.loading,
+    codeBlockNode.diff,
+    codeBlockNode.code,
+    codeBlockNode.originalCode,
+    codeBlockNode.updatedCode,
+    codeBlockNode.raw,
+    codeBlockNode.startLine,
+    codeBlockNode.endLine,
+  ] as const
 
-  const cached = codeBlockRenderCache.get(index)
-  if (cached && cached.signature === signature)
+  const cached = codeBlockRenderCache[index]
+  if (cached && signature.every((value, signatureIndex) => value === cached.signature[signatureIndex]))
     return cached.node
 
   const cloned = { ...codeBlockNode } as ParsedNode
-  codeBlockRenderCache.set(index, { signature, node: cloned })
+  codeBlockRenderCache[index] = { signature, node: cloned }
   return cloned
 }
 

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -896,7 +896,7 @@ const nodeSlotElements = new Map<number, HTMLElement | null>()
 const nodeContentResizeObserverTargets = new Map<number, HTMLElement>()
 const nodeContentResizeObserverIndexes = new WeakMap<Element, number>()
 let nodeContentResizeObserver: ResizeObserver | null = null
-const codeBlockRenderCache = new WeakMap<object, { signature: string, node: ParsedNode }>()
+const codeBlockRenderCache = new Map<number, { signature: string, node: ParsedNode }>()
 // Height signatures per node index, stored in a flat array so stale-range
 // scans can start at the parser's dirty start instead of walking the whole
 // measured set on every streaming commit. `undefined` = no signature yet.
@@ -5403,7 +5403,7 @@ const tableBindings = computed(() => ({
   ...(typeof resolvedShowTooltips.value === 'boolean' ? { showTooltips: resolvedShowTooltips.value } : {}),
 }))
 
-function getCodeBlockRenderNode(node: ParsedNode) {
+function getCodeBlockRenderNode(node: ParsedNode, index: number) {
   if (node.type !== 'code_block')
     return node
 
@@ -5418,12 +5418,12 @@ function getCodeBlockRenderNode(node: ParsedNode) {
     String(codeBlockNode.raw ?? ''),
   ].join('\u0000')
 
-  const cached = codeBlockRenderCache.get(codeBlockNode)
+  const cached = codeBlockRenderCache.get(index)
   if (cached && cached.signature === signature)
     return cached.node
 
   const cloned = { ...codeBlockNode } as ParsedNode
-  codeBlockRenderCache.set(codeBlockNode, { signature, node: cloned })
+  codeBlockRenderCache.set(index, { signature, node: cloned })
   return cloned
 }
 
@@ -5555,7 +5555,7 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }) {
 
   // Reuse the previous shallow clone for code blocks unless the visible
   // payload changed, so parent recomputations do not churn stream-diffs props.
-  let node = getCodeBlockRenderNode(item.node)
+  let node = getCodeBlockRenderNode(item.node, item.index)
   const language = getCodeBlockLanguage(node)
   let component = getNodeComponent(node, language)
 

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5429,6 +5429,8 @@ function getCodeBlockRenderNode(node: ParsedNode, index: number) {
     codeBlockNode.raw,
     codeBlockNode.startLine,
     codeBlockNode.endLine,
+    codeBlockNode.sourceMap?.startLine,
+    codeBlockNode.sourceMap?.endLine,
   ] as const
 
   const cached = codeBlockRenderCache[index]

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -799,6 +799,44 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
+  it('applies the latest theme when it changes again during queued theme sync', async () => {
+    const workerThemeResolvers: Array<() => void> = []
+    const setRenderOptions = vi.fn(() => new Promise<void>((resolve) => {
+      workerThemeResolvers.push(resolve)
+    }))
+    setStreamDiffsWorkerPool({ setRenderOptions })
+    const runtime = helpers()
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+        isDark: true,
+        darkTheme: 'queued-surface-dark',
+        lightTheme: 'queued-surface-light',
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(setRenderOptions).toHaveBeenCalledTimes(1))
+
+    await wrapper.setProps({ isDark: false })
+    workerThemeResolvers[0]!()
+    await vi.waitFor(() => expect(setRenderOptions).toHaveBeenCalledTimes(2))
+
+    await wrapper.setProps({ isDark: true })
+    workerThemeResolvers[1]!()
+    await vi.waitFor(() => expect(setRenderOptions).toHaveBeenCalledTimes(3))
+    workerThemeResolvers[2]!()
+
+    await vi.waitFor(() => expect(runtime.setTheme).toHaveBeenLastCalledWith('queued-surface-dark'))
+    expect(runtime.createEditor).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
   it('creates one FileDiff surface only after a visible diff completes', async () => {
     const runtime = helpers()
     const diffNode = {

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -731,7 +731,7 @@ describe('codeBlockNode final Diffs gate', () => {
     wrapper.unmount()
   })
 
-  it('applies the active theme after a visible File surface mounts', async () => {
+  it('passes the active theme when creating a visible File surface', async () => {
     const runtime = helpers()
     const wrapper = mount(DeferredCodeBlockNode, {
       props: {
@@ -748,11 +748,11 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
     observers.at(-1)?.emit()
     await vi.waitFor(() => {
+      expect(runtime.createCodeBlockRuntime.mock.calls[0]?.[0]?.theme).toBe('initial-surface-dark')
       expect(runtime.createEditor).toHaveBeenCalledTimes(1)
-      expect(runtime.setTheme).toHaveBeenCalledWith('initial-surface-dark')
     })
+    expect(runtime.setTheme).not.toHaveBeenCalled()
 
-    runtime.setTheme.mockClear()
     await wrapper.setProps({ isDark: false })
     await vi.waitFor(() => {
       expect(runtime.setTheme).toHaveBeenCalledWith('initial-surface-light')
@@ -889,6 +889,7 @@ describe('codeBlockNode final Diffs gate', () => {
     await flush()
     observers.at(-1)?.emit()
     await vi.waitFor(() => expect(runtime.createDiffEditor).toHaveBeenCalledTimes(1))
+    expect(runtime.setTheme).not.toHaveBeenCalled()
     runtime.safeClean.mockClear()
     runtime.createDiffEditor.mockClear()
     runtime.setTheme.mockClear()

--- a/test/code-block-finalize-gate.test.ts
+++ b/test/code-block-finalize-gate.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, nextTick } from 'vue'
 import CodeBlockNode from '../src/components/CodeBlockNode/CodeBlockNode.vue'
 import { resetCodeBlockRuntimeReadyForTest } from '../src/components/CodeBlockNode/runtime'
+import { clearStreamDiffsWorkerPool, setStreamDiffsWorkerPool } from '../src/components/CodeBlockNode/streamDiffsWorker'
 import { provideOffscreenHeavyNodeDeferral, provideViewportPriority } from '../src/composables/viewportPriority'
 
 interface VisibilityObserver {
@@ -133,9 +134,11 @@ describe('codeBlockNode final Diffs gate', () => {
     observers.length = 0
     vi.stubGlobal('IntersectionObserver', IntersectionObserverStub)
     resetHelpers()
+    clearStreamDiffsWorkerPool()
   })
 
   afterEach(() => {
+    clearStreamDiffsWorkerPool()
     vi.unstubAllGlobals()
   })
 
@@ -757,6 +760,40 @@ describe('codeBlockNode final Diffs gate', () => {
     await vi.waitFor(() => {
       expect(runtime.setTheme).toHaveBeenCalledWith('initial-surface-light')
     })
+    expect(runtime.createEditor).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('applies a theme change queued while the worker prepares the initial surface', async () => {
+    let resolveWorkerTheme!: () => void
+    const workerThemePending = new Promise<void>((resolve) => {
+      resolveWorkerTheme = resolve
+    })
+    const setRenderOptions = vi.fn(() => workerThemePending)
+    setStreamDiffsWorkerPool({ setRenderOptions })
+    const runtime = helpers()
+    const wrapper = mount(DeferredCodeBlockNode, {
+      props: {
+        node: makeNode('const ready = true', false),
+        loading: false,
+        stream: true,
+        showHeader: false,
+        isDark: true,
+        darkTheme: 'queued-surface-dark',
+        lightTheme: 'queued-surface-light',
+      },
+    })
+
+    await flush()
+    observers.at(-1)?.emit()
+    await vi.waitFor(() => expect(setRenderOptions).toHaveBeenCalledTimes(1))
+    expect(runtime.createEditor).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ isDark: false })
+    resolveWorkerTheme()
+
+    await vi.waitFor(() => expect(runtime.setTheme).toHaveBeenCalledWith('queued-surface-light'))
     expect(runtime.createEditor).toHaveBeenCalledTimes(1)
 
     wrapper.unmount()

--- a/test/code-block-streaming-stability.test.ts
+++ b/test/code-block-streaming-stability.test.ts
@@ -150,4 +150,56 @@ describe('code block streaming stability', () => {
       wrapper.unmount()
     }
   })
+
+  it('refreshes an externally supplied code block when its source map changes', async () => {
+    const CodeBlockProbe = defineComponent({
+      props: {
+        node: { type: Object, required: true },
+      },
+      setup(props) {
+        return () => h('div', {
+          'class': 'code-block-probe',
+          'data-source-line': String((props.node as any).sourceMap?.startLine ?? ''),
+        })
+      },
+    })
+    const codeBlock = {
+      type: 'code_block',
+      language: 'typescript',
+      code: 'const value = 1',
+      raw: '```typescript\nconst value = 1\n```',
+      loading: false,
+      sourceMap: { startLine: 1, endLine: 4 },
+    }
+
+    setCustomComponents(customId, { code_block: CodeBlockProbe as any })
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        nodes: [codeBlock],
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        viewportPriority: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      expect(wrapper.get('.code-block-probe').attributes('data-source-line')).toBe('1')
+
+      await wrapper.setProps({
+        nodes: [{
+          ...codeBlock,
+          sourceMap: { startLine: 10, endLine: 13 },
+        }],
+      })
+      await flushAll()
+
+      expect(wrapper.get('.code-block-probe').attributes('data-source-line')).toBe('10')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
 })

--- a/test/code-block-streaming-stability.test.ts
+++ b/test/code-block-streaming-stability.test.ts
@@ -1,0 +1,89 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h, onMounted, onUnmounted, watch } from 'vue'
+import NodeRenderer from '../src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
+import { flushAll } from './setup/flush-all'
+
+const customId = 'code-block-streaming-stability'
+
+describe('code block streaming stability', () => {
+  afterEach(() => {
+    removeCustomComponents(customId)
+  })
+
+  it('keeps an equivalent settled code block node stable while trailing content streams', async () => {
+    let mountCount = 0
+    let unmountCount = 0
+    let nodeChangeCount = 0
+
+    const CodeBlockProbe = defineComponent({
+      inheritAttrs: false,
+      props: {
+        node: { type: Object, required: true },
+      },
+      setup(props) {
+        onMounted(() => mountCount++)
+        onUnmounted(() => unmountCount++)
+        watch(() => props.node, () => nodeChangeCount++)
+        return () => h('div', {
+          'class': 'code-block-probe',
+          'data-code': String((props.node as any).code ?? ''),
+        })
+      },
+    })
+
+    const makeCodeBlock = (updatedCode = 'const value = 2') => ({
+      type: 'code_block',
+      language: 'diff',
+      code: `-const value = 1\n+${updatedCode}`,
+      raw: `\`\`\`diff\n-const value = 1\n+${updatedCode}\n\`\`\``,
+      diff: true,
+      originalCode: 'const value = 1',
+      updatedCode,
+      loading: false,
+    })
+    const makeParagraph = (content: string) => ({
+      type: 'paragraph',
+      children: [{ type: 'text', content, raw: content }],
+      raw: content,
+    })
+
+    setCustomComponents(customId, { code_block: CodeBlockProbe as any })
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        nodes: [makeCodeBlock(), makeParagraph('tail')],
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        viewportPriority: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      expect(mountCount).toBe(1)
+
+      await wrapper.setProps({
+        nodes: [makeCodeBlock(), makeParagraph('tail continues streaming')],
+      })
+      await flushAll()
+
+      expect(nodeChangeCount).toBe(0)
+      expect(mountCount).toBe(1)
+      expect(unmountCount).toBe(0)
+
+      await wrapper.setProps({
+        nodes: [makeCodeBlock('const value = 3'), makeParagraph('tail continues streaming')],
+      })
+      await flushAll()
+
+      expect(nodeChangeCount).toBe(1)
+      expect(wrapper.get('.code-block-probe').attributes('data-code')).toContain('const value = 3')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/test/code-block-streaming-stability.test.ts
+++ b/test/code-block-streaming-stability.test.ts
@@ -29,11 +29,12 @@ describe('code block streaming stability', () => {
         return () => h('div', {
           'class': 'code-block-probe',
           'data-code': String((props.node as any).code ?? ''),
+          'data-start-line': String((props.node as any).startLine ?? ''),
         })
       },
     })
 
-    const makeCodeBlock = (updatedCode = 'const value = 2') => ({
+    const makeCodeBlock = (updatedCode = 'const value = 2', startLine = 1) => ({
       type: 'code_block',
       language: 'diff',
       code: `-const value = 1\n+${updatedCode}`,
@@ -42,6 +43,8 @@ describe('code block streaming stability', () => {
       originalCode: 'const value = 1',
       updatedCode,
       loading: false,
+      startLine,
+      endLine: startLine + 3,
     })
     const makeParagraph = (content: string) => ({
       type: 'paragraph',
@@ -75,12 +78,73 @@ describe('code block streaming stability', () => {
       expect(unmountCount).toBe(0)
 
       await wrapper.setProps({
-        nodes: [makeCodeBlock('const value = 3'), makeParagraph('tail continues streaming')],
+        nodes: [makeCodeBlock('const value = 2', 10), makeParagraph('tail continues streaming')],
       })
       await flushAll()
 
       expect(nodeChangeCount).toBe(1)
+      expect(wrapper.get('.code-block-probe').attributes('data-start-line')).toBe('10')
+
+      await wrapper.setProps({
+        nodes: [makeCodeBlock('const value = 3', 10), makeParagraph('tail continues streaming')],
+      })
+      await flushAll()
+
+      expect(nodeChangeCount).toBe(2)
       expect(wrapper.get('.code-block-probe').attributes('data-code')).toContain('const value = 3')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('drops cached code blocks after the node list shrinks', async () => {
+    const mountedNodes: object[] = []
+    const CodeBlockProbe = defineComponent({
+      props: {
+        node: { type: Object, required: true },
+      },
+      setup(props) {
+        onMounted(() => mountedNodes.push(props.node))
+        return () => h('div', { class: 'code-block-probe' })
+      },
+    })
+    const codeBlock = {
+      type: 'code_block',
+      language: 'typescript',
+      code: 'const value = 1',
+      raw: '```typescript\nconst value = 1\n```',
+      loading: false,
+    }
+    const paragraph = {
+      type: 'paragraph',
+      children: [{ type: 'text', content: 'before', raw: 'before' }],
+      raw: 'before',
+    }
+
+    setCustomComponents(customId, { code_block: CodeBlockProbe as any })
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        nodes: [paragraph, codeBlock],
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        viewportPriority: false,
+      },
+    })
+
+    try {
+      await flushAll()
+      const firstNode = mountedNodes[0]
+
+      await wrapper.setProps({ nodes: [paragraph] })
+      await flushAll()
+      await wrapper.setProps({ nodes: [paragraph, { ...codeBlock }] })
+      await flushAll()
+
+      expect(mountedNodes).toHaveLength(2)
+      expect(mountedNodes[1]).not.toBe(firstNode)
     }
     finally {
       wrapper.unmount()


### PR DESCRIPTION
## Root cause

After a diff fence settled and stream-diffs committed the highlighted surface, later markdown chunks still produced fresh but equivalent `code_block` objects. The Vue 3 and Vue 2 renderers cached their render nodes by parser object identity, so every trailing chunk invalidated the cache and patched the large highlighted diff again. This was especially visible as flicker at mobile widths.

## Fix

- cache Vue 3 and Vue 2 code-block render nodes by renderer node index and visible content signature
- keep the same node prop while an already-settled code block is unchanged
- still update normally when the code-block payload changes
- avoid the redundant Vue 3 initial theme render and sync an injected worker theme before surface creation
- queue theme changes arriving during asynchronous worker/editor creation and apply them before revealing the surface

React/Octane already stabilize parsed node references. Svelte effects subscribe to derived payload values, and Angular equivalent-input synchronization is covered in #698.

## Verification

- reproduced on `playground/test` at 390x844 with the Diff and code streaming sample
- before: the settled diff node kept updating for trailing chunks
- after: one settle update, one surface creation, no unmounts, stable ready Shadow DOM
- Vue 2 package build and focused renderer tests
- theme-race regression with a pending worker update
- `pnpm vitest run test/code-block-finalize-gate.test.ts test/code-block-streaming-stability.test.ts test/code-block-runtime-generation.test.ts test/code-block-collapse-scroll.test.ts` (30 tests)
- `pnpm typecheck`
- targeted ESLint checks

The docs frontmatter commit fixes the pre-existing showcase parity/build failure so this branch passes those checks independently.