### PR TITLE
perf: optimize streaming and loading animations

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -4226,11 +4226,21 @@ onUnmounted(() => {
   }
 }
 
-.code-block-container.is-rendering .code-height-placeholder{
-  background-size: 400% 100%;
-  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
+.code-block-container.is-rendering .code-height-placeholder {
+  position: relative;
+  overflow: hidden;
   min-height: var(--ms-size-skeleton-min-height);
+  background: var(--loading-shimmer);
+}
+
+.code-block-container.is-rendering .code-height-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
   background: linear-gradient(90deg, var(--loading-shimmer) 25%, hsl(var(--ms-muted) / 0.7) 37%, var(--loading-shimmer) 63%);
+  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 /* Loading placeholder styles */
@@ -4246,24 +4256,44 @@ onUnmounted(() => {
 }
 
 .skeleton-line {
+  position: relative;
+  overflow: hidden;
   height: 1rem;
-  background: linear-gradient(90deg, var(--loading-shimmer) 25%, hsl(var(--ms-muted) / 0.7) 37%, var(--loading-shimmer) 63%);
-  background-size: 400% 100%;
-  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
   border-radius: calc(var(--ms-radius) * 0.5);
+  background: var(--loading-shimmer);
+}
+
+.skeleton-line::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
+  background: linear-gradient(90deg, var(--loading-shimmer) 25%, hsl(var(--ms-muted) / 0.7) 37%, var(--loading-shimmer) 63%);
+}
+
+.code-block-container.is-rendering .skeleton-line::before {
+  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 .skeleton-line.short {
   width: 60%;
 }
 
-.code-block-container[data-markstream-viewport-pending='true'] .code-height-placeholder,
-.code-block-container[data-markstream-viewport-pending='true'] .skeleton-line {
+.code-block-container[data-markstream-viewport-pending='true'] .code-height-placeholder::before,
+.code-block-container[data-markstream-viewport-pending='true'] .skeleton-line::before {
   animation: none;
 }
 
 @keyframes code-skeleton-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: 0 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(75%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-block-container.is-rendering .code-height-placeholder::before,
+  .skeleton-line::before {
+    animation: none;
+  }
 }
 </style>

--- a/src/components/ImageNode/ImageNode.vue
+++ b/src/components/ImageNode/ImageNode.vue
@@ -402,27 +402,39 @@ onBeforeUnmount(() => {
 }
 
 .image-shimmer {
+  position: relative;
   display: block;
   width: 100%;
   height: 100%;
   min-height: 8rem;
+  overflow: hidden;
+  background: hsl(var(--ms-muted));
+}
+
+.image-shimmer::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 300%;
   background: linear-gradient(
     90deg,
     hsl(var(--ms-muted)) 0%,
     hsl(var(--ms-muted-foreground) / 0.06) 50%,
     hsl(var(--ms-muted)) 100%
   );
-  background-size: 200% 100%;
+  background-position: 100% 0;
+  background-size: 66.6667% 100%;
   animation: image-shimmer 1.5s ease-in-out infinite;
 }
 
-.image-node-container[data-markstream-viewport-pending='true'] .image-shimmer {
+.image-node-container[data-markstream-viewport-pending='true'] .image-shimmer::before {
   animation: none;
 }
 
 @keyframes image-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: -100% 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(66.6667%); }
 }
 
 .image-error {
@@ -445,6 +457,6 @@ onBeforeUnmount(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .image-shimmer { animation: none !important; }
+  .image-shimmer::before { animation: none !important; }
 }
 </style>

--- a/src/components/TableNode/TableNode.vue
+++ b/src/components/TableNode/TableNode.vue
@@ -421,15 +421,7 @@ onBeforeUnmount(stopColumnResize)
   position: absolute;
   inset: 0;
   border-radius: calc(var(--ms-radius) * 0.5);
-  background: linear-gradient(
-    90deg,
-    var(--loading-shimmer) 25%,
-    var(--loading-shimmer) 50%,
-    var(--loading-shimmer) 75%
-  );
-  background-size: 200% 100%;
-  animation: table-node-shimmer 1.2s linear infinite;
-  will-change: background-position;
+  background: var(--loading-shimmer);
 }
 
 .table-node__loading {
@@ -480,12 +472,6 @@ onBeforeUnmount(stopColumnResize)
   overflow-wrap: inherit;
   word-break: inherit;
   max-width: none;
-}
-
-@keyframes table-node-shimmer {
-  0% { background-position: 0% 0%; }
-  50% { background-position: 100% 0%; }
-  100% { background-position: 200% 0%; }
 }
 
 .hr + .table-node-wrapper {

--- a/src/components/TextNode/TextNode.vue
+++ b/src/components/TextNode/TextNode.vue
@@ -53,10 +53,50 @@ let stopStreamVersionWatch: (() => void) | undefined
 // The settled node is therefore written ONCE and never touched again: each
 // delta settle appends the increment as a NEW sibling text node, so existing
 // nodes keep their identity and content forever.
+//
+// Coalesce appended increments unless doing so would disturb a selection.
 const settledTextEl = ref<HTMLElement | null>(null)
 const settledAppendsEl = ref<HTMLElement | null>(null)
+const streamedDeltaEl = ref<HTMLElement | null>(null)
 let frozenSettledText = ''
 let settledTextNode: Text | null = null
+let pendingSelectedContent: string | null = null
+let settleAfterSelection = false
+let watchedSelectionDocument: Document | undefined
+
+const SETTLED_APPENDS_COALESCE_THRESHOLD = 4
+
+function selectionTouches(element: Element) {
+  const selection = document.getSelection?.()
+  if (!selection || selection.rangeCount === 0)
+    return false
+  const { anchorNode, focusNode } = selection
+  return (anchorNode != null && element.contains(anchorNode))
+    || (focusNode != null && element.contains(focusNode))
+}
+
+function activeSelectionIntersects(element: Element) {
+  const selection = document.getSelection?.()
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed)
+    return false
+  for (let index = 0; index < selection.rangeCount; index++) {
+    if (selection.getRangeAt(index).intersectsNode(element))
+      return true
+  }
+  return false
+}
+
+function coalesceSettledAppends(appendsEl: HTMLElement) {
+  if (appendsEl.childNodes.length <= SETTLED_APPENDS_COALESCE_THRESHOLD)
+    return
+  if (selectionTouches(appendsEl))
+    return
+  let merged = ''
+  for (let index = 0; index < appendsEl.childNodes.length; index++)
+    merged += appendsEl.childNodes[index]?.textContent ?? ''
+  appendsEl.textContent = merged
+}
+
 function syncSettledText() {
   const el = settledTextEl.value
   if (!el)
@@ -94,6 +134,7 @@ function syncSettledText() {
     // Growth: never touch the frozen node — append a new sibling text node.
     appendsEl.appendChild(document.createTextNode(text.slice(frozenSettledText.length)))
     frozenSettledText = text
+    coalesceSettledAppends(appendsEl)
   }
 }
 
@@ -109,6 +150,12 @@ function stopWatchingStreamVersion() {
 }
 
 function settleStreamedDelta() {
+  if (streamedDeltaEl.value && activeSelectionIntersects(streamedDeltaEl.value)) {
+    settleAfterSelection = true
+    watchSelectionRelease()
+    return
+  }
+  settleAfterSelection = false
   stopWatchingStreamVersion()
   if (!streamedDelta.value)
     return
@@ -131,35 +178,76 @@ function watchStreamVersionWhileDeltaActive() {
   )
 }
 
+function applyStreamingUpdate(normalized: string) {
+  const key = streamStateKey.value
+  const result = resolveStreamingTextUpdate({
+    nextContent: normalized,
+    persistedContent: key ? inheritedTextStreamState?.get(key) : undefined,
+    currentState: { settledContent: settledContent.value, streamedDelta: streamedDelta.value },
+    typewriterEnabled: fadeEnabled.value,
+  })
+
+  settledContent.value = result.settledContent
+  streamedDelta.value = result.streamedDelta
+  if (result.appended) {
+    streamFadeVersion.value += 1
+    watchStreamVersionWhileDeltaActive()
+  }
+  else if (!streamedDelta.value) {
+    stopWatchingStreamVersion()
+  }
+
+  if (key)
+    inheritedTextStreamState?.set(key, normalized)
+}
+
 watch(
   [() => props.node.content, streamStateKey, fadeEnabled],
   ([next]) => {
     const normalized = String(next ?? '')
-    const key = streamStateKey.value
-    const result = resolveStreamingTextUpdate({
-      nextContent: normalized,
-      persistedContent: key ? inheritedTextStreamState?.get(key) : undefined,
-      currentState: { settledContent: settledContent.value, streamedDelta: streamedDelta.value },
-      typewriterEnabled: fadeEnabled.value,
-    })
-
-    settledContent.value = result.settledContent
-    streamedDelta.value = result.streamedDelta
-    if (result.appended) {
-      streamFadeVersion.value += 1
-      watchStreamVersionWhileDeltaActive()
+    if (streamedDeltaEl.value && activeSelectionIntersects(streamedDeltaEl.value)) {
+      pendingSelectedContent = normalized
+      watchSelectionRelease()
+      return
     }
-    else if (!streamedDelta.value) {
-      stopWatchingStreamVersion()
-    }
-
-    if (key)
-      inheritedTextStreamState?.set(key, normalized)
+    pendingSelectedContent = null
+    settleAfterSelection = false
+    applyStreamingUpdate(normalized)
   },
   { immediate: true },
 )
 
-onScopeDispose(stopWatchingStreamVersion)
+function handleSelectionChange() {
+  if (streamedDeltaEl.value && activeSelectionIntersects(streamedDeltaEl.value))
+    return
+  stopWatchingSelectionRelease()
+  if (pendingSelectedContent != null) {
+    const pending = pendingSelectedContent
+    pendingSelectedContent = null
+    settleAfterSelection = false
+    applyStreamingUpdate(pending)
+  }
+  else if (settleAfterSelection) {
+    settleStreamedDelta()
+  }
+}
+
+function watchSelectionRelease() {
+  if (watchedSelectionDocument)
+    return
+  watchedSelectionDocument = document
+  watchedSelectionDocument.addEventListener('selectionchange', handleSelectionChange)
+}
+
+function stopWatchingSelectionRelease() {
+  watchedSelectionDocument?.removeEventListener('selectionchange', handleSelectionChange)
+  watchedSelectionDocument = undefined
+}
+
+onScopeDispose(() => {
+  stopWatchingStreamVersion()
+  stopWatchingSelectionRelease()
+})
 
 const streamedDeltaClass = computed(() => (
   streamFadeVersion.value % 2 === 0
@@ -183,6 +271,7 @@ const streamedDeltaClass = computed(() => (
     />
     <span
       v-if="streamedDelta"
+      ref="streamedDeltaEl"
       class="text-node-stream-delta" :class="[streamedDeltaClass]"
       @animationend="settleStreamedDelta"
     >
@@ -206,7 +295,6 @@ const streamedDeltaClass = computed(() => (
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, 280ms));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, cubic-bezier(0.33, 0, 0.67, 1)));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 .text-node-stream-delta--a {
   animation-name: text-node-stream-update-fade-a;

--- a/test/text-node-selection.test.ts
+++ b/test/text-node-selection.test.ts
@@ -114,4 +114,77 @@ describe('text node streaming selection', () => {
       wrapper.unmount()
     }
   })
+
+  it('coalesces settled append nodes during long streams', async () => {
+    const wrapper = mountRenderer('base')
+    try {
+      for (let index = 1; index <= 12; index++) {
+        await wrapper.setProps({ content: `base${'x'.repeat(index)}` })
+        await flushAll()
+      }
+
+      const appends = wrapper.find('.text-node > span:nth-child(2)').element
+      expect(appends.childNodes.length).toBeLessThanOrEqual(4)
+      expect(wrapper.find('.text-node').element.textContent).toBe('basexxxxxxxxxxxx')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('does not coalesce append nodes that contain the selection', async () => {
+    const wrapper = mountRenderer('base')
+    try {
+      const content = 'base123456789'
+      await wrapper.setProps({ content: 'base1' })
+      await flushAll()
+      await wrapper.setProps({ content: 'base12' })
+      await flushAll()
+
+      const appends = wrapper.find('.text-node > span:nth-child(2)').element
+      const selectedNode = appends.firstChild as Text
+      expect(selectText(selectedNode, 0, 1)).toBe('1')
+
+      for (let index = 3; index <= 9; index++) {
+        await wrapper.setProps({ content: content.slice(0, 4 + index) })
+        await flushAll()
+      }
+
+      expect(appends.childNodes.length).toBeGreaterThan(4)
+      expect(appends.firstChild).toBe(selectedNode)
+      expect(document.getSelection()?.toString()).toBe('1')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps an active delta selection until the selection is released', async () => {
+    const wrapper = mountRenderer('base')
+    try {
+      await wrapper.setProps({ content: 'base tail' })
+      await flushAll()
+
+      const delta = wrapper.find('.text-node-stream-delta')
+      const selectedNode = delta.element.firstChild as Text
+      const selectedBefore = selectText(selectedNode, 1, 4)
+      expect(selectedBefore).toBe('tai')
+
+      await wrapper.setProps({ content: 'base tail more' })
+      await flushAll()
+
+      expect(document.getSelection()?.toString()).toBe(selectedBefore)
+      expect(selectedNode.isConnected).toBe(true)
+      expect(wrapper.find('.text-node').element.textContent).toBe('base tail')
+
+      document.getSelection()?.removeAllRanges()
+      document.dispatchEvent(new Event('selectionchange'))
+      await flushAll()
+
+      expect(wrapper.find('.text-node').element.textContent).toBe('base tail more')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- preserve text selections across active streaming delta updates and coalesce settled text nodes only when selection-safe
- move image and code skeleton shimmer motion from `background-position` to compositor-friendly `transform`
- keep the code skeleton gradient, stops, easing, and travel visually equivalent to the original implementation
- remove the invisible table shimmer animation and persistent delta `will-change`

## Performance impact

- bounds settled text-node growth during long streams while retaining selection behavior
- avoids per-frame background-position paint for visible shimmer animations
- keeps the exact 400% code skeleton texture as a deliberate visual-fidelity tradeoff
- installs `selectionchange` only while an active delta update is deferred, then removes it after catch-up

## Validation

- `pnpm test` — 336 files / 2974 tests passed
- `pnpm typecheck`
- ESLint on all changed files
- browser comparison of original and transform shimmer at matched animation positions