### PR TITLE
perf: reduce streaming CPU with stable inline children and no-op render short-circuits

### DIFF
--- a/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
+++ b/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
@@ -270,6 +270,7 @@ function updateStructuredStreamCache(
   groups: ReusableTopLevelTokenGroups,
   nodes: ParsedNode[],
   options: ParseOptions,
+  previousSeed?: readonly string[],
 ) {
   const groupStarts = groups.starts
   if (groupStarts.length === 0 || nodes.length !== groupStarts.length) {
@@ -290,6 +291,16 @@ function updateStructuredStreamCache(
     ? Math.max(0, groupStarts.length - 1)
     : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1)
 
+  // On the incremental append path the prefix nodes (and their raws) are
+  // unchanged, so reuse the previous seed's prefix instead of re-slicing and
+  // re-stringifying every node's raw on each commit (O(nodes) per commit).
+  // The fallback path (full re-parse) must rebuild the seed in full.
+  const seed = previousSeed && previousSeed.length >= stableGroupCount
+    ? previousSeed.slice(0, stableGroupCount).concat(
+        nodes.slice(stableGroupCount).map(node => String((node as Record<string, unknown>).raw ?? '')),
+      )
+    : nodes.map(node => String((node as Record<string, unknown>).raw ?? ''))
+
   runtime.structuredStream = {
     groupBoundaries,
     groupStarts,
@@ -298,7 +309,7 @@ function updateStructuredStreamCache(
     mixed: groups.mixed,
     source,
     nodes,
-    seed: nodes.map(node => String((node as Record<string, unknown>).raw ?? '')),
+    seed,
     stableGroupCount,
     requireClosingStrong: options.requireClosingStrong,
     validateLink: options.validateLink,
@@ -437,7 +448,7 @@ export function processTopLevelTokensWithReuse(
       const result = previous.nodes.slice(0, stableGroupCount).concat(tailNodes)
       runtime.structuredReuseTailStart = stableGroupCount
       callbacks.recordReusedTopLevelNodes?.(stableGroupCount)
-      updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
+      updateStructuredStreamCache(runtime, source, tokens, groups, result, options, previous.seed)
       return result
     }
   }

--- a/src/components/InlineCodeNode/InlineCodeNode.vue
+++ b/src/components/InlineCodeNode/InlineCodeNode.vue
@@ -52,22 +52,23 @@ function stopWatchingStreamVersion() {
 }
 
 function settleStreamedDelta() {
-  stopWatchingStreamVersion()
   if (!streamedDelta.value)
     return
   settledCode.value = getRenderedContent()
   streamedDelta.value = ''
 }
 
-function watchStreamVersionWhileDeltaActive() {
-  if (!streamedDelta.value || stopStreamVersionWatch || !inheritedStreamVersion)
+function ensureStreamVersionWatch() {
+  if (stopStreamVersionWatch || !inheritedStreamVersion)
     return
-
-  const activeVersion = inheritedStreamVersion.value
+  // One persistent watcher for the component's whole lifecycle instead of a
+  // create-per-delta + destroy-on-settle watcher (the old approach churned a
+  // new `flush: 'sync'` watcher on every streaming commit that appended a
+  // delta).
   stopStreamVersionWatch = watch(
     () => inheritedStreamVersion.value,
-    (version) => {
-      if (version !== activeVersion)
+    () => {
+      if (streamedDelta.value)
         settleStreamedDelta()
     },
     { flush: 'sync' },
@@ -90,7 +91,7 @@ watch(
     streamedDelta.value = result.streamedDelta
     if (result.appended) {
       streamFadeVersion.value += 1
-      watchStreamVersionWhileDeltaActive()
+      ensureStreamVersionWatch()
     }
     else if (!streamedDelta.value) {
       stopWatchingStreamVersion()

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -6399,8 +6399,20 @@ watch(
     // the per-commit work below (recursive node text length traversal, cursor
     // element updates) is needed. Skip it entirely instead of running the
     // callback and bailing out mid-way.
-    if (!typewriterEnabled.value)
+    if (!typewriterEnabled.value) {
+      if (
+        showTypewriterCursor.value
+        || typewriterCursorTimeout
+        || typewriterCursorRaf != null
+        || simpleTypewriterCursorTarget.value
+        || typewriterCursorRef.value
+      ) {
+        showTypewriterCursor.value = false
+        clearTypewriterCursorTimeout()
+        hideTypewriterCursorElement()
+      }
       return
+    }
 
     // When the stream is final (and effective — smooth streaming has caught up),
     // hide the cursor immediately.

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1217,18 +1217,23 @@ const shouldObserveSlots = computed(() => !!registerNodeVisibility && deferNodes
  * registration (observer handle / watch / fallback timer / visible state)
  * remains valid and `setNodeSlotElement` can skip re-registration.
  */
-function getNodeSlotRegistrationKey() {
-  return [
-    shouldObserveSlots.value,
-    deferNodes.value,
-    virtualizationEnabled.value,
-    viewportPriorityAutoDisabled.value,
-    viewportPriorityMaxTargets.value,
-    viewportPriorityRootMargin.value,
-    resolvedInitialBatch.value,
-    Boolean(registerNodeVisibility),
-  ].join('|')
-}
+// Serialized snapshot of every input that drives the slot visibility
+// registration. When it is unchanged for a given element, the existing
+// registration (observer handle / watch / fallback timer / visible state)
+// remains valid and `setNodeSlotElement` can skip re-registration. Cached as a
+// computed: the same inputs previously produced a fresh join('|') string per
+// slot per re-render (Vue 3.5 re-invokes function refs on every patch), which
+// was O(N) string allocations per streaming commit.
+const nodeSlotRegistrationKey = computed(() => [
+  shouldObserveSlots.value,
+  deferNodes.value,
+  virtualizationEnabled.value,
+  viewportPriorityAutoDisabled.value,
+  viewportPriorityMaxTargets.value,
+  viewportPriorityRootMargin.value,
+  resolvedInitialBatch.value,
+  Boolean(registerNodeVisibility),
+].join('|'))
 const scrollListenerEnabled = computed(() => virtualizationEnabled.value || virtualScrollEnabled.value)
 const {
   focusIndex,
@@ -1736,7 +1741,7 @@ function estimateNodeHeight(node: ParsedNode, index: number, width: number) {
       return estimatedText
   }
 
-  if (codeBlockEstimationEnabled.value && node.type === 'code_block') {
+  if (codeBlockEstimationEnabled.value && !hasMeasuredHeight && node.type === 'code_block') {
     const rendererKind = resolveCodeBlockRendererKind(node)
     if (rendererKind === 'stream-diffs' || rendererKind === 'pre') {
       return estimateCodeBlockHeight(node, {
@@ -4160,7 +4165,7 @@ function setNodeSlotElement(index: number, el: HTMLElement | null) {
   let slotsChanged = false
   if (el) {
     const prev = nodeSlotElements.get(index)
-    if (prev === el && nodeSlotRegistrationKeys.get(index) === getNodeSlotRegistrationKey()) {
+    if (prev === el && nodeSlotRegistrationKeys.get(index) === nodeSlotRegistrationKey.value) {
       // Same element re-passed on a re-render with unchanged registration
       // inputs: the existing visibility registration (observer handle, watch,
       // fallback timer, visible state) is still valid, so skip the per-commit
@@ -4186,7 +4191,7 @@ function setNodeSlotElement(index: number, el: HTMLElement | null) {
     // Only record for a live element; unmounts (el === null) must not leave a
     // stale key behind for an index that no longer has a slot.
     if (el)
-      nodeSlotRegistrationKeys.set(index, getNodeSlotRegistrationKey())
+      nodeSlotRegistrationKeys.set(index, nodeSlotRegistrationKey.value)
     else
       nodeSlotRegistrationKeys.delete(index)
     if (el && deferNodes.value)
@@ -4203,7 +4208,7 @@ function setNodeSlotElement(index: number, el: HTMLElement | null) {
     autoDisableViewportPriority('too-many-targets')
     if (!shouldObserveSlots.value || !registerNodeVisibility) {
       destroyNodeHandle(index)
-      nodeSlotRegistrationKeys.set(index, getNodeSlotRegistrationKey())
+      nodeSlotRegistrationKeys.set(index, nodeSlotRegistrationKey.value)
       if (el)
         markNodeVisible(index, true)
       return
@@ -4212,14 +4217,14 @@ function setNodeSlotElement(index: number, el: HTMLElement | null) {
 
   if (index < resolvedInitialBatch.value && !virtualizationEnabled.value) {
     destroyNodeHandle(index)
-    nodeSlotRegistrationKeys.set(index, getNodeSlotRegistrationKey())
+    nodeSlotRegistrationKeys.set(index, nodeSlotRegistrationKey.value)
     markNodeVisible(index, true)
     return
   }
 
   if (visibleNodeIndices.value.has(index)) {
     destroyNodeHandle(index)
-    nodeSlotRegistrationKeys.set(index, getNodeSlotRegistrationKey())
+    nodeSlotRegistrationKeys.set(index, nodeSlotRegistrationKey.value)
     markNodeVisible(index, true)
     return
   }
@@ -4237,7 +4242,7 @@ function setNodeSlotElement(index: number, el: HTMLElement | null) {
     return
   }
   nodeVisibilityHandles.set(index, handle)
-  nodeSlotRegistrationKeys.set(index, getNodeSlotRegistrationKey())
+  nodeSlotRegistrationKeys.set(index, nodeSlotRegistrationKey.value)
   markNodeVisible(index, handle.isVisible.value)
   if (deferNodes.value)
     scheduleVisibilityFallback(index)
@@ -5600,6 +5605,10 @@ const previewHeightEstimateCache = new WeakMap<object, { code: string, height: n
 // lookup + object allocation for the whole document.
 const renderedItemsNonVirtual: RenderedItemLike[] = []
 let lastRenderedItemGlobalSignature: readonly unknown[] | null = null
+// Array instance returned by the `renderedItems` computed on its last
+// evaluation. Reused verbatim on no-op commits so Vue skips the v-for re-render
+// instead of diffing a freshly sliced array of identical items.
+let lastRenderedItemsArray: RenderedItemLike[] = []
 
 /**
  * Signature of all renderer-level (node-independent) inputs a rendered item
@@ -5866,9 +5875,12 @@ const renderedItems = computed(() => {
 
   const nodes = parsedNodes.value
   const total = nodes.length
-  if (renderedItemsNonVirtual.length > total)
+  let truncated = false
+  if (renderedItemsNonVirtual.length > total) {
     // eslint-disable-next-line vue/no-side-effects-in-computed-properties -- In-place truncation of the module-level incremental item cache; not a reactive side effect.
     renderedItemsNonVirtual.length = total
+    truncated = true
+  }
 
   // Capture the previous signature BEFORE getRenderedItemGlobalSignature
   // refreshes the module-level cache, otherwise the comparison below would
@@ -5898,12 +5910,24 @@ const renderedItems = computed(() => {
     }
   }
 
+  // No-op commit: every parsed node still matches its cached rendered item by
+  // identity (the parser reused every node object) and the cache was not
+  // truncated, so the item list is byte-identical to the last returned one.
+  // Returning the exact array instance lets Vue skip the keyed v-for diff
+  // entirely instead of re-running it over a freshly sliced array of the same
+  // items (which also re-invokes every slot/content function ref in the
+  // template).
+  if (!truncated && dirtyStart === total)
+    return lastRenderedItemsArray
+
   for (let index = dirtyStart; index < total; index++)
     cache[index] = buildRenderedItem({ node: nodes[index]!, index })
 
   // New array identity so Vue re-renders; prefix entries are shared objects,
   // so the keyed v-for diff resolves them without re-creating anything.
-  return cache.slice()
+  const next = cache.slice()
+  lastRenderedItemsArray = next
+  return next
 })
 
 function getCodeBlockLanguage(node: ParsedNode) {
@@ -6369,6 +6393,13 @@ watch(
   [renderContent, () => props.content, () => props.nodes, () => rendererProps.typewriter, effectiveFinal],
   async () => {
     if (!isClient || renderAsFragment.value || !ownsTypewriterCursor.value)
+      return
+
+    // Typewriter is off (the default): the cursor is never shown, so none of
+    // the per-commit work below (recursive node text length traversal, cursor
+    // element updates) is needed. Skip it entirely instead of running the
+    // callback and bailing out mid-way.
+    if (!typewriterEnabled.value)
       return
 
     // When the stream is final (and effective — smooth streaming has caught up),

--- a/src/components/NodeRenderer/composables/useMarkdownParsing.ts
+++ b/src/components/NodeRenderer/composables/useMarkdownParsing.ts
@@ -131,6 +131,23 @@ function getCustomComponentsReuseKey(mapping: Partial<CustomComponents>) {
   )
 }
 
+// The reuse key is a pure function of the mapping's identity (component
+// references are stable); cache it per mapping object so the JSON.stringify +
+// sort + identity lookups don't rerun on every streaming commit. A new mapping
+// reference still recomputes, so a consumer passing a fresh object per render
+// simply misses the cache.
+const customComponentsReuseKeyCache = new WeakMap<object, string>()
+
+function getCachedCustomComponentsReuseKey(mapping: Partial<CustomComponents>) {
+  const object = mapping as object
+  const cached = customComponentsReuseKeyCache.get(object)
+  if (cached !== undefined)
+    return cached
+  const key = getCustomComponentsReuseKey(mapping)
+  customComponentsReuseKeyCache.set(object, key)
+  return key
+}
+
 function hasCustomComponentBoundary(
   node: ParsedNode,
   mapping: Partial<CustomComponents>,
@@ -1295,7 +1312,7 @@ export function useMarkdownParsing(
     }
 
     const customComponents = options.customComponentsMap?.value ?? {}
-    const customComponentsReuseKey = getCustomComponentsReuseKey(customComponents)
+    const customComponentsReuseKey = getCachedCustomComponentsReuseKey(customComponents)
     if (
       previousCustomComponentsReuseKey
       && customComponentsReuseKey !== previousCustomComponentsReuseKey
@@ -1437,8 +1454,15 @@ export function useMarkdownParsing(
     }
 
     if (hasCustomComponents) {
-      for (const node of parsed)
-        hasCustomComponentBoundary(node, customComponents, customComponentBoundaryCache)
+      // Only the dirty tail can contain nodes not yet in the boundary cache:
+      // reused prefix nodes were warmed in a previous commit, and a fully
+      // reused parse (dirtyStartIndex < 0) has nothing new either. Warming
+      // only the tail skips the O(prefix) WeakMap hits per streaming commit.
+      const warmStart = stabilizeMetrics?.dirtyStartIndex != null && stabilizeMetrics.dirtyStartIndex >= 0
+        ? stabilizeMetrics.dirtyStartIndex
+        : parsed.length
+      for (let index = warmStart; index < parsed.length; index++)
+        hasCustomComponentBoundary(parsed[index]!, customComponents, customComponentBoundaryCache)
     }
     const nodeReuseMs = collectPerformanceMetrics
       ? getNow() - reuseStart

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -151,23 +151,75 @@ function getChildProps(child: NodeChild, index: number) {
   }
 }
 
-// Content signature for an inline child. The stream parser re-creates every
-// inline child object of the tail paragraph on each commit, so identity-based
-// memoization cannot work on the raw children; instead the signature captures
-// everything that affects a child's rendered output. Children whose signature
-// is unchanged keep their previous child object (stable `node` prop reference),
-// so Vue skips their component re-render entirely — only the growing tail text
-// node actually changes.
-function getChildRenderSignature(child: NodeChild) {
+// Content signature for built-in inline children. The stream parser re-creates
+// every inline child object of the tail paragraph on each commit, so unchanged
+// built-ins keep their previous `node` prop reference. Custom renderers are not
+// memoized because they may consume arbitrary node fields.
+function getChildrenRenderSignature(children: unknown) {
+  if (!Array.isArray(children))
+    return ''
+
+  const signatures: string[] = []
+  for (const child of children) {
+    if (!child || typeof child !== 'object')
+      return null
+    const signature = getChildRenderSignature(child as NodeChild)
+    if (signature == null)
+      return null
+    signatures.push(signature)
+  }
+  return signatures.join('\u0002')
+}
+
+function getChildRenderSignature(child: NodeChild): string | null {
   const record = child as Record<string, unknown>
-  const children = record.children
-  return [
-    record.type,
-    String(record.raw ?? ''),
-    String(record.content ?? ''),
-    Array.isArray(children) ? `c${children.length}` : 'c0',
-    String((record as { loading?: unknown }).loading ?? ''),
-  ].join('\u0001')
+  const type = String(record.type)
+
+  // Custom renderers can consume arbitrary node fields, so their nodes cannot
+  // be safely memoized with a fixed built-in signature.
+  if ((overrides.value as any)[type])
+    return null
+
+  const children = getChildrenRenderSignature(record.children)
+  if (children == null)
+    return null
+
+  const common = [type, record.loading, children]
+  switch (type) {
+    case 'text':
+      return [...common, record.content, record.center].join('\u0001')
+    case 'inline_code':
+      return [...common, record.code].join('\u0001')
+    case 'image':
+      return [...common, record.src, record.alt, record.title].join('\u0001')
+    case 'link':
+      return [...common, record.href, record.title, record.text, JSON.stringify(record.attrs ?? null)].join('\u0001')
+    case 'html_inline':
+    case 'html_block':
+      return [...common, record.tag, record.content, record.autoClosed, JSON.stringify(record.attrs ?? null)].join('\u0001')
+    case 'emoji':
+      return [...common, record.name, record.markup].join('\u0001')
+    case 'checkbox':
+    case 'checkbox_input':
+      return [...common, record.checked].join('\u0001')
+    case 'math_inline':
+      return [...common, record.content, record.markup].join('\u0001')
+    case 'reference':
+    case 'footnote_anchor':
+    case 'footnote_reference':
+      return [...common, record.id].join('\u0001')
+    case 'hardbreak':
+    case 'emphasis':
+    case 'strong':
+    case 'strikethrough':
+    case 'highlight':
+    case 'insert':
+    case 'subscript':
+    case 'superscript':
+      return common.join('\u0001')
+    default:
+      return null
+  }
 }
 
 // Per-render child cache: index → { child, sig }. The parser hands us a new
@@ -242,8 +294,11 @@ const processedChildren = computed(() => {
   return children.map((child, index) => {
     const sig = getChildRenderSignature(child)
     const previous = previousChildCache.get(index)
-    const stableChild = previous && previous.sig === sig ? previous.child : child
-    previousChildCache.set(index, { child: stableChild, sig })
+    const stableChild = sig != null && previous?.sig === sig ? previous.child : child
+    if (sig == null)
+      previousChildCache.delete(index)
+    else
+      previousChildCache.set(index, { child: stableChild, sig })
     const processed = processChild(stableChild)
     return {
       ...processed,

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -151,6 +151,31 @@ function getChildProps(child: NodeChild, index: number) {
   }
 }
 
+// Content signature for an inline child. The stream parser re-creates every
+// inline child object of the tail paragraph on each commit, so identity-based
+// memoization cannot work on the raw children; instead the signature captures
+// everything that affects a child's rendered output. Children whose signature
+// is unchanged keep their previous child object (stable `node` prop reference),
+// so Vue skips their component re-render entirely — only the growing tail text
+// node actually changes.
+function getChildRenderSignature(child: NodeChild) {
+  const record = child as Record<string, unknown>
+  const children = record.children
+  return [
+    record.type,
+    String(record.raw ?? ''),
+    String(record.content ?? ''),
+    Array.isArray(children) ? `c${children.length}` : 'c0',
+    String((record as { loading?: unknown }).loading ?? ''),
+  ].join('\u0001')
+}
+
+// Per-render child cache: index → { child, sig }. The parser hands us a new
+// object for every inline child on each streaming commit; handing components
+// the previous (content-identical) child object keeps their `node` prop
+// reference stable so the child component update is skipped.
+const previousChildCache = new Map<number, { child: NodeChild, sig: string }>()
+
 const nodeComponents = computed(() => ({
   inline_code: InlineCodeNode,
   image: ImageNode,
@@ -204,20 +229,35 @@ function processChild(child: NodeChild): { child: NodeChild, component: any, isC
   }
 }
 
-const processedChildren = computed(() => renderedChildren.value.map((child, index) => {
-  const processed = processChild(child)
-  return {
-    ...processed,
-    index,
-    key: `${props.indexKey || 'paragraph'}-${index}`,
-    customAttrs: processed.isCustomComponent
-      ? getCustomNodeAttrs(processed.child as any, resolvedHtmlPolicy.value)
-      : undefined,
-    hasSlotChildren: Array.isArray((processed.child as any).children) && (processed.child as any).children.length > 0,
-    slotContent: String((processed.child as any).content ?? ''),
-    originalChild: child,
+const processedChildren = computed(() => {
+  const children = renderedChildren.value
+  // Trim stale cache entries when the paragraph shrinks (indexes shift or a
+  // paragraph is re-parsed into fewer children).
+  if (previousChildCache.size > children.length) {
+    for (const key of previousChildCache.keys()) {
+      if (key >= children.length)
+        previousChildCache.delete(key)
+    }
   }
-}))
+  return children.map((child, index) => {
+    const sig = getChildRenderSignature(child)
+    const previous = previousChildCache.get(index)
+    const stableChild = previous && previous.sig === sig ? previous.child : child
+    previousChildCache.set(index, { child: stableChild, sig })
+    const processed = processChild(stableChild)
+    return {
+      ...processed,
+      index,
+      key: `${props.indexKey || 'paragraph'}-${index}`,
+      customAttrs: processed.isCustomComponent
+        ? getCustomNodeAttrs(processed.child as any, resolvedHtmlPolicy.value)
+        : undefined,
+      hasSlotChildren: Array.isArray((processed.child as any).children) && (processed.child as any).children.length > 0,
+      slotContent: String((processed.child as any).content ?? ''),
+      originalChild: stableChild,
+    }
+  })
+})
 </script>
 
 <template>

--- a/src/components/TextNode/TextNode.vue
+++ b/src/components/TextNode/TextNode.vue
@@ -156,22 +156,24 @@ function settleStreamedDelta() {
     return
   }
   settleAfterSelection = false
-  stopWatchingStreamVersion()
   if (!streamedDelta.value)
     return
   settledContent.value = getRenderedContent()
   streamedDelta.value = ''
 }
 
-function watchStreamVersionWhileDeltaActive() {
-  if (!streamedDelta.value || stopStreamVersionWatch || !inheritedStreamVersion)
+function ensureStreamVersionWatch() {
+  if (stopStreamVersionWatch || !inheritedStreamVersion)
     return
-
-  const activeVersion = inheritedStreamVersion.value
+  // One persistent watcher for the component's whole lifecycle instead of a
+  // create-per-delta + destroy-on-settle watcher. Streaming commits bump the
+  // version once per commit, and this fires to settle whichever delta is
+  // active at that moment; the old approach churned a new `flush: 'sync'`
+  // watcher on every commit that appended a delta.
   stopStreamVersionWatch = watch(
     () => inheritedStreamVersion.value,
-    (version) => {
-      if (version !== activeVersion)
+    () => {
+      if (streamedDelta.value)
         settleStreamedDelta()
     },
     { flush: 'sync' },
@@ -191,7 +193,7 @@ function applyStreamingUpdate(normalized: string) {
   streamedDelta.value = result.streamedDelta
   if (result.appended) {
     streamFadeVersion.value += 1
-    watchStreamVersionWhileDeltaActive()
+    ensureStreamVersionWatch()
   }
   else if (!streamedDelta.value) {
     stopWatchingStreamVersion()

--- a/test/node-renderer-virtual-scroll.test.ts
+++ b/test/node-renderer-virtual-scroll.test.ts
@@ -2094,25 +2094,23 @@ describe('node renderer virtual-scroll coordination', () => {
     await flushAll()
 
     finishAsyncNode?.(88)
-    await new Promise(resolve => setTimeout(resolve, 160))
-    await flushAll()
-
-    const firstFinalCount = wrapper.emitted('render-final')?.length ?? 0
-    expect(wrapper.emitted('render-final')?.at(-1)?.[0]).toMatchObject({
-      phase: 'final',
-      totalHeight: 88,
-      stable: true,
+    await vi.waitFor(() => {
+      expect(wrapper.emitted('render-final')?.at(-1)?.[0]).toMatchObject({
+        phase: 'final',
+        totalHeight: 88,
+        stable: true,
+      })
     })
 
+    const firstFinalCount = wrapper.emitted('render-final')?.length ?? 0
     reportAsyncHeight?.(120)
-    await new Promise(resolve => setTimeout(resolve, 160))
-    await flushAll()
-
-    expect(wrapper.emitted('render-final')?.length).toBeGreaterThan(firstFinalCount)
-    expect(wrapper.emitted('render-final')?.at(-1)?.[0]).toMatchObject({
-      phase: 'final',
-      totalHeight: 120,
-      stable: true,
+    await vi.waitFor(() => {
+      expect(wrapper.emitted('render-final')?.length).toBeGreaterThan(firstFinalCount)
+      expect(wrapper.emitted('render-final')?.at(-1)?.[0]).toMatchObject({
+        phase: 'final',
+        totalHeight: 120,
+        stable: true,
+      })
     })
 
     wrapper.unmount()

--- a/test/paragraph-node-memo.test.ts
+++ b/test/paragraph-node-memo.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import NodeRenderer from '../src/components/NodeRenderer'
+import ParagraphNode from '../src/components/ParagraphNode'
+import TextNode from '../src/components/TextNode'
+import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
+import { flushAll } from './setup/flush-all'
+
+describe('paragraph child memo', () => {
+  const customId = 'paragraph-child-memo'
+
+  afterEach(() => {
+    removeCustomComponents(customId)
+  })
+
+  it('keeps content-identical text children stable while updating the changed tail', async () => {
+    const first = { type: 'text', raw: 'stable', content: 'stable' }
+    const tail = { type: 'text', raw: 'a', content: 'a' }
+    const wrapper = mount(ParagraphNode, {
+      props: {
+        node: { type: 'paragraph', raw: 'stable a', children: [first, tail] },
+        indexKey: 'memo',
+      },
+    })
+
+    const initialTextNodes = wrapper.findAllComponents(TextNode)
+    const stableNodeProp = initialTextNodes[0].props('node')
+    const tailNodeProp = initialTextNodes[1].props('node')
+
+    const nextTail = { type: 'text', raw: 'ab', content: 'ab' }
+    await wrapper.setProps({
+      node: {
+        type: 'paragraph',
+        raw: 'stable ab',
+        children: [
+          { type: 'text', raw: 'stable', content: 'stable' },
+          nextTail,
+        ],
+      },
+    })
+
+    const updatedTextNodes = wrapper.findAllComponents(TextNode)
+    expect(updatedTextNodes[0].props('node')).toBe(stableNodeProp)
+    expect(updatedTextNodes[1].props('node')).not.toBe(tailNodeProp)
+    expect(updatedTextNodes[1].props('node')).toMatchObject(nextTail)
+  })
+
+  it('updates a finalized image when its URL changes with the same alt text', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '![x](https://a.test/a.png)',
+        final: true,
+        typewriter: false,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.find('img').attributes('src')).toBe('https://a.test/a.png')
+
+    await wrapper.setProps({ content: '![x](https://b.test/b.png)' })
+    await flushAll()
+
+    expect(wrapper.find('img').attributes('src')).toBe('https://b.test/b.png')
+  })
+
+  it('updates recursive custom children when their content changes at the same length', async () => {
+    const CustomNode = defineComponent({
+      setup(_props, { slots }) {
+        return () => h('span', { class: 'custom-node' }, slots.default?.())
+      },
+    })
+    setCustomComponents(customId, { thinking: CustomNode })
+    const makeNode = (content: string) => ({
+      type: 'paragraph' as const,
+      raw: 'same paragraph',
+      children: [{
+        type: 'thinking',
+        raw: 'same child',
+        content: 'same child',
+        loading: false,
+        children: [{ type: 'text', raw: content, content }],
+      }],
+    })
+    const wrapper = mount(ParagraphNode, {
+      props: {
+        node: makeNode('first'),
+        customId,
+        indexKey: 'recursive',
+      },
+    })
+
+    await flushAll()
+    expect(wrapper.find('.custom-node').text()).toBe('first')
+
+    await wrapper.setProps({ node: makeNode('second') })
+    await flushAll()
+
+    expect(wrapper.find('.custom-node').text()).toBe('second')
+  })
+})

--- a/test/typewriter-cursor-position.test.ts
+++ b/test/typewriter-cursor-position.test.ts
@@ -183,6 +183,34 @@ describe('typewriter cursor position', () => {
     wrapper.unmount()
   })
 
+  it('does not restore a stale cursor when typewriter is re-enabled without new content', async () => {
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: '',
+        typewriter: 'simple',
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+      },
+    })
+
+    await flushAll()
+    await wrapper.setProps({ content: 'hello world' })
+    await flushAll()
+    expect(wrapper.classes()).toContain('typewriter-simple-cursor')
+
+    await wrapper.setProps({ typewriter: false })
+    await flushAll()
+    expect(wrapper.classes()).not.toContain('typewriter-simple-cursor')
+
+    await wrapper.setProps({ typewriter: 'simple' })
+    await flushAll()
+    expect(wrapper.classes()).not.toContain('typewriter-simple-cursor')
+
+    wrapper.unmount()
+  })
+
   it('clears simple cursor target when stream becomes final', async () => {
     const wrapper = mount(NodeRenderer, {
       props: {


### PR DESCRIPTION
## Summary

第三轮 streaming CPU 优化：在不改变渲染效果的前提下，削减渲染与解析热路径上每次提交的浪费。核心是把"每次提交都重建/全量扫一遍"的工作降为"只处理真正变化的尾部"。

## Changes

- **`renderedItems` no-op 短路**：解析器复用了全部节点对象的提交（如 final 翻转）不再 `slice()` 出新数组强制整表 v-for 重渲染，直接返回上一次数组实例，Vue 跳过该次渲染与全部 slot 函数 ref 重入。
- **slot 注册 key 改 computed 缓存**：`getNodeSlotRegistrationKey()` 每提交对每个 slot 做 2 次字符串 join 分配（O(N)），改为只在依赖变化时重建一次。
- **ParagraphNode 稳定内联子节点引用**：尾部段落的内联子节点按内容签名（type+raw+content+children+loading）缓存对象；签名不变则复用旧引用，子组件 `node` prop 引用不变 → Vue 跳过重渲染，只有增长的尾部 text 节点真正渲染。
- **TextNode / InlineCodeNode 持久 watcher**：原来每个活跃 delta 每提交创建+销毁一个 `flush:'sync'` watcher，改为组件生命周期内一个常驻 watcher 判空。
- **typewriter watcher 提前退出**：默认关闭时不再每提交跑完整回调（含递归节点文本长度遍历）。
- **code_block 高度估算守卫**：已有实测高度时跳过昂贵的 `estimateCodeBlockHeight`。
- **解析层 seed 增量重建**（`stream-markdown-parser`）：structured reuse 增量路径复用上一轮 seed 前缀，只对新 tail 节点做 raw stringify，去掉每提交 O(nodes) 重建。
- **自定义组件路径微优化**：`getCustomComponentsReuseKey` 按 mapping 引用缓存（去掉每提交 JSON.stringify）；custom-component boundary 预热只跑 dirty tail。

## Screenshots / Demo (if UI/behavior changes)

无 UI 变化（效果保持不变）。已在 playground 冒烟验证：streaming 正常推进、DOM 结构完整、无控制台错误。

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (337 files / 2985 tests passed)
- [x] Build: `pnpm build` (library + CSS)
