### PR TITLE
fix(parser): opt into safe tail rule reuse

### DIFF
--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -188,17 +188,18 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
     ? Boolean(markdownItOptions.stream)
     : true
   const hasCustomValidateLink = Object.prototype.hasOwnProperty.call(markdownItOptions, 'validateLink')
+  const experimentalOptions = {
+    stream,
+    streamTailLocalPostBlockRules: true,
+    ...experimental,
+  }
 
   const md = new MarkdownIt({
     html: true,
     linkify: true,
     typographer: true,
     ...markdownItOptions,
-    experimental: {
-      stream,
-      streamTailLocalPostBlockRules: true,
-      ...experimental,
-    },
+    experimental: experimentalOptions,
   }) as unknown as MarkdownItInstance
 
   if (!hasCustomValidateLink) {

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -190,7 +190,6 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
   const hasCustomValidateLink = Object.prototype.hasOwnProperty.call(markdownItOptions, 'validateLink')
   const experimentalOptions = {
     stream,
-    streamTailLocalPostBlockRules: true,
     ...experimental,
   }
 
@@ -201,6 +200,13 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
     ...markdownItOptions,
     experimental: experimentalOptions,
   }) as unknown as MarkdownItInstance
+
+  const tailLocalOption = 'streamTailLocalPostBlockRules'
+  const hasTailLocalSetting = Object.prototype.hasOwnProperty.call(markdownItOptions, tailLocalOption)
+    || Object.prototype.hasOwnProperty.call(experimental, tailLocalOption)
+  if (!hasTailLocalSetting && Object.prototype.hasOwnProperty.call(md.options, tailLocalOption)) {
+    (md.options as Record<string, unknown>)[tailLocalOption] = true
+  }
 
   if (!hasCustomValidateLink) {
     const validateLink = (url: string) => !isUnsafeHtmlUrl(url, { tagName: 'a', attrName: 'href' })

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -196,6 +196,7 @@ export function factory(opts: FactoryOptions = {}): MarkdownItInstance {
     ...markdownItOptions,
     experimental: {
       stream,
+      streamTailLocalPostBlockRules: true,
       ...experimental,
     },
   }) as unknown as MarkdownItInstance

--- a/packages/markdown-parser/test/parser-runtime-lifecycle.test.ts
+++ b/packages/markdown-parser/test/parser-runtime-lifecycle.test.ts
@@ -36,6 +36,15 @@ function paragraphChildren(node: ParsedNode | undefined) {
 }
 
 describe('parser runtime lifecycle characterization', () => {
+  it('marks factory post-block rules as tail-local by default', () => {
+    expect((factory() as any).options.streamTailLocalPostBlockRules).toBe(true)
+    expect((factory({
+      markdownItOptions: {
+        experimental: { streamTailLocalPostBlockRules: false },
+      },
+    }) as any).options.streamTailLocalPostBlockRules).toBe(false)
+  })
+
   it('keeps same-source replay idempotent and append-only prefix identity eligible', () => {
     const md = getMarkdown('parser-runtime-replay-append')
     const base = 'alpha\n\nbeta\n\n'

--- a/packages/markdown-parser/test/parser-runtime-lifecycle.test.ts
+++ b/packages/markdown-parser/test/parser-runtime-lifecycle.test.ts
@@ -37,12 +37,14 @@ function paragraphChildren(node: ParsedNode | undefined) {
 
 describe('parser runtime lifecycle characterization', () => {
   it('marks factory post-block rules as tail-local by default', () => {
-    expect((factory() as any).options.streamTailLocalPostBlockRules).toBe(true)
+    const option = 'streamTailLocalPostBlockRules'
+    const parserSupportsOption = Object.prototype.hasOwnProperty.call(new MarkdownItEngine().options, option)
+    expect((factory() as any).options[option]).toBe(parserSupportsOption ? true : undefined)
     expect((factory({
       markdownItOptions: {
-        experimental: { streamTailLocalPostBlockRules: false },
+        experimental: { [option]: false },
       },
-    }) as any).options.streamTailLocalPostBlockRules).toBe(false)
+    }) as any).options[option]).toBe(false)
   })
 
   it('keeps same-source replay idempotent and append-only prefix identity eligible', () => {


### PR DESCRIPTION
## Summary
- opt markstream-vue built-in post-block rules into markdown-it-ts bounded tail reuse
- preserve an explicit consumer override
- cover the factory default and override

Depends on Simon-He95/markdown-it-ts#28.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- markdown-parser: 563 tests passed
- playground stream-vs-cold randomized chunking: 300/300 passed