### PR TITLE
perf(streaming): round-4 CPU optimizations (line-offset cache, code-block item reuse, smooth-reset prefix skip)

### DIFF
--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -15,7 +15,7 @@ import { applyPostTransformNodes, finalizeHtmlBlockLoading } from './nodes/final
 import { getInternalNodeSourceRange, processTokensWithContext } from './nodes/token-to-nodes'
 import { createParseContext, ensureParseContext } from './parse-context'
 import { processTopLevelTokensWithReuse } from './reuse/structured-node-reuse'
-import { getParserRuntime } from './runtime'
+import { getCachedSourceLineOffsets, getParserRuntime } from './runtime'
 import { createSourceLineMapper } from './source-line-mapper'
 import { getSafeMarkdown } from './streaming/safe-markdown'
 import {
@@ -165,6 +165,10 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
       ? createSourceLineMapper(sourceMarkdown, safeMarkdown)
       : undefined,
     sourceMarkdown: safeMarkdown,
+    // Line-start offsets are a pure function of the source; cache them on the
+    // runtime and extend incrementally across streaming appends so the
+    // per-commit O(document) newline scan only touches the appended tail.
+    sourceLineOffsets: getCachedSourceLineOffsets(runtime, safeMarkdown),
     customHtmlBlockCursor: 0,
   }
   let result = processTopLevelTokensWithReuse(runtime, safeMarkdown, transformedTokens, internalOptions, {

--- a/packages/markdown-parser/src/parser/runtime.ts
+++ b/packages/markdown-parser/src/parser/runtime.ts
@@ -73,6 +73,48 @@ export interface SiblingHtmlChildrenRuntimeState {
   validateLink: ParseOptions['validateLink']
 }
 
+export interface SourceLineOffsetsRuntimeState {
+  /** The safe-markdown source the offsets were computed for. */
+  source: string
+  /** Position after the k-th newline (offsets[0] = 0). */
+  offsets: number[]
+}
+
+/**
+ * Resolve (and cache) the line-start offsets for a source string.
+ *
+ * Streaming commits grow the source append-only, so a previously cached
+ * offset array can be extended by scanning only the appended tail instead of
+ * re-scanning the whole document on every commit (the previous behavior
+ * rebuilt the offsets from scratch once per parse). Correctness is preserved
+ * by keying on the actual string: if the new source is not an extension of
+ * the cached one, the cache is rebuilt from scratch.
+ */
+export function getCachedSourceLineOffsets(runtime: ParserRuntime, source: string): number[] {
+  const cached = runtime.sourceLineOffsets
+
+  if (cached && cached.source === source)
+    return cached.offsets
+
+  if (cached && source.length > cached.source.length && source.startsWith(cached.source)) {
+    const offsets = cached.offsets
+    for (let i = cached.source.length; i < source.length; i++) {
+      if (source.charCodeAt(i) === 10)
+        offsets.push(i + 1)
+    }
+    cached.source = source
+    return offsets
+  }
+
+  const offsets = [0]
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10)
+      offsets.push(i + 1)
+  }
+  runtime.sourceLineOffsets = { source, offsets }
+  return offsets
+}
+
 export interface ParserRuntimeSemantics {
   customHtmlTags: string
   hasCustomParserExtensions: boolean
@@ -126,6 +168,7 @@ export class ParserRuntime {
   detailsStitchCache = new WeakMap<object, { openRaw: string, explicitClose: boolean, closeSliceEnd: number, middleSource: string, node: ParsedNode }>()
   siblingHtmlChildren?: SiblingHtmlChildrenRuntimeState
   nodeSourceRanges = new WeakMap<object, { start: number, end: number }>()
+  sourceLineOffsets?: SourceLineOffsetsRuntimeState
   private documentSource?: string
   private semantics?: ParserRuntimeSemantics
   private finalized = false
@@ -230,6 +273,7 @@ export class ParserRuntime {
     this.siblingHtmlChildren = undefined
     this.detailsStitchCache = new WeakMap()
     this.nodeSourceRanges = new WeakMap()
+    this.sourceLineOffsets = undefined
   }
 }
 

--- a/packages/markstream-core/src/smooth-stream-controller.ts
+++ b/packages/markstream-core/src/smooth-stream-controller.ts
@@ -228,13 +228,22 @@ class SmoothMarkdownStreamControllerImpl {
     this.emit()
   }
 
-  reset = (initialMarkdown = ''): void => {
+  reset = (initialMarkdown = '', options?: { prefixKnown?: boolean }): void => {
     if (this.destroyed)
       return
 
     this.cancelLoop()
 
-    if (initialMarkdown.startsWith(this.source)) {
+    if (options?.prefixKnown) {
+      // The caller (e.g. useSmoothStreamingBridge) has already verified that
+      // initialMarkdown extends this.source, so skip the redundant O(n)
+      // startsWith re-check the append branch would otherwise perform. Streaming
+      // appends hit this path on every chunk, so this avoids a second full
+      // string comparison of the whole accumulated source per commit.
+      this.source = initialMarkdown
+      this.scanAppendedSource()
+    }
+    else if (initialMarkdown.startsWith(this.source)) {
       this.source = initialMarkdown
       this.scanAppendedSource()
     }

--- a/packages/markstream-core/src/types.ts
+++ b/packages/markstream-core/src/types.ts
@@ -38,7 +38,7 @@ export interface SmoothMarkdownStreamController {
   enqueue: (chunk: string) => void
   finish: (options?: { flush?: boolean }) => void
   flush: () => void
-  reset: (initialMarkdown?: string) => void
+  reset: (initialMarkdown?: string, options?: { prefixKnown?: boolean }) => void
   pause: () => void
   resume: () => void
   destroy: () => void

--- a/packages/markstream-core/test/smooth-stream-controller.test.ts
+++ b/packages/markstream-core/test/smooth-stream-controller.test.ts
@@ -261,6 +261,35 @@ describe('smoothMarkdownStreamController', () => {
     controller.destroy()
   })
 
+  it('reset with prefixKnown extends the source without re-checking the prefix', () => {
+    const controller = createController()
+
+    controller.enqueue('hello')
+    // prefixKnown is only valid when the new content extends the source; the
+    // caller (e.g. useSmoothStreamingBridge) performs the full check.
+    controller.reset('hello world', { prefixKnown: true })
+
+    expect(controller.getSnapshot().source).toBe('hello world')
+    controller.destroy()
+  })
+
+  it('reset with prefixKnown matches the append branch of a plain reset', () => {
+    const withCheck = createController()
+    const known = createController()
+
+    withCheck.enqueue('abc')
+    known.enqueue('abc')
+
+    withCheck.reset('abcdef')
+    known.reset('abcdef', { prefixKnown: true })
+
+    expect(known.getSnapshot().source).toBe(withCheck.getSnapshot().source)
+    expect(known.getSnapshot().visible).toBe(withCheck.getSnapshot().visible)
+    expect(known.getSnapshot().pendingChars).toBe(withCheck.getSnapshot().pendingChars)
+    withCheck.destroy()
+    known.destroy()
+  })
+
   it('reopens the stream when enqueue is called after finish', () => {
     const controller = createController()
 

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5614,6 +5614,12 @@ const previewHeightEstimateCache = new WeakMap<object, { code: string, height: n
 // rebuilt), which removes the per-commit O(N) signature build + WeakMap
 // lookup + object allocation for the whole document.
 const renderedItemsNonVirtual: RenderedItemLike[] = []
+// Source node each non-virtualized cache entry was built from. Code blocks are
+// rendered from a shallow clone (not the source node), so this parallel array
+// lets the identity scan distinguish a parser-reused source node (same object,
+// clean) from an externally supplied replacement node (new object, dirty)
+// without comparing against the clone in the item.
+const renderedItemSourceNodes: Array<ParsedNode | undefined> = []
 let lastRenderedItemGlobalSignature: readonly unknown[] | null = null
 // Array instance returned by the `renderedItems` computed on its last
 // evaluation. Reused verbatim on no-op commits so Vue skips the v-for re-render
@@ -5889,6 +5895,8 @@ const renderedItems = computed(() => {
   if (renderedItemsNonVirtual.length > total) {
     // eslint-disable-next-line vue/no-side-effects-in-computed-properties -- In-place truncation of the module-level incremental item cache; not a reactive side effect.
     renderedItemsNonVirtual.length = total
+    // eslint-disable-next-line vue/no-side-effects-in-computed-properties -- In-place truncation of the parallel source-node cache; not a reactive side effect.
+    renderedItemSourceNodes.length = total
     truncated = true
   }
 
@@ -5904,13 +5912,40 @@ const renderedItems = computed(() => {
   // by identity or loading snapshot. Stable-prefix nodes are reused by the
   // parser across streaming commits, while consumers may update loading in
   // place; both checks stay O(N) primitive/reference comparisons.
+  //
+  // Code blocks are rendered from a shallow clone (getCodeBlockRenderNode), so
+  // their cached item's node is the clone, never the source node. Comparing
+  // against the clone cache instead keeps the scan O(dirty tail): the clone is
+  // only recreated when the visible payload (language/loading/diff/code/raw/
+  // sourceMap) changes, so clone identity proves the item is fresh. Without
+  // this, any code block made the cached node !== source node, so the scan
+  // always fell back to the first code block and forced a full item rebuild +
+  // fresh array every streaming commit (defeating the no-op array reuse below).
   const cache = renderedItemsNonVirtual
   const identityLimit = Math.min(cache.length, total)
   let dirtyStart = globalChanged ? 0 : identityLimit
   if (!globalChanged) {
     for (let index = 0; index < identityLimit; index++) {
       const sourceNode = nodes[index]!
-      if (
+      if (sourceNode.type === 'code_block') {
+        // Code blocks are rendered from a shallow clone (getCodeBlockRenderNode),
+        // so their cached item's node is the clone, never the source node. The
+        // clone is only recreated when the visible payload changes, so clone
+        // identity + source-node identity + loading snapshot together prove the
+        // item is fresh. Without this, any code block made the cached node !==
+        // source node, so the scan always fell back to the first code block and
+        // forced a full item rebuild + fresh array every streaming commit
+        // (defeating the no-op array reuse below).
+        if (
+          cache[index]?.node !== codeBlockRenderCache[index]?.node
+          || renderedItemSourceNodes[index] !== sourceNode
+          || !Object.is(cache[index]?.sourceLoading, (sourceNode as { loading?: unknown }).loading)
+        ) {
+          dirtyStart = index
+          break
+        }
+      }
+      else if (
         cache[index]?.node !== sourceNode
         || !Object.is(cache[index]?.sourceLoading, (sourceNode as { loading?: unknown }).loading)
       ) {
@@ -5930,8 +5965,11 @@ const renderedItems = computed(() => {
   if (!truncated && dirtyStart === total)
     return lastRenderedItemsArray
 
-  for (let index = dirtyStart; index < total; index++)
+  for (let index = dirtyStart; index < total; index++) {
     cache[index] = buildRenderedItem({ node: nodes[index]!, index })
+    // eslint-disable-next-line vue/no-side-effects-in-computed-properties -- In-place maintenance of the parallel source-node cache; not a reactive side effect.
+    renderedItemSourceNodes[index] = nodes[index]!
+  }
 
   // New array identity so Vue re-renders; prefix entries are shared objects,
   // so the keyed v-for diff resolves them without re-creating anything.

--- a/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
+++ b/src/components/NodeRenderer/composables/useSmoothStreamingBridge.ts
@@ -143,7 +143,10 @@ export function useSmoothStreamingBridge(
             && pendingBeforeAppend <= CONTINUOUS_STREAM_CHUNK_MAX_LENGTH
           )) {
             continuousSmallStream = true
-            smoothStream.reset(nextContent)
+            // The startsWith check above already proved nextContent extends
+            // source, so tell the controller to skip its internal re-check
+            // (another O(accumulated source) comparison per chunk).
+            smoothStream.reset(nextContent, { prefixKnown: true })
           }
           else {
             smoothStream.enqueue(appended)

--- a/src/composables/useSmoothMarkdownStream.ts
+++ b/src/composables/useSmoothMarkdownStream.ts
@@ -15,7 +15,7 @@ export interface SmoothMarkdownStreamControllerVue {
   enqueue: (chunk: string) => void
   finish: (options?: { flush?: boolean }) => void
   flush: () => void
-  reset: (initialMarkdown?: string) => void
+  reset: (initialMarkdown?: string, options?: { prefixKnown?: boolean }) => void
   pause: () => void
   resume: () => void
 }
@@ -59,7 +59,7 @@ export function useSmoothMarkdownStream(options: SmoothMarkdownStreamOptions = {
     enqueue: (chunk: string) => controller.enqueue(chunk),
     finish: (finishOptions?: { flush?: boolean }) => controller.finish(finishOptions),
     flush: () => controller.flush(),
-    reset: (initialMarkdown?: string) => controller.reset(initialMarkdown),
+    reset: (initialMarkdown?: string, options?: { prefixKnown?: boolean }) => controller.reset(initialMarkdown, options),
     pause: () => controller.pause(),
     resume: () => controller.resume(),
   }

--- a/test/benchmark/render-items-incremental.bench.test.ts
+++ b/test/benchmark/render-items-incremental.bench.test.ts
@@ -150,3 +150,142 @@ describe('render item incremental maintenance benchmark', () => {
     expect(newMs).toBeLessThan(oldMs)
   }, 120_000)
 })
+
+describe('code-block identity scan', () => {
+  // Mirrors the `renderedItems` computed scan branch in NodeRenderer.vue for
+  // code blocks. Code blocks are rendered from a shallow clone (not the source
+  // node), so the cache stores the clone; a cached item is fresh only when the
+  // clone matches the code-block render cache, the source node is the same
+  // object it was built from, and the loading snapshot is unchanged.
+  function findDirtyStart(
+    nodes: Array<{ type: string, loading?: unknown }>,
+    cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined>,
+    clones: Array<unknown | undefined>,
+    sourceNodes: Array<unknown | undefined>,
+  ) {
+    const identityLimit = Math.min(cache.length, nodes.length)
+    let dirtyStart = identityLimit
+    for (let index = 0; index < identityLimit; index++) {
+      const sourceNode = nodes[index]!
+      if (sourceNode.type === 'code_block') {
+        if (
+          cache[index]?.node !== clones[index]
+          || sourceNodes[index] !== sourceNode
+          || !Object.is(cache[index]?.sourceLoading, sourceNode.loading)
+        ) {
+          dirtyStart = index
+          break
+        }
+      }
+      else if (
+        cache[index]?.node !== sourceNode
+        || !Object.is(cache[index]?.sourceLoading, sourceNode.loading)
+      ) {
+        dirtyStart = index
+        break
+      }
+    }
+    return dirtyStart
+  }
+
+  function buildCommit(
+    nodes: Array<{ type: string, loading?: unknown }>,
+    cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined>,
+    clones: Array<unknown | undefined>,
+    sourceNodes: Array<unknown | undefined>,
+  ) {
+    if (cache.length > nodes.length) {
+      cache.length = nodes.length
+      clones.length = nodes.length
+      sourceNodes.length = nodes.length
+    }
+    for (let index = 0; index < nodes.length; index++) {
+      const sourceNode = nodes[index]!
+      // Code blocks render a fresh clone object; other nodes render the source.
+      const rendered = sourceNode.type === 'code_block'
+        ? { ...sourceNode }
+        : sourceNode
+      cache[index] = { node: rendered, sourceLoading: sourceNode.loading }
+      if (sourceNode.type === 'code_block')
+        clones[index] = rendered
+      sourceNodes[index] = sourceNode
+    }
+  }
+
+  it('keeps a stable-prefix code block clean while the tail grows (no full rebuild)', () => {
+    const codeBlock = { type: 'code_block', loading: false }
+    const paragraph = { type: 'paragraph' }
+    const nodes: Array<{ type: string, loading?: unknown }> = Array.from(
+      { length: 50 },
+      (_, i) => (i === 10 ? { ...codeBlock } : { ...paragraph }),
+    )
+    const cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined> = []
+    const clones: Array<unknown | undefined> = []
+    const sourceNodes: Array<unknown | undefined> = []
+    buildCommit(nodes, cache, clones, sourceNodes)
+
+    for (let append = 0; append < 10; append++) {
+      const start = nodes.length
+      for (let i = 0; i < 5; i++)
+        nodes.push({ ...paragraph })
+      // Tail entries are built once (only the tail is dirty).
+      for (let i = start; i < nodes.length; i++) {
+        const sourceNode = nodes[i]!
+        cache[i] = { node: sourceNode, sourceLoading: undefined }
+        sourceNodes[i] = sourceNode
+      }
+      // The scan must not fall back to the code block at index 10; the whole
+      // array (including the previously built tail) is clean, so the dirty
+      // start lands on `nodes.length` (the no-op case in the real computed).
+      expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(nodes.length)
+    }
+  })
+
+  it('detects a replaced code block source node as dirty', () => {
+    const codeBlock = { type: 'code_block', loading: false }
+    const paragraph = { type: 'paragraph' }
+    const nodes: Array<{ type: string, loading?: unknown }> = [
+      { ...paragraph },
+      { ...codeBlock },
+      { ...paragraph },
+    ]
+    const cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined> = []
+    const clones: Array<unknown | undefined> = []
+    const sourceNodes: Array<unknown | undefined> = []
+    buildCommit(nodes, cache, clones, sourceNodes)
+    expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(3)
+
+    // Parent supplies a NEW code block object with identical content.
+    nodes[1] = { type: 'code_block', loading: false }
+    expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(1)
+  })
+
+  it('detects an in-place loading flip on a reused code block as dirty', () => {
+    const codeBlock = { type: 'code_block', loading: false }
+    const nodes: Array<{ type: string, loading?: unknown }> = [{ ...codeBlock }]
+    const cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined> = []
+    const clones: Array<unknown | undefined> = []
+    const sourceNodes: Array<unknown | undefined> = []
+    buildCommit(nodes, cache, clones, sourceNodes)
+    expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(1)
+
+    // Same source object, loading flipped in place.
+    nodes[0]!.loading = true
+    expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(0)
+  })
+
+  it('detects a code block payload change via a fresh clone', () => {
+    const codeBlock = { type: 'code_block', loading: false }
+    const nodes: Array<{ type: string, loading?: unknown }> = [{ ...codeBlock }]
+    const cache: Array<{ node: unknown, sourceLoading?: unknown } | undefined> = []
+    const clones: Array<unknown | undefined> = []
+    const sourceNodes: Array<unknown | undefined> = []
+    buildCommit(nodes, cache, clones, sourceNodes)
+
+    // Payload changed (new code) -> the render cache produces a NEW clone.
+    const changed = { type: 'code_block', loading: false }
+    nodes[0] = changed
+    clones[0] = { ...changed }
+    expect(findDirtyStart(nodes, cache, clones, sourceNodes)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Streaming CPU round 4: three independent optimizations that keep rendering output byte-identical while cutting per-commit work in the streaming hot paths.

### 1. `perf(parser)`: cache source line offsets incrementally across streaming appends
`recordInternalNodeSourceRange` rebuilt the line-start offset array from scratch on every parse commit (O(document) newline scan), even though streaming appends grow the source append-only. The offsets are now cached on the parser runtime and extended by scanning only the appended tail.

Deterministic parser benchmark (single-run, `--profile deterministic`):

| case | before | after |
|---|---|---|
| prose-code-math x1 | 75.2ms | 48.6ms (-35%) |
| prose-code-math x4 | 26.9ms | 23.0ms (-15%) |
| headings-lists x1 | 8.1ms | 7.0ms (-14%) |
| headings-lists x4 | 20.7ms | 14.3ms (-31%) |

Reuse ratios identical in every case (output structure unchanged).

### 2. `perf(renderer)`: keep stable code-block render items fresh in the identity scan
Code blocks render from a shallow clone, so the `renderedItems` identity scan always saw `cachedNode !== sourceNode` for code blocks. Any document containing a code block fell back to rebuilding every item from the first code block and returned a fresh array each streaming commit, defeating the no-op array reuse that lets Vue skip the keyed v-for diff. The scan now compares the clone against `codeBlockRenderCache`, the source node against a parallel per-index reference array, and the loading snapshot — so a reused stable-prefix code block stays clean while the tail streams. Externally supplied replacement nodes still rebuild correctly.

### 3. `perf(core)`: skip redundant source prefix check on verified smooth-stream resets
V8's `startsWith` is O(n) on the append-success path; the smooth-streaming bridge already verified `nextContent.startsWith(source)` before routing a continuous small append through `reset(nextContent)`, and the controller re-checked the same prefix inside `reset` (doubling the per-chunk O(accumulated source) comparison — measured ~1.1s CPU for a 100KB / 4k-chunk stream). Added a backward-compatible `{ prefixKnown }` option to `reset` that takes the append branch directly; behavior is byte-identical to the append branch.

## Tests
- Full suite: 338 files / 2998 tests passing (6 new: 4 render-items scan regression tests + 2 core `reset` tests)
- `pnpm typecheck` (root + parser + core), `pnpm lint`, parser & core package builds all green
- Core package (`markstream-core`) ships via `dist`; rebuilt locally, needs a core release before publishing

## Note
- No UI-visible changes (no screenshots); benchmark evidence above.
- No linked issues.