### PR TITLE
chore(parser): upgrade markdown-it-ts to 1.1.0

### DIFF
--- a/packages/markdown-parser/package.json
+++ b/packages/markdown-parser/package.json
@@ -60,7 +60,7 @@
     "markdown-it-mark": "^4.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-checkbox": "^1.0.6",
-    "markdown-it-ts": "^1.0.7"
+    "markdown-it-ts": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       markdown-it-ts:
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^22.20.1
@@ -10172,8 +10172,8 @@ packages:
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
-  markdown-it-ts@1.0.7:
-    resolution: {integrity: sha512-gGDZxv51QgitJhdoTHU/JtgpquCbmTRdhH8nsRG7BknLh69jCuE3ism28i5EUY+7BQRj6evZA8YSNK+CcM2/sA==}
+  markdown-it-ts@1.1.0:
+    resolution: {integrity: sha512-ycYoj3jeP0zHW9u4vxtSuuq9JaitIRxxYbRtns9D4fDR5mzSpFnb855KclFBGiKFJxVi+8EkMB938oZpdDVc0A==}
     engines: {node: '>=20.19'}
 
   markdown-it@14.2.0:
@@ -10272,6 +10272,9 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   measury@0.1.4:
     resolution: {integrity: sha512-AAY8ojVbYNdv1S+vrx7tEQe0LAL3EwzWnjHWwsjnmU34XH9LECfsstHv3y+gJkZjMOwmBArej561n7Hk6gKMGQ==}
@@ -25095,11 +25098,11 @@ snapshots:
 
   markdown-it-task-checkbox@1.0.6: {}
 
-  markdown-it-ts@1.0.7:
+  markdown-it-ts@1.1.0:
     dependencies:
       entities: 8.0.0
       linkify-it: 6.1.0
-      mdurl: 2.0.0
+      mdurl: 2.1.0
       punycode.js: 2.3.1
 
   markdown-it@14.2.0:
@@ -25322,6 +25325,8 @@ snapshots:
   mdn-data@2.12.2: {}
 
   mdurl@2.0.0: {}
+
+  mdurl@2.1.0: {}
 
   measury@0.1.4: {}
 


### PR DESCRIPTION
## Review scope

Review-only PR for commit `fd2cbe5f05e7203aee0a6886baf0153fac68e2bc`. The change is already on `main`; this temporary base preserves the exact pre-upgrade diff for Codex review. This PR will not be merged.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- markdown-parser: 563 tests passed
- playground stream-vs-cold randomized chunking: 300/300 passed