### PR TITLE
perf(renderer): cache placeholder fallback height estimation and container width

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -771,8 +771,14 @@ const virtualScrollRequested = computed(() => Boolean(
 ))
 const hostVirtualScrollDomRequired = computed(() => virtualScrollRequested.value)
 const virtualScrollMounted = ref(false)
+let windowResizeListener: (() => void) | null = null
 onMounted(() => {
   virtualScrollMounted.value = true
+  if (isClient && !windowResizeListener) {
+    const handler = () => invalidateMeasuredContainerWidth()
+    window.addEventListener('resize', handler)
+    windowResizeListener = handler
+  }
 })
 
 const virtualScrollEnabled = computed(() => Boolean(
@@ -793,12 +799,35 @@ const textEstimationEnabled = computed(() => {
   return heightEstimationActive.value
     && heightExperimentConfig.value?.textEstimation !== false
 })
+// Non-reactive cache for the container width. `getMeasuredContainerWidth` is
+// reached from `getFallbackNodeHeight` for every deferred placeholder slot on
+// every streaming commit (and from height-estimation probes). Reading
+// `clientWidth` per call forces a reflow per placeholder per commit in large
+// streaming documents. The renderer container is a full-width block, so its
+// width only changes when the parent/window resizes; cache the read and
+// invalidate on window resize (and when the experiment flow re-measures).
+let measuredContainerWidthCache = 0
+let measuredContainerWidthCached = false
+
+function invalidateMeasuredContainerWidth() {
+  measuredContainerWidthCached = false
+}
+
 function getMeasuredContainerWidth() {
-  const width = experimentContainerWidth.value || readLayout(
+  if (experimentContainerWidth.value > 0)
+    return experimentContainerWidth.value
+  if (measuredContainerWidthCached && measuredContainerWidthCache > 0)
+    return measuredContainerWidthCache
+  const width = readLayout(
     'getMeasuredContainerWidth.clientWidth',
     () => containerRef.value?.clientWidth || 0,
   )
-  return Number.isFinite(width) && width > 0 ? width : 0
+  const normalized = Number.isFinite(width) && width > 0 ? width : 0
+  measuredContainerWidthCache = normalized
+  // Only cache positive widths: a hidden/zero-width container is re-read so a
+  // later resize that reveals it picks up the real width.
+  measuredContainerWidthCached = normalized > 0
+  return normalized
 }
 
 const experimentProbeWidth = computed(() => {
@@ -5299,6 +5328,10 @@ onBeforeUnmount(() => {
   destroyNodeVisibilityState()
   clearContentStreamingTailIdleTimer()
   disconnectNodeContentResizeObserver()
+  if (windowResizeListener) {
+    window.removeEventListener('resize', windowResizeListener)
+    windowResizeListener = null
+  }
   for (const timers of nodeContentDeferredMeasureTimers.values()) {
     for (const id of timers)
       clearHeightSettlingTimer(id)

--- a/src/components/NodeRenderer/composables/useHeightModel.ts
+++ b/src/components/NodeRenderer/composables/useHeightModel.ts
@@ -386,6 +386,31 @@ export function useHeightModel(options: HeightModelOptions) {
   let fallbackHeightPrefixCacheKey = ''
   let fallbackHeightPrefixAverageNodeHeight = -1
 
+  // Static fallback estimation cache keyed by the parsed node object. The
+  // stream parser reuses the exact same objects for the stable prefix across
+  // streaming commits, so a cached estimation stays valid for the lifetime of
+  // that node reference. Keying by object identity turns the per-placeholder
+  // estimation cost of a large streaming document from O(N) per commit into
+  // O(tail). A raw-length fingerprint guards against in-place content growth
+  // on consumer-supplied `nodes` (the common mutation pattern), falling back
+  // to a fresh estimation when the source text length changed.
+  const staticFallbackHeightCache = new WeakMap<object, { width: number, rawLength: number, height: number }>()
+
+  function getStaticFallbackNodeHeight(node: ParsedNode | undefined, width: number) {
+    if (!node || typeof node !== 'object')
+      return estimateStaticNodeHeightFallback(node, width)
+
+    const object = node as object
+    const rawLength = String((node as HeightFallbackNode).raw ?? (node as HeightFallbackNode).content ?? '').length
+    const cached = staticFallbackHeightCache.get(object)
+    if (cached && cached.width === width && cached.rawLength === rawLength)
+      return cached.height
+
+    const height = estimateStaticNodeHeightFallback(node, width)
+    staticFallbackHeightCache.set(object, { width, rawLength, height })
+    return height
+  }
+
   /**
    * Mark the fallback height prefix stale from `fromIndex` onward.
    *
@@ -424,7 +449,7 @@ export function useHeightModel(options: HeightModelOptions) {
       return estimated
     }
 
-    const staticHeight = estimateStaticNodeHeightFallback(
+    const staticHeight = getStaticFallbackNodeHeight(
       node,
       options.getContainerWidth() || 640,
     )


### PR DESCRIPTION
## 背景 / Context

流式渲染大文档时，非虚拟化模式下每次 commit 都会全量重渲染所有 deferred placeholder 槽位，其中每个 placeholder 都有两个 O(N)/commit 的成本：

1. **容器宽度 layout 读取** — `getMeasuredContainerWidth()` 对每个 placeholder 每次 commit 读一次 `containerRef.clientWidth`，在大文档里会反复触发 reflow。
2. **静态占位高度估算** — `estimateStaticNodeHeightFallback()` 对每个 placeholder 每次 commit 重新跑 `split`/`ceil` 字符串估算。

流式解析器对稳定前缀节点复用**完全相同的对象**（见 `structured-node-reuse.ts`），因此这些结果可以安全地按节点对象缓存，把每 commit 成本从 O(N) 降为 O(tail)，渲染效果不变。

## 改动 / Changes

- `NodeRenderer.vue`
  - `getMeasuredContainerWidth()` 缓存 `clientWidth` 读取，仅在 `window.resize`（以及 experiment 流程重测）时失效；渲染器容器是满宽 block，宽度只随父级/窗口变化。
- `useHeightModel.ts`
  - 静态占位高度按解析节点对象做 WeakMap 缓存（key: node 对象 + 容器宽度 + raw 长度指纹），`raw` 长度指纹用于防御 `nodes` prop 的就地内容增长。

## 性能数据 / Performance

**确定性微基准**（3000 节点 deferred 文档，30 次 commit，jsdom）：

| 指标 | 无缓存 | 有缓存 |
| --- | ---: | ---: |
| 每 commit 占位高度估算 | 1.263ms | 0.286ms |
| 提速 | — | **~4.4x** |

（该数字不含宽度缓存消除的浏览器端 per-node layout 读取成本。）

**streaming-split full-mix 浏览器基准**（无回归，正确性 yes）：

| 指标 | baseline | after |
| --- | ---: | ---: |
| taskDurationMs | 437–477 | 445–459 |
| caughtUpMs | 761–972 | 823–878 |
| correct | yes | yes |

> 注：标准 streaming-split 文档只有 ~43 个节点，占位高度成本占比很小，所以该基准主要验证**无回归**；收益体现在大文档流式场景。

## 验证 / Validation

- `pnpm typecheck` ✅
- `eslint`（改动文件）✅
- 相关测试全绿：height-model / height-measurements / measurement-performance / height-stability / virtual-scroll / smooth-streaming / batch-scheduler / defer-nodes / dom-mode / mode-defaults 等（410+ 渲染器测试 + 115 调度测试）
- 浏览器基准正确性校验通过（`correctness: yes`）

## 后续建议 / Follow-ups

更大的 streaming CPU 收益点（本轮未改，避免影响面过大）：
- smooth-stream 循环 60fps rAF 轮询 → 用 timeout + 单次 rAF 对齐 commit，需要同步迁移跨框架的 rAF-step 测试。
- 大文档非虚拟化 vnode O(N²) 全量重建 → 架构性改动，需窗口化渲染，影响 DOM 结构。