### PR TITLE
fix(react): avoid replaying fade on streamed nodes

### DIFF
--- a/docs/zh/guide/showcase.md
+++ b/docs/zh/guide/showcase.md
@@ -1,3 +1,11 @@
+---
+title: Showcase（占位）
+description: markstream 流式 Markdown 渲染器的示例与场景演示占位页，覆盖流式对话、长文档、代码评审、图表、自定义组件与安全复现流程，等待与英文版同步。
+keywords:
+  - markstream showcase
+  - 流式 markdown 演示
+---
+
 # Showcase（中文占位）
 
 > 原文节选（仅供翻译参考）：

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -446,6 +446,7 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
     const datasetChanged = datasetKey !== undefined
       ? datasetKey !== prevCtx.key
       : total !== prevCtx.total
+    const datasetIdentityChanged = datasetKey !== prevCtx.key
     previousDatasetRef.current = { key: datasetKey, total }
     const prevBatch = previousBatchConfigRef.current
     const currentDelay = props.renderBatchDelay ?? 16
@@ -463,10 +464,10 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
 
     if (datasetChanged || batchConfigChanged || !incrementalRenderingActive)
       cancelBatchTimers()
-    if (datasetChanged || batchConfigChanged) {
+    if (datasetChanged || batchConfigChanged)
       adaptiveBatchSizeRef.current = Math.max(1, resolvedBatchSize || 1)
+    if (datasetIdentityChanged)
       nodeSeenRef.current.clear()
-    }
 
     if (!total) {
       renderedCountRef.current = 0

--- a/packages/markstream-react/src/components/NodeRenderer.tsx
+++ b/packages/markstream-react/src/components/NodeRenderer.tsx
@@ -262,6 +262,7 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
     key: props.indexKey,
     total: parsedNodes.length,
   })
+  const previousParsedNodesRef = useRef(parsedNodes)
   const previousBatchConfigRef = useRef({
     batchSize: resolvedBatchSize,
     initial: resolvedInitialBatch,
@@ -446,7 +447,15 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
     const datasetChanged = datasetKey !== undefined
       ? datasetKey !== prevCtx.key
       : total !== prevCtx.total
-    const datasetIdentityChanged = datasetKey !== prevCtx.key
+    const previousParsedNodes = previousParsedNodesRef.current
+    const sharedNodeCount = Math.min(previousParsedNodes.length, parsedNodes.length)
+    let stablePrefixLength = 0
+    while (
+      stablePrefixLength < sharedNodeCount
+      && previousParsedNodes[stablePrefixLength] === parsedNodes[stablePrefixLength]
+    ) {
+      stablePrefixLength += 1
+    }
     previousDatasetRef.current = { key: datasetKey, total }
     const prevBatch = previousBatchConfigRef.current
     const currentDelay = props.renderBatchDelay ?? 16
@@ -466,8 +475,15 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
       cancelBatchTimers()
     if (datasetChanged || batchConfigChanged)
       adaptiveBatchSizeRef.current = Math.max(1, resolvedBatchSize || 1)
-    if (datasetIdentityChanged)
+    if (datasetKey !== prevCtx.key) {
       nodeSeenRef.current.clear()
+    }
+    else if (datasetChanged) {
+      for (const index of nodeSeenRef.current) {
+        if (index >= stablePrefixLength)
+          nodeSeenRef.current.delete(index)
+      }
+    }
 
     if (!total) {
       renderedCountRef.current = 0
@@ -510,6 +526,10 @@ const NodeRendererInner: React.FC<NodeRendererInnerProps> = ({
     resolvedInitialBatch,
     scheduleBatch,
   ])
+
+  useEffect(() => {
+    previousParsedNodesRef.current = parsedNodes
+  }, [parsedNodes])
 
   useEffect(() => {
     if (!virtualizationEnabled) {

--- a/test/react-text-node-streaming-fade.test.tsx
+++ b/test/react-text-node-streaming-fade.test.tsx
@@ -176,6 +176,44 @@ describe('markstream-react text streaming fade', () => {
     })
   })
 
+  it('does not replay enter fade on existing nodes when a top-level node is appended', async () => {
+    ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const renderMarkdown = (content: string) =>
+      React.createElement(NodeRenderer as any, {
+        content,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        viewportPriority: false,
+        smoothStreaming: false,
+      })
+
+    await act(async () => {
+      root.render(renderMarkdown('# Heading\n\nParagraph'))
+    })
+    await flushReact()
+
+    const headingContent = host.querySelector('[data-node-index="0"] .node-content')
+    const paragraphContent = host.querySelector('[data-node-index="1"] .node-content')
+
+    await act(async () => {
+      root.render(renderMarkdown('# Heading\n\nParagraph\n\n## Next'))
+    })
+    await flushReact()
+
+    expect(host.querySelector('[data-node-index="0"] .node-content')).toBe(headingContent)
+    expect(host.querySelector('[data-node-index="1"] .node-content')).toBe(paragraphContent)
+    expect(headingContent?.classList.contains('fade-node')).toBe(false)
+    expect(paragraphContent?.classList.contains('fade-node')).toBe(false)
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
   it('settles a finished strong-node delta when following sibling text keeps streaming', async () => {
     ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 

--- a/test/react-text-node-streaming-fade.test.tsx
+++ b/test/react-text-node-streaming-fade.test.tsx
@@ -214,6 +214,40 @@ describe('markstream-react text streaming fade', () => {
     })
   })
 
+  it('replays enter fade for a non-append document replacement', async () => {
+    ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const renderMarkdown = (content: string) =>
+      React.createElement(NodeRenderer as any, {
+        content,
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        viewportPriority: false,
+        smoothStreaming: false,
+      })
+
+    await act(async () => {
+      root.render(renderMarkdown('# First\n\nParagraph'))
+    })
+    await flushReact()
+
+    await act(async () => {
+      root.render(renderMarkdown('## Replacement\n\nSecond paragraph\n\n---'))
+    })
+    await flushReact()
+
+    const replacedNodes = Array.from(host.querySelector('.markdown-renderer')?.querySelectorAll(':scope > .node-slot > .node-content') ?? [])
+    expect(replacedNodes).toHaveLength(3)
+    expect(replacedNodes.every(node => node.classList.contains('fade-node'))).toBe(true)
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
   it('settles a finished strong-node delta when following sibling text keeps streaming', async () => {
     ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 


### PR DESCRIPTION
## Summary

- preserve enter-fade state when streaming appends top-level parsed nodes
- only reset seen-node animation state when the renderer dataset identity changes
- add a React DOM regression test that verifies existing node wrappers stay mounted without replaying fade

## Tests

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (336 files, 2969 tests)

Closes #702