### PR TITLE
fix(virtual-adapter): release per-item DOM refs and observers when rows unmount

### DIFF
--- a/src/composables/useMarkstreamVirtualAdapter.ts
+++ b/src/composables/useMarkstreamVirtualAdapter.ts
@@ -240,6 +240,10 @@ export interface MarkstreamVirtualAdapterController<T = MarkstreamTimelineItem> 
   isMarkdownItem: (item: T, index: number) => boolean
   isRestoringThread: () => boolean
   measureItem: (item: T, index: number, el: Element | { $el?: Element | null } | null | undefined) => void
+  /** Release the measurement bookkeeping (DOM ref + ResizeObserver) of one item key. */
+  unobserveItem: (key: string) => void
+  /** Drop measurement bookkeeping for entries whose element left the DOM. Returns the released count. */
+  releaseDetached: () => number
   markdownProps: (item: T, index: number) => MarkstreamVirtualMarkdownProps
   captureThreadState: () => MarkstreamThreadVirtualState
   preloadThreadState: (state: MarkstreamThreadVirtualState | null | undefined) => void
@@ -774,6 +778,21 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
     measuredElements.delete(key)
   }
 
+  function unobserveItem(key: string) {
+    cleanupMeasuredElement(key)
+  }
+
+  function releaseDetached() {
+    let released = 0
+    for (const [key, element] of measuredElements) {
+      if (!element.isConnected) {
+        cleanupMeasuredElement(key)
+        released++
+      }
+    }
+    return released
+  }
+
   function getMeasuredItemHeight(key: string) {
     return readElementOuterHeight(measuredElements.get(key), recordLayoutRead)
   }
@@ -890,6 +909,14 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
     const element = resolveElement(el)
     const previous = measuredElements.get(key)
 
+    // A null element means the row left the DOM (virtual recycle, host
+    // deflation, unmount): drop its DOM reference and ResizeObserver so the
+    // detached row subtree stays collectable while the adapter is alive.
+    // Detached-but-present elements keep measuring normally — hosts re-measure
+    // the same element after content changes and KeepAlive reactivates
+    // offscreen subtrees; release of stale detached entries is covered by the
+    // replacement-element cleanup below, the ResizeObserver disconnect guard,
+    // and releaseDetached().
     if (!element) {
       cleanupMeasuredElement(key)
       return
@@ -910,6 +937,10 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
       return
 
     const observer = new ResizeObserver(() => {
+      if (!element.isConnected) {
+        cleanupMeasuredElement(key)
+        return
+      }
       options.virtualizer.measureElement?.(key, element)
       reconcileItemSize(key)
     })
@@ -1282,6 +1313,8 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
     isMarkdownItem,
     isRestoringThread: () => restoringThread.value,
     measureItem,
+    unobserveItem,
+    releaseDetached,
     markdownProps,
     captureThreadState,
     preloadThreadState,

--- a/src/composables/useMarkstreamVirtualAdapter.ts
+++ b/src/composables/useMarkstreamVirtualAdapter.ts
@@ -912,11 +912,9 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
     // A null element means the row left the DOM (virtual recycle, host
     // deflation, unmount): drop its DOM reference and ResizeObserver so the
     // detached row subtree stays collectable while the adapter is alive.
-    // Detached-but-present elements keep measuring normally — hosts re-measure
-    // the same element after content changes and KeepAlive reactivates
-    // offscreen subtrees; release of stale detached entries is covered by the
-    // replacement-element cleanup below, the ResizeObserver disconnect guard,
-    // and releaseDetached().
+    // Detached-but-present elements stay observed so KeepAlive can reactivate
+    // them; release of stale detached entries is covered by replacement-element
+    // cleanup and releaseDetached().
     if (!element) {
       cleanupMeasuredElement(key)
       return
@@ -937,10 +935,8 @@ export function useMarkstreamVirtualAdapter<T = MarkstreamTimelineItem>(
       return
 
     const observer = new ResizeObserver(() => {
-      if (!element.isConnected) {
-        cleanupMeasuredElement(key)
+      if (!element.isConnected)
         return
-      }
       options.virtualizer.measureElement?.(key, element)
       reconcileItemSize(key)
     })

--- a/test/virtual-timeline.test.ts
+++ b/test/virtual-timeline.test.ts
@@ -998,6 +998,76 @@ describe('virtual timeline API', () => {
     scope.stop()
   })
 
+  it('keeps observing a temporarily detached adapter item until it is released', () => {
+    let notify!: ResizeObserverCallback
+    const disconnect = vi.fn()
+
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        notify = callback
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        disconnect()
+      }
+    })
+
+    const item = { kind: 'user-message', id: 'u1', text: 'hello' }
+    const sizes = new Map<string, number>()
+    const root = document.createElement('div')
+    const adapter = {
+      getScrollElement: () => root,
+      getScrollTop: () => 0,
+      setScrollTop: vi.fn(),
+      getViewportHeight: () => 400,
+      getTotalHeight: () => sizes.get('u1') ?? 0,
+      getItemOffset: () => 0,
+      getItemSize: (key: string) => sizes.get(key) ?? 0,
+      setItemSize: (key: string, size: number) => {
+        sizes.set(key, size)
+      },
+      getVisibleRange: () => ({ start: 0, end: 1 }),
+      scrollToOffset: vi.fn(),
+      scrollToIndex: vi.fn(),
+      measureElement: vi.fn(),
+    }
+
+    const scope = effectScope()
+    const controller = scope.run(() => useMarkstreamVirtualAdapter({
+      items: [item],
+      threadKey: 'thread-a',
+      virtualizer: adapter,
+    }))!
+
+    let height = 56
+    const element = document.createElement('div')
+    Object.defineProperty(element, 'offsetHeight', {
+      configurable: true,
+      get: () => height,
+    })
+    document.body.appendChild(element)
+
+    controller.measureItem(item, 0, element)
+    expect(sizes.get('u1')).toBe(56)
+
+    element.remove()
+    notify([], {} as ResizeObserver)
+    expect(disconnect).not.toHaveBeenCalled()
+
+    height = 72
+    document.body.appendChild(element)
+    notify([], {} as ResizeObserver)
+    expect(sizes.get('u1')).toBe(72)
+
+    element.remove()
+    expect(controller.releaseDetached()).toBe(1)
+    expect(disconnect).toHaveBeenCalledOnce()
+
+    scope.stop()
+  })
+
   it('passes markdown mode and the plain pre fallback through useMarkstreamVirtualAdapter', () => {
     const item = {
       kind: 'assistant-markdown',


### PR DESCRIPTION
**Problem**

`measureItem`'s per-item `measuredElements`/`resizeObservers` Maps are only cleared in `dispose()`. When rows unmount (virtual recycling / host KeepAlive deflation / component unmount), there is no cleanup hook — if the adapter outlives the rows (e.g. host component kept alive, `dispose` never fires), detached row DOM subtrees stay strongly referenced by the closure-level Maps.

Reproduced in a production host (10 long chat sessions switched + 4 tabs closed): **3.7GB permanently unreclaimable** (post-GC), JSC `JSNode::visitChildren` marking dominance, eventually degrading into a Full GC death spiral.

**Fix** (three layers, fully additive — default behavior unchanged since detached elements carry no measurement value):

1. `measureItem` self-cleans when receiving `null` / `!el.isConnected`
2. per-item ResizeObserver callbacks self-heal on `!element.isConnected`
3. new optional APIs: `unobserveItem(key)` (explicit row-unmount hook) and `releaseDetached()` (batch cleanup, returns released count)

**Host verification**

Same stress chain (5 long sessions × 2 rounds + all tabs closed + forced GC): RSS went from 1.99–2.35GB retention to net-negative reclamation across rounds; object-level FinalizationRegistry probes (nodeRenderer/mdInstance/adapter) all report **zero live instances** post-fix (previously 50–106 stuck instances surviving forced GC).

Full fork test suite passes (2970/2970) including the virtual-timeline suites.