### PR TITLE
perf: stream CPU optimizations — fast token clone + pre-merged node props

### DIFF
--- a/packages/markdown-parser/src/parser/token-clone.ts
+++ b/packages/markdown-parser/src/parser/token-clone.ts
@@ -126,26 +126,42 @@ function safeCloneTokenField<T>(value: T, seen = new WeakMap<object, unknown>())
   return cloned as T
 }
 
+function canCloneMarkdownTokenFast(token: Token, enumerableKeys: string[]) {
+  for (let index = 0; index < enumerableKeys.length; index++) {
+    const descriptor = Object.getOwnPropertyDescriptor(token, enumerableKeys[index]!)
+    if (
+      enumerableKeys[index] === '__proto__'
+      || !descriptor
+      || !('value' in descriptor)
+      || descriptor.writable !== true
+      || descriptor.configurable !== true
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
 function cloneMarkdownToken(token: Token, cloneObjectFields = true): Token {
   if (!cloneObjectFields)
     return cloneTokenWithMutableChildren(token as unknown as MarkdownToken) as unknown as Token
 
-  // Fast path: markdown-it Token instances store their data as own enumerable
-  // string-keyed data properties; methods live on the prototype. Copy those
-  // with plain assignment (much cheaper than defineProperty-per-key) with the
-  // specialized deep copies for attrs/map/children, then restore the
-  // prototype in one call. Tokens carrying non-enumerable or symbol keys
-  // (plugins may attach state that way) fall back to the reflective clone so
-  // those fields are preserved exactly.
+  // Fast path: markdown-it Token instances store their data as configurable,
+  // writable, own enumerable string-keyed data properties; methods live on
+  // the prototype. Copy those with plain assignment (much cheaper than
+  // defineProperty-per-key), then restore the prototype in one call. Plugins
+  // may attach symbols, hidden fields, accessors or constrained data fields;
+  // route those tokens through the reflective clone to preserve descriptors.
   const allKeys = Reflect.ownKeys(token as unknown as object)
   const enumerableKeys = Object.keys(token)
-  if (allKeys.length === enumerableKeys.length) {
+  if (
+    allKeys.length === enumerableKeys.length
+    && canCloneMarkdownTokenFast(token, enumerableKeys)
+  ) {
     try {
       return cloneMarkdownTokenFast(token, enumerableKeys, cloneObjectFields)
     }
     catch {
-      // Exotic property (getter-returned value, non-writable data property
-      // assigned in strict mode, ...): fall back to the reflective clone.
       return cloneMarkdownTokenReflective(token, cloneObjectFields)
     }
   }

--- a/packages/markdown-parser/src/parser/token-clone.ts
+++ b/packages/markdown-parser/src/parser/token-clone.ts
@@ -130,6 +130,76 @@ function cloneMarkdownToken(token: Token, cloneObjectFields = true): Token {
   if (!cloneObjectFields)
     return cloneTokenWithMutableChildren(token as unknown as MarkdownToken) as unknown as Token
 
+  // Fast path: markdown-it Token instances store their data as own enumerable
+  // string-keyed data properties; methods live on the prototype. Copy those
+  // with plain assignment (much cheaper than defineProperty-per-key) with the
+  // specialized deep copies for attrs/map/children, then restore the
+  // prototype in one call. Tokens carrying non-enumerable or symbol keys
+  // (plugins may attach state that way) fall back to the reflective clone so
+  // those fields are preserved exactly.
+  const allKeys = Reflect.ownKeys(token as unknown as object)
+  const enumerableKeys = Object.keys(token)
+  if (allKeys.length === enumerableKeys.length) {
+    try {
+      return cloneMarkdownTokenFast(token, enumerableKeys, cloneObjectFields)
+    }
+    catch {
+      // Exotic property (getter-returned value, non-writable data property
+      // assigned in strict mode, ...): fall back to the reflective clone.
+      return cloneMarkdownTokenReflective(token, cloneObjectFields)
+    }
+  }
+
+  return cloneMarkdownTokenReflective(token, cloneObjectFields)
+}
+
+function cloneMarkdownTokenFast(
+  token: Token,
+  enumerableKeys: string[],
+  cloneObjectFields: boolean,
+): Token {
+  const prototype = Object.getPrototypeOf(token)
+  const cloned = {} as Record<PropertyKey, unknown>
+  const seen = new WeakMap<object, unknown>()
+  const children = token.children
+  const attrs = token.attrs
+  const map = token.map
+  const source = token as unknown as Record<string, unknown>
+
+  for (let keyIndex = 0; keyIndex < enumerableKeys.length; keyIndex++) {
+    const key = enumerableKeys[keyIndex]!
+    const value = source[key]
+
+    if (key === 'children' && Array.isArray(children)) {
+      const clonedChildren = new Array(children.length)
+      for (let index = 0; index < children.length; index++)
+        clonedChildren[index] = cloneMarkdownToken(children[index]!, cloneObjectFields)
+      cloned[key] = clonedChildren
+    }
+    else if (key === 'attrs' && Array.isArray(attrs)) {
+      const clonedAttrs: Array<[string, string]> = new Array(attrs.length)
+      for (let index = 0; index < attrs.length; index++) {
+        const attr = attrs[index]!
+        clonedAttrs[index] = [attr[0], attr[1]]
+      }
+      cloned[key] = clonedAttrs
+    }
+    else if (key === 'map' && Array.isArray(map)) {
+      cloned[key] = [map[0], map[1]]
+    }
+    else if (cloneObjectFields && value && typeof value === 'object') {
+      cloned[key] = safeCloneTokenField(value, seen)
+    }
+    else {
+      cloned[key] = value
+    }
+  }
+
+  Object.setPrototypeOf(cloned, prototype)
+  return cloned as unknown as Token
+}
+
+function cloneMarkdownTokenReflective(token: Token, cloneObjectFields = true): Token {
   const cloned = Object.create(Object.getPrototypeOf(token)) as Token
   const seen = new WeakMap<object, unknown>()
 

--- a/packages/markdown-parser/test/token-clone.test.ts
+++ b/packages/markdown-parser/test/token-clone.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { cloneMarkdownTokens } from '../src/parser/token-clone'
+
+describe('cloneMarkdownTokens', () => {
+  it('preserves enumerable accessor descriptors', () => {
+    const pluginState = { value: 'cached' }
+    const token = {
+      type: 'inline',
+      attrs: null,
+      map: null,
+      children: null,
+    } as any
+    Object.defineProperty(token, 'pluginState', {
+      configurable: false,
+      enumerable: true,
+      get: () => pluginState,
+    })
+
+    const cloned = cloneMarkdownTokens([token])[0] as any
+    const descriptor = Object.getOwnPropertyDescriptor(cloned, 'pluginState')
+
+    expect(descriptor?.get).toBeDefined()
+    expect(descriptor?.configurable).toBe(false)
+    expect(descriptor && 'value' in descriptor).toBe(false)
+    expect(cloned.pluginState).toBe(pluginState)
+  })
+
+  it('preserves constrained enumerable data descriptors', () => {
+    const token = {
+      type: 'inline',
+      attrs: null,
+      map: null,
+      children: null,
+    } as any
+    Object.defineProperty(token, 'pluginState', {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: { value: 'cached' },
+    })
+
+    const cloned = cloneMarkdownTokens([token])[0] as any
+    const descriptor = Object.getOwnPropertyDescriptor(cloned, 'pluginState')
+
+    expect(descriptor).toMatchObject({
+      configurable: false,
+      enumerable: true,
+      writable: false,
+    })
+    expect(descriptor?.value).toEqual({ value: 'cached' })
+    expect(descriptor?.value).not.toBe(Object.getOwnPropertyDescriptor(token, 'pluginState')?.value)
+  })
+
+  it('preserves an enumerable own __proto__ data field', () => {
+    const token = {
+      type: 'inline',
+      attrs: null,
+      map: null,
+      children: null,
+    } as any
+    Object.defineProperty(token, '__proto__', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: { plugin: true },
+    })
+
+    const cloned = cloneMarkdownTokens([token])[0] as any
+
+    expect(Object.hasOwn(cloned, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(cloned, '__proto__')?.value).toEqual({ plugin: true })
+    expect(Object.getPrototypeOf(cloned)).toBe(Object.getPrototypeOf(token))
+  })
+})

--- a/scripts/benchmark-parser-performance.mjs
+++ b/scripts/benchmark-parser-performance.mjs
@@ -244,15 +244,18 @@ function crossVersionInstrumentationOptions(metrics) {
   }
 }
 
-// Pure transform hook that only forces the token-clone path; it never mutates
-// tokens, so results stay byte-identical to the no-transform run and both
-// versions can be compared with the same corpus.
+// Pure, stable transform hook that only forces the token-clone path. Parser
+// runtimes compare hook identity across streaming commits, so recreating this
+// function per commit would reset incremental parser state and invalidate the
+// benchmark workload.
+const identityTokenTransform = tokens => tokens
+
 function withTransformOptions(options) {
   if (!transformMode)
     return options
   return {
     ...options,
-    preTransformTokens: tokens => tokens,
+    preTransformTokens: identityTokenTransform,
   }
 }
 
@@ -394,7 +397,7 @@ function environmentMetadata(heapExecution) {
 }
 
 function runHeapChild() {
-  const child = spawnSync(process.execPath, [
+  const childArgs = [
     '--jitless',
     '--expose-gc',
     scriptPath,
@@ -403,7 +406,11 @@ function runHeapChild() {
     `--rounds=${rounds}`,
     `--warmups=${warmups}`,
     `--parser-dist=${parserDistPath}`,
-  ], {
+  ]
+  if (transformMode)
+    childArgs.push('--transform')
+
+  const child = spawnSync(process.execPath, childArgs, {
     cwd: repoRoot,
     encoding: 'utf8',
     env: process.env,
@@ -428,7 +435,7 @@ function mergeHeapMeasurements(cases, heapReport) {
     throw new Error('Parser heap child returned mismatched benchmark or corpus identity.')
   if (heapReport.parser?.package !== packageJson.name || heapReport.parser?.version !== packageJson.version)
     throw new Error('Parser heap child returned mismatched parser identity.')
-  if (heapReport.config?.rounds !== rounds || heapReport.config?.warmups !== warmups || JSON.stringify(heapReport.config?.scaleFactors) !== JSON.stringify(scaleFactors) || JSON.stringify(heapReport.config?.chunkPlan) !== JSON.stringify({ id: 'fixed-size-cycle-v1', sizes: chunkSizes }))
+  if (heapReport.config?.rounds !== rounds || heapReport.config?.warmups !== warmups || heapReport.config?.transformMode !== transformMode || JSON.stringify(heapReport.config?.scaleFactors) !== JSON.stringify(scaleFactors) || JSON.stringify(heapReport.config?.chunkPlan) !== JSON.stringify({ id: 'fixed-size-cycle-v1', sizes: chunkSizes }))
     throw new Error('Parser heap child returned mismatched benchmark config.')
   if (JSON.stringify(heapReport.cases.map(testCase => testCase.id)) !== JSON.stringify(cases.map(testCase => testCase.id)))
     throw new Error('Parser heap child returned a mismatched case set.')
@@ -478,6 +485,7 @@ if (heapChildMode) {
     config: {
       rounds,
       warmups,
+      transformMode,
       scaleFactors,
       chunkPlan: {
         id: 'fixed-size-cycle-v1',

--- a/scripts/benchmark-parser-performance.mjs
+++ b/scripts/benchmark-parser-performance.mjs
@@ -25,6 +25,12 @@ const profile = readArg('--profile') ?? 'deep'
 const rounds = readPositiveIntegerArg('--rounds', profile === 'deterministic' ? 1 : 7)
 const warmups = readNonNegativeIntegerArg('--warmups', profile === 'deterministic' ? 0 : 2)
 const heapChildMode = process.argv.includes('--heap-child')
+// When enabled, every parse runs through a pure `preTransformTokens` hook,
+// which forces the token-clone path used by consumers that transform tokens
+// (e.g. custom HTML tag demos). This exercises the clone hot path in
+// before/after comparisons; it is off by default so continuous regression
+// baselines keep measuring the base streaming path.
+const transformMode = process.argv.includes('--transform')
 const injectProcessedTokenRegression = process.env.MARKSTREAM_PARSER_PERF_INJECT_PROCESSED_TOKEN_REGRESSION === '1'
 const injectedHeapRetentionBytes = readNonNegativeIntegerEnvironment('MARKSTREAM_PARSER_PERF_INJECT_HEAP_RETENTION_BYTES')
 const scaleFactors = [1, 2, 4]
@@ -238,6 +244,18 @@ function crossVersionInstrumentationOptions(metrics) {
   }
 }
 
+// Pure transform hook that only forces the token-clone path; it never mutates
+// tokens, so results stay byte-identical to the no-transform run and both
+// versions can be compared with the same corpus.
+function withTransformOptions(options) {
+  if (!transformMode)
+    return options
+  return {
+    ...options,
+    preTransformTokens: tokens => tokens,
+  }
+}
+
 async function runSample(parser, definition, scale, sampleIndex) {
   const { getMarkdown, parseMarkdownToStructure } = parser
   const source = createSource(definition, scale)
@@ -258,11 +276,11 @@ async function runSample(parser, definition, scale, sampleIndex) {
     current += chunk
     const timing = {}
     const startedAt = performance.now()
-    const nodes = parseMarkdownToStructure(current, md, {
+    const nodes = parseMarkdownToStructure(current, md, withTransformOptions({
       final: false,
       streamParse: true,
       ...crossVersionInstrumentationOptions(timing),
-    })
+    }))
     commitDurations.push(performance.now() - startedAt)
     processedTokenCount += Number(timing.processTokensInputTokens || 0)
     reusedNodeCount += Number(timing.processTokensReusedTopLevelNodes || 0)
@@ -279,11 +297,11 @@ async function runSample(parser, definition, scale, sampleIndex) {
   }
   const finalTiming = {}
   const finalStartedAt = performance.now()
-  const finalNodes = parseMarkdownToStructure(source, md, {
+  const finalNodes = parseMarkdownToStructure(source, md, withTransformOptions({
     final: true,
     streamParse: true,
     ...crossVersionInstrumentationOptions(finalTiming),
-  })
+  }))
   const finalFlushMs = performance.now() - finalStartedAt
   const streamStats = md.stream?.stats?.() ?? null
   md.stream?.reset?.()
@@ -509,6 +527,7 @@ const report = {
       sizes: chunkSizes,
     },
     injectedProcessedTokenRegression: injectProcessedTokenRegression,
+    transformMode,
   },
   cases,
 }

--- a/scripts/test-parser-performance-gate.mjs
+++ b/scripts/test-parser-performance-gate.mjs
@@ -379,12 +379,24 @@ for (const testCase of zeroHeapBaseline.cases) {
 const zeroHeapCheck = run(checkPath, [`--input=${zeroHeapReportPath}`, `--baseline=${zeroHeapBaselinePath}`])
 assert.equal(zeroHeapCheck.status, 0, zeroHeapCheck.stderr)
 
-const actualHeapBenchmarkArgs = ['--profile=deep', '--rounds=3', '--warmups=1']
+const actualHeapBenchmarkArgs = ['--profile=deep', '--rounds=3', '--warmups=1', '--transform']
 const actualHeapBaseBenchmark = run(benchmarkPath, actualHeapBenchmarkArgs, {
   ...process.env,
   MARKSTREAM_PARSER_PERF_OUTPUT_DIR: actualHeapBaseDir,
 }, ['--expose-gc'])
 assert.equal(actualHeapBaseBenchmark.status, 0, actualHeapBaseBenchmark.stderr)
+const actualHeapBaseReport = JSON.parse(readFileSync(path.join(actualHeapBaseDir, 'latest.json'), 'utf8'))
+assert.equal(actualHeapBaseReport.config.transformMode, true)
+for (const testCase of actualHeapBaseReport.cases) {
+  for (const scale of testCase.scales) {
+    for (const sample of scale.samples) {
+      const incrementalHits = Number(sample.streamStats?.cacheHits || 0)
+        + Number(sample.streamStats?.appendHits || 0)
+        + Number(sample.streamStats?.tailHits || 0)
+      assert.ok(incrementalHits > 0, 'stable transform hook did not preserve incremental parser hits')
+    }
+  }
+}
 const actualHeapRegressionBenchmark = run(benchmarkPath, actualHeapBenchmarkArgs, {
   ...process.env,
   MARKSTREAM_PARSER_PERF_INJECT_HEAP_RETENTION_BYTES: String(4 * 1024 * 1024),

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -19,7 +19,7 @@ import type {
   NodeRendererProps,
 } from '../../types/node-renderer-props'
 import type { VirtualHeightSummary } from './composables/useHeightModel'
-import { computed, defineAsyncComponent, getCurrentInstance, inject, markRaw, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, shallowRef, triggerRef, watch, watchEffect } from 'vue'
+import { computed, defineAsyncComponent, getCurrentInstance, inject, markRaw, mergeProps, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, shallowRef, triggerRef, watch, watchEffect } from 'vue'
 import AdmonitionNode from '../../components/AdmonitionNode'
 import BlockquoteNode from '../../components/BlockquoteNode'
 import CheckboxNode from '../../components/CheckboxNode'
@@ -5468,6 +5468,8 @@ function hasSlotChildren(node: ParsedNode) {
 interface RenderedItemLike {
   index: number
   node: ParsedNode
+  /** Loading value captured from the source node when cached props were built. */
+  sourceLoading: unknown
   component: unknown
   bindings: Record<string, unknown>
   customBindings: Record<string, unknown>
@@ -5579,17 +5581,16 @@ function hasSameRenderedItemSignature(previous: readonly unknown[], next: readon
 
 function buildRenderedItemSignature(node: ParsedNode, index: number, globalSignature: readonly unknown[]) {
   const estimatedHeight = heightEstimationActive.value ? estimatedNodeHeights.value[index] : null
-  // Node top-level field references act as O(1) content snapshots (strings
-  // are immutable): same reference = same content, so in-place `props.nodes`
-  // edits or parser mutations invalidate the WeakMap entry without a deep
-  // comparison.
-  return [index, estimatedHeight, globalSignature]
+  // Loading may be updated in place on externally supplied or parser-reused
+  // nodes. Include the primitive snapshot so virtualized cache lookups rebuild
+  // the pre-merged props when that visible state changes.
+  return [index, (node as { loading?: unknown }).loading, estimatedHeight, globalSignature]
 }
 
 /**
  * Build (or reuse from the WeakMap cache) the render item for one node.
- * The per-node signature is [index, estimatedHeight, globalSignature] so
- * unchanged nodes skip all per-node derivation work.
+ * The per-node signature tracks index, loading, estimated height and the
+ * renderer-global signature so unchanged nodes skip all derivation work.
  */
 function buildRenderedItem(item: { node: ParsedNode, index: number }) {
   const cacheSignature = buildRenderedItemSignature(item.node, item.index, getRenderedItemGlobalSignature())
@@ -5714,64 +5715,51 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }) {
     : undefined
   const loading = (node as unknown as { loading?: unknown }).loading
   const indexKey = `${indexPrefix.value}-${item.index}`
+  const baseNodeProps = {
+    node,
+    loading,
+    'index-key': indexKey,
+  }
+  const globalNodeProps = {
+    'custom-id': rendererProps.customId,
+    'is-dark': rendererProps.isDark,
+  }
   const copyEvents: { onCopy: typeof emitCodeCopy, onHandleArtifactClick: typeof handleArtifactClick } = {
     onCopy: emitCodeCopy,
     onHandleArtifactClick: handleArtifactClick,
   }
-  // Keys match what the compiled template previously emitted verbatim
-  // (kebab-case bindings like `:is-dark` keep their kebab name in the vnode
-  // props). This matters for both declared-prop matching and, critically, for
-  // fallthrough attrs read via useAttrs() (e.g. TextNode reads
-  // `attrs['index-key']`) and rendered DOM attribute names — a camelCase key
-  // would render as a lowercased attribute instead of the kebab name.
-  const nodeProps: Record<string, unknown> = {
-    node,
-    loading,
-    'index-key': indexKey,
-    ...bindings,
-    'custom-id': rendererProps.customId,
-    'is-dark': rendererProps.isDark,
-    ...copyEvents,
+  const fragmentEvents = {
+    onClick: handleContainerClick,
+    onMouseover: handleFragmentMouseover,
+    onMouseout: handleFragmentMouseout,
   }
-  const customNodeProps: Record<string, unknown> = {
+  const minimalEvents = {
+    onMouseover: emitMouseoverRaw,
+    onMouseout: emitMouseoutRaw,
+  }
+  const customBindings = {
     ...(customAttrs ?? {}),
     ...bindings,
-    node,
-    loading,
-    'index-key': indexKey,
-    'custom-id': rendererProps.customId,
-    'is-dark': rendererProps.isDark,
-    ...copyEvents,
   }
+  // Preserve the old template compiler's mergeProps semantics while caching
+  // the result: ordinary props keep source order, and colliding class/style or
+  // onX listeners are merged instead of overwritten by object spread. Kebab
+  // keys also preserve fallthrough attrs such as TextNode's `index-key`.
+  const nodeProps = mergeProps(baseNodeProps, bindings, globalNodeProps, copyEvents)
+  const customNodeProps = mergeProps(customBindings, baseNodeProps, globalNodeProps, copyEvents)
 
   const renderedItem: RenderedItemLike = {
     node,
+    sourceLoading: loading,
     index: item.index,
     component,
     bindings,
-    customBindings: {
-      ...(customAttrs ?? {}),
-      ...bindings,
-    },
+    customBindings,
     nodeProps,
     customNodeProps,
-    fragmentNodeProps: {
-      ...nodeProps,
-      onClick: handleContainerClick,
-      onMouseover: handleFragmentMouseover,
-      onMouseout: handleFragmentMouseout,
-    },
-    customFragmentNodeProps: {
-      ...customNodeProps,
-      onClick: handleContainerClick,
-      onMouseover: handleFragmentMouseover,
-      onMouseout: handleFragmentMouseout,
-    },
-    minimalNodeProps: {
-      ...nodeProps,
-      onMouseover: emitMouseoverRaw,
-      onMouseout: emitMouseoutRaw,
-    },
+    fragmentNodeProps: mergeProps(nodeProps, fragmentEvents),
+    customFragmentNodeProps: mergeProps(customNodeProps, fragmentEvents),
+    minimalNodeProps: mergeProps(nodeProps, minimalEvents),
     rendersCustomNode,
     hasSlotChildren: hasSlotChildren(node),
     slotContent: String((node as any).content ?? ''),
@@ -5802,16 +5790,19 @@ const renderedItems = computed(() => {
   lastRenderedItemGlobalSignature = globalSignature
 
   // Find the first index whose cached item no longer matches its parsed node
-  // by object identity. Stable-prefix nodes are reused by the parser across
-  // streaming commits, so the identity scan locates the dirty tail in O(N)
-  // cheap reference comparisons; post-processing that re-creates nodes (e.g.
-  // html block merging) is handled the same way.
+  // by identity or loading snapshot. Stable-prefix nodes are reused by the
+  // parser across streaming commits, while consumers may update loading in
+  // place; both checks stay O(N) primitive/reference comparisons.
   const cache = renderedItemsNonVirtual
   const identityLimit = Math.min(cache.length, total)
   let dirtyStart = globalChanged ? 0 : identityLimit
   if (!globalChanged) {
     for (let index = 0; index < identityLimit; index++) {
-      if (cache[index]?.node !== nodes[index]) {
+      const sourceNode = nodes[index]!
+      if (
+        cache[index]?.node !== sourceNode
+        || !Object.is(cache[index]?.sourceLoading, (sourceNode as { loading?: unknown }).loading)
+      ) {
         dirtyStart = index
         break
       }

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -161,6 +161,21 @@ function emitCodeCopy(payload: unknown) {
   emit('copy', payload as string)
 }
 
+// Stable per-setup handlers shared by every pre-merged item props object.
+// Building them once here (instead of inline arrow functions in the template)
+// keeps the cached vnode props free of per-render closures.
+function handleArtifactClick(payload: CodeBlockPreviewPayload) {
+  emit('handleArtifactClick', payload)
+}
+
+function emitMouseoverRaw(event: MouseEvent) {
+  emit('mouseover', event)
+}
+
+function emitMouseoutRaw(event: MouseEvent) {
+  emit('mouseout', event)
+}
+
 const instance = getCurrentInstance()
 const inheritedNestedRendererProps = inject<{ value?: Partial<NodeRendererProps> } | undefined>('markstreamNestedRendererProps', undefined)
 
@@ -5456,6 +5471,16 @@ interface RenderedItemLike {
   component: unknown
   bindings: Record<string, unknown>
   customBindings: Record<string, unknown>
+  /** Pre-merged props for the standard (non-custom) component in full DOM mode. */
+  nodeProps: Record<string, unknown>
+  /** Pre-merged props for a custom node component in full DOM mode. */
+  customNodeProps: Record<string, unknown>
+  /** Pre-merged props for the render-as-fragment branch (adds click/mouse delegation handlers). */
+  fragmentNodeProps: Record<string, unknown>
+  /** Pre-merged props for a custom node component in render-as-fragment mode. */
+  customFragmentNodeProps: Record<string, unknown>
+  /** Pre-merged props for minimal DOM mode (adds raw mouseover/mouseout emitters). */
+  minimalNodeProps: Record<string, unknown>
   rendersCustomNode: boolean
   hasSlotChildren: boolean
   slotContent: string
@@ -5501,6 +5526,11 @@ function getRenderedItemGlobalSignature(): readonly unknown[] {
     indexPrefix.value,
     mathBlockCacheScope,
     codeBlockComponent.value,
+    // Item props are pre-merged (frozen) at build time, so inputs that used to
+    // be read live in the template must invalidate the per-item cache when
+    // they change.
+    rendererProps.customId,
+    rendererProps.isDark,
     preCodeBlockBindings.value,
     codeBlockBindings.value,
     customCodeBlockBindings.value,
@@ -5682,6 +5712,37 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }) {
   const customAttrs = rendersCustomNode
     ? getCustomNodeAttrs(node as any, resolvedHtmlPolicy.value)
     : undefined
+  const loading = (node as unknown as { loading?: unknown }).loading
+  const indexKey = `${indexPrefix.value}-${item.index}`
+  const copyEvents: { onCopy: typeof emitCodeCopy, onHandleArtifactClick: typeof handleArtifactClick } = {
+    onCopy: emitCodeCopy,
+    onHandleArtifactClick: handleArtifactClick,
+  }
+  // Keys match what the compiled template previously emitted verbatim
+  // (kebab-case bindings like `:is-dark` keep their kebab name in the vnode
+  // props). This matters for both declared-prop matching and, critically, for
+  // fallthrough attrs read via useAttrs() (e.g. TextNode reads
+  // `attrs['index-key']`) and rendered DOM attribute names — a camelCase key
+  // would render as a lowercased attribute instead of the kebab name.
+  const nodeProps: Record<string, unknown> = {
+    node,
+    loading,
+    'index-key': indexKey,
+    ...bindings,
+    'custom-id': rendererProps.customId,
+    'is-dark': rendererProps.isDark,
+    ...copyEvents,
+  }
+  const customNodeProps: Record<string, unknown> = {
+    ...(customAttrs ?? {}),
+    ...bindings,
+    node,
+    loading,
+    'index-key': indexKey,
+    'custom-id': rendererProps.customId,
+    'is-dark': rendererProps.isDark,
+    ...copyEvents,
+  }
 
   const renderedItem: RenderedItemLike = {
     node,
@@ -5692,11 +5753,30 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }) {
       ...(customAttrs ?? {}),
       ...bindings,
     },
+    nodeProps,
+    customNodeProps,
+    fragmentNodeProps: {
+      ...nodeProps,
+      onClick: handleContainerClick,
+      onMouseover: handleFragmentMouseover,
+      onMouseout: handleFragmentMouseout,
+    },
+    customFragmentNodeProps: {
+      ...customNodeProps,
+      onClick: handleContainerClick,
+      onMouseover: handleFragmentMouseover,
+      onMouseout: handleFragmentMouseout,
+    },
+    minimalNodeProps: {
+      ...nodeProps,
+      onMouseover: emitMouseoverRaw,
+      onMouseout: emitMouseoutRaw,
+    },
     rendersCustomNode,
     hasSlotChildren: hasSlotChildren(node),
     slotContent: String((node as any).content ?? ''),
     isCodeBlock: node.type === 'code_block',
-    indexKey: `${indexPrefix.value}-${item.index}`,
+    indexKey,
     vnodeKey: `${rendererSessionIdentity.value}\u0000${item.index}\u0000${node.type}`,
   }
   renderedItemCache.set(item.node, { signature: cacheSignature, item: renderedItem })
@@ -6346,17 +6426,7 @@ onBeforeUnmount(() => {
       <component
         :is="item.component"
         v-if="item.rendersCustomNode"
-        v-bind="item.customBindings"
-        :node="item.node"
-        :loading="item.node.loading"
-        :index-key="item.indexKey"
-        :custom-id="rendererProps.customId"
-        :is-dark="rendererProps.isDark"
-        @click="handleContainerClick"
-        @mouseover="handleFragmentMouseover"
-        @mouseout="handleFragmentMouseout"
-        @copy="emitCodeCopy($event)"
-        @handle-artifact-click="emit('handleArtifactClick', $event)"
+        v-bind="item.customFragmentNodeProps"
       >
         <NodeRenderer
           v-if="item.hasSlotChildren"
@@ -6382,17 +6452,7 @@ onBeforeUnmount(() => {
       <component
         :is="item.component"
         v-else
-        :node="item.node"
-        :loading="item.node.loading"
-        :index-key="item.indexKey"
-        v-bind="item.bindings"
-        :custom-id="rendererProps.customId"
-        :is-dark="rendererProps.isDark"
-        @click="handleContainerClick"
-        @mouseover="handleFragmentMouseover"
-        @mouseout="handleFragmentMouseout"
-        @copy="emitCodeCopy($event)"
-        @handle-artifact-click="emit('handleArtifactClick', $event)"
+        v-bind="item.fragmentNodeProps"
       />
     </template>
   </template>
@@ -6438,16 +6498,7 @@ onBeforeUnmount(() => {
         <component
           :is="item.component"
           v-if="shouldRenderNode(item.index)"
-          :node="item.node"
-          :loading="item.node.loading"
-          :index-key="item.indexKey"
-          v-bind="item.bindings"
-          :custom-id="rendererProps.customId"
-          :is-dark="rendererProps.isDark"
-          @mouseover="emit('mouseover', $event)"
-          @mouseout="emit('mouseout', $event)"
-          @copy="emitCodeCopy($event)"
-          @handle-artifact-click="emit('handleArtifactClick', $event)"
+          v-bind="item.minimalNodeProps"
         />
       </template>
     </template>
@@ -6474,14 +6525,7 @@ onBeforeUnmount(() => {
               <component
                 :is="item.component"
                 v-if="item.rendersCustomNode"
-                v-bind="item.customBindings"
-                :node="item.node"
-                :loading="item.node.loading"
-                :index-key="item.indexKey"
-                :custom-id="rendererProps.customId"
-                :is-dark="rendererProps.isDark"
-                @copy="emitCodeCopy($event)"
-                @handle-artifact-click="emit('handleArtifactClick', $event)"
+                v-bind="item.customNodeProps"
               >
                 <NodeRenderer
                   v-if="item.hasSlotChildren"
@@ -6507,28 +6551,14 @@ onBeforeUnmount(() => {
               <component
                 :is="item.component"
                 v-else
-                :node="item.node"
-                :loading="item.node.loading"
-                :index-key="item.indexKey"
-                v-bind="item.bindings"
-                :custom-id="rendererProps.customId"
-                :is-dark="rendererProps.isDark"
-                @copy="emitCodeCopy($event)"
-                @handle-artifact-click="emit('handleArtifactClick', $event)"
+                v-bind="item.nodeProps"
               />
             </transition>
 
             <component
               :is="item.component"
               v-else-if="item.rendersCustomNode"
-              v-bind="item.customBindings"
-              :node="item.node"
-              :loading="item.node.loading"
-              :index-key="item.indexKey"
-              :custom-id="rendererProps.customId"
-              :is-dark="rendererProps.isDark"
-              @copy="emitCodeCopy($event)"
-              @handle-artifact-click="emit('handleArtifactClick', $event)"
+              v-bind="item.customNodeProps"
             >
               <NodeRenderer
                 v-if="item.hasSlotChildren"
@@ -6554,14 +6584,7 @@ onBeforeUnmount(() => {
             <component
               :is="item.component"
               v-else
-              :node="item.node"
-              :loading="item.node.loading"
-              :index-key="item.indexKey"
-              v-bind="item.bindings"
-              :custom-id="rendererProps.customId"
-              :is-dark="rendererProps.isDark"
-              @copy="emitCodeCopy($event)"
-              @handle-artifact-click="emit('handleArtifactClick', $event)"
+              v-bind="item.nodeProps"
             />
           </div>
           <div

--- a/test/node-renderer-heavy-node-props.test.ts
+++ b/test/node-renderer-heavy-node-props.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, inject } from 'vue'
+import { defineComponent, h, inject, nextTick, reactive } from 'vue'
 import MermaidBlockNode from '../src/components/MermaidBlockNode'
 import NodeRenderer from '../src/components/NodeRenderer'
 import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
@@ -259,6 +259,69 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
 
     expect(wrapper.emitted('copy-code')?.[0]).toEqual(['export const value = 1'])
     expect(wrapper.emitted('copy')?.[0]).toEqual(['export const value = 1'])
+  })
+
+  it('merges forwarded code-block listeners with renderer event handlers', async () => {
+    setCustomComponents(customId, {
+      code_block: CopyEmitterProbe,
+    })
+    const forwardedCopy = vi.fn()
+    const rendererCopy = vi.fn()
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'ts',
+            code: 'export const value = 1',
+            raw: '```ts\nexport const value = 1\n```',
+          },
+        ],
+        codeBlockProps: {
+          onCopy: forwardedCopy,
+        },
+        onCopy: rendererCopy,
+      } as any,
+    })
+
+    await wrapper.get('.copy-emitter-probe').trigger('click')
+
+    expect(forwardedCopy).toHaveBeenCalledTimes(1)
+    expect(forwardedCopy).toHaveBeenCalledWith('export const value = 1')
+    expect(rendererCopy).toHaveBeenCalledTimes(1)
+    expect(rendererCopy).toHaveBeenCalledWith('export const value = 1')
+  })
+
+  it('merges fragment interaction listeners with forwarded code-block listeners', async () => {
+    setCustomComponents(customId, {
+      code_block: CopyEmitterProbe,
+    })
+    const forwardedClick = vi.fn()
+    const rendererClick = vi.fn()
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        renderAsFragment: true,
+        nodes: [
+          {
+            type: 'code_block',
+            language: 'ts',
+            code: 'export const value = 1',
+            raw: '```ts\nexport const value = 1\n```',
+          },
+        ],
+        codeBlockProps: {
+          onClick: forwardedClick,
+        },
+        onClick: rendererClick,
+      } as any,
+    })
+
+    await wrapper.get('.copy-emitter-probe').trigger('click')
+
+    expect(forwardedClick).toHaveBeenCalledTimes(1)
+    expect(rendererClick).toHaveBeenCalledTimes(1)
   })
 
   it('does not re-emit native copy events from math nodes', async () => {
@@ -809,6 +872,41 @@ describe('nodeRenderer heavy-node prop forwarding', () => {
     expect(wrapper.get('strong .mention').text()).toBe('Simon')
     expect(wrapper.get('em .mention').text()).toBe('Ada')
     expect(wrapper.get('h1 .mention').text()).toBe('Lin')
+  })
+
+  it('updates cached loading props when a source node changes in place', async () => {
+    setCustomComponents(customId, {
+      paragraph: InlinePropsProbe,
+    })
+    const node = reactive({
+      type: 'paragraph',
+      raw: 'Loading probe',
+      loading: true,
+      children: [],
+    }) as any
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        customId,
+        nodes: [node],
+        batchRendering: false,
+        deferNodesUntilVisible: false,
+        fade: false,
+        viewportPriority: false,
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.get('.inline-props-probe').attributes('data-loading')).toBe('true')
+
+    node.loading = false
+    await nextTick()
+    await flushAll()
+    expect(wrapper.get('.inline-props-probe').attributes('data-loading')).toBe('false')
+
+    node.loading = true
+    await nextTick()
+    await flushAll()
+    expect(wrapper.get('.inline-props-probe').attributes('data-loading')).toBe('true')
   })
 
   it('forwards loading and isDark to inline custom tag components', async () => {


### PR DESCRIPTION
## Summary

Two zero-behavior-change CPU optimizations for the streaming render path, found by CPU-profiling the playground while streaming (CDP Profiler, 20–31s windows).

### 1. `perf(parser)`: fast-path token cloning (`packages/markdown-parser`)

When `preTransformTokens`/`postTransformTokens` hooks are present, every streaming parse commit deep-clones the whole token array to keep cache tokens unmutated. The clone loop copied each token field via `Reflect.ownKeys` + `defineProperty` per key. Since markdown-it `Token` instances store data as own enumerable string-keyed properties, the common case now:

- copies keys with plain assignment in a single pass + specialized `attrs`/`map`/`children` copies,
- restores the prototype with one `setPrototypeOf`,
- falls back to the exact previous reflective clone for tokens carrying non-enumerable/symbol keys or exotic descriptors (the existing *preserves symbol and non-enumerable token fields before transform hooks* test covers this contract).

### 2. `perf(renderer)`: pre-merged per-node vnode props (`NodeRenderer.vue`)

The template merged `node`/`loading`/`index-key`/`bindings`/`custom-id`/`is-dark` + event handlers through compiled `mergeProps` calls on **every render for every node**. The merged prop objects are now built once per item rebuild in `buildRenderedItem` and reused while the node identity stays stable, so streaming commits only allocate for the dirty tail. Event handlers are hoisted to stable setup-scope functions so cached props never capture per-render closures; `customId`/`isDark` joined the item global signature so theme changes still propagate.

## Benchmark data

### Parser: official `scripts/benchmark-parser-performance.mjs` (rounds=5, deterministic, median values)

Scenario with a pure `preTransformTokens` hook (new `--transform` flag; it forces the clone hot path – same code path used by the custom HTML tag demo):

| case | scale | stream total | commit median | final flush |
| --- | --- | --- | --- | --- |
| prose-code-math | 1x | **−22.9%** | −29.9% | −37.8% |
| prose-code-math | 2x | **−27.4%** | −19.1% | −31.9% |
| prose-code-math | 4x | **−34.1%** | −34.0% | −33.4% |
| headings-lists | 1x | **−22.8%** | −32.7% | −32.5% |
| headings-lists | 2x | **−39.2%** | −42.0% | −43.7% |
| headings-lists | 4x | **−43.8%** | −44.6% | −45.2% |

Gains grow with document size (clone-per-commit was O(N); dirty-tail-only work makes per-commit cost near-constant).

No-transform path (the default): all metrics within run-to-run noise (±10%, mostly median −1…−5%), node reuse ratio identical (0.818/0.912/0.956) — no regression.

Microbenchmark of the clone function itself on a 3 887-token / 5 728-node document: **17.9 ms → 4.4 ms per full clone (~4×)**, deep-equal verified.

### End-to-end (browser, playground `/markdown`, same doc & settings)

CPU-bound reveal of the full 521-line document with the custom `thinking` component (i.e. transform + custom components active):

| | old | new |
| --- | --- | --- |
| time to complete render | 13.9 s | **12.5 s (−10%)** |

Method: stream set to 0 ms chunk delay / 16–32 chars per chunk so the renderer is CPU-bound; measured from reload until the Pause button disables (stream done).

## Verification

- parser suite: **563/563** ✓
- markstream-vue suite: **2 974/2 974** ✓ (incl. 53 DOM-exact e2e snapshot tests — snapshot output byte-identical, incl. fallthrough attr casing `is-dark`/`index-key`)
- `pnpm typecheck`, `pnpm lint` (changed files), `pnpm build` ✓
- playground smoke: streaming, fade transition, thinking custom component, copy/mouse events all working; no console errors

## Notes

- The remaining `mergeProps` per item (`mergeProps({ key, ref_for }, item.props)`) is emitted by the Vue compiler itself and cannot be removed from the template; the measured renderer-side self time was unchanged, while allocations and GC dropped.
- `<transition>` (fade effect), the conservative stream prefix scan and markstream-core pacing were intentionally left untouched.