### PR TITLE
fix(renderer): correct placeholder cache invalidation

### DIFF
--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -323,7 +323,7 @@ const streamRenderVersion = ref(0)
 // initializes; guard prefix invalidation until the model exists. The first
 // prefix build is full anyway, so dropping the early mark is safe.
 let heightModelReady = false
-const experimentContainerWidth = ref(0)
+const measuredContainerWidth = ref(0)
 const simpleTextProbeProfile = ref(createEmptySimpleTextProbeProfile())
 
 function resolveViewportPriorityRootMargin(value: unknown, fallback: string) {
@@ -771,14 +771,8 @@ const virtualScrollRequested = computed(() => Boolean(
 ))
 const hostVirtualScrollDomRequired = computed(() => virtualScrollRequested.value)
 const virtualScrollMounted = ref(false)
-let windowResizeListener: (() => void) | null = null
 onMounted(() => {
   virtualScrollMounted.value = true
-  if (isClient && !windowResizeListener) {
-    const handler = () => invalidateMeasuredContainerWidth()
-    window.addEventListener('resize', handler)
-    windowResizeListener = handler
-  }
 })
 
 const virtualScrollEnabled = computed(() => Boolean(
@@ -799,35 +793,14 @@ const textEstimationEnabled = computed(() => {
   return heightEstimationActive.value
     && heightExperimentConfig.value?.textEstimation !== false
 })
-// Non-reactive cache for the container width. `getMeasuredContainerWidth` is
-// reached from `getFallbackNodeHeight` for every deferred placeholder slot on
-// every streaming commit (and from height-estimation probes). Reading
-// `clientWidth` per call forces a reflow per placeholder per commit in large
-// streaming documents. The renderer container is a full-width block, so its
-// width only changes when the parent/window resizes; cache the read and
-// invalidate on window resize (and when the experiment flow re-measures).
-let measuredContainerWidthCache = 0
-let measuredContainerWidthCached = false
-
-function invalidateMeasuredContainerWidth() {
-  measuredContainerWidthCached = false
-}
-
 function getMeasuredContainerWidth() {
-  if (experimentContainerWidth.value > 0)
-    return experimentContainerWidth.value
-  if (measuredContainerWidthCached && measuredContainerWidthCache > 0)
-    return measuredContainerWidthCache
+  if (measuredContainerWidth.value > 0)
+    return measuredContainerWidth.value
   const width = readLayout(
     'getMeasuredContainerWidth.clientWidth',
     () => containerRef.value?.clientWidth || 0,
   )
-  const normalized = Number.isFinite(width) && width > 0 ? width : 0
-  measuredContainerWidthCache = normalized
-  // Only cache positive widths: a hidden/zero-width container is re-read so a
-  // later resize that reveals it picks up the real width.
-  measuredContainerWidthCached = normalized > 0
-  return normalized
+  return Number.isFinite(width) && width > 0 ? width : 0
 }
 
 const experimentProbeWidth = computed(() => {
@@ -1221,6 +1194,11 @@ function pruneHeightMeasurements(size: number) {
 }
 const deferNodes = computed(() => {
   return deferNodesDomRequired.value && viewportPriorityEnabled.value
+})
+const measuredContainerWidthActive = computed(() => {
+  return heightEstimationActive.value
+    || incrementalRenderingDomRequired.value
+    || (deferNodes.value && parsedNodes.value.length > resolvedInitialBatch.value)
 })
 const incrementalRenderingConfigured = computed(() => {
   return !renderAsFragment.value
@@ -1685,35 +1663,37 @@ function readSimpleTextProbeProfile() {
   markFallbackHeightPrefixDirty()
 }
 
-function updateExperimentContainerWidth() {
-  if (!heightEstimationActive.value) {
-    experimentContainerWidth.value = 0
+function updateMeasuredContainerWidth() {
+  if (!measuredContainerWidthActive.value) {
+    measuredContainerWidth.value = 0
     return
   }
-  const width = readLayout('updateExperimentContainerWidth.clientWidth', () => containerRef.value?.clientWidth ?? 0)
-  experimentContainerWidth.value = width > 0 ? width : 0
+  const width = readLayout('updateMeasuredContainerWidth.clientWidth', () => containerRef.value?.clientWidth ?? 0)
+  measuredContainerWidth.value = width > 0 ? width : 0
 }
 
-let experimentResizeObserver: ResizeObserver | null = null
+let containerResizeObserver: ResizeObserver | null = null
 
-function cleanupExperimentResizeObserver() {
-  experimentResizeObserver?.disconnect()
-  experimentResizeObserver = null
+function cleanupContainerResizeObserver() {
+  containerResizeObserver?.disconnect()
+  containerResizeObserver = null
 }
 
-function setupExperimentResizeObserver() {
-  cleanupExperimentResizeObserver()
-  if (!heightEstimationActive.value || !containerRef.value || typeof ResizeObserver === 'undefined')
+function setupContainerResizeObserver() {
+  cleanupContainerResizeObserver()
+  if (!measuredContainerWidthActive.value || !containerRef.value || typeof ResizeObserver === 'undefined')
     return
-  experimentResizeObserver = new ResizeObserver(() => {
-    updateExperimentContainerWidth()
+  containerResizeObserver = new ResizeObserver(() => {
+    updateMeasuredContainerWidth()
+    if (!heightEstimationActive.value)
+      return
     if (activeRestoreAnchor.value)
       scheduleRestoreReconcile()
     if (activeVirtualBottomAnchor.value)
       scheduleVirtualBottomRestoreReconcile()
     scheduleVirtualMetricsEmit('resize')
   })
-  experimentResizeObserver.observe(containerRef.value)
+  containerResizeObserver.observe(containerRef.value)
 }
 
 const codeBlockComponent = computed(() => {
@@ -1833,7 +1813,7 @@ watchEffect(() => {
     return
   }
 
-  const width = experimentContainerWidth.value || readLayout('estimatedNodeHeights.clientWidth', () => containerRef.value?.clientWidth || 0)
+  const width = measuredContainerWidth.value || readLayout('estimatedNodeHeights.clientWidth', () => containerRef.value?.clientWidth || 0)
   if (!Number.isFinite(width) || width <= 0) {
     estimatedNodeHeightsCache = []
     estimatedNodeHeightsContext = []
@@ -1882,9 +1862,10 @@ heightModel = useHeightModel({
   heightEstimationActive,
   estimatedNodeHeights,
   getContainerWidth: getMeasuredContainerWidth,
+  shouldCacheStaticFallbackHeight: () => !props.nodes?.length,
   hasCustomParagraphComponent: () => Boolean(customComponentsMap.value.paragraph),
   getPrefixCacheKeyParts: () => {
-    const width = experimentContainerWidth.value || readLayout('getFallbackHeightPrefix.clientWidth', () => containerRef.value?.clientWidth || 0)
+    const width = measuredContainerWidth.value || readLayout('getFallbackHeightPrefix.clientWidth', () => containerRef.value?.clientWidth || 0)
     const widthBucket = getHeightCacheWidthBucket(width)
     const measurementKey = props.virtualScroll?.measurementKey == null
       ? ''
@@ -4718,15 +4699,15 @@ watch(
 )
 
 watch(
-  [() => containerRef.value, heightEstimationActive],
+  [() => containerRef.value, measuredContainerWidthActive],
   () => {
-    if (!heightEstimationActive.value) {
-      cleanupExperimentResizeObserver()
-      experimentContainerWidth.value = 0
+    if (!measuredContainerWidthActive.value) {
+      cleanupContainerResizeObserver()
+      measuredContainerWidth.value = 0
       return
     }
-    updateExperimentContainerWidth()
-    setupExperimentResizeObserver()
+    updateMeasuredContainerWidth()
+    setupContainerResizeObserver()
   },
   { immediate: true },
 )
@@ -4758,7 +4739,7 @@ watch(
 )
 
 watch(
-  [heightEstimationActive, experimentContainerWidth],
+  [heightEstimationActive, measuredContainerWidth],
   () => {
     markFallbackHeightPrefixDirty()
     if (virtualizationEnabled.value)
@@ -5050,7 +5031,7 @@ watch(
     () => props.virtualScroll?.measurementKey,
     () => parsedNodes.value.length,
     () => getVirtualSessionKey(),
-    experimentContainerWidth,
+    measuredContainerWidth,
   ],
   () => {
     tryImportVirtualHeightCache()
@@ -5066,7 +5047,7 @@ watch(
     () => props.virtualScroll?.measurementKey,
     () => parsedNodes.value.length,
     () => getVirtualSessionKey(),
-    experimentContainerWidth,
+    measuredContainerWidth,
   ],
   async ([enabled, state]) => {
     if (!enabled || !state)
@@ -5084,7 +5065,7 @@ watch(
 )
 
 watch(
-  [virtualScrollEnabled, experimentContainerWidth, () => props.virtualScroll?.restoreState, () => props.virtualScroll?.measurementKey],
+  [virtualScrollEnabled, measuredContainerWidth, () => props.virtualScroll?.restoreState, () => props.virtualScroll?.measurementKey],
   ([enabled]) => {
     if (!enabled)
       return
@@ -5112,7 +5093,7 @@ watch(
     virtualScrollEnabled,
     () => parsedNodes.value.length,
     () => getVirtualSessionKey(),
-    experimentContainerWidth,
+    measuredContainerWidth,
   ],
   async ([enabled]) => {
     const state = pendingImperativeVirtualRestoreState
@@ -5328,10 +5309,6 @@ onBeforeUnmount(() => {
   destroyNodeVisibilityState()
   clearContentStreamingTailIdleTimer()
   disconnectNodeContentResizeObserver()
-  if (windowResizeListener) {
-    window.removeEventListener('resize', windowResizeListener)
-    windowResizeListener = null
-  }
   for (const timers of nodeContentDeferredMeasureTimers.values()) {
     for (const id of timers)
       clearHeightSettlingTimer(id)
@@ -5341,7 +5318,7 @@ onBeforeUnmount(() => {
   nodeHeightSignatures.length = 0
   clearFinalHeightConvergenceTimers()
   clearPendingHeightMeasurements()
-  cleanupExperimentResizeObserver()
+  cleanupContainerResizeObserver()
   clearRestoreReconcile()
   clearActiveVirtualBottomAnchor()
   clearVirtualMetricsSchedule()
@@ -5679,7 +5656,7 @@ function getRenderedItemGlobalSignature(): readonly unknown[] {
     // `estimatedHeight`; fold it in so estimation changes rebuild all items.
     heightEstimationActive.value,
     heightEstimationExperimentRevision.value,
-    experimentContainerWidth.value,
+    measuredContainerWidth.value,
   ]
   if (lastRenderedItemGlobalSignature && hasSameRenderedItemSignature(lastRenderedItemGlobalSignature, values))
     return lastRenderedItemGlobalSignature

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1664,7 +1664,7 @@ function readSimpleTextProbeProfile() {
 }
 
 function updateMeasuredContainerWidth() {
-  if (!measuredContainerWidthActive.value) {
+  if (!measuredContainerWidthActive.value || typeof ResizeObserver === 'undefined') {
     measuredContainerWidth.value = 0
     return
   }

--- a/src/components/NodeRenderer/composables/useHeightModel.ts
+++ b/src/components/NodeRenderer/composables/useHeightModel.ts
@@ -32,6 +32,7 @@ export interface HeightModelOptions {
   heightEstimationActive: ComputedRef<boolean>
   estimatedNodeHeights: ComputedRef<readonly (EstimatedNodeHeight | null)[]>
   getContainerWidth: () => number
+  shouldCacheStaticFallbackHeight?: () => boolean
   hasCustomParagraphComponent?: () => boolean
   getPrefixCacheKeyParts: () => readonly unknown[]
   fenwickRangeSum: (tree: number[], start: number, end: number) => number
@@ -389,25 +390,21 @@ export function useHeightModel(options: HeightModelOptions) {
   // Static fallback estimation cache keyed by the parsed node object. The
   // stream parser reuses the exact same objects for the stable prefix across
   // streaming commits, so a cached estimation stays valid for the lifetime of
-  // that node reference. Keying by object identity turns the per-placeholder
-  // estimation cost of a large streaming document from O(N) per commit into
-  // O(tail). A raw-length fingerprint guards against in-place content growth
-  // on consumer-supplied `nodes` (the common mutation pattern), falling back
-  // to a fresh estimation when the source text length changed.
-  const staticFallbackHeightCache = new WeakMap<object, { width: number, rawLength: number, height: number }>()
+  // that node reference. Consumer-supplied nodes can mutate in place, so the
+  // renderer disables this cache for that input mode.
+  const staticFallbackHeightCache = new WeakMap<object, { width: number, height: number }>()
 
   function getStaticFallbackNodeHeight(node: ParsedNode | undefined, width: number) {
-    if (!node || typeof node !== 'object')
+    if (!node || typeof node !== 'object' || options.shouldCacheStaticFallbackHeight?.() === false)
       return estimateStaticNodeHeightFallback(node, width)
 
     const object = node as object
-    const rawLength = String((node as HeightFallbackNode).raw ?? (node as HeightFallbackNode).content ?? '').length
     const cached = staticFallbackHeightCache.get(object)
-    if (cached && cached.width === width && cached.rawLength === rawLength)
+    if (cached && cached.width === width)
       return cached.height
 
     const height = estimateStaticNodeHeightFallback(node, width)
-    staticFallbackHeightCache.set(object, { width, rawLength, height })
+    staticFallbackHeightCache.set(object, { width, height })
     return height
   }
 

--- a/test/node-renderer-height-model.test.ts
+++ b/test/node-renderer-height-model.test.ts
@@ -28,6 +28,7 @@ function createModel(options: {
   active?: boolean
   estimates?: Array<EstimatedNodeHeight | null>
   hasCustomParagraphComponent?: boolean
+  shouldCacheStaticFallbackHeight?: boolean
   width?: number
 }) {
   const nodes = ref(options.nodes)
@@ -46,6 +47,7 @@ function createModel(options: {
     heightEstimationActive: computed(() => active.value),
     estimatedNodeHeights: computed(() => estimates.value),
     getContainerWidth: () => width.value,
+    shouldCacheStaticFallbackHeight: () => options.shouldCacheStaticFallbackHeight !== false,
     hasCustomParagraphComponent: () => Boolean(options.hasCustomParagraphComponent),
     getPrefixCacheKeyParts: () => [
       nodes.value.length,
@@ -111,6 +113,24 @@ describe('useHeightModel', () => {
     expect(mermaid).toBeGreaterThanOrEqual(360)
     expect(infographic).toBeGreaterThanOrEqual(360)
     expect(ordinaryCode).toBe(96)
+  })
+
+  it('re-estimates mutable consumer nodes when static caching is disabled', () => {
+    const node = {
+      type: 'code_block',
+      language: 'ts',
+      raw: 'consumer-managed source',
+      code: 'x',
+    } as ParsedNode
+    const { model } = createModel({
+      nodes: [node],
+      shouldCacheStaticFallbackHeight: false,
+      width: 320,
+    })
+
+    expect(model.getFallbackNodeHeight(0)).toBe(96)
+    ;(node as any).code = Array.from({ length: 100 }, () => 'line').join('\n')
+    expect(model.getFallbackNodeHeight(0)).toBeGreaterThan(1900)
   })
 
   it('uses visible text to estimate list and table fallback heights', () => {

--- a/test/node-renderer-measurement-performance.test.ts
+++ b/test/node-renderer-measurement-performance.test.ts
@@ -214,6 +214,32 @@ describe('node renderer measurement performance', () => {
     wrapper.unmount()
   })
 
+  it('does not cache the container width without ResizeObserver', async () => {
+    vi.stubGlobal('ResizeObserver', undefined)
+    let width = 320
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => width)
+
+    const NodeRenderer = (await import('../src/components/NodeRenderer')).default
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: Array.from({ length: 41 }, (_, index) => {
+          return `Paragraph ${index} ${'x'.repeat(240)}`
+        }).join('\n\n'),
+        final: true,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const state = setupState(wrapper)
+    const narrowHeight = state.getFallbackNodeHeight(40)
+    width = 960
+
+    expect(state.getFallbackNodeHeight(40)).toBeLessThan(narrowHeight)
+    wrapper.unmount()
+  })
+
   it('reuses stable estimated height entries after unrelated measurements', async () => {
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => 640)
 

--- a/test/node-renderer-measurement-performance.test.ts
+++ b/test/node-renderer-measurement-performance.test.ts
@@ -182,6 +182,38 @@ describe('node renderer measurement performance', () => {
     wrapper.unmount()
   })
 
+  it('updates deferred fallback heights when the renderer container resizes', async () => {
+    const platform = installManualMeasurementPlatform()
+    let width = 320
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => width)
+
+    const NodeRenderer = (await import('../src/components/NodeRenderer')).default
+    const content = Array.from({ length: 41 }, (_, index) => {
+      return `Paragraph ${index} ${'x'.repeat(240)}`
+    }).join('\n\n')
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        final: true,
+        fade: false,
+      },
+    })
+
+    await flushAll()
+
+    const state = setupState(wrapper)
+    const narrowHeight = state.getFallbackNodeHeight(40)
+    const resize = platform.resizeCallbacks.get(wrapper.element)
+    expect(resize).toBeTypeOf('function')
+
+    width = 960
+    resize?.([], {} as ResizeObserver)
+    await nextTick()
+
+    expect(state.getFallbackNodeHeight(40)).toBeLessThan(narrowHeight)
+    wrapper.unmount()
+  })
+
   it('reuses stable estimated height entries after unrelated measurements', async () => {
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => 640)
 


### PR DESCRIPTION
## Summary

- reuse the renderer container ResizeObserver for deferred placeholder width caching instead of adding one window resize listener per NodeRenderer
- limit the observer to renderers that actually need placeholder or virtual height measurement
- keep static fallback caching for parser-owned stable nodes while re-estimating consumer-supplied nodes that may mutate in place
- add regressions for parent-driven container resizes and mutable consumer code blocks

## Performance

- no per-node observer or deep content hash is added
- removes the raw-length string fingerprint from cache hits
- 3000-node / 30-commit microbenchmark: 2.844ms uncached vs 1.627ms cached per commit, about 1.75x faster

## Validation

- pnpm test: 338 files / 2991 tests passed
- pnpm typecheck
- pnpm lint