### PR TITLE
perf(parser): selectively reuse nodes with custom renderers

### DIFF
--- a/docs/zh/guide/showcase.md
+++ b/docs/zh/guide/showcase.md
@@ -1,3 +1,11 @@
+---
+title: Showcase（占位）
+description: markstream 流式 Markdown 渲染器的示例与场景演示占位页，覆盖流式对话、长文档、代码评审、图表、自定义组件与安全复现流程，等待与英文版同步。
+keywords:
+  - markstream showcase
+  - 流式 markdown 演示
+---
+
 # Showcase（中文占位）
 
 > 原文节选（仅供翻译参考）：

--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -309,6 +309,7 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   private copyTimer: number | null = null
   private deferredHeightSyncRaf: number | null = null
   private lastCodeBlockOptions?: CodeBlockOptions
+  private lastEditorInputSignature = ''
   private lastRuntimeHostKey = ''
 
   get t() {
@@ -579,13 +580,23 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
       themes[1],
       this.resolvedShowLineNumbers ? 'lines' : 'no-lines',
     ].join('\u0000')
-    if (nextOptions !== this.lastCodeBlockOptions || runtimeHostKey !== this.lastRuntimeHostKey) {
+    const runtimeChanged = nextOptions !== this.lastCodeBlockOptions || runtimeHostKey !== this.lastRuntimeHostKey
+    if (runtimeChanged) {
       this.lastCodeBlockOptions = nextOptions
       this.lastRuntimeHostKey = runtimeHostKey
       this.disposeRuntimeHelpers()
     }
+    const editorInputSignature = JSON.stringify([
+      this.isDiff,
+      this.originalCode,
+      this.resolvedCode,
+      this.language,
+      this.showLoadingPlaceholder,
+    ])
+    const editorInputChanged = editorInputSignature !== this.lastEditorInputSignature
+    this.lastEditorInputSignature = editorInputSignature
     this.applyInitialFontSize()
-    if (!this.viewReady)
+    if (!this.viewReady || (!runtimeChanged && !editorInputChanged))
       return
     void this.syncEditorState()
   }

--- a/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
+++ b/packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component.ts
@@ -309,7 +309,12 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
   private copyTimer: number | null = null
   private deferredHeightSyncRaf: number | null = null
   private lastCodeBlockOptions?: CodeBlockOptions
-  private lastEditorInputSignature = ''
+  private hasEditorInput = false
+  private lastEditorIsDiff = false
+  private lastEditorOriginalCode = ''
+  private lastEditorResolvedCode = ''
+  private lastEditorLanguage = ''
+  private lastEditorShowLoadingPlaceholder = false
   private lastRuntimeHostKey = ''
 
   get t() {
@@ -586,15 +591,23 @@ export class CodeBlockNodeComponent implements AfterViewInit, OnChanges, OnDestr
       this.lastRuntimeHostKey = runtimeHostKey
       this.disposeRuntimeHelpers()
     }
-    const editorInputSignature = JSON.stringify([
-      this.isDiff,
-      this.originalCode,
-      this.resolvedCode,
-      this.language,
-      this.showLoadingPlaceholder,
-    ])
-    const editorInputChanged = editorInputSignature !== this.lastEditorInputSignature
-    this.lastEditorInputSignature = editorInputSignature
+    const isDiff = this.isDiff
+    const originalCode = this.originalCode
+    const resolvedCode = this.resolvedCode
+    const language = this.language
+    const showLoadingPlaceholder = this.showLoadingPlaceholder
+    const editorInputChanged = !this.hasEditorInput
+      || isDiff !== this.lastEditorIsDiff
+      || originalCode !== this.lastEditorOriginalCode
+      || resolvedCode !== this.lastEditorResolvedCode
+      || language !== this.lastEditorLanguage
+      || showLoadingPlaceholder !== this.lastEditorShowLoadingPlaceholder
+    this.hasEditorInput = true
+    this.lastEditorIsDiff = isDiff
+    this.lastEditorOriginalCode = originalCode
+    this.lastEditorResolvedCode = resolvedCode
+    this.lastEditorLanguage = language
+    this.lastEditorShowLoadingPlaceholder = showLoadingPlaceholder
     this.applyInitialFontSize()
     if (!this.viewReady || (!runtimeChanged && !editorInputChanged))
       return

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -19,7 +19,6 @@ import type {
   NodeRendererProps,
 } from '../../types/node-renderer-props'
 import type { VirtualHeightSummary } from './composables/useHeightModel'
-import { normalizeShikiLanguage } from 'markstream-core'
 import { computed, defineAsyncComponent, getCurrentInstance, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, shallowRef, triggerRef, watch, watchEffect } from 'vue'
 import AdmonitionNode from '../../components/AdmonitionNode'
 import BlockquoteNode from '../../components/BlockquoteNode'
@@ -62,10 +61,10 @@ import {
   registerHeightEstimationRendererController,
 } from '../../internal/heightEstimationExperiment'
 import { getCodeBlockExtraProps } from '../../utils/codeBlockExtraProps'
+import { getCustomCodeLanguageComponent } from '../../utils/customCodeLanguageComponent'
 import { isDevEnvironment } from '../../utils/devEnv'
 import { clampInfographicPreviewHeight, clampMermaidPreviewHeight, estimateInfographicPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber } from '../../utils/diagramHeight'
 import { getCustomNodeAttrs, getHtmlTagFromContent, shouldRenderUnknownHtmlTagAsText, stripCustomHtmlWrapper } from '../../utils/htmlRenderer'
-import { normalizeLanguageIdentifier } from '../../utils/languageIcon'
 import { isReservedNodeComponentKey, useCustomNodeComponents } from '../../utils/nodeComponents'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { setNormalizedElementScrollTop } from '../../utils/normalizedScroll'
@@ -5736,23 +5735,6 @@ function getCodeBlockLanguage(node: ParsedNode) {
   return node?.type === 'code_block'
     ? String((node as RuntimeCodeBlockNode).language ?? '').trim().toLowerCase()
     : ''
-}
-
-function getCustomCodeLanguageComponent(
-  customComponents: Record<string, unknown>,
-  language: string,
-) {
-  const raw = language.trim().toLowerCase()
-  if (!raw)
-    return undefined
-
-  for (const key of [raw, normalizeLanguageIdentifier(raw), normalizeShikiLanguage(raw)]) {
-    const component = key && customComponents[key]
-    if (component)
-      return component
-  }
-
-  return undefined
 }
 
 function getPreviewBindingsFor(

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -132,6 +132,16 @@ function getCustomComponentsReuseKey(mapping: Partial<CustomComponents>) {
   )
 }
 
+const PARSED_NODE_CONTAINER_FIELDS = [
+  'children',
+  'items',
+  'header',
+  'rows',
+  'cells',
+  'term',
+  'definition',
+] as const
+
 function hasCustomComponentBoundary(node: ParsedNode, mapping: Partial<CustomComponents>): boolean {
   const type = String(node.type).trim().toLowerCase()
   if (mapping[type])
@@ -141,16 +151,26 @@ function hasCustomComponentBoundary(node: ParsedNode, mapping: Partial<CustomCom
     const language = String((node as ParsedNode & { language?: string }).language ?? '').trim().toLowerCase()
     if (
       language
-      && [language, normalizeLanguageIdentifier(language), normalizeShikiLanguage(language)]
+      && [
+        language,
+        normalizeLanguageIdentifier(language),
+        normalizeShikiLanguage(language),
+        language === 'd2lang' ? 'd2' : '',
+      ]
         .some(key => Boolean(key && mapping[key]))
     ) {
       return true
     }
   }
 
-  const children = (node as ParsedNode & { children?: ParsedNode[] }).children
-  return Array.isArray(children)
-    && children.some(child => hasCustomComponentBoundary(child, mapping))
+  const record = node as ParsedNode & Record<string, unknown>
+  return PARSED_NODE_CONTAINER_FIELDS.some((field) => {
+    const value = record[field]
+    if (Array.isArray(value)) {
+      return value.some(child => isParsedNodeLike(child) && hasCustomComponentBoundary(child, mapping))
+    }
+    return isParsedNodeLike(value) && hasCustomComponentBoundary(value, mapping)
+  })
 }
 
 const DEFAULT_PARSE_COALESCE_MS = 80

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -5,7 +5,6 @@ import type {
 import type { ComputedRef } from 'vue'
 import type { CustomComponents } from '../../../types'
 import type { NodeRendererProps } from '../../../types/node-renderer-props'
-import { normalizeShikiLanguage } from 'markstream-core'
 import {
   BLOCKED_HTML_TAGS,
   EXTENDED_STANDARD_HTML_TAGS,
@@ -16,7 +15,7 @@ import {
   resolveCustomHtmlTags,
 } from 'stream-markdown-parser'
 import { computed, markRaw, onScopeDispose, ref, watch } from 'vue'
-import { normalizeLanguageIdentifier } from '../../../utils/languageIcon'
+import { getCustomCodeLanguageComponent } from '../../../utils/customCodeLanguageComponent'
 import { isReservedNodeComponentKey } from '../../../utils/nodeComponents'
 
 type RendererParseOptions = NonNullable<NodeRendererProps['parseOptions']>
@@ -132,45 +131,39 @@ function getCustomComponentsReuseKey(mapping: Partial<CustomComponents>) {
   )
 }
 
-const PARSED_NODE_CONTAINER_FIELDS = [
-  'children',
-  'items',
-  'header',
-  'rows',
-  'cells',
-  'term',
-  'definition',
-] as const
+function hasCustomComponentBoundary(
+  node: ParsedNode,
+  mapping: Partial<CustomComponents>,
+  cache: WeakMap<object, boolean>,
+): boolean {
+  const object = node as object
+  if (cache.has(object))
+    return cache.get(object)!
 
-function hasCustomComponentBoundary(node: ParsedNode, mapping: Partial<CustomComponents>): boolean {
   const type = String(node.type).trim().toLowerCase()
-  if (mapping[type])
+  if (mapping[type]) {
+    cache.set(object, true)
     return true
+  }
 
   if (type === 'code_block') {
     const language = String((node as ParsedNode & { language?: string }).language ?? '').trim().toLowerCase()
-    if (
-      language
-      && [
-        language,
-        normalizeLanguageIdentifier(language),
-        normalizeShikiLanguage(language),
-        language === 'd2lang' ? 'd2' : '',
-      ]
-        .some(key => Boolean(key && mapping[key]))
-    ) {
+    if (language && getCustomCodeLanguageComponent(mapping, language)) {
+      cache.set(object, true)
       return true
     }
   }
 
   const record = node as ParsedNode & Record<string, unknown>
-  return PARSED_NODE_CONTAINER_FIELDS.some((field) => {
-    const value = record[field]
+  cache.set(object, false)
+  const hasBoundary = Object.values(record).some((value) => {
     if (Array.isArray(value)) {
-      return value.some(child => isParsedNodeLike(child) && hasCustomComponentBoundary(child, mapping))
+      return value.some(child => isParsedNodeLike(child) && hasCustomComponentBoundary(child, mapping, cache))
     }
-    return isParsedNodeLike(value) && hasCustomComponentBoundary(value, mapping)
+    return isParsedNodeLike(value) && hasCustomComponentBoundary(value, mapping, cache)
   })
+  cache.set(object, hasBoundary)
+  return hasBoundary
 }
 
 const DEFAULT_PARSE_COALESCE_MS = 80
@@ -1077,6 +1070,7 @@ export function useMarkdownParsing(
   let previousContent = ''
   let previousExternalNodeMutationBoundary = false
   let previousCustomComponentsReuseKey = ''
+  let customComponentBoundaryCache = new WeakMap<object, boolean>()
   const scanGlobalReferenceAppend = createGlobalReferenceScanner()
   let parseCoalesceTimer: ReturnType<typeof setTimeout> | undefined
   let parseCommitCount = 0
@@ -1295,6 +1289,7 @@ export function useMarkdownParsing(
     ) {
       previousParsedNodes = []
       previousContent = ''
+      customComponentBoundaryCache = new WeakMap<object, boolean>()
     }
     const hasCustomComponents = Object.keys(customComponents).length > 0
     const hasExternalNodeMutationBoundary = typeof mergedParseOptions.value.postTransformNodes === 'function'
@@ -1315,9 +1310,18 @@ export function useMarkdownParsing(
       ? {}
       : undefined
     const parserHasCustomExtensions = hasCustomParserExtensions(md)
+    const previousHasCustomComponentBoundary = hasCustomComponents
+      && previousParsedNodes.some(node => hasCustomComponentBoundary(
+        node,
+        customComponents,
+        customComponentBoundaryCache,
+      ))
     const reuseStableTopLevelNodes = !parserHasCustomExtensions
       && !hasExternalNodeMutationBoundary
-      && !hasCustomComponents
+      && (
+        !hasCustomComponents
+        || (previousParsedNodes.length > 0 && !previousHasCustomComponentBoundary)
+      )
     const parseOptionsForCall = {
       ...mergedParseOptions.value,
       reuseStableTopLevelNodes,
@@ -1371,7 +1375,11 @@ export function useMarkdownParsing(
       referenceDefinitionScanChars = scannedChars
       const reuseDirtyTail = scanStartIndex <= 0
       const canReuseNode = hasCustomComponents
-        ? (node: ParsedNode) => !hasCustomComponentBoundary(node, customComponents)
+        ? (node: ParsedNode) => !hasCustomComponentBoundary(
+            node,
+            customComponents,
+            customComponentBoundaryCache,
+          )
         : undefined
       if (signatureTiming) {
         const result = stabilizeParsedNodesWithMetrics(nextParsed, previousParsedNodes, signatureTiming, {
@@ -1415,6 +1423,10 @@ export function useMarkdownParsing(
         primeParsedNodeSignatures(parsed, primeStartIndex)
     }
 
+    if (hasCustomComponents) {
+      for (const node of parsed)
+        hasCustomComponentBoundary(node, customComponents, customComponentBoundaryCache)
+    }
     const nodeReuseMs = collectPerformanceMetrics
       ? getNow() - reuseStart
       : 0

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -5,6 +5,7 @@ import type {
 import type { ComputedRef } from 'vue'
 import type { CustomComponents } from '../../../types'
 import type { NodeRendererProps } from '../../../types/node-renderer-props'
+import { normalizeShikiLanguage } from 'markstream-core'
 import {
   BLOCKED_HTML_TAGS,
   EXTENDED_STANDARD_HTML_TAGS,
@@ -15,6 +16,7 @@ import {
   resolveCustomHtmlTags,
 } from 'stream-markdown-parser'
 import { computed, markRaw, onScopeDispose, ref, watch } from 'vue'
+import { normalizeLanguageIdentifier } from '../../../utils/languageIcon'
 import { isReservedNodeComponentKey } from '../../../utils/nodeComponents'
 
 type RendererParseOptions = NonNullable<NodeRendererProps['parseOptions']>
@@ -66,6 +68,7 @@ interface ParsedNodeStabilizeResult {
 }
 
 interface ParsedNodeStabilizeOptions {
+  canReuseNode?: (node: ParsedNode) => boolean
   reuseDirtyTail?: boolean
   scanStartIndex?: number
 }
@@ -119,6 +122,35 @@ function getAutoCustomHtmlTags(mapping: Partial<CustomComponents>) {
         : ''
     })
     .filter(Boolean)
+}
+
+function getCustomComponentsReuseKey(mapping: Partial<CustomComponents>) {
+  return JSON.stringify(
+    Object.entries(mapping)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, component]) => [key, getIdentityKey(component)]),
+  )
+}
+
+function hasCustomComponentBoundary(node: ParsedNode, mapping: Partial<CustomComponents>): boolean {
+  const type = String(node.type).trim().toLowerCase()
+  if (mapping[type])
+    return true
+
+  if (type === 'code_block') {
+    const language = String((node as ParsedNode & { language?: string }).language ?? '').trim().toLowerCase()
+    if (
+      language
+      && [language, normalizeLanguageIdentifier(language), normalizeShikiLanguage(language)]
+        .some(key => Boolean(key && mapping[key]))
+    ) {
+      return true
+    }
+  }
+
+  const children = (node as ParsedNode & { children?: ParsedNode[] }).children
+  return Array.isArray(children)
+    && children.some(child => hasCustomComponentBoundary(child, mapping))
 }
 
 const DEFAULT_PARSE_COALESCE_MS = 80
@@ -811,16 +843,24 @@ function areTopLevelNodesStableWithMetrics(
   return isParsedNodeStableWithMetrics(previous, next, signatureTiming)
 }
 
-function findDirtyStartIndex(nextNodes: ParsedNode[], previousNodes: ParsedNode[], scanStartIndex = 0) {
+function findDirtyStartIndex(
+  nextNodes: ParsedNode[],
+  previousNodes: ParsedNode[],
+  options: ParsedNodeStabilizeOptions,
+) {
   const limit = Math.min(nextNodes.length, previousNodes.length)
-  const startIndex = Math.min(limit, Math.max(0, scanStartIndex))
+  const startIndex = Math.min(limit, Math.max(0, options.scanStartIndex ?? 0))
 
   for (let index = startIndex; index < limit; index++) {
     const previous = previousNodes[index]
     const next = nextNodes[index]
 
-    if (!areTopLevelNodesStable(previous, next))
+    if (
+      (options.canReuseNode && (!options.canReuseNode(previous) || !options.canReuseNode(next)))
+      || !areTopLevelNodesStable(previous, next)
+    ) {
       return index
+    }
   }
 
   return nextNodes.length === previousNodes.length ? -1 : limit
@@ -830,16 +870,19 @@ function findDirtyStartIndexWithMetrics(
   nextNodes: ParsedNode[],
   previousNodes: ParsedNode[],
   signatureTiming: ParsedNodeSignatureTimingMetrics,
-  scanStartIndex = 0,
+  options: ParsedNodeStabilizeOptions,
 ) {
   const limit = Math.min(nextNodes.length, previousNodes.length)
-  const startIndex = Math.min(limit, Math.max(0, scanStartIndex))
+  const startIndex = Math.min(limit, Math.max(0, options.scanStartIndex ?? 0))
 
   for (let index = startIndex; index < limit; index++) {
     const previous = previousNodes[index]
     const next = nextNodes[index]
 
-    if (!areTopLevelNodesStableWithMetrics(previous, next, signatureTiming)) {
+    if (
+      (options.canReuseNode && (!options.canReuseNode(previous) || !options.canReuseNode(next)))
+      || !areTopLevelNodesStableWithMetrics(previous, next, signatureTiming)
+    ) {
       return index
     }
   }
@@ -859,9 +902,8 @@ function stabilizeParsedNodes(
     }
   }
 
-  const scanStartIndex = options.scanStartIndex ?? 0
   const reuseDirtyTail = options.reuseDirtyTail !== false
-  const dirtyStartIndex = findDirtyStartIndex(nextNodes, previousNodes, scanStartIndex)
+  const dirtyStartIndex = findDirtyStartIndex(nextNodes, previousNodes, options)
 
   if (dirtyStartIndex < 0) {
     return {
@@ -886,7 +928,11 @@ function stabilizeParsedNodes(
       const previous = previousNodes[index]
       const next = nextNodes[index]
 
-      if (previous && isParsedNodeStable(previous, next)) {
+      if (
+        previous
+        && (!options.canReuseNode || (options.canReuseNode(previous) && options.canReuseNode(next)))
+        && isParsedNodeStable(previous, next)
+      ) {
         stableNodes[index] = previous
         reusedNodeCount += 1
       }
@@ -917,9 +963,8 @@ function stabilizeParsedNodesWithMetrics(
     }
   }
 
-  const scanStartIndex = options.scanStartIndex ?? 0
   const reuseDirtyTail = options.reuseDirtyTail !== false
-  const dirtyStartIndex = findDirtyStartIndexWithMetrics(nextNodes, previousNodes, signatureTiming, scanStartIndex)
+  const dirtyStartIndex = findDirtyStartIndexWithMetrics(nextNodes, previousNodes, signatureTiming, options)
 
   if (dirtyStartIndex < 0) {
     return {
@@ -944,7 +989,11 @@ function stabilizeParsedNodesWithMetrics(
       const previous = previousNodes[index]
       const next = nextNodes[index]
 
-      if (previous && isParsedNodeStableWithMetrics(previous, next, signatureTiming)) {
+      if (
+        previous
+        && (!options.canReuseNode || (options.canReuseNode(previous) && options.canReuseNode(next)))
+        && isParsedNodeStableWithMetrics(previous, next, signatureTiming)
+      ) {
         stableNodes[index] = previous
         reusedNodeCount += 1
       }
@@ -1007,6 +1056,7 @@ export function useMarkdownParsing(
   let previousNodeReuseSemanticKey = ''
   let previousContent = ''
   let previousExternalNodeMutationBoundary = false
+  let previousCustomComponentsReuseKey = ''
   const scanGlobalReferenceAppend = createGlobalReferenceScanner()
   let parseCoalesceTimer: ReturnType<typeof setTimeout> | undefined
   let parseCommitCount = 0
@@ -1217,8 +1267,17 @@ export function useMarkdownParsing(
       previousContent = ''
     }
 
-    const hasExternalNodeMutationBoundary = Object.keys(options.customComponentsMap?.value ?? {}).length > 0
-      || typeof mergedParseOptions.value.postTransformNodes === 'function'
+    const customComponents = options.customComponentsMap?.value ?? {}
+    const customComponentsReuseKey = getCustomComponentsReuseKey(customComponents)
+    if (
+      previousCustomComponentsReuseKey
+      && customComponentsReuseKey !== previousCustomComponentsReuseKey
+    ) {
+      previousParsedNodes = []
+      previousContent = ''
+    }
+    const hasCustomComponents = Object.keys(customComponents).length > 0
+    const hasExternalNodeMutationBoundary = typeof mergedParseOptions.value.postTransformNodes === 'function'
     if (hasExternalNodeMutationBoundary !== previousExternalNodeMutationBoundary) {
       previousParsedNodes = []
       previousContent = ''
@@ -1238,6 +1297,7 @@ export function useMarkdownParsing(
     const parserHasCustomExtensions = hasCustomParserExtensions(md)
     const reuseStableTopLevelNodes = !parserHasCustomExtensions
       && !hasExternalNodeMutationBoundary
+      && !hasCustomComponents
     const parseOptionsForCall = {
       ...mergedParseOptions.value,
       reuseStableTopLevelNodes,
@@ -1277,19 +1337,25 @@ export function useMarkdownParsing(
       const stabilizeStart = collectPerformanceMetrics
         ? getNow()
         : 0
-      const [scanStartIndex, scannedChars] = getStablePrefixScanStartIndex({
-        content,
-        previousContent,
-        previousDirtyStartIndex: parsedNodesDirtyStartIndexValue,
-        parseOptions: mergedParseOptions.value,
-        customMarkdownIt: props.customMarkdownIt,
-        md,
-        scanGlobalReferenceAppend,
-      })
+      const [scanStartIndex, scannedChars] = hasCustomComponents
+        ? [0, 0]
+        : getStablePrefixScanStartIndex({
+            content,
+            previousContent,
+            previousDirtyStartIndex: parsedNodesDirtyStartIndexValue,
+            parseOptions: mergedParseOptions.value,
+            customMarkdownIt: props.customMarkdownIt,
+            md,
+            scanGlobalReferenceAppend,
+          })
       referenceDefinitionScanChars = scannedChars
       const reuseDirtyTail = scanStartIndex <= 0
+      const canReuseNode = hasCustomComponents
+        ? (node: ParsedNode) => !hasCustomComponentBoundary(node, customComponents)
+        : undefined
       if (signatureTiming) {
         const result = stabilizeParsedNodesWithMetrics(nextParsed, previousParsedNodes, signatureTiming, {
+          canReuseNode,
           reuseDirtyTail,
           scanStartIndex,
         })
@@ -1298,6 +1364,7 @@ export function useMarkdownParsing(
       }
       else {
         const result = stabilizeParsedNodes(nextParsed, previousParsedNodes, {
+          canReuseNode,
           reuseDirtyTail,
           scanStartIndex,
         })
@@ -1336,6 +1403,7 @@ export function useMarkdownParsing(
     previousParserCacheSemanticKey = currentParserCacheSemanticKey
     previousNodeReuseSemanticKey = currentNodeReuseSemanticKey
     previousExternalNodeMutationBoundary = hasExternalNodeMutationBoundary
+    previousCustomComponentsReuseKey = customComponentsReuseKey
     previousParsedNodes = parsed
     commitParsedNodesDirtyStartIndex(stabilizeMetrics?.dirtyStartIndex ?? 0)
 

--- a/src/utils/customCodeLanguageComponent.ts
+++ b/src/utils/customCodeLanguageComponent.ts
@@ -1,0 +1,24 @@
+import { normalizeShikiLanguage } from 'markstream-core'
+import { normalizeLanguageIdentifier } from './languageIcon'
+
+export function getCustomCodeLanguageComponent<T>(
+  customComponents: Readonly<Partial<Record<string, T>>>,
+  language: string,
+) {
+  const raw = language.trim().toLowerCase()
+  if (!raw)
+    return undefined
+
+  for (const key of [
+    raw,
+    normalizeLanguageIdentifier(raw),
+    normalizeShikiLanguage(raw),
+    raw === 'd2lang' ? 'd2' : '',
+  ]) {
+    const component = key && customComponents[key]
+    if (component)
+      return component
+  }
+
+  return undefined
+}

--- a/test/markstream-angular-code-block-stability.test.ts
+++ b/test/markstream-angular-code-block-stability.test.ts
@@ -1,0 +1,50 @@
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const angularCompilerEntry = require.resolve('@angular/compiler', {
+  paths: [
+    resolve(process.cwd(), 'packages/markstream-angular'),
+    resolve(process.cwd(), 'node_modules/.pnpm/node_modules'),
+  ],
+})
+await import(angularCompilerEntry)
+const { CodeBlockNodeComponent } = await import('../packages/markstream-angular/src/components/CodeBlockNode/CodeBlockNode.component')
+
+describe('angular code block stability', () => {
+  it('does not resync the editor for an equivalent code block node', () => {
+    const component = Object.create(CodeBlockNodeComponent.prototype) as any
+    Object.assign(component, {
+      codeBlockOptions: undefined,
+      context: undefined,
+      lastCodeBlockOptions: undefined,
+      lastEditorInputSignature: '',
+      lastRuntimeHostKey: '',
+      node: {
+        type: 'code_block',
+        language: 'ts',
+        code: 'const value = 1',
+        originalCode: 'const value = 0',
+        diff: true,
+        loading: false,
+      },
+      props: {},
+      viewReady: true,
+    })
+    component.applyInitialFontSize = vi.fn()
+    component.disposeRuntimeHelpers = vi.fn()
+    component.syncEditorState = vi.fn()
+
+    component.ngOnChanges()
+    component.node = { ...component.node }
+    component.ngOnChanges()
+
+    expect(component.syncEditorState).toHaveBeenCalledTimes(1)
+
+    component.node = { ...component.node, code: 'const value = 2' }
+    component.ngOnChanges()
+
+    expect(component.syncEditorState).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/markstream-angular-code-block-stability.test.ts
+++ b/test/markstream-angular-code-block-stability.test.ts
@@ -55,4 +55,48 @@ describe('angular code block stability', () => {
     expect(component.syncEditorState).toHaveBeenCalledTimes(2)
     expect(stringify).not.toHaveBeenCalled()
   })
+
+  it('resyncs for every editor and runtime input transition', () => {
+    const component = Object.create(CodeBlockNodeComponent.prototype) as any
+    Object.assign(component, {
+      codeBlockOptions: undefined,
+      context: undefined,
+      hasEditorInput: false,
+      lastCodeBlockOptions: undefined,
+      lastEditorIsDiff: false,
+      lastEditorLanguage: '',
+      lastEditorOriginalCode: '',
+      lastEditorResolvedCode: '',
+      lastEditorShowLoadingPlaceholder: false,
+      lastRuntimeHostKey: '',
+      node: {
+        type: 'code_block',
+        language: 'ts',
+        code: 'const value = 1',
+        originalCode: 'const value = 0',
+        diff: true,
+        loading: false,
+      },
+      props: {},
+      viewReady: true,
+    })
+    component.applyInitialFontSize = vi.fn()
+    component.disposeRuntimeHelpers = vi.fn()
+    component.syncEditorState = vi.fn()
+
+    component.ngOnChanges()
+    component.node = { ...component.node, language: 'js' }
+    component.ngOnChanges()
+    component.node = { ...component.node, diff: false }
+    component.ngOnChanges()
+    component.props = { loading: true, stream: false }
+    component.ngOnChanges()
+    component.props = { ...component.props, isDark: true }
+    component.ngOnChanges()
+    component.codeBlockOptions = { fontSize: 14 }
+    component.ngOnChanges()
+
+    expect(component.syncEditorState).toHaveBeenCalledTimes(6)
+    expect(component.disposeRuntimeHelpers).toHaveBeenCalledTimes(3)
+  })
 })

--- a/test/markstream-angular-code-block-stability.test.ts
+++ b/test/markstream-angular-code-block-stability.test.ts
@@ -18,8 +18,13 @@ describe('angular code block stability', () => {
     Object.assign(component, {
       codeBlockOptions: undefined,
       context: undefined,
+      hasEditorInput: false,
       lastCodeBlockOptions: undefined,
-      lastEditorInputSignature: '',
+      lastEditorIsDiff: false,
+      lastEditorLanguage: '',
+      lastEditorOriginalCode: '',
+      lastEditorResolvedCode: '',
+      lastEditorShowLoadingPlaceholder: false,
       lastRuntimeHostKey: '',
       node: {
         type: 'code_block',
@@ -36,6 +41,8 @@ describe('angular code block stability', () => {
     component.disposeRuntimeHelpers = vi.fn()
     component.syncEditorState = vi.fn()
 
+    const stringify = vi.spyOn(JSON, 'stringify')
+
     component.ngOnChanges()
     component.node = { ...component.node }
     component.ngOnChanges()
@@ -46,5 +53,6 @@ describe('angular code block stability', () => {
     component.ngOnChanges()
 
     expect(component.syncEditorState).toHaveBeenCalledTimes(2)
+    expect(stringify).not.toHaveBeenCalled()
   })
 })

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -822,6 +822,70 @@ describe('useMarkdownParsing performance behavior', () => {
     scope.stop()
   })
 
+  it('does not reuse aggregate nodes containing custom-rendered descendants', () => {
+    const content = ref([
+      '| Column |',
+      '| --- |',
+      '| Value |',
+      '',
+      'Streaming tail',
+    ].join('\n'))
+    const props = reactive({} as NodeRendererProps)
+    const scope = effectScope()
+    const state = scope.run(() => useMarkdownParsing(props, {
+      instanceMsgId: 'nested-custom-component-boundary',
+      renderContent: computed(() => content.value),
+      effectiveFinal: computed(() => false),
+      debugPerformanceEnabled: computed(() => false),
+      customComponentsMap: computed(() => ({ text: {} })),
+      logPerf: vi.fn(),
+    }))
+
+    if (!state)
+      throw new Error('failed to create parsing state')
+
+    const firstTable = state.parsedNodes.value[0] as any
+    firstTable.header.cells[0].children[0].content = 'caller mutation'
+    content.value += ' chunk'
+
+    expect(state.parsedNodes.value[0]).not.toBe(firstTable)
+    expect((state.parsedNodes.value[0] as any).header.cells[0].children[0].content).toBe('Column')
+
+    scope.stop()
+  })
+
+  it('treats a custom d2 renderer as the boundary for d2lang fences', () => {
+    const content = ref([
+      '```d2lang',
+      'a -> b',
+      '```',
+      '',
+      'Streaming tail',
+    ].join('\n'))
+    const props = reactive({} as NodeRendererProps)
+    const scope = effectScope()
+    const state = scope.run(() => useMarkdownParsing(props, {
+      instanceMsgId: 'd2lang-custom-component-boundary',
+      renderContent: computed(() => content.value),
+      effectiveFinal: computed(() => false),
+      debugPerformanceEnabled: computed(() => false),
+      customComponentsMap: computed(() => ({ d2: {} })),
+      logPerf: vi.fn(),
+    }))
+
+    if (!state)
+      throw new Error('failed to create parsing state')
+
+    const firstCodeBlock = state.parsedNodes.value[0] as any
+    firstCodeBlock.code = 'caller mutation'
+    content.value += ' chunk'
+
+    expect(state.parsedNodes.value[0]).not.toBe(firstCodeBlock)
+    expect((state.parsedNodes.value[0] as any).code).toBe('a -> b\n')
+
+    scope.stop()
+  })
+
   it('does not reuse a paragraph when children differ but raw is unchanged', () => {
     const content = ref('[x](https://example.com)')
     const { props, scope, state } = createParsingState(content)

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -822,6 +822,64 @@ describe('useMarkdownParsing performance behavior', () => {
     scope.stop()
   })
 
+  it('retains a custom boundary after the renderer mutates the node type', () => {
+    const content = ref('Custom paragraph.\n\nStreaming tail')
+    const props = reactive({} as NodeRendererProps)
+    const scope = effectScope()
+    const state = scope.run(() => useMarkdownParsing(props, {
+      instanceMsgId: 'mutated-custom-component-type',
+      renderContent: computed(() => content.value),
+      effectiveFinal: computed(() => false),
+      debugPerformanceEnabled: computed(() => false),
+      customComponentsMap: computed(() => ({ paragraph: {} })),
+      logPerf: vi.fn(),
+    }))
+
+    if (!state)
+      throw new Error('failed to create parsing state')
+
+    const previous = state.parsedNodes.value[0] as any
+    previous.type = 'heading'
+    previous.raw = 'caller mutation'
+    content.value += ' chunk'
+
+    expect(state.parsedNodes.value[0]).not.toBe(previous)
+    expect(state.parsedNodes.value[0]?.type).toBe('paragraph')
+    expect(state.parsedNodes.value[0]?.raw).toBe('Custom paragraph.')
+
+    scope.stop()
+  })
+
+  it('keeps structured parser reuse for custom renderers absent from the document', () => {
+    const content = ref(`${buildParagraphs(200)}\n\n`)
+    const logPerf = vi.fn()
+    const props = reactive({} as NodeRendererProps)
+    const scope = effectScope()
+    const state = scope.run(() => useMarkdownParsing(props, {
+      instanceMsgId: 'custom-component-without-boundary',
+      renderContent: computed(() => content.value),
+      effectiveFinal: computed(() => false),
+      debugPerformanceEnabled: computed(() => true),
+      customComponentsMap: computed(() => ({ code_block: {} })),
+      logPerf,
+    }))
+
+    if (!state)
+      throw new Error('failed to create parsing state')
+
+    const previous = state.parsedNodes.value
+    content.value += 'Appended paragraph.\n\n'
+    void state.parsedNodes.value
+    content.value += 'Second appended paragraph.\n\n'
+    const next = state.parsedNodes.value
+
+    expect(next.slice(0, previous.length)).toEqual(previous)
+    expect(next.slice(0, previous.length).every((node, index) => node === previous[index])).toBe(true)
+    expect(logPerf.mock.calls.at(-1)?.[1]?.processTokensReusedTopLevelNodes).toBeGreaterThan(0)
+
+    scope.stop()
+  })
+
   it('does not reuse aggregate nodes containing custom-rendered descendants', () => {
     const content = ref([
       '| Column |',

--- a/test/use-markdown-parsing-performance.test.ts
+++ b/test/use-markdown-parsing-performance.test.ts
@@ -784,6 +784,44 @@ describe('useMarkdownParsing performance behavior', () => {
     scope.stop()
   })
 
+  it('reuses settled built-in nodes alongside custom component mutation boundaries', () => {
+    const content = ref([
+      'Custom paragraph.',
+      '',
+      '```diff',
+      '- old',
+      '+ new',
+      '```',
+      '',
+      'Streaming tail',
+    ].join('\n'))
+    const customComponents = ref<Record<string, unknown>>({ paragraph: {} })
+    const props = reactive({} as NodeRendererProps)
+    const scope = effectScope()
+    const state = scope.run(() => useMarkdownParsing(props, {
+      instanceMsgId: 'selective-custom-component-boundary',
+      renderContent: computed(() => content.value),
+      effectiveFinal: computed(() => false),
+      debugPerformanceEnabled: computed(() => false),
+      customComponentsMap: computed(() => customComponents.value),
+      logPerf: vi.fn(),
+    }))
+
+    if (!state)
+      throw new Error('failed to create parsing state')
+
+    const firstParagraph = state.parsedNodes.value[0]
+    const firstCodeBlock = state.parsedNodes.value[1]
+    ;(firstParagraph as any).raw = 'caller mutation'
+    content.value += ' chunk'
+
+    expect(state.parsedNodes.value[0]).not.toBe(firstParagraph)
+    expect(state.parsedNodes.value[0]?.raw).toBe('Custom paragraph.')
+    expect(state.parsedNodes.value[1]).toBe(firstCodeBlock)
+
+    scope.stop()
+  })
+
   it('does not reuse a paragraph when children differ but raw is unchanged', () => {
     const content = ref('[x](https://example.com)')
     const { props, scope, state } = createParsingState(content)


### PR DESCRIPTION
## Summary

- stop treating the presence of any custom component as a global parsed-node reuse boundary
- preserve equivalent built-in node identity across streaming appends while excluding nodes and aggregate subtrees actually handled by custom renderers
- traverse table, list, and definition-list parsed-node containers when detecting mutation boundaries
- include the renderer-equivalent `d2lang → d2` custom component route
- keep custom-component mutations isolated, invalidate reuse when the mapping changes, and retain `postTransformNodes` as a full AST mutation boundary
- skip Angular editor synchronization when a streaming parse replaces a code block with an equivalent object
- compare Angular editor inputs field by field so equivalent-node checks do not serialize and allocate copies of large code payloads

This is a parser-level follow-up to #697. That PR keeps the Vue renderers resilient to equivalent fresh nodes; this PR avoids producing those replacements for unrelated built-in nodes in the first place and prevents the same equivalent-node churn from reaching Angular `updateDiff`.

Svelte was audited as well. Its editor effect subscribes to the derived code, diff, language, loading, theme, and option values rather than the `node` object identity, so an equivalent replacement does not trigger the same resync path and no Svelte change is needed.

## Regression coverage

- custom-rendered paragraphs remain mutation boundaries while a settled built-in diff code block keeps object identity
- custom descendants inside aggregate table nodes prevent unsafe parent reuse
- `d2lang` fences owned by a custom `d2` renderer are not reused
- Angular schedules one editor synchronization for equivalent code block objects, still synchronizes when code changes, and performs the comparison without `JSON.stringify`

## Validation

- `pnpm test` (335 files, 2959 tests)
- focused parser and Angular suite (67 tests)
- `pnpm typecheck`
- `pnpm -C packages/markstream-angular typecheck`
- `pnpm -C packages/markstream-angular build`
- targeted ESLint checks

The docs frontmatter commit is included so this branch independently passes the existing docs parity/build checks; it is the same baseline fix already validated on #697.
