### PR TITLE
fix(parser): stop leftover strong reparse from overflowing the stack

### DIFF
--- a/packages/markdown-parser/src/parser/inline-parsers/text-token-handler.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/text-token-handler.ts
@@ -46,8 +46,14 @@ const STRIKETHROUGH_RE = /[^~]*~{2,}[^~]+/
 const HAS_STRONG_RE = /\*\*/
 const INLINE_REPARSE_MARKER_RE = /[[_*^~]/
 
+function isCurrentStreamToken(state: InlineParseState, token: MarkdownToken) {
+  return token === state.tokens[state.index]
+}
+
 function handleEmphasisAndStrikethrough(state: InlineParseState, content: string, token: MarkdownToken): boolean {
-  const rawSource = state.tokens.length === 1 ? state.raw : String(token.content ?? '')
+  const rawSource = isCurrentStreamToken(state, token) && state.tokens.length === 1
+    ? state.raw
+    : String(token.content ?? '')
   const markerCandidates: Array<{
     type: 'strong' | 'emphasis' | 'strikethrough'
     index: number
@@ -491,7 +497,7 @@ export function handleTextToken(state: InlineParseState, token: MarkdownToken) {
   const rawContent = String(token.content ?? '')
   const rawMarkerFlags = getInlineTextMarkerFlags(rawContent)
   const rawHasBackslash = (rawMarkerFlags & INLINE_TEXT_MARKER_BACKSLASH) !== 0
-  const rawSource = state.tokens.length === 1 && rawHasBackslash && typeof state.raw === 'string'
+  const rawSource = isCurrentStreamToken(state, token) && state.tokens.length === 1 && rawHasBackslash && typeof state.raw === 'string'
     ? String(state.raw)
     : ''
   let content = rawSource

--- a/packages/markdown-parser/test/issue-721-strong-escaped-percent.test.ts
+++ b/packages/markdown-parser/test/issue-721-strong-escaped-percent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+describe('issue #721 - strong followed by escaped-paren percent', () => {
+  it.each([true, false])('does not overflow the stack for strong A followed by \\(0.0002\\%\\) (final=%s)', { timeout: 1000 }, (final) => {
+    const md = getMarkdown('issue-721-strong-escaped-percent')
+    const input = String.raw`**A** \(0.0002\%\)`
+
+    let nodes: any[] | undefined
+    expect(() => {
+      nodes = parseMarkdownToStructure(input, md, { final }) as any[]
+    }).not.toThrow()
+
+    const paragraph = nodes![0]
+    expect(paragraph.type).toBe('paragraph')
+    expect(paragraph.children).toHaveLength(2)
+    expect(paragraph.children[0]).toMatchObject({
+      type: 'strong',
+      children: [{ type: 'text', content: 'A' }],
+    })
+    expect(paragraph.children[1]).toMatchObject({
+      type: 'text',
+      content: String.raw` (0.0002\%)`,
+    })
+  })
+})


### PR DESCRIPTION
Leftover text after a strong span reused the original raw token stream, so strong-plus-escaped-paren-percent markdown re-entered strong parsing until the stack overflowed. Only reuse original raw when handling the current stream token. Parser regression included. Fixes #721