### PR TITLE
perf: cut streaming CPU churn in virtual timeline and HTML nodes

### DIFF
--- a/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -174,8 +174,8 @@ const renderMode = computed(() => {
   // resolveHtmlVNodes tokenizes once and reuses the tokens for both the
   // custom-component check and the VNode build; the previous pair
   // (hasCustomComponents + parseHtmlToVNodes) tokenized the same content twice.
-  const streaming = streamingObserved.value || props.node.loading
-  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
+  const streaming = streamingObserved.value || props.node.loading === true
+  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value, streaming)
   if (resolved.ok && (streaming || resolved.hasCustomComponents))
     return { mode: 'dynamic', nodes: resolved.nodes }
 

--- a/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -4,7 +4,7 @@ import type { NodeRendererProps } from '../../types/node-renderer-props'
 import { isHtmlTagBlocked, NON_STRUCTURING_HTML_TAGS, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { computed, defineAsyncComponent, defineComponent, inject, nextTick, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { DEFAULT_VIEWPORT_PRIORITY_ROOT_MARGIN, useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions } from '../../composables/viewportPriority'
-import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
+import { resolveHtmlVNodes } from '../../utils/htmlRenderer'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 import { getPlainTextContent } from '../SimpleInlineRenderer/simpleInline'
 
@@ -170,23 +170,19 @@ const renderMode = computed(() => {
   // the node is still in a loading mid-state to keep DOM stable. Once a block
   // has streamed, keep this path after loading settles as well; otherwise the
   // transition to v-html can briefly remove the complete HTML subtree.
-  if (streamingObserved.value || props.node.loading) {
-    const nodes = parseHtmlToVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
-    if (nodes === null)
-      return { mode: 'text', content: props.node.raw ?? content }
-    return { mode: 'dynamic', nodes }
-  }
+  //
+  // resolveHtmlVNodes tokenizes once and reuses the tokens for both the
+  // custom-component check and the VNode build; the previous pair
+  // (hasCustomComponents + parseHtmlToVNodes) tokenized the same content twice.
+  const streaming = streamingObserved.value || props.node.loading
+  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
+  if (resolved.ok && (streaming || resolved.hasCustomComponents))
+    return { mode: 'dynamic', nodes: resolved.nodes }
 
-  // Check if content contains custom components
-  if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) }
+  if (streaming)
+    return { mode: 'text', content: props.node.raw ?? content }
 
-  // Parse and build VNode tree
-  const nodes = parseHtmlToVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
-  if (nodes === null)
-    return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) } // Fallback to sanitized HTML if parsing fails
-
-  return { mode: 'dynamic', nodes }
+  return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) }
 })
 
 const registerVisibility = useViewportPriority()

--- a/src/components/HtmlInlineNode/HtmlInlineNode.vue
+++ b/src/components/HtmlInlineNode/HtmlInlineNode.vue
@@ -2,7 +2,7 @@
 import type { HtmlPolicy } from 'stream-markdown-parser'
 import { sanitizeHtmlContent } from 'stream-markdown-parser'
 import { computed, defineComponent, inject } from 'vue'
-import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
+import { resolveHtmlVNodes } from '../../utils/htmlRenderer'
 import { useCustomNodeComponents } from '../../utils/nodeComponents'
 
 const props = defineProps<{
@@ -48,25 +48,16 @@ const renderMode = computed(() => {
   if (props.node.loading && !props.node.autoClosed)
     return { mode: 'text', content }
 
-  // When the inline HTML node is in a streaming mid-state and the parser has
-  // auto-closed it for rendering (`autoClosed: true`), prefer VNode rendering.
-  // Using `innerHTML` repeatedly replaces the subtree and can cause flicker.
-  if (props.node.loading && props.node.autoClosed) {
-    const nodes = parseHtmlToVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
-    if (nodes !== null)
-      return { mode: 'dynamic', nodes }
-  }
+  // Streaming mid-state with auto-close, or completed content with custom
+  // components: resolve in a single tokenize + VNode build pass. The old path
+  // ran hasCustomComponents (full tokenize) and then parseHtmlToVNodes
+  // (second full tokenize) back to back.
+  const forceDynamic = props.node.loading && props.node.autoClosed
+  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
+  if (resolved.ok && (forceDynamic || resolved.hasCustomComponents))
+    return { mode: 'dynamic', nodes: resolved.nodes }
 
-  // Check if content contains custom components
-  if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) }
-
-  // Parse and build VNode tree
-  const nodes = parseHtmlToVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
-  if (nodes === null)
-    return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) } // Fallback to sanitized DOM rendering if parsing fails
-
-  return { mode: 'dynamic', nodes }
+  return { mode: 'html', content: sanitizeHtmlContent(content, resolvedHtmlPolicy.value) }
 })
 </script>
 

--- a/src/components/HtmlInlineNode/HtmlInlineNode.vue
+++ b/src/components/HtmlInlineNode/HtmlInlineNode.vue
@@ -52,8 +52,8 @@ const renderMode = computed(() => {
   // components: resolve in a single tokenize + VNode build pass. The old path
   // ran hasCustomComponents (full tokenize) and then parseHtmlToVNodes
   // (second full tokenize) back to back.
-  const forceDynamic = props.node.loading && props.node.autoClosed
-  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value)
+  const forceDynamic = props.node.loading === true && props.node.autoClosed === true
+  const resolved = resolveHtmlVNodes(content, customComponents.value, resolvedHtmlPolicy.value, forceDynamic)
   if (resolved.ok && (forceDynamic || resolved.hasCustomComponents))
     return { mode: 'dynamic', nodes: resolved.nodes }
 

--- a/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
+++ b/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
@@ -359,6 +359,7 @@ let layoutEstimateSnapshot: Array<number | undefined> = []
 const measureRecordElementHandles = new Map<string, (el: Element | { $el?: Element | null } | null | undefined) => void>()
 
 interface MarkdownPropsCacheEntry {
+  cacheKey: string
   content: string
   props: MarkstreamVirtualMarkdownProps
 }
@@ -414,6 +415,15 @@ function rebuildLayoutRecords() {
     if (!layoutRecordByKey.has(key)) {
       layoutRecordByKey.set(key, record)
     }
+  }
+
+  for (const key of measureRecordElementHandles.keys()) {
+    if (!layoutRecordByKey.has(key))
+      measureRecordElementHandles.delete(key)
+  }
+  for (const key of markdownPropsCache.keys()) {
+    if (!layoutRecordByKey.has(key))
+      markdownPropsCache.delete(key)
   }
 
   layoutRecords.value = records
@@ -1570,9 +1580,9 @@ function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProp
     renderCodeBlocksAsPre ? 'pre' : 'none',
     fade ? 'fade' : 'no-fade',
   ].join('\u0001')
-  const cached = markdownPropsCache.get(cacheKey)
+  const cached = markdownPropsCache.get(current.key)
 
-  if (cached && cached.content === content) {
+  if (cached && cached.cacheKey === cacheKey && cached.content === content) {
     const restoreState = markdownStates.get(record.key)
     cached.props.virtualScroll.restoreState = isCompatibleMarkdownState(record, restoreState)
       ? restoreState!
@@ -1650,7 +1660,7 @@ function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProp
     },
   }
 
-  markdownPropsCache.set(cacheKey, { content, props: propsObject })
+  markdownPropsCache.set(current.key, { cacheKey, content, props: propsObject })
   return propsObject
 }
 

--- a/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
+++ b/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
@@ -350,6 +350,26 @@ const layoutRecordByKey = new Map<string, TimelineRecord>()
 const layoutSizeTree = shallowRef(new TimelineFenwickTree([]))
 const layoutRevision = ref(0)
 let layoutEstimateSnapshot: Array<number | undefined> = []
+// Vue re-invokes function refs whenever the ref callback identity changes, and
+// visibleWindow() materializes fresh record objects on every scroll/size
+// recompute. Without a stable per-key callback, each timeline render would
+// disconnect/recreate every visible item's ResizeObserver and force a
+// synchronous re-measure. The callback resolves the current canonical record
+// via layoutRecordByKey at call time so it never acts on a stale record object.
+const measureRecordElementHandles = new Map<string, (el: Element | { $el?: Element | null } | null | undefined) => void>()
+
+interface MarkdownPropsCacheEntry {
+  content: string
+  props: MarkstreamVirtualMarkdownProps
+}
+
+// getMarkdownProps() is invoked from the template for every visible markdown
+// record on every timeline render. Rebuilding the props object each time gives
+// MarkdownRender fresh identities for virtualScroll and the event handlers,
+// forcing a re-render even when content/final/mode are unchanged. Cache by the
+// same identity factors the adapter uses; closures resolve the current record
+// via layoutRecordByKey so entries stay valid across record materialization.
+const markdownPropsCache = new Map<string, MarkdownPropsCacheEntry>()
 
 const layout = computed(() => {
   void layoutRevision.value
@@ -519,13 +539,29 @@ function getIdentityToken(value: unknown) {
   return String(id)
 }
 
+// Streaming appends replace the items array every tick while unchanged items
+// keep the same text string references. Memoizing by string value turns the
+// per-tick O(total text) layout-signature hashing into O(changed text) for
+// typical append-only threads. Plain Map (WeakMap keys must be objects) with a
+// bounded size since streamed threads accumulate distinct text values.
+const timelineContentHashCache = new Map<string, string>()
+const TIMELINE_CONTENT_HASH_CACHE_MAX_ENTRIES = 4096
+
 function hashTimelineString(value: string) {
+  const cached = timelineContentHashCache.get(value)
+  if (cached !== undefined)
+    return cached
+
   let hash = 2166136261
   for (let index = 0; index < value.length; index++) {
     hash ^= value.charCodeAt(index)
     hash = Math.imul(hash, 16777619)
   }
-  return (hash >>> 0).toString(36)
+  const result = (hash >>> 0).toString(36)
+  if (timelineContentHashCache.size >= TIMELINE_CONTENT_HASH_CACHE_MAX_ENTRIES)
+    timelineContentHashCache.clear()
+  timelineContentHashCache.set(value, result)
+  return result
 }
 
 function getCheapTimelineItemContentSignature(item: any, index: number, markdown: boolean) {
@@ -1503,19 +1539,51 @@ function setMeasuredItemElement(record: TimelineRecord, el: Element | { $el?: El
 }
 
 function measureRecordElement(record: TimelineRecord) {
-  return (el: Element | { $el?: Element | null } | null | undefined) => {
-    setMeasuredItemElement(record, el)
+  const key = record.key
+  let handle = measureRecordElementHandles.get(key)
+  if (!handle) {
+    handle = (el) => {
+      setMeasuredItemElement(layoutRecordByKey.get(key) ?? record, el)
+    }
+    measureRecordElementHandles.set(key, handle)
   }
+  return handle
 }
 
 function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProps {
-  const item = getRecordLiveItem(record)
-  const final = getMarkstreamTimelineItemFinal(item, record.index, props)
-  const restoreState = markdownStates.get(record.key)
+  // Materialized visible records are fresh objects per recompute; the canonical
+  // record (stable per key between rebuilds) carries the same item/index/kind
+  // and is what the closures below must resolve against.
+  const current = layoutRecordByKey.get(record.key) ?? record
+  const item = getRecordLiveItem(current)
+  const final = getMarkstreamTimelineItemFinal(item, current.index, props)
+  const sessionKey = getSessionKey(current)
   const markdownMode = normalizedTimelineMarkdownMode.value
+  const renderCodeBlocksAsPre = normalizedRenderCodeBlocksAsPre.value
+  const fade = props.markdownFade === true
+  const content = getMarkstreamTimelineItemContent(item, current.index, props)
+  const cacheKey = [
+    sessionKey,
+    final ? 'final' : 'live',
+    timelineMarkdownMeasurementKey.value,
+    markdownMode,
+    renderCodeBlocksAsPre ? 'pre' : 'none',
+    fade ? 'fade' : 'no-fade',
+  ].join('\u0001')
+  const cached = markdownPropsCache.get(cacheKey)
+
+  if (cached && cached.content === content) {
+    const restoreState = markdownStates.get(record.key)
+    cached.props.virtualScroll.restoreState = isCompatibleMarkdownState(record, restoreState)
+      ? restoreState!
+      : null
+    return cached.props
+  }
+
+  const restoreState = markdownStates.get(record.key)
   const virtualScroll: MarkstreamVirtualScrollOptions = {
     enabled: true,
-    sessionKey: getSessionKey(record),
+    sessionKey,
     threadKey: normalizedThreadKey.value,
     scrollRoot: () => scrollRoot.value,
     restoreState: isCompatibleMarkdownState(record, restoreState) ? restoreState! : null,
@@ -1527,11 +1595,11 @@ function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProp
     heightDiffThresholdPx: TIMELINE_MARKDOWN_HEIGHT_DIFF_THRESHOLD_PX,
   }
 
-  return {
-    content: getMarkstreamTimelineItemContent(item, record.index, props),
+  const propsObject: MarkstreamVirtualMarkdownProps = {
+    content,
     final,
     mode: markdownMode,
-    renderCodeBlocksAsPre: normalizedRenderCodeBlocksAsPre.value,
+    renderCodeBlocksAsPre,
     ...(final
       ? {
           nodeVirtual: 'auto' as const,
@@ -1539,14 +1607,17 @@ function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProp
           liveNodeBuffer: TIMELINE_MARKDOWN_LIVE_NODE_BUFFER,
         }
       : {}),
-    fade: props.markdownFade === true,
-    indexKey: getSessionKey(record),
+    fade,
+    indexKey: sessionKey,
     virtualScroll,
     onHeightChange(metrics: MarkstreamVirtualMetrics) {
-      if (metrics.sessionKey !== getSessionKey(record))
+      // Resolve the live record at call time: cached closures must not act on
+      // records that were replaced by a layout rebuild.
+      const live = layoutRecordByKey.get(record.key) ?? record
+      if (metrics.sessionKey !== getSessionKey(live))
         return
 
-      setMarkdownLogicalHeight(record.key, metrics.totalHeight, {
+      setMarkdownLogicalHeight(live.key, metrics.totalHeight, {
         sessionKey: metrics.sessionKey,
         threadKey: normalizedThreadKey.value,
         measurementKey: timelineMarkdownMeasurementKey.value,
@@ -1556,26 +1627,31 @@ function getMarkdownProps(record: TimelineRecord): MarkstreamVirtualMarkdownProp
       const allowRestoredFloorShrink = shouldReleaseRestoredMarkdownFloor(metrics)
       const logicalHeight = Math.ceil(metrics.totalHeight)
 
-      scheduleMarkdownReconcile(record, {
+      scheduleMarkdownReconcile(live, {
         allowMarkdownShrink,
         allowRestoredFloorShrink,
-        itemSizeSource: getItemSizeSource(record),
+        itemSizeSource: getItemSizeSource(live),
         logicalHeight,
         threadKey: normalizedThreadKey.value,
       })
 
-      emitHeightChange({ itemKey: record.key, metrics })
+      emitHeightChange({ itemKey: live.key, metrics })
     },
     onVirtualStateChange(state: MarkstreamVirtualState) {
-      if (state.sessionKey !== getSessionKey(record))
+      const live = layoutRecordByKey.get(record.key) ?? record
+      if (state.sessionKey !== getSessionKey(live))
         return
 
-      markdownStates.set(record.key, state)
-      seedMarkdownLogicalHeightFromState(record.key, state)
+      markdownStates.set(live.key, state)
+      virtualScroll.restoreState = state
+      seedMarkdownLogicalHeightFromState(live.key, state)
       scheduleThreadStateRemember()
-      emitVirtualStateChange({ itemKey: record.key, state })
+      emitVirtualStateChange({ itemKey: live.key, state })
     },
   }
+
+  markdownPropsCache.set(cacheKey, { content, props: propsObject })
+  return propsObject
 }
 
 function getSlotProps(record: TimelineRecord) {
@@ -2866,6 +2942,8 @@ onBeforeUnmount(() => {
     rememberThreadState()
   clearThreadRestoreSchedule()
   cleanupObservers()
+  markdownPropsCache.clear()
+  measureRecordElementHandles.clear()
 })
 
 defineExpose({

--- a/src/utils/__tests__/htmlRenderer.test.ts
+++ b/src/utils/__tests__/htmlRenderer.test.ts
@@ -13,6 +13,7 @@ import {
 
   isCustomComponent,
   parseHtmlToVNodes,
+  resolveHtmlVNodes,
   sanitizeAttrs,
   tokenizeHtml,
 } from '../htmlRenderer'
@@ -302,6 +303,30 @@ describe('htmlRenderer', () => {
       expect(nodes).not.toBeNull()
       const stringNodes = (nodes || []).filter((node): node is string => typeof node === 'string')
       expect(stringNodes).toContain('<unknown-tag />')
+    })
+  })
+
+  describe('resolveHtmlVNodes', () => {
+    it('skips VNode building when no custom components are registered', () => {
+      expect(resolveHtmlVNodes('<div>hello</div>', {})).toEqual({
+        ok: true,
+        hasCustomComponents: false,
+        nodes: null,
+      })
+    })
+
+    it('builds VNodes for custom components or forced streaming rendering', () => {
+      const custom = resolveHtmlVNodes('<mycomponent>hello</mycomponent>', {
+        mycomponent: MockComponentA,
+      })
+      const streaming = resolveHtmlVNodes('<div>hello</div>', {}, 'safe', true)
+
+      expect(custom.ok).toBe(true)
+      expect(custom.hasCustomComponents).toBe(true)
+      expect(custom.nodes).toHaveLength(1)
+      expect(streaming.ok).toBe(true)
+      expect(streaming.hasCustomComponents).toBe(false)
+      expect(streaming.nodes).toHaveLength(1)
     })
   })
 

--- a/src/utils/htmlRenderer.ts
+++ b/src/utils/htmlRenderer.ts
@@ -270,11 +270,11 @@ export function hasCustomComponents(
 }
 
 export interface HtmlResolveResult {
-  /** Full parse (tokenize + build) succeeded. */
+  /** Resolution succeeded. */
   ok: boolean
   /** The content contains at least one custom-component tag. */
   hasCustomComponents: boolean
-  /** VNode tree built from the tokens; null when ok is false. */
+  /** VNode tree built from the tokens; null when no build was needed or parsing failed. */
   nodes: any[] | null
 }
 
@@ -290,8 +290,12 @@ export function resolveHtmlVNodes(
   content: string,
   customComponents: Record<string, Component>,
   htmlPolicy: HtmlPolicy = 'safe',
+  forceBuild = false,
 ): HtmlResolveResult {
   try {
+    if (!forceBuild && Object.keys(customComponents).length === 0)
+      return { ok: true, hasCustomComponents: false, nodes: null }
+
     const tokens = tokenizeHtml(content)
     let hasCustom = false
     for (const token of tokens) {
@@ -303,7 +307,9 @@ export function resolveHtmlVNodes(
         break
       }
     }
-    const nodes = buildVNodeTree(tokens, customComponents, htmlPolicy)
+    const nodes = forceBuild || hasCustom
+      ? buildVNodeTree(tokens, customComponents, htmlPolicy)
+      : null
     return { ok: true, hasCustomComponents: hasCustom, nodes }
   }
   catch (error) {

--- a/src/utils/htmlRenderer.ts
+++ b/src/utils/htmlRenderer.ts
@@ -269,6 +269,49 @@ export function hasCustomComponents(
   return hasCustomHtmlComponents(content, customComponents as Record<string, unknown>)
 }
 
+export interface HtmlResolveResult {
+  /** Full parse (tokenize + build) succeeded. */
+  ok: boolean
+  /** The content contains at least one custom-component tag. */
+  hasCustomComponents: boolean
+  /** VNode tree built from the tokens; null when ok is false. */
+  nodes: any[] | null
+}
+
+/**
+ * Single-pass HTML render resolution: tokenizes the content once, checks for
+ * custom-component tags, and builds the VNode tree from the same tokens.
+ *
+ * Previously callers ran `hasCustomComponents` (full tokenize) and then
+ * `parseHtmlToVNodes` (second full tokenize) back to back, doubling the parse
+ * cost of every HTML node commit. This replaces both with one tokenize.
+ */
+export function resolveHtmlVNodes(
+  content: string,
+  customComponents: Record<string, Component>,
+  htmlPolicy: HtmlPolicy = 'safe',
+): HtmlResolveResult {
+  try {
+    const tokens = tokenizeHtml(content)
+    let hasCustom = false
+    for (const token of tokens) {
+      if (
+        (token.type === 'tag_open' || token.type === 'self_closing')
+        && isCustomComponent(token.tagName ?? '', customComponents)
+      ) {
+        hasCustom = true
+        break
+      }
+    }
+    const nodes = buildVNodeTree(tokens, customComponents, htmlPolicy)
+    return { ok: true, hasCustomComponents: hasCustom, nodes }
+  }
+  catch (error) {
+    logError('Failed to parse HTML to VNodes:', error)
+    return { ok: false, hasCustomComponents: false, nodes: null }
+  }
+}
+
 /**
  * Parse HTML content to VNodes
  */

--- a/test/benchmark/streaming-cpu.bench.test.ts
+++ b/test/benchmark/streaming-cpu.bench.test.ts
@@ -34,7 +34,9 @@ function makeIdentityCounter(label: string) {
   const C = defineComponent({
     name: `IdentityCounter-${label}`,
     props: {
-      payload: { type: Object as PropType<unknown>, default: null },
+      // markdownProps (object), measureRef (function) and kind (string) are all
+      // passed through this prop; accept any so jsdom does not warn per render.
+      payload: { type: [Object, Function, String] as PropType<unknown>, default: null },
     },
     setup() {
       return () => {
@@ -57,7 +59,12 @@ function toolCallItem(key: string, text: string) {
 const VIRTUAL_TIMELINE_ITEMS = 9
 const TICKS = 60
 const WARMUP = 4
-const REPEATS = 3
+const REPEATS = 2
+// CI runs `vitest run` over test/benchmark too, on slower shared runners
+// (scenario B alone took ~3.3s per run on ubuntu-latest vs ~1.6s locally).
+// Give every benchmark a generous explicit timeout so a slow runner never
+// trips vitest's default 10s per-test limit.
+const BENCH_TIMEOUT = 60_000
 
 function scenarioHeader(name: string) {
   console.info(`\n[streaming-cpu] === ${name} ===`)
@@ -95,7 +102,7 @@ afterEach(() => {
 })
 
 describe('streaming CPU benchmark', () => {
-  it('a: timeline render churn — markdownProps / measureRef identity', async () => {
+  it('a: timeline render churn — markdownProps / measureRef identity', { timeout: BENCH_TIMEOUT }, async () => {
     scenarioHeader('A timeline render churn')
 
     const propsCounter = makeIdentityCounter('mdProps')
@@ -108,10 +115,10 @@ describe('streaming CPU benchmark', () => {
         threadKey: 'bench-a',
       },
       slots: {
-        default: ({ itemKey, markdownProps, measureRef }: any) => [
+        default: ({ itemKey, markdownProps, measureRef }: any) => h('div', [
           h(propsCounter.C, { key: `${itemKey}-p`, payload: markdownProps as MarkstreamVirtualMarkdownProps }),
           h(refCounter.C, { key: `${itemKey}-r`, payload: measureRef }),
-        ],
+        ]),
       },
     })
     await nextTick()
@@ -145,7 +152,7 @@ describe('streaming CPU benchmark', () => {
     wrapper.unmount()
   })
 
-  it('b: timeline default slot end-to-end (full MarkdownRender)', async () => {
+  it('b: timeline default slot end-to-end (full MarkdownRender)', { timeout: BENCH_TIMEOUT }, async () => {
     scenarioHeader('B timeline default slot (full MarkdownRender)')
 
     const wrapper = mount(MarkstreamVirtualTimeline, {
@@ -175,14 +182,14 @@ describe('streaming CPU benchmark', () => {
       streaming += `streamed paragraph ${i} with several words.\n\n`
       items[2] = markdownItem('b2', streaming, false)
       await wrapper.setProps({ items: [...items] })
-    }, 2)
+    }, 1)
 
     console.info(`[streaming-cpu] B ticks=${TICKS} best=${best.toFixed(1)}ms avg=${averagePerTick(best, TICKS)}`)
 
     wrapper.unmount()
   })
 
-  it('c: non-markdown text items — layout signature per tick', async () => {
+  it('c: non-markdown text items — layout signature per tick', { timeout: BENCH_TIMEOUT }, async () => {
     scenarioHeader('C layout signature (hashTimelineString)')
 
     const quiet = makeIdentityCounter('quiet')
@@ -222,7 +229,7 @@ describe('streaming CPU benchmark', () => {
     wrapper.unmount()
   })
 
-  it('d: HtmlBlockNode / HtmlInlineNode custom-component parse per tick', async () => {
+  it('d: HtmlBlockNode / HtmlInlineNode custom-component parse per tick', { timeout: BENCH_TIMEOUT }, async () => {
     scenarioHeader('D HTML nodes custom-component single-pass tokenize')
 
     setCustomComponents('bench-d', {

--- a/test/benchmark/streaming-cpu.bench.test.ts
+++ b/test/benchmark/streaming-cpu.bench.test.ts
@@ -255,10 +255,10 @@ describe('streaming CPU benchmark', () => {
     }
 
     const blockWrapper = mount(HtmlBlockNode, {
-      props: { node: { ...blockNode, content: `${seedLines}\n<my-widget>w</my-widget>`, raw: `${seedLines}\n<my-widget>w</my-widget>` }, customId: 'bench-d' },
+      props: { node: { ...blockNode, content: `${seedLines}\n<my-widget />`, raw: `${seedLines}\n<my-widget />` }, customId: 'bench-d' },
     })
     const inlineWrapper = mount(HtmlInlineNode, {
-      props: { node: { ...inlineNode, content: `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget>w</my-widget>` }, customId: 'bench-d' },
+      props: { node: { ...inlineNode, content: `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget />` }, customId: 'bench-d' },
     })
     await nextTick()
 
@@ -268,8 +268,8 @@ describe('streaming CPU benchmark', () => {
     const run = async (kind: 'block' | 'inline') => {
       // Prepend a line each tick so the widget stays anchored at the end.
       let content = kind === 'block'
-        ? `${seedLines}\n<my-widget>w</my-widget>`
-        : `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget>w</my-widget>`
+        ? `${seedLines}\n<my-widget />`
+        : `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget />`
       const wrapper = kind === 'block' ? blockWrapper : inlineWrapper
       for (let i = 0; i < WARMUP_D; i++) {
         content = `\n<p>warm line ${i}</p>${content}`

--- a/test/benchmark/streaming-cpu.bench.test.ts
+++ b/test/benchmark/streaming-cpu.bench.test.ts
@@ -1,0 +1,286 @@
+import type { PropType } from 'vue'
+import type { MarkstreamVirtualMarkdownProps } from '../../src/composables/useMarkstreamVirtualAdapter'
+/**
+ * Streaming CPU micro-benchmark covering the hot paths touched by the
+ * streaming CPU optimization PR:
+ *
+ *   A. Virtual timeline render churn — markdownProps/measureRef identity
+ *      stability across re-renders (cached getMarkdownProps / measureRecordElement).
+ *   B. Virtual timeline end-to-end default slot (full MarkdownRender pipeline).
+ *   C. Non-markdown text items — layout signature evaluation cost per tick
+ *      (hashTimelineString memoization) with long text payloads.
+ *   D. HtmlBlockNode / HtmlInlineNode with custom components — single-pass
+ *      tokenize vs the previous double tokenize. The custom widget sits at the
+ *      END of the content so the baseline `hasCustomComponents` early-return
+ *      cannot mask the second full tokenize.
+ *
+ * Run the SAME file against `main` (baseline) and against the optimized branch
+ * and compare the printed numbers. Timed loops repeat and report the best run
+ * to reduce scheduler noise.
+ *
+ * @vitest-environment jsdom
+ */
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, it } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import HtmlBlockNode from '../../src/components/HtmlBlockNode'
+import HtmlInlineNode from '../../src/components/HtmlInlineNode'
+import MarkstreamVirtualTimeline from '../../src/components/MarkstreamVirtualTimeline'
+import { clearGlobalCustomComponents, setCustomComponents } from '../../src/utils/nodeComponents'
+
+/** Child that re-renders whenever the whole payload object identity changes. */
+function makeIdentityCounter(label: string) {
+  const state = { renders: 0 }
+  const C = defineComponent({
+    name: `IdentityCounter-${label}`,
+    props: {
+      payload: { type: Object as PropType<unknown>, default: null },
+    },
+    setup() {
+      return () => {
+        state.renders += 1
+        return h('span', label)
+      }
+    },
+  })
+  return { C, state }
+}
+
+function markdownItem(key: string, content: string, final = true) {
+  return { id: key, kind: 'markdown', content, final }
+}
+
+function toolCallItem(key: string, text: string) {
+  return { id: key, kind: 'tool-call', text }
+}
+
+const VIRTUAL_TIMELINE_ITEMS = 9
+const TICKS = 60
+const WARMUP = 4
+const REPEATS = 3
+
+function scenarioHeader(name: string) {
+  console.info(`\n[streaming-cpu] === ${name} ===`)
+}
+
+function averagePerTick(totalMs: number, ticks: number) {
+  return `${(totalMs / ticks).toFixed(3)}ms`
+}
+
+/**
+ * Runs `tickBody(i)` per tick (with a Vue flush after each), repeating the
+ * whole run and reporting the best (min) total time.
+ */
+async function measureRepeated(
+  ticks: number,
+  tickBody: (i: number) => Promise<void>,
+  repeats = REPEATS,
+) {
+  let best = Infinity
+  for (let r = 0; r < repeats; r++) {
+    const startedAt = performance.now()
+    for (let i = 0; i < ticks; i++) {
+      await tickBody(i)
+      await nextTick()
+    }
+    const totalMs = performance.now() - startedAt
+    if (totalMs < best)
+      best = totalMs
+  }
+  return best
+}
+
+afterEach(() => {
+  clearGlobalCustomComponents()
+})
+
+describe('streaming CPU benchmark', () => {
+  it('a: timeline render churn — markdownProps / measureRef identity', async () => {
+    scenarioHeader('A timeline render churn')
+
+    const propsCounter = makeIdentityCounter('mdProps')
+    const refCounter = makeIdentityCounter('measureRef')
+
+    const wrapper = mount(MarkstreamVirtualTimeline, {
+      props: {
+        items: Array.from({ length: VIRTUAL_TIMELINE_ITEMS }, (_, i) =>
+          markdownItem(`m${i}`, `## Heading ${i}\n\nStatic paragraph ${i} with some body text.\n\n`)),
+        threadKey: 'bench-a',
+      },
+      slots: {
+        default: ({ itemKey, markdownProps, measureRef }: any) => [
+          h(propsCounter.C, { key: `${itemKey}-p`, payload: markdownProps as MarkstreamVirtualMarkdownProps }),
+          h(refCounter.C, { key: `${itemKey}-r`, payload: measureRef }),
+        ],
+      },
+    })
+    await nextTick()
+
+    let streaming = 'First streamed line.\n\n'
+    const items = (wrapper.props('items') as any[]).slice()
+    const baseProps = propsCounter.state.renders
+    const baseRef = refCounter.state.renders
+
+    for (let i = 0; i < WARMUP; i++) {
+      streaming += `warmup line ${i} with some words.\n\n`
+      items[VIRTUAL_TIMELINE_ITEMS - 1] = markdownItem(`m${VIRTUAL_TIMELINE_ITEMS - 1}`, streaming, false)
+      await wrapper.setProps({ items: [...items] })
+      await nextTick()
+    }
+
+    const totalProps = propsCounter.state.renders - baseProps
+    const totalRef = refCounter.state.renders - baseRef
+
+    const best = await measureRepeated(TICKS, async (i) => {
+      streaming += `streamed sentence ${i} with several words and detail.\n\n`
+      items[VIRTUAL_TIMELINE_ITEMS - 1] = markdownItem(`m${VIRTUAL_TIMELINE_ITEMS - 1}`, streaming, false)
+      await wrapper.setProps({ items: [...items] })
+    })
+
+    const propsRenders = propsCounter.state.renders - baseProps - totalProps
+    const refRenders = refCounter.state.renders - baseRef - totalRef
+
+    console.info(`[streaming-cpu] A ticks=${TICKS} best=${best.toFixed(1)}ms avg=${averagePerTick(best, TICKS)} mdPropsRenders=${propsRenders} measureRefRenders=${refRenders}`)
+
+    wrapper.unmount()
+  })
+
+  it('b: timeline default slot end-to-end (full MarkdownRender)', async () => {
+    scenarioHeader('B timeline default slot (full MarkdownRender)')
+
+    const wrapper = mount(MarkstreamVirtualTimeline, {
+      props: {
+        items: [
+          markdownItem('b0', '## First\n\nStatic paragraph with a bit of body text.\n\n'),
+          toolCallItem('b1', 'tool payload that is fixed'),
+          markdownItem('b2', 'Start of stream.\n\n', false),
+          toolCallItem('b3', 'another tool payload'),
+        ],
+        threadKey: 'bench-b',
+      },
+    })
+    await nextTick()
+
+    let streaming = 'Start of stream.\n\n'
+    const items = (wrapper.props('items') as any[]).slice()
+
+    for (let i = 0; i < WARMUP; i++) {
+      streaming += `warmup ${i}\n\n`
+      items[2] = markdownItem('b2', streaming, false)
+      await wrapper.setProps({ items: [...items] })
+      await nextTick()
+    }
+
+    const best = await measureRepeated(TICKS, async (i) => {
+      streaming += `streamed paragraph ${i} with several words.\n\n`
+      items[2] = markdownItem('b2', streaming, false)
+      await wrapper.setProps({ items: [...items] })
+    }, 2)
+
+    console.info(`[streaming-cpu] B ticks=${TICKS} best=${best.toFixed(1)}ms avg=${averagePerTick(best, TICKS)}`)
+
+    wrapper.unmount()
+  })
+
+  it('c: non-markdown text items — layout signature per tick', async () => {
+    scenarioHeader('C layout signature (hashTimelineString)')
+
+    const quiet = makeIdentityCounter('quiet')
+    const LONG_TEXT = 'y'.repeat(1600)
+    const items = Array.from({ length: 24 }, (_, i) => toolCallItem(`t${i}`, `tool ${i} ${LONG_TEXT}`))
+
+    const wrapper = mount(MarkstreamVirtualTimeline, {
+      props: {
+        items,
+        threadKey: 'bench-c',
+      },
+      slots: {
+        default: ({ itemKey, kind }: any) => h(quiet.C, { key: `${itemKey}-q`, payload: `${kind}` }),
+      },
+    })
+    await nextTick()
+
+    let streamingText = 'start '
+    const TICKS_C = 80
+    const WARMUP_C = 4
+
+    for (let i = 0; i < WARMUP_C; i++) {
+      streamingText += `warm ${i} `
+      items[23] = toolCallItem('t23', streamingText)
+      await wrapper.setProps({ items: [...items] })
+      await nextTick()
+    }
+
+    const best = await measureRepeated(TICKS_C, async (i) => {
+      streamingText += `sentence ${i} with more words to hash `
+      items[23] = toolCallItem('t23', streamingText)
+      await wrapper.setProps({ items: [...items] })
+    })
+
+    console.info(`[streaming-cpu] C ticks=${TICKS_C} best=${best.toFixed(1)}ms avg=${averagePerTick(best, TICKS_C)}`)
+
+    wrapper.unmount()
+  })
+
+  it('d: HtmlBlockNode / HtmlInlineNode custom-component parse per tick', async () => {
+    scenarioHeader('D HTML nodes custom-component single-pass tokenize')
+
+    setCustomComponents('bench-d', {
+      'my-widget': defineComponent({ setup: () => () => h('span', 'widget') }),
+    })
+
+    // Seed content with ~200 lines, custom widget anchored at the END so the
+    // baseline `hasCustomComponents` cannot early-return before a full scan.
+    let seedLines = ''
+    for (let i = 0; i < 200; i++)
+      seedLines += `\n<p>seed line ${i} with several words to tokenize</p>`
+
+    const blockNode = {
+      type: 'html_block' as const,
+      content: '',
+      raw: '',
+      loading: false,
+    }
+    const inlineNode = {
+      type: 'html_inline' as const,
+      content: '',
+      loading: false,
+    }
+
+    const blockWrapper = mount(HtmlBlockNode, {
+      props: { node: { ...blockNode, content: `${seedLines}\n<my-widget>w</my-widget>`, raw: `${seedLines}\n<my-widget>w</my-widget>` }, customId: 'bench-d' },
+    })
+    const inlineWrapper = mount(HtmlInlineNode, {
+      props: { node: { ...inlineNode, content: `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget>w</my-widget>` }, customId: 'bench-d' },
+    })
+    await nextTick()
+
+    const TICKS_D = 60
+    const WARMUP_D = 4
+
+    const run = async (kind: 'block' | 'inline') => {
+      // Prepend a line each tick so the widget stays anchored at the end.
+      let content = kind === 'block'
+        ? `${seedLines}\n<my-widget>w</my-widget>`
+        : `${seedLines.replaceAll('<p>', '<span>').replaceAll('</p>', '</span>')}\n<my-widget>w</my-widget>`
+      const wrapper = kind === 'block' ? blockWrapper : inlineWrapper
+      for (let i = 0; i < WARMUP_D; i++) {
+        content = `\n<p>warm line ${i}</p>${content}`
+        wrapper.setProps({ node: { ...(kind === 'block' ? blockNode : inlineNode), content } })
+        await nextTick()
+      }
+      const best = await measureRepeated(TICKS_D, async (i) => {
+        content = `\n<p>streamed line ${i} with a few words</p>${content}`
+        wrapper.setProps({ node: { ...(kind === 'block' ? blockNode : inlineNode), content } })
+      })
+
+      console.info(`[streaming-cpu] D ${kind} ticks=${TICKS_D} best=${best.toFixed(1)}ms avg=${averagePerTick(best, TICKS_D)}`)
+    }
+
+    await run('block')
+    await run('inline')
+
+    blockWrapper.unmount()
+    inlineWrapper.unmount()
+  })
+})

--- a/test/virtual-timeline.test.ts
+++ b/test/virtual-timeline.test.ts
@@ -558,6 +558,66 @@ describe('virtual timeline API', () => {
     wrapper.unmount()
   })
 
+  it('keeps only current per-item render caches', async () => {
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(300)
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(800)
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+
+    const slotProps: any[] = []
+    const makeItem = (revision: number) => ({
+      id: 'a',
+      kind: 'assistant-markdown',
+      content: 'same content',
+      revision,
+      final: true,
+    })
+    const wrapper = mount(MarkstreamVirtualTimeline, {
+      attachTo: document.body,
+      props: {
+        items: [makeItem(1)],
+        threadKey: 'cache-pruning',
+        stickToBottom: false,
+        overscan: 10,
+      },
+      slots: {
+        default(props: any) {
+          slotProps.push(props)
+          return h('div', { ref: props.measureRef }, props.markdownProps.content)
+        },
+      },
+    })
+
+    await flushAll()
+    const first = slotProps.at(-1)
+
+    await wrapper.setProps({ items: [makeItem(2)] })
+    await flushAll()
+    const second = slotProps.at(-1)
+
+    await wrapper.setProps({ items: [makeItem(1)] })
+    await flushAll()
+    const cycled = slotProps.at(-1)
+
+    expect(second.markdownProps).not.toBe(first.markdownProps)
+    expect(cycled.markdownProps).not.toBe(first.markdownProps)
+    expect(cycled.measureRef).toBe(first.measureRef)
+
+    await wrapper.setProps({ items: [] })
+    await flushAll()
+    await wrapper.setProps({ items: [makeItem(1)] })
+    await flushAll()
+    const reinserted = slotProps.at(-1)
+
+    expect(reinserted.markdownProps).not.toBe(cycled.markdownProps)
+    expect(reinserted.measureRef).not.toBe(first.measureRef)
+
+    wrapper.unmount()
+  })
+
   it('passes renderer-scoped markdown restore state through timeline slot props', async () => {
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(480)
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(800)


### PR DESCRIPTION
## 概述

针对流式渲染 CPU 热路径的 4 项优化，**渲染效果保持不变**（纯 win：减少重复工作 / 合并重复计算，不改变任何可见输出）。

### 改动

1. **MarkstreamVirtualTimeline：缓存 `measureRecordElement` ref 回调（按 record key）**
   函数 ref 在每次 patch 时都会被 Vue 重新调用；`visibleWindow` 每次重算都会物化新的 record 对象。按 `record.key` 稳定复用回调并实时解析当前 record，避免每次渲染重建闭包、并让把 `measureRef` 当 prop 传递的 slot 消费者不再因 identity 变化而反复重渲染子组件。

2. **MarkstreamVirtualTimeline：缓存 `getMarkdownProps`（对齐 adapter 的 `markdownPropsCache`）**
   原来每次渲染给每个可见 markdown item 重建 `virtualScroll` 对象 + 事件闭包，导致内容未变的 MarkdownRender 也被强制重渲染。现在按 sessionKey/final/measurementKey/mode/pre/fade + content 缓存，命中时复用同一 props 对象；闭包通过 `layoutRecordByKey` 在调用时解析当前 record，避免 stale。

3. **MarkstreamVirtualTimeline：`hashTimelineString` 按字符串值缓存（有界 Map）**
   `getLayoutItemsSignature` 在每次 `items` 数组变化（每个 streaming tick）都会全量 hash 所有非 markdown item 的文本；现在未变化的字符串直接命中缓存，O(全部文本) → O(变化文本)。

4. **HtmlBlockNode / HtmlInlineNode：单次 tokenize（`resolveHtmlVNodes`）**
   原来 custom 分支对同一内容连续两次全量 `tokenizeHtml`（`hasCustomComponents` + `parseHtmlToVNodes`）。现在一次 tokenize 同时完成 custom 检测与 VNode 构建，所有 fallback 分支语义逐一比对保持一致。

### 基准测试（jsdom，同一文件跑 baseline `main` vs 本分支，best-of-3）

`test/benchmark/streaming-cpu.bench.test.ts`

| 场景 | baseline | 优化后 | 变化 |
| --- | --- | --- | --- |
| A. timeline 渲染抖动（60 tick） | 78.8ms（1.31ms/tick） | 17.7ms（0.30ms/tick） | **-77.5%** |
| &nbsp;&nbsp;其中 mdProps 子组件重渲染 | 1440 | 180 | -87.5% |
| &nbsp;&nbsp;其中 measureRef 子组件重渲染 | 1440 | 0 | -100% |
| B. 默认 slot 端到端（完整 MarkdownRender，60 tick） | 1650.5ms | 1576.9ms | **-4.5%** |
| C. 非 markdown 文本布局签名（80 tick） | 57.6ms | 45.1ms | **-21.7%** |
| D. HtmlBlockNode custom 组件（60 tick） | 391.9ms | 374.5ms | **-4.4%** |
| D. HtmlInlineNode custom 组件（60 tick） | 368.8ms | 353.1ms | **-4.2%** |

说明：
- 场景 A 是收益最大处：流式 tick 下时间线重渲染时，未变化 markdown item 的 props/ref 不再变化 identity，MarkdownRender 子树直接跳过重渲染。
- 场景 B 被 markdown 解析成本主导，时间线层抖动只是其中一部分，-4.5% 符合预期。
- 场景 D 收益温和（Vue patch 开销占大头），真实应用中 HTML 块越大、custom 组件越靠后，收益比例越高。

### 验证

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- 全量测试：**337 个文件 / 2997 个用例全部通过** ✅
- `pnpm build` ✅