### PR TITLE
fix: keep code block loading header height stable

### DIFF
--- a/src/components/NodeRenderer/CodeBlockNodeLoading.ts
+++ b/src/components/NodeRenderer/CodeBlockNodeLoading.ts
@@ -157,7 +157,7 @@ export default defineComponent({
                   header.caption ? h('div', { class: 'code-header-caption' }, header.caption) : null,
                 ]),
               ]),
-              h('div', { class: 'code-header-actions' }, [
+              h('div', { class: 'flex items-center gap-0.5' }, [
                 stats
                   ? h('div', { 'class': 'code-diff-stats', 'aria-label': `-${stats.removed} +${stats.added}` }, [
                       h('span', { class: 'code-diff-stat removed' }, `-${stats.removed}`),
@@ -166,7 +166,7 @@ export default defineComponent({
                   : null,
                 props.showCopyButton === false ? null : action('copy'),
                 props.showCollapseButton === false ? null : action('collapse'),
-                showMore ? action('more') : null,
+                showMore ? h('div', { class: 'relative' }, [action('more')]) : null,
               ]),
             ]),
         h('div', {

--- a/src/components/NodeRenderer/codeBlockNodeLoading.css
+++ b/src/components/NodeRenderer/codeBlockNodeLoading.css
@@ -44,10 +44,6 @@
   overflow: visible;
 }
 
-[data-markstream-enhanced='false'] > .code-block-header {
-  min-height: 41px;
-}
-
 .code-block-header .code-header-main {
   min-width: 0;
   flex: 1 1 auto;
@@ -78,14 +74,6 @@
   white-space: nowrap;
   font-size: 12px;
   color: var(--code-line-number);
-}
-
-.code-block-header .code-header-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--ms-gap-header-actions);
-  flex-wrap: wrap;
 }
 
 .code-block-header .icon-slot {

--- a/test/virtual-timeline-restore-readiness.test.ts
+++ b/test/virtual-timeline-restore-readiness.test.ts
@@ -1689,6 +1689,11 @@ describe('virtual timeline restore visual readiness', () => {
     expect(iconSlot.classes()).toContain('h-4')
     expect(iconSlot.classes()).toContain('w-4')
     expect(iconSlot.classes()).toContain('flex-shrink-0')
+    const headerActions = headerMain.parentElement?.lastElementChild as HTMLElement
+    expect(headerActions.classList).toContain('flex')
+    expect(headerActions.classList).toContain('items-center')
+    expect(headerActions.classList).toContain('gap-0.5')
+    expect(wrapper.get('.code-loading-action--more').element.parentElement?.classList).toContain('relative')
     for (const icon of wrapper.findAll('.code-action-btn .action-icon')) {
       expect(icon.attributes('width')).toBe('1em')
       expect(icon.attributes('height')).toBe('1em')


### PR DESCRIPTION
## Summary

Keep the async code block loading header geometrically aligned with the final highlighted header at non-default root font sizes. This removes the height shrink seen during timeline restoration in consumers using a 15px root font size.

## Changes

- Remove the fixed 41px loading-header minimum height.
- Match the final header action-group and overflow-button DOM structure.
- Add regression assertions for loading-shell action structure.

## Screenshots / Demo

- Browser geometry check at a 15px root font size: loading 43.5px, final 43.5px.

## Checklist

- [x] Targeted lint: pnpm exec eslint on changed TypeScript files
- [x] Targeted tests: 23/23 in virtual-timeline-restore-readiness.test.ts
- [x] Library build completed
- [x] Consumer renderer typecheck completed
