### PR TITLE
fix(code-block): match diff fallback gutter background

### DIFF
--- a/src/components/PreCodeNode/PreCodeNode.vue
+++ b/src/components/PreCodeNode/PreCodeNode.vue
@@ -680,7 +680,7 @@ function getDiffLineStyle(index: number, side: 'original' | 'modified') {
   box-shadow: none;
   padding-left: var(--markstream-pre-diff-line-number-padding-left, 2ch);
   padding-right: var(--markstream-pre-diff-line-number-padding-right, 1ch);
-  border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--code-bg);
+  border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--markstream-diff-editor-bg, var(--code-bg));
   color: var(--code-line-number);
   font-variant-numeric: tabular-nums;
   line-height: var(--markstream-pre-diff-line-height, 18px);

--- a/test/pre-code-node-diff-preview.test.ts
+++ b/test/pre-code-node-diff-preview.test.ts
@@ -825,7 +825,7 @@ describe('pre code node diff preview', () => {
     expect(source).not.toContain('linear-gradient(\n      var(--markstream-diff-removed-line-fill')
     expect(source).toContain('--markstream-pre-diff-line-number-bg: var(')
     expect(source).toContain('background: var(--markstream-pre-diff-line-number-bg);')
-    expect(source).toContain('border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--code-bg);')
+    expect(source).toContain('border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--markstream-diff-editor-bg, var(--code-bg));')
     expect(source).toContain('--markstream-pre-diff-content-height')
     for (const selector of [
       'pre.markstream-pre--diff-preview .markstream-pre__diff-line::before',
@@ -913,7 +913,7 @@ describe('pre code node diff preview', () => {
     expect(source).toContain('padding-left: var(--markstream-pre-diff-line-number-padding-left, 2ch);')
     expect(source).toContain('padding-right: var(--markstream-pre-diff-line-number-padding-right, 1ch);')
     expect(source).toContain('min-width: var(--markstream-pre-diff-line-number-width);')
-    expect(source).toContain('border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--code-bg);')
+    expect(source).toContain('border-right: var(--markstream-pre-diff-line-number-separator-width, 2px) solid var(--markstream-diff-editor-bg, var(--code-bg));')
     expect(source).toContain('width: var(--markstream-pre-diff-gutter-marker-width, 4px);')
   })
 


### PR DESCRIPTION
## Summary

- use the resolved diff editor background for the pre fallback line-number separator
- keep the separator color aligned when the page theme and code theme differ
- update the existing diff preview gutter regression assertions

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test (336 files, 2971 tests)
- visual check: /diff-handoff-check?theme=dark&codeOverflow=wrap