### PR TITLE
perf: optimize animations across framework packages

### DIFF
--- a/packages/markstream-angular/src/index.css
+++ b/packages/markstream-angular/src/index.css
@@ -97,12 +97,23 @@ markstream-angular {
 }
 
 .markstream-angular .node-placeholder {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
   border-radius: 0.5rem;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.markstream-angular .node-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 500%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
+  background-size: 40% 100%;
   animation: node-placeholder-shimmer 1.1s ease-in-out infinite;
 }
 
@@ -114,7 +125,6 @@ markstream-angular {
 .markstream-angular .typewriter-node {
   opacity: 0;
   animation: node-enter-fade var(--fade-duration, var(--typewriter-fade-duration, 280ms)) var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))) both;
-  will-change: opacity;
 }
 
 .markstream-angular .markstream-angular-text-node {
@@ -135,7 +145,6 @@ markstream-angular {
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 
 .markstream-angular .markstream-angular-text__stream-delta--a {
@@ -239,7 +248,6 @@ markstream-angular {
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: markstream-angular-link-loading-pulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }
@@ -260,6 +268,10 @@ markstream-angular {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .markstream-angular .node-placeholder::before {
+    animation: none !important;
+  }
+
   .markstream-angular .link-loading-indicator {
     animation: none !important;
     opacity: var(--underline-rest-opacity, 0.18);
@@ -1060,13 +1072,8 @@ body > div[id^="dmermaid-"] {
 }
 
 @keyframes node-placeholder-shimmer {
-  from {
-    background-position: 200% 0%;
-  }
-
-  to {
-    background-position: -200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(80%); }
 }
 
 @keyframes spin {

--- a/packages/markstream-octane/src/index.css
+++ b/packages/markstream-octane/src/index.css
@@ -63,12 +63,23 @@
 }
 
 :where(.markstream-octane) .node-placeholder {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
   border-radius: 0.5rem;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+:where(.markstream-octane) .node-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 500%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
+  background-size: 40% 100%;
   animation: markstream-octane-node-placeholder-shimmer 1.1s ease-in-out infinite;
 }
 
@@ -110,7 +121,6 @@
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 
 :where(.markstream-octane) .text-node-stream-delta--a {
@@ -218,7 +228,6 @@
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: markstream-octane-link-loading-pulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }
@@ -257,6 +266,13 @@
   :where(.markstream-octane) .typewriter-cursor {
     animation: none !important;
     opacity: 1;
+  }
+
+  :where(.markstream-octane) .node-placeholder::before,
+  :where(.markstream-octane) .table-node--loading tbody td::after,
+  :where(.markstream-octane) .html-block-node__placeholder-bar::before,
+  :where(.markstream-octane) .skeleton-line::before {
+    animation: none !important;
   }
 }
 
@@ -445,6 +461,7 @@
 :where(.markstream-octane) .table-node--loading tbody td {
   position: relative;
   overflow: hidden;
+  border-radius: 0.25rem;
 }
 
 :where(.markstream-octane) .table-node--loading tbody td > * {
@@ -454,7 +471,9 @@
 :where(.markstream-octane) .table-node--loading tbody td::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
   border-radius: 0.25rem;
   background: linear-gradient(
     90deg,
@@ -462,9 +481,8 @@
     rgba(148, 163, 184, 0.28) 50%,
     rgba(148, 163, 184, 0.16) 75%
   );
-  background-size: 200% 100%;
+  background-size: 66.6667% 100%;
   animation: markstream-octane-table-node-shimmer 1.2s linear infinite;
-  will-change: background-position;
 }
 
 :where(.markstream-octane) .table-node__loading {
@@ -508,15 +526,8 @@
 }
 
 @keyframes markstream-octane-table-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  50% {
-    background-position: 100% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
 }
 
 :where(.markstream-octane) .hr + .table-node-wrapper {
@@ -954,21 +965,28 @@
 }
 
 :where(.markstream-octane) .html-block-node__placeholder-bar {
+  position: relative;
+  overflow: hidden;
   display: block;
   height: 0.8rem;
   border-radius: 9999px;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+:where(.markstream-octane) .html-block-node__placeholder-bar::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
+  background-size: 66.6667% 100%;
   animation: markstream-octane-html-block-node-shimmer 1.2s ease infinite;
 }
 
 @keyframes markstream-octane-html-block-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
 }
 
 :where(.markstream-octane) .vmr-container {
@@ -1612,16 +1630,29 @@
 }
 
 :where(.markstream-octane) .skeleton-line {
+  position: relative;
+  overflow: hidden;
   height: 1rem;
-  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
-  background-size: 400% 100%;
-  animation: markstream-octane-code-skeleton-shimmer 1.2s ease-in-out infinite;
   border-radius: 0.25rem;
+  background: rgba(0,0,0,0.06);
+}
+
+:where(.markstream-octane) .skeleton-line::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
+  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
+  animation: markstream-octane-code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 :where(.markstream-octane) .code-block-container.is-dark .skeleton-line {
+  background: rgba(255,255,255,0.06);
+}
+
+:where(.markstream-octane) .code-block-container.is-dark .skeleton-line::before {
   background: linear-gradient(90deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.12) 37%, rgba(255,255,255,0.06) 63%);
-  background-size: 400% 100%;
 }
 
 :where(.markstream-octane) .skeleton-line.short {
@@ -1629,8 +1660,8 @@
 }
 
 @keyframes markstream-octane-code-skeleton-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: 0 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(75%); }
 }
 
 .markstream-octane pre[class^='language-'],
@@ -1810,12 +1841,8 @@
 }
 
 @keyframes markstream-octane-node-placeholder-shimmer {
-  from {
-    background-position: 200% 0%;
-  }
-  to {
-    background-position: -200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(80%); }
 }
 
 @keyframes markstream-octane-node-enter-fade {

--- a/packages/markstream-react/src/index.css
+++ b/packages/markstream-react/src/index.css
@@ -84,12 +84,23 @@
 }
 
 :where(.markstream-react) .node-placeholder {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
   border-radius: 0.5rem;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+:where(.markstream-react) .node-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 500%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
+  background-size: 40% 100%;
   animation: markstream-react-node-placeholder-shimmer 1.1s ease-in-out infinite;
 }
 
@@ -131,7 +142,6 @@
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 
 :where(.markstream-react) .text-node-stream-delta--a {
@@ -239,7 +249,6 @@
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: markstream-react-link-loading-pulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }
@@ -278,6 +287,13 @@
   :where(.markstream-react) .typewriter-cursor {
     animation: none !important;
     opacity: 1;
+  }
+
+  :where(.markstream-react) .node-placeholder::before,
+  :where(.markstream-react) .table-node--loading tbody td::after,
+  :where(.markstream-react) .html-block-node__placeholder-bar::before,
+  :where(.markstream-react) .skeleton-line::before {
+    animation: none !important;
   }
 }
 
@@ -466,6 +482,7 @@
 :where(.markstream-react) .table-node--loading tbody td {
   position: relative;
   overflow: hidden;
+  border-radius: 0.25rem;
 }
 
 :where(.markstream-react) .table-node--loading tbody td > * {
@@ -475,7 +492,9 @@
 :where(.markstream-react) .table-node--loading tbody td::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
   border-radius: 0.25rem;
   background: linear-gradient(
     90deg,
@@ -483,9 +502,8 @@
     rgba(148, 163, 184, 0.28) 50%,
     rgba(148, 163, 184, 0.16) 75%
   );
-  background-size: 200% 100%;
+  background-size: 66.6667% 100%;
   animation: markstream-react-table-node-shimmer 1.2s linear infinite;
-  will-change: background-position;
 }
 
 :where(.markstream-react) .table-node__loading {
@@ -529,15 +547,8 @@
 }
 
 @keyframes markstream-react-table-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  50% {
-    background-position: 100% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
 }
 
 :where(.markstream-react) .hr + .table-node-wrapper {
@@ -1047,21 +1058,28 @@
 }
 
 :where(.markstream-react) .html-block-node__placeholder-bar {
+  position: relative;
+  overflow: hidden;
   display: block;
   height: 0.8rem;
   border-radius: 9999px;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+:where(.markstream-react) .html-block-node__placeholder-bar::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
+  background-size: 66.6667% 100%;
   animation: markstream-react-html-block-node-shimmer 1.2s ease infinite;
 }
 
 @keyframes markstream-react-html-block-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
 }
 
 :where(.markstream-react) .vmr-container {
@@ -1738,16 +1756,29 @@
 }
 
 :where(.markstream-react) .skeleton-line {
+  position: relative;
+  overflow: hidden;
   height: 1rem;
-  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
-  background-size: 400% 100%;
-  animation: markstream-react-code-skeleton-shimmer 1.2s ease-in-out infinite;
   border-radius: 0.25rem;
+  background: rgba(0,0,0,0.06);
+}
+
+:where(.markstream-react) .skeleton-line::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
+  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
+  animation: markstream-react-code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 :where(.markstream-react) .code-block-container.is-dark .skeleton-line {
+  background: rgba(255,255,255,0.06);
+}
+
+:where(.markstream-react) .code-block-container.is-dark .skeleton-line::before {
   background: linear-gradient(90deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.12) 37%, rgba(255,255,255,0.06) 63%);
-  background-size: 400% 100%;
 }
 
 :where(.markstream-react) .skeleton-line.short {
@@ -1755,8 +1786,8 @@
 }
 
 @keyframes markstream-react-code-skeleton-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: 0 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(75%); }
 }
 
 .markstream-react pre[class^='language-'],
@@ -1911,12 +1942,8 @@
 }
 
 @keyframes markstream-react-node-placeholder-shimmer {
-  from {
-    background-position: 200% 0%;
-  }
-  to {
-    background-position: -200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(80%); }
 }
 
 @keyframes markstream-react-node-enter-fade {

--- a/packages/markstream-svelte/src/index.css
+++ b/packages/markstream-svelte/src/index.css
@@ -128,12 +128,23 @@ markstream-svelte {
 }
 
 .markstream-svelte .node-placeholder {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
   border-radius: 0.5rem;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.markstream-svelte .node-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 500%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
+  background-size: 40% 100%;
   animation: node-placeholder-shimmer 1.1s ease-in-out infinite;
 }
 
@@ -145,7 +156,6 @@ markstream-svelte {
 .markstream-svelte .fade-node {
   opacity: 0;
   animation: typewriter-fade var(--fade-duration, var(--typewriter-fade-duration, 280ms)) var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))) both;
-  will-change: opacity;
 }
 
 .markstream-svelte .markstream-svelte-text-node {
@@ -166,7 +176,6 @@ markstream-svelte {
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 
 .markstream-svelte .markstream-svelte-text__stream-delta--a {
@@ -270,7 +279,6 @@ markstream-svelte {
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: markstream-svelte-link-loading-pulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }
@@ -314,6 +322,10 @@ markstream-svelte {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .markstream-svelte .node-placeholder::before {
+    animation: none !important;
+  }
+
   .markstream-svelte .link-loading-indicator {
     animation: none !important;
     opacity: var(--underline-rest-opacity, 0.18);
@@ -512,17 +524,29 @@ markstream-svelte {
 }
 
 .markstream-svelte .image-shimmer {
+  position: relative;
+  overflow: hidden;
   display: block;
   width: 100%;
   height: 100%;
   min-height: 8rem;
+  background: hsl(var(--ms-muted));
+}
+
+.markstream-svelte .image-shimmer::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 300%;
   background: linear-gradient(
     90deg,
     hsl(var(--ms-muted)) 0%,
     hsl(var(--ms-muted-foreground) / 0.06) 50%,
     hsl(var(--ms-muted)) 100%
   );
-  background-size: 200% 100%;
+  background-position: 100% 0;
+  background-size: 66.6667% 100%;
   animation: markstream-svelte-image-shimmer 1.5s ease-in-out infinite;
 }
 
@@ -546,12 +570,12 @@ markstream-svelte {
 }
 
 @keyframes markstream-svelte-image-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: -100% 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(66.6667%); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .markstream-svelte .image-shimmer {
+  .markstream-svelte .image-shimmer::before {
     animation: none !important;
   }
 
@@ -1450,13 +1474,8 @@ body > div[id^="dmermaid-"] {
 }
 
 @keyframes node-placeholder-shimmer {
-  from {
-    background-position: 200% 0%;
-  }
-
-  to {
-    background-position: -200% 0%;
-  }
+  from { transform: translateX(0); }
+  to { transform: translateX(80%); }
 }
 
 @keyframes spin {

--- a/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/packages/markstream-vue2/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -1948,11 +1948,21 @@ pre.code-pre-fallback.markstream-pre--diff-preview,
   );
 }
 
-.code-block-container.is-rendering .code-height-placeholder{
-  background-size: 400% 100%;
-  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
+.code-block-container.is-rendering .code-height-placeholder {
+  position: relative;
+  overflow: hidden;
   min-height: 120px;
+  background: rgba(0,0,0,0.04);
+}
+
+.code-block-container.is-rendering .code-height-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
   background: linear-gradient(90deg, rgba(0,0,0,0.04) 25%, rgba(0,0,0,0.08) 37%, rgba(0,0,0,0.04) 63%);
+  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 /* Loading placeholder styles */
@@ -1968,16 +1978,29 @@ pre.code-pre-fallback.markstream-pre--diff-preview,
 }
 
 .skeleton-line {
+  position: relative;
+  overflow: hidden;
   height: 1rem;
-  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
-  background-size: 400% 100%;
-  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
   border-radius: 0.25rem;
+  background: rgba(0,0,0,0.06);
+}
+
+.skeleton-line::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -300%;
+  width: 400%;
+  background: linear-gradient(90deg, rgba(0,0,0,0.06) 25%, rgba(0,0,0,0.12) 37%, rgba(0,0,0,0.06) 63%);
+  animation: code-skeleton-shimmer 1.2s ease-in-out infinite;
 }
 
 .code-block-container.is-dark .skeleton-line {
+  background: rgba(255,255,255,0.06);
+}
+
+.code-block-container.is-dark .skeleton-line::before {
   background: linear-gradient(90deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.12) 37%, rgba(255,255,255,0.06) 63%);
-  background-size: 400% 100%;
 }
 
 .skeleton-line.short {
@@ -1985,8 +2008,15 @@ pre.code-pre-fallback.markstream-pre--diff-preview,
 }
 
 @keyframes code-skeleton-shimmer {
-  0% { background-position: 100% 0; }
-  100% { background-position: 0 0; }
+  from { transform: translateX(0); }
+  to { transform: translateX(75%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-block-container.is-rendering .code-height-placeholder::before,
+  .skeleton-line::before {
+    animation: none !important;
+  }
 }
 
 .code-action-btn {

--- a/packages/markstream-vue2/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/packages/markstream-vue2/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -204,20 +204,33 @@ onBeforeUnmount(() => {
   padding: 0.5rem 0;
 }
 .html-block-node__placeholder-bar {
+  position: relative;
+  overflow: hidden;
   display: block;
   height: 0.8rem;
   border-radius: 9999px;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.html-block-node__placeholder-bar::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.35));
+  background-size: 66.6667% 100%;
   animation: html-block-node-shimmer 1.2s ease infinite;
 }
 
 @keyframes html-block-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .html-block-node__placeholder-bar::before {
+    animation: none !important;
   }
 }
 </style>

--- a/packages/markstream-vue2/src/components/InlineCodeNode/InlineCodeNode.vue
+++ b/packages/markstream-vue2/src/components/InlineCodeNode/InlineCodeNode.vue
@@ -165,7 +165,6 @@ watch(
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 .inline-code-stream-delta--a {
   animation-name: inline-code-stream-update-fade-a;

--- a/packages/markstream-vue2/src/components/LinkNode/LinkNode.vue
+++ b/packages/markstream-vue2/src/components/LinkNode/LinkNode.vue
@@ -301,7 +301,6 @@ onBeforeUnmount(() => {
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: underlinePulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }

--- a/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
+++ b/packages/markstream-vue2/src/components/NodeRenderer/NodeRenderer.vue
@@ -2667,12 +2667,23 @@ watch(
 }
 
 .node-placeholder {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   min-height: 1rem;
   margin: 0.25rem 0;
   border-radius: 0.5rem;
-  background-image: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
-  background-size: 200% 100%;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.node-placeholder::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -200%;
+  width: 500%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.18));
+  background-size: 40% 100%;
   animation: node-placeholder-shimmer 1.1s ease-in-out infinite;
 }
 
@@ -2681,11 +2692,13 @@ watch(
 }
 
 @keyframes node-placeholder-shimmer {
-  from {
-    background-position: 200% 0%;
-  }
-  to {
-    background-position: -200% 0%;
+  from { transform: translateX(0); }
+  to { transform: translateX(80%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .node-placeholder::before {
+    animation: none !important;
   }
 }
 

--- a/packages/markstream-vue2/src/components/TableNode/TableNode.vue
+++ b/packages/markstream-vue2/src/components/TableNode/TableNode.vue
@@ -293,6 +293,7 @@ onBeforeUnmount(stopColumnResize)
 .table-node--loading tbody td {
   position: relative;
   overflow: hidden;
+  border-radius: 0.25rem;
 }
 
 .table-node--loading tbody td > * {
@@ -302,7 +303,9 @@ onBeforeUnmount(stopColumnResize)
 .table-node--loading tbody td::after {
   content: '';
   position: absolute;
-  inset: 0;
+  inset-block: 0;
+  left: 0;
+  width: 300%;
   border-radius: 0.25rem;
   background: linear-gradient(
     90deg,
@@ -310,9 +313,8 @@ onBeforeUnmount(stopColumnResize)
     rgba(148, 163, 184, 0.28) 50%,
     rgba(148, 163, 184, 0.16) 75%
   );
-  background-size: 200% 100%;
+  background-size: 66.6667% 100%;
   animation: table-node-shimmer 1.2s linear infinite;
-  will-change: background-position;
 }
 
 .table-node__loading {
@@ -373,14 +375,13 @@ onBeforeUnmount(stopColumnResize)
 }
 
 @keyframes table-node-shimmer {
-  0% {
-    background-position: 0% 0%;
-  }
-  50% {
-    background-position: 100% 0%;
-  }
-  100% {
-    background-position: 200% 0%;
+  from { transform: translateX(0); }
+  to { transform: translateX(-66.6667%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .table-node--loading tbody td::after {
+    animation: none !important;
   }
 }
 

--- a/packages/markstream-vue2/src/components/TextNode/TextNode.vue
+++ b/packages/markstream-vue2/src/components/TextNode/TextNode.vue
@@ -201,7 +201,6 @@ watch(
   animation-duration: var(--stream-update-fade-duration, var(--fade-duration, var(--typewriter-fade-duration, 280ms)));
   animation-timing-function: var(--stream-update-fade-ease, var(--fade-ease, var(--typewriter-fade-ease, cubic-bezier(0.33, 0, 0.67, 1))));
   animation-fill-mode: both;
-  will-change: opacity;
 }
 .text-node-stream-delta--a {
   animation-name: text-node-stream-update-fade-a;

--- a/src/components/LinkNode/LinkNode.vue
+++ b/src/components/LinkNode/LinkNode.vue
@@ -235,7 +235,6 @@ const title = computed(() => {
   bottom: var(--underline-bottom, -3px);
   background: currentColor;
   border-radius: 999px;
-  will-change: opacity;
   opacity: var(--underline-rest-opacity, 0.18);
   animation: underlinePulse var(--underline-duration, 1.6s) var(--underline-timing, ease-in-out) var(--underline-iteration, infinite);
 }


### PR DESCRIPTION
## Summary

- port the compositor-friendly shimmer implementations to React, Octane, Angular, Svelte, and Vue 2
- preserve the original gradient stops, background periods, travel distance, duration, and easing while moving animation to `transform`
- cover code skeleton, table loading, HTML placeholder, virtual node placeholder, and Svelte image shimmer states
- remove persistent `will-change: opacity` and `will-change: background-position` hints from streaming text, inline code, node entry, and loading-link animations
- add reduced-motion handling for the newly transformed shimmer pseudo-elements

## Visual fidelity

The transform layers retain the original raster dimensions instead of approximating the highlight band:

- code skeleton: original 400% gradient moved by the equivalent 300% container distance
- table and HTML placeholders: original repeated 200% pattern and full travel
- virtual node placeholders: both original shimmer periods across the 1.1s animation
- Svelte image: same 200% gradient phase and direction as Vue 3

## Validation

- `pnpm test` — 336 files / 2974 tests passed
- `pnpm lint`
- Vue 3, React, Octane, Angular, and Svelte typechecks
- Octane client + SSR tests — 49 tests passed
- Vue 2 full package build and dist validation
- PostCSS parsing for all four standalone framework stylesheets