### PR TITLE
perf: reduce streaming and restore CPU work

### DIFF
--- a/packages/markdown-parser/src/parser/html/structure.ts
+++ b/packages/markdown-parser/src/parser/html/structure.ts
@@ -526,12 +526,13 @@ export function mergeSplitTopLevelHtmlBlocks(
   source: string,
   context: HtmlStructureContext,
   options?: ParseContext,
+  initialSourceCursor = 0,
 ) {
   if (!source)
     return nodes
 
   const merged = nodes.slice()
-  let sourceHtmlCursor = 0
+  let sourceHtmlCursor = initialSourceCursor
 
   for (let i = 0; i < merged.length; i++) {
     const node = merged[i]

--- a/packages/markdown-parser/src/parser/html/structure.ts
+++ b/packages/markdown-parser/src/parser/html/structure.ts
@@ -185,7 +185,6 @@ export function structureGenericHtmlBlockChildren(
   context: HtmlStructureContext,
   options: ParseContext,
   final: boolean,
-  tailStart = 0,
 ): ParsedNode[] {
   const processNode = (node: ParsedNode): ParsedNode => {
     if (node?.type !== 'html_block')
@@ -234,9 +233,7 @@ export function structureGenericHtmlBlockChildren(
     return node
   }
 
-  if (tailStart <= 0)
-    return nodes.map(processNode)
-  return nodes.slice(0, tailStart).concat(nodes.slice(tailStart).map(processNode))
+  return nodes.map(processNode)
 }
 
 export function hasTopLevelHtmlBlock(nodes: ParsedNode[], start = 0) {

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -199,13 +199,10 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
     }
   }
 
-  // The structured-reuse path rebuilds nodes from the dirty tail, but the
-  // html passes still run over the whole result: mergeSplit and combine
-  // re-derive post-pass prefix nodes from the pre-pass cache (split html
-  // fragments and un-stitched details live in the reused prefix), so they must
-  // re-run every append. structureGeneric keeps parsed children on the source
-  // node, so reused generic html prefixes are already structured and it can
-  // start at the reused tail safely.
+  // The structured-reuse path rebuilds nodes from the dirty tail. Reuse the
+  // same window for HTML passes only when the previous pass kept every node
+  // identity and the reused prefix contains no details blocks; otherwise the
+  // passes must see the full result to merge across node boundaries.
   const reuseTailStart = runtime.structuredReuseTailStart
   const tailStart = reuseTailStart && reuseTailStart > 0 && reuseTailStart < result.length
     ? reuseTailStart
@@ -218,15 +215,19 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
       markdownIt: md,
       parseFragment: (fragment, fragmentOptions) => parseMarkdownWithContext(fragment, fragmentOptions),
     }
-    const tailSourceStart = tailStart > 0
+    const canReuseHtmlPrefix = tailStart > 0 && runtime.htmlPassIdentityPreserving
+    const tailSourceStart = canReuseHtmlPrefix
       ? getInternalNodeSourceRange(result[tailStart]!, runtime)?.start
       : undefined
-    const hasDetailsInput = result.some(node =>
-      node.type === 'html_block'
-      && String(node.tag ?? '').toLowerCase() === 'details',
-    )
-    const useHtmlTail = tailStart > 0
-      && runtime.htmlPassIdentityPreserving
+    let hasDetailsInput = false
+    for (let i = canReuseHtmlPrefix ? tailStart : 0; i < result.length; i++) {
+      const node = result[i]!
+      if (node.type === 'html_block' && String(node.tag ?? '').toLowerCase() === 'details') {
+        hasDetailsInput = true
+        break
+      }
+    }
+    const useHtmlTail = canReuseHtmlPrefix
       && !hasDetailsInput
       && tailSourceStart != null
     const prefix = useHtmlTail ? result.slice(0, tailStart) : []
@@ -242,15 +243,11 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
     )
     const mergeIdentityPreserving = htmlResult.length === htmlInput.length
       && htmlResult.every((node, index) => node === htmlInput[index])
-    const hasDetails = hasDetailsInput || htmlResult.some(node =>
-      node.type === 'html_block'
-      && String(node.tag ?? '').toLowerCase() === 'details',
-    )
-    if (hasDetails)
+    if (hasDetailsInput)
       htmlResult = combineStructuredDetailsHtmlBlocks(htmlResult, safeMarkdown, htmlStructureContext, internalOptions, isFinal, htmlSourceStart)[0]
     htmlResult = structureGenericHtmlBlockChildren(htmlResult, htmlStructureContext, internalOptions, isFinal)
     result = useHtmlTail ? prefix.concat(htmlResult) : htmlResult
-    runtime.htmlPassIdentityPreserving = !hasDetails && mergeIdentityPreserving
+    runtime.htmlPassIdentityPreserving = !hasDetailsInput && mergeIdentityPreserving
     if (timing)
       addTiming(timing, 'htmlBlockPassesMs', getParserNow() - htmlPassesStartedAt)
   }

--- a/packages/markdown-parser/src/parser/index.ts
+++ b/packages/markdown-parser/src/parser/index.ts
@@ -210,18 +210,52 @@ function parseMarkdownWithContext(markdown: string, inputContext: ParseContext):
   const tailStart = reuseTailStart && reuseTailStart > 0 && reuseTailStart < result.length
     ? reuseTailStart
     : 0
-  if (hasTopLevelHtmlBlock(result)) {
+  const hasHtml = hasTopLevelHtmlBlock(result)
+  if (hasHtml) {
     const htmlPassesStartedAt = timing ? getParserNow() : 0
     const htmlStructureContext: HtmlStructureContext = {
       getInternalNodeSourceRange: node => getInternalNodeSourceRange(node, runtime),
       markdownIt: md,
       parseFragment: (fragment, fragmentOptions) => parseMarkdownWithContext(fragment, fragmentOptions),
     }
-    result = mergeSplitTopLevelHtmlBlocks(result, isFinal, safeMarkdown, htmlStructureContext, internalOptions)
-    result = combineStructuredDetailsHtmlBlocks(result, safeMarkdown, htmlStructureContext, internalOptions, isFinal)[0]
-    result = structureGenericHtmlBlockChildren(result, htmlStructureContext, internalOptions, isFinal, tailStart)
+    const tailSourceStart = tailStart > 0
+      ? getInternalNodeSourceRange(result[tailStart]!, runtime)?.start
+      : undefined
+    const hasDetailsInput = result.some(node =>
+      node.type === 'html_block'
+      && String(node.tag ?? '').toLowerCase() === 'details',
+    )
+    const useHtmlTail = tailStart > 0
+      && runtime.htmlPassIdentityPreserving
+      && !hasDetailsInput
+      && tailSourceStart != null
+    const prefix = useHtmlTail ? result.slice(0, tailStart) : []
+    const htmlInput = useHtmlTail ? result.slice(tailStart) : result
+    const htmlSourceStart = useHtmlTail ? tailSourceStart : 0
+    let htmlResult = mergeSplitTopLevelHtmlBlocks(
+      htmlInput,
+      isFinal,
+      safeMarkdown,
+      htmlStructureContext,
+      internalOptions,
+      htmlSourceStart,
+    )
+    const mergeIdentityPreserving = htmlResult.length === htmlInput.length
+      && htmlResult.every((node, index) => node === htmlInput[index])
+    const hasDetails = hasDetailsInput || htmlResult.some(node =>
+      node.type === 'html_block'
+      && String(node.tag ?? '').toLowerCase() === 'details',
+    )
+    if (hasDetails)
+      htmlResult = combineStructuredDetailsHtmlBlocks(htmlResult, safeMarkdown, htmlStructureContext, internalOptions, isFinal, htmlSourceStart)[0]
+    htmlResult = structureGenericHtmlBlockChildren(htmlResult, htmlStructureContext, internalOptions, isFinal)
+    result = useHtmlTail ? prefix.concat(htmlResult) : htmlResult
+    runtime.htmlPassIdentityPreserving = !hasDetails && mergeIdentityPreserving
     if (timing)
       addTiming(timing, 'htmlBlockPassesMs', getParserNow() - htmlPassesStartedAt)
+  }
+  else {
+    runtime.htmlPassIdentityPreserving = true
   }
 
   if (isFinal)

--- a/packages/markdown-parser/src/parser/linkifyHeuristics.ts
+++ b/packages/markdown-parser/src/parser/linkifyHeuristics.ts
@@ -245,7 +245,8 @@ export function createLinkifyDemotionContextTracker(
   options?: ParseOptions,
   sticky = false,
 ) {
-  let context: LinkifyDemotionContext | undefined
+  const parseContext = ensureParseContext(options)
+  let context: LinkifyDemotionContext | undefined = parseContext.linkifyDemotionSeedContext
 
   return {
     options(raw?: string) {
@@ -267,6 +268,9 @@ export function createLinkifyDemotionContextTracker(
     },
     reset() {
       context = undefined
+    },
+    snapshot() {
+      return context
     },
   }
 }

--- a/packages/markdown-parser/src/parser/nodes/token-to-nodes.ts
+++ b/packages/markdown-parser/src/parser/nodes/token-to-nodes.ts
@@ -172,18 +172,8 @@ export function processTokensWithContext(
     return []
 
   const result: ParsedNode[] = []
+  const resultContexts: ParseContext['linkifyDemotionResultContexts'] = []
   const linkifyContext = createLinkifyDemotionContextTracker(options)
-  const seedRaws = options.linkifyDemotionSeed
-  if (Array.isArray(seedRaws) && seedRaws.length) {
-    // Replay the reused prefix node raws into the demotion tracker. This is a
-    // top-level-node granularity approximation: a full parse remembers raws at
-    // nested granularity too (per-list-item paragraphs etc.). The demotion
-    // heuristics absorb the difference (continuation inheritance + per-block
-    // re-inference), and `test/linkify-seed-granularity.test.ts` pins the
-    // streamed == cold behavior for mixed-feature prefixes.
-    for (const raw of seedRaws)
-      linkifyContext.remember(String(raw ?? ''))
-  }
   const includeSourceMap = options?.includeSourceMap === true
   let i = 0
   // Note: table token normalization is applied during markdown-it parsing
@@ -197,6 +187,7 @@ export function processTokensWithContext(
       recordInternalNodeSourceRange(handled[0], tokens[i], options)
       result.push(handled[0])
       linkifyContext.remember(handled[0].raw)
+      resultContexts.push(linkifyContext.snapshot())
       i = handled[1]
       continue
     }
@@ -350,7 +341,11 @@ export function processTokensWithContext(
         i += 1
         break
     }
+    const context = linkifyContext.snapshot()
+    while (resultContexts.length < result.length)
+      resultContexts.push(context)
   }
 
+  options.linkifyDemotionResultContexts = resultContexts
   return result
 }

--- a/packages/markdown-parser/src/parser/parse-context.ts
+++ b/packages/markdown-parser/src/parser/parse-context.ts
@@ -1,5 +1,6 @@
 import type { MarkdownIt } from '../markdown-it-types'
 import type { MarkdownNodeSourceMap, ParseOptions } from '../types'
+import type { LinkifyDemotionContext } from './linkifyHeuristics'
 import type { ParserRuntime } from './runtime'
 
 const PARSE_CONTEXT = Symbol('markstream.parse-context')
@@ -11,12 +12,9 @@ export interface ParseContext extends ParseOptions {
   disableStructuredReuse: boolean
   insideStrong: boolean
   isFragment: boolean
-  linkifyDemotionContext?: {
-    filename?: boolean
-    explicitFilename?: boolean
-    marketTicker?: boolean
-  }
-  linkifyDemotionSeed?: string[]
+  linkifyDemotionContext?: LinkifyDemotionContext
+  linkifyDemotionResultContexts?: Array<LinkifyDemotionContext | undefined>
+  linkifyDemotionSeedContext?: LinkifyDemotionContext
   markdownIt?: MarkdownIt
   runtime?: ParserRuntime
   sourceLineMapper?: (line: number) => MarkdownNodeSourceMap

--- a/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
+++ b/packages/markdown-parser/src/parser/reuse/structured-node-reuse.ts
@@ -82,8 +82,8 @@ function hasOnlyReusableInlineTokens(tokens: MarkdownToken[], validateLink: Pars
       // Explicit links carry an empty markup. markdown-it linkify emits
       // `link_open`/`link_close` pairs with markup `linkify`/`autolink`;
       // their node output is deterministic given the token, and the tail
-      // re-parse seeds the linkify demotion tracker with the reused prefix
-      // context, so these pairs are safe to reuse.
+      // re-parse restores the linkify demotion context at the reused prefix
+      // boundary, so these pairs are safe to reuse.
       const markup = token.markup ?? ''
       if (markup !== '' && markup !== 'linkify' && markup !== 'autolink')
         return false
@@ -271,7 +271,9 @@ function updateStructuredStreamCache(
   groups: ReusableTopLevelTokenGroups,
   nodes: ParsedNode[],
   options: ParseOptions,
-  previousSeed?: readonly string[],
+  linkifyDemotionContexts?: ParseContext['linkifyDemotionResultContexts'],
+  linkifyDemotionContextOffset = 0,
+  fallbackLinkifyDemotionContext?: ParseContext['linkifyDemotionSeedContext'],
 ) {
   const groupStarts = groups.starts
   if (groupStarts.length === 0 || nodes.length !== groupStarts.length) {
@@ -291,16 +293,10 @@ function updateStructuredStreamCache(
   const stableGroupCount = groups.mixed
     ? Math.max(0, groupStarts.length - 1)
     : sourceEndsWithBlankLine(source) ? groupStarts.length : Math.max(0, groupStarts.length - 1)
-
-  // On the incremental append path the prefix nodes (and their raws) are
-  // unchanged, so reuse the previous seed's prefix instead of re-slicing and
-  // re-stringifying every node's raw on each commit (O(nodes) per commit).
-  // The fallback path (full re-parse) must rebuild the seed in full.
-  const seed = previousSeed && previousSeed.length >= stableGroupCount
-    ? previousSeed.slice(0, stableGroupCount).concat(
-        nodes.slice(stableGroupCount).map(node => String((node as Record<string, unknown>).raw ?? '')),
-      )
-    : nodes.map(node => String((node as Record<string, unknown>).raw ?? ''))
+  const linkifyContextIndex = stableGroupCount - linkifyDemotionContextOffset - 1
+  const linkifyDemotionContext = linkifyContextIndex >= 0
+    ? linkifyDemotionContexts?.[linkifyContextIndex]
+    : fallbackLinkifyDemotionContext
 
   runtime.structuredStream = {
     groupBoundaries,
@@ -310,7 +306,7 @@ function updateStructuredStreamCache(
     mixed: groups.mixed,
     source,
     nodes,
-    seed,
+    linkifyDemotionContext,
     stableGroupCount,
     requireClosingStrong: options.requireClosingStrong,
     validateLink: options.validateLink,
@@ -437,24 +433,33 @@ export function processTopLevelTokensWithReuse(
     && hasStableStructuredStreamGroupBoundaries(previous, tokens, groupStarts, stableGroupCount)
   ) {
     const tailStart = groupStarts[stableGroupCount] ?? tokens.length
-    const tailNodes = callbacks.processTokens(tokens.slice(tailStart), {
+    const tailOptions = {
       ...options,
-      // Prefix raws are cached and append-only: reuse the stored seed instead
-      // of re-slicing + re-stringifying every prefix node on each append.
-      linkifyDemotionSeed: previous.seed.slice(0, stableGroupCount),
-    } as ParseContext)
+      linkifyDemotionSeedContext: previous.linkifyDemotionContext,
+    } as ParseContext
+    const tailNodes = callbacks.processTokens(tokens.slice(tailStart), tailOptions)
     const expectedTailNodes = groupStarts.length - stableGroupCount
 
     if (tailNodes.length === expectedTailNodes) {
       const result = previous.nodes.slice(0, stableGroupCount).concat(tailNodes)
       runtime.structuredReuseTailStart = stableGroupCount
       callbacks.recordReusedTopLevelNodes?.(stableGroupCount)
-      updateStructuredStreamCache(runtime, source, tokens, groups, result, options, previous.seed)
+      updateStructuredStreamCache(
+        runtime,
+        source,
+        tokens,
+        groups,
+        result,
+        options,
+        tailOptions.linkifyDemotionResultContexts,
+        stableGroupCount,
+        previous.linkifyDemotionContext,
+      )
       return result
     }
   }
 
   const result = callbacks.processTokens(tokens, options)
-  updateStructuredStreamCache(runtime, source, tokens, groups, result, options)
+  updateStructuredStreamCache(runtime, source, tokens, groups, result, options, options.linkifyDemotionResultContexts)
   return result
 }

--- a/packages/markdown-parser/src/parser/runtime.ts
+++ b/packages/markdown-parser/src/parser/runtime.ts
@@ -1,5 +1,6 @@
 import type { MarkdownIt } from '../markdown-it-types'
 import type { MarkdownToken, ParsedNode, ParseOptions } from '../types'
+import type { LinkifyDemotionContext } from './linkifyHeuristics'
 
 export interface ExplicitBracketMathContext {
   fenceChar: '`' | '~' | ''
@@ -61,8 +62,7 @@ export interface StructuredStreamRuntimeState {
   mixed: boolean
   source: string
   nodes: ParsedNode[]
-  /** Cached prefix node raws for incremental linkify demotion seeding. */
-  seed: string[]
+  linkifyDemotionContext?: LinkifyDemotionContext
   stableGroupCount: number
   requireClosingStrong: boolean | undefined
   validateLink: ParseOptions['validateLink']
@@ -163,6 +163,7 @@ export class ParserRuntime {
    * it re-processed the whole document. Lets downstream passes tail-window.
    */
   structuredReuseTailStart?: number
+  htmlPassIdentityPreserving = false
   /**
    * Stitched `<details>` output cache keyed by the pre-pass details opener
    * html_block node. Reused prefix details keep the same opener object across
@@ -292,6 +293,7 @@ export class ParserRuntime {
     this.streamParseEnvs.clear()
     this.topLevelStreamParseMode = undefined
     this.structuredStream = undefined
+    this.htmlPassIdentityPreserving = false
     this.siblingHtmlChildren = undefined
     this.detailsStitchCache = new WeakMap()
     this.nodeSourceRanges = new WeakMap()

--- a/packages/markdown-parser/test/html-block-reuse-streaming.test.ts
+++ b/packages/markdown-parser/test/html-block-reuse-streaming.test.ts
@@ -143,6 +143,17 @@ describe('html_block top-level reuse streaming', () => {
     expectStreamingMatchesCold(full, boundaries)
   })
 
+  it('handles details appended after a reusable generic html prefix', () => {
+    const md = getMarkdown(`html-reuse-appended-details-${Math.random()}`)
+    const prefix = '<div>stable prefix</div>\n\ntrailing paragraph\n\n'
+    parseStreaming(prefix, md)
+
+    const source = `${prefix}<details>\n<summary>open me</summary>\n\nbody\n</details>\n`
+    const parserMetrics: { processTokensReusedTopLevelNodes?: number } = {}
+    expect(parseStreaming(source, md, parserMetrics)).toEqual(parseCold(source))
+    expect(parserMetrics.processTokensReusedTopLevelNodes).toBe(1)
+  })
+
   it('keeps streamed and cold output identical when an unclosed <details> grows then closes', () => {
     const full = [
       '<details open>',

--- a/packages/markdown-parser/test/issue-380-html-wrapper-markdown.test.ts
+++ b/packages/markdown-parser/test/issue-380-html-wrapper-markdown.test.ts
@@ -136,7 +136,7 @@ describe('issue 380 html wrapper markdown regression', () => {
     expect(nodes[0]?.children).toBeUndefined()
   })
 
-  it('does not turn indented nested HTML into code blocks while the wrapper streams', () => {
+  it('keeps issue #713 pure-html cards unstructured through streaming reuse', () => {
     const html = `<div>
   <h3>Deployment summary</h3>
   <p>This card keeps growing while it streams.</p>
@@ -152,13 +152,47 @@ describe('issue 380 html wrapper markdown regression', () => {
     <tr><td>worker</td><td>1.9.7</td><td>8</td></tr>
   </table>
 </div>`
-    const md = getMarkdown('streaming-pure-html-card')
+    const markdown = `# Streaming sample
 
-    for (let end = 20; end <= html.length; end += 20) {
-      const nodes = parseMarkdownToStructure(html.slice(0, end), md, { final: false }) as any[]
-      const block = nodes.find(node => node?.type === 'html_block')
-      expect(block?.children, `stream offset ${end}`).toBeUndefined()
+This document streams into the renderer in small chunks.
+
+## HTML card
+
+${html}
+
+## Following content
+
+    More content keeps streaming after the completed card.`
+    const md = getMarkdown('streaming-pure-html-card')
+    let reusedNodes = 0
+
+    for (let end = 20; end <= markdown.length; end += 20) {
+      const parserMetrics: { processTokensReusedTopLevelNodes?: number } = {}
+      const streamed = parseMarkdownToStructure(markdown.slice(0, end), md, {
+        final: false,
+        parserMetrics,
+        reuseStableTopLevelNodes: true,
+        streamParse: true,
+      }) as any[]
+      const block = streamed.find(node => node?.type === 'html_block' && node?.tag === 'div')
+      if (block)
+        expect(block.children, `stream offset ${end}`).toBeUndefined()
+      reusedNodes += parserMetrics.processTokensReusedTopLevelNodes ?? 0
     }
+
+    const finalStreamed = parseMarkdownToStructure(markdown, md, {
+      final: true,
+      reuseStableTopLevelNodes: true,
+      streamParse: true,
+    }) as any[]
+    const cold = parseMarkdownToStructure(markdown, getMarkdown('streaming-pure-html-card-cold'), {
+      final: true,
+      streamParse: false,
+    }) as any[]
+
+    expect(reusedNodes).toBeGreaterThan(0)
+    expect(finalStreamed).toEqual(cold)
+    expect(finalStreamed.find(node => node?.type === 'html_block' && node?.tag === 'div')?.children).toBeUndefined()
   })
 
   it('does not recursively parse a large pure-html wrapper', () => {

--- a/packages/markdown-parser/test/linkify-seed-granularity.test.ts
+++ b/packages/markdown-parser/test/linkify-seed-granularity.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { getMarkdown, parseMarkdownToStructure } from '../src'
 
 /**
- * The reuse tail seeds its linkify demotion tracker with the reused prefix
- * nodes' raw strings. The real parse remembers block-level raws DURING nested
- * processing (e.g. per-list-item paragraphs), so a top-level list whose raw
- * contains a filename keyword while its LAST item does not should produce the
- * same output as a cold parse (where the last remembered context has no
- * filename signal).
+ * The reuse tail restores the linkify demotion context captured at the stable
+ * prefix boundary. A top-level list whose raw contains a filename keyword
+ * while its LAST item does not should therefore produce the same output as a
+ * cold parse, where the last remembered context has no filename signal.
  */
 describe('structured reuse linkify seed granularity', () => {
   it('streamed reuse output matches cold parse when prefix list mixes filename keyword and plain items', () => {

--- a/packages/markdown-parser/test/stream-parser-integration.test.ts
+++ b/packages/markdown-parser/test/stream-parser-integration.test.ts
@@ -613,9 +613,9 @@ describe('parseMarkdownToStructure stream parser integration', () => {
     expect(streamed).toEqual(cold)
     expect(streamed.find(node => node.raw === 'foo.md')?.children?.[0]?.type).toBe('text')
     expect(streamed.find(node => node.raw === 'bar.md')?.children?.[0]?.type).toBe('text')
-    // The tail's linkify demotion tracker is seeded with the reused prefix
-    // node raws, so cross-block demotion context (Files:) is preserved while
-    // the stable prefix is still reused.
+    // The tail's linkify demotion tracker resumes from the stable-prefix
+    // boundary context, so cross-block demotion context (Files:) is preserved
+    // while the stable prefix is still reused.
     expect(timing.processTokensInputTokens).toBeLessThan((md as any).stream.peek().length)
     expect(timing.processTokensReusedTopLevelNodes ?? 0).toBeGreaterThan(0)
   })

--- a/scripts/benchmark-heavy-restore.mjs
+++ b/scripts/benchmark-heavy-restore.mjs
@@ -24,6 +24,7 @@ const cpuThrottleRate = Number(process.env.MARKSTREAM_HEAVY_RESTORE_CPU_THROTTLE
 const observationMs = Number(process.env.MARKSTREAM_HEAVY_RESTORE_OBSERVATION_MS || 1800)
 const timeoutMs = Number(process.env.MARKSTREAM_HEAVY_RESTORE_TIMEOUT_MS || 12000)
 const traceEnabled = process.env.MARKSTREAM_HEAVY_RESTORE_TRACE !== '0'
+const cpuProfileEnabled = process.env.MARKSTREAM_HEAVY_RESTORE_CPU_PROFILE === '1'
 const allowFailure = process.env.MARKSTREAM_HEAVY_RESTORE_ALLOW_FAILURE === '1'
 const disableAutoVirtual = process.env.MARKSTREAM_HEAVY_RESTORE_DISABLE_AUTO_VIRTUAL === '1'
 const tailNodes = Number(process.env.MARKSTREAM_HEAVY_RESTORE_TAIL_NODES || 72)
@@ -149,6 +150,32 @@ function requestDelta(before, after) {
   return Object.fromEntries(Object.keys(after).map(key => [key, after[key] - (before[key] || 0)]))
 }
 
+function summarizeCpuProfile(profile) {
+  const nodes = new Map(profile.nodes.map(node => [node.id, node]))
+  const totals = new Map()
+  for (let index = 0; index < (profile.samples?.length ?? 0); index++) {
+    const node = nodes.get(profile.samples[index])
+    if (!node)
+      continue
+    const frame = node.callFrame
+    const key = `${frame.functionName}\n${frame.url}\n${frame.lineNumber}`
+    const current = totals.get(key) ?? {
+      functionName: frame.functionName || '(anonymous)',
+      url: frame.url,
+      line: frame.lineNumber + 1,
+      selfTimeMs: 0,
+      samples: 0,
+    }
+    current.selfTimeMs += (profile.timeDeltas?.[index] ?? 0) / 1000
+    current.samples += 1
+    totals.set(key, current)
+  }
+  return Array.from(totals.values())
+    .sort((a, b) => b.selfTimeMs - a.selfTimeMs)
+    .slice(0, 30)
+    .map(entry => ({ ...entry, selfTimeMs: round(entry.selfTimeMs) }))
+}
+
 async function measurePhase(client, page, functionName, options, requests) {
   await client.send('HeapProfiler.collectGarbage').catch(() => {})
   const before = await getMetrics(client)
@@ -159,7 +186,14 @@ async function measurePhase(client, page, functionName, options, requests) {
       transferMode: 'ReturnAsStream',
     })
   }
+  if (cpuProfileEnabled) {
+    await client.send('Profiler.enable')
+    await client.send('Profiler.start')
+  }
   const result = await page.evaluate(({ functionName, options }) => window[functionName](options), { functionName, options })
+  const cpuProfile = cpuProfileEnabled
+    ? summarizeCpuProfile((await client.send('Profiler.stop')).profile)
+    : undefined
   const after = await getMetrics(client)
   const trace = traceEnabled ? await stopTracing(client) : {}
   await client.send('HeapProfiler.collectGarbage').catch(() => {})
@@ -177,6 +211,7 @@ async function measurePhase(client, page, functionName, options, requests) {
       retainedHeapDeltaMB: (retainedHeap - beforeHeap) / 1024 / 1024,
       requests: requestDelta(requestsBefore, requests),
       trace,
+      cpuProfile,
     },
   }
 }
@@ -427,7 +462,7 @@ async function main() {
       source: 'scripts/benchmark-heavy-restore.mjs',
       fixture: 'test/benchmark/heavy-restore',
       method: `${repeats}-run median, 4x CPU by default after page ready, ${observationMs}ms unscrolled observation, deterministic counted heavy loaders, per-phase CDP trace`,
-      config: { repeats, cpuThrottleRate, observationMs, timeoutMs, traceEnabled, allowFailure, disableAutoVirtual, tailNodes, sourceRoot },
+      config: { repeats, cpuThrottleRate, observationMs, timeoutMs, traceEnabled, cpuProfileEnabled, allowFailure, disableAutoVirtual, tailNodes, sourceRoot },
       environment: {
         platform: platform(),
         release: release(),

--- a/scripts/benchmark-real-corpus-performance.mjs
+++ b/scripts/benchmark-real-corpus-performance.mjs
@@ -30,6 +30,8 @@ const browserViewportWidth = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_
 const browserViewportHeight = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_VIEWPORT_HEIGHT', 900)
 const browserCpuThrottleRate = readPositiveIntEnv('MARKSTREAM_REAL_CORPUS_BROWSER_CPU_THROTTLE_RATE', 1)
 const browserDebugPerformance = process.env.MARKSTREAM_REAL_CORPUS_DEBUG_PERFORMANCE !== '0'
+const browserChatRestoreOverscan = readNonNegativeNumberEnv('MARKSTREAM_REAL_CORPUS_CHAT_RESTORE_OVERSCAN', 1000000)
+const browserChatRestoreOverscanPx = readNonNegativeNumberEnv('MARKSTREAM_REAL_CORPUS_CHAT_RESTORE_OVERSCAN_PX', 1000000)
 const browserCoreSmoothStreamingDefaults = {
   minCharsPerSecond: 40,
   maxCharsPerSecond: 1000,
@@ -601,6 +603,8 @@ const timelineItems = ref([])
 const timelineInitialState = ref(null)
 const timelineThreadKey = ref('')
 const timelineRef = ref(null)
+const timelineOverscan = ref(1000000)
+const timelineOverscanPx = ref(1000000)
 const smoothStreamingOptions = ${JSON.stringify(browserSmoothStreamingOptions)}
 const rendererOptions = ${JSON.stringify(browserRendererOptions)}
 const debugPerformance = ${JSON.stringify(browserDebugPerformance)}
@@ -1284,6 +1288,8 @@ async function prepareChatRestore(options) {
   resetParsePerformance()
   const startedAt = performance.now()
   surface.value = 'timeline'
+  timelineOverscan.value = 1000000
+  timelineOverscanPx.value = 1000000
   timelineThreadKey.value = item.threadKey
   timelineInitialState.value = null
   timelineItems.value = item.items
@@ -1328,6 +1334,8 @@ async function runChatRestore(options) {
   const observers = startRunObservers(root)
   const startedAt = performance.now()
   surface.value = 'timeline'
+  timelineOverscan.value = ${JSON.stringify(browserChatRestoreOverscan)}
+  timelineOverscanPx.value = ${JSON.stringify(browserChatRestoreOverscanPx)}
   timelineThreadKey.value = item.threadKey
   timelineInitialState.value = preparedState
   timelineItems.value = item.items
@@ -1337,11 +1345,12 @@ async function runChatRestore(options) {
   const firstSnapshot = getDomSnapshot()
   const firstTimelineSnapshot = getTimelineSnapshot()
   const hiddenRestoreSlots = measureSlots()
-  const restoreReady = await waitForTimelineReady(options.timeoutMs ?? 30000, item.endMarker)
+  const requiresEndMarker = timelineOverscan.value >= item.itemCount
+  const restoreReady = await waitForTimelineReady(options.timeoutMs ?? 30000, requiresEndMarker ? item.endMarker : undefined)
   const firstVisibleSnapshot = getDomSnapshot()
   const firstVisibleTimelineSnapshot = getTimelineSnapshot()
   const firstVisibleSlots = measureSlots()
-  const stable = await waitForStableRender(options.timeoutMs ?? 30000, item.endMarker)
+  const stable = await waitForStableRender(options.timeoutMs ?? 30000, requiresEndMarker ? item.endMarker : undefined)
   const settledSlots = measureSlots()
   const totalMs = performance.now() - startedAt
   const observerState = observers.stop()
@@ -1510,8 +1519,8 @@ const App = defineComponent({
           items: timelineItems.value,
           threadKey: timelineThreadKey.value,
           initialThreadState: timelineInitialState.value,
-          overscan: 1000000,
-          overscanPx: 1000000,
+          overscan: timelineOverscan.value,
+          overscanPx: timelineOverscanPx.value,
           stickToBottom: false,
           markdownMode: 'chat',
           renderCodeBlocksAsPre: true,
@@ -2042,6 +2051,8 @@ async function main() {
       browserViewportHeight,
       browserCpuThrottleRate,
       browserDebugPerformance,
+      browserChatRestoreOverscan,
+      browserChatRestoreOverscanPx,
       rendererOptions: browserRendererOptions,
       finalTimelineMarkdownOptions: browserFinalTimelineMarkdownOptions,
       standaloneFinalRestoreAutoExpectedOptions: browserStandaloneFinalRestoreAutoExpectedOptions,

--- a/scripts/benchmark-streaming-split.mjs
+++ b/scripts/benchmark-streaming-split.mjs
@@ -35,6 +35,7 @@ const smoothMaxCharsPerCommit = Number(process.env.MARKSTREAM_STREAMING_SPLIT_SM
 const smoothMaxCommitFps = Number(process.env.MARKSTREAM_STREAMING_SPLIT_SMOOTH_MAX_FPS || 20)
 const skipConfigProbe = process.env.MARKSTREAM_STREAMING_SPLIT_SKIP_CONFIG_PROBE === '1'
 const traceEnabled = process.env.MARKSTREAM_STREAMING_SPLIT_TRACE === '1'
+const cpuProfileEnabled = process.env.MARKSTREAM_STREAMING_SPLIT_CPU_PROFILE === '1'
 const selectedCaseIds = (process.env.MARKSTREAM_STREAMING_SPLIT_CASES || '')
   .split(',')
   .map(value => value.trim())
@@ -325,6 +326,32 @@ function median(values) {
   return sorted[Math.floor(sorted.length / 2)]
 }
 
+function summarizeCpuProfile(profile) {
+  const nodes = new Map(profile.nodes.map(node => [node.id, node]))
+  const totals = new Map()
+  for (let index = 0; index < (profile.samples?.length ?? 0); index++) {
+    const node = nodes.get(profile.samples[index])
+    if (!node)
+      continue
+    const frame = node.callFrame
+    const key = `${frame.functionName}\n${frame.url}\n${frame.lineNumber}`
+    const current = totals.get(key) ?? {
+      functionName: frame.functionName || '(anonymous)',
+      url: frame.url,
+      line: frame.lineNumber + 1,
+      selfTimeMs: 0,
+      samples: 0,
+    }
+    current.selfTimeMs += (profile.timeDeltas?.[index] ?? 0) / 1000
+    current.samples += 1
+    totals.set(key, current)
+  }
+  return Array.from(totals.values())
+    .sort((a, b) => b.selfTimeMs - a.selfTimeMs)
+    .slice(0, 30)
+    .map(entry => ({ ...entry, selfTimeMs: round(entry.selfTimeMs) }))
+}
+
 function medianResult(runs) {
   const keys = [
     'totalMs',
@@ -426,6 +453,10 @@ async function runOnce(browser, port, rendererConfig, chunks, caseId) {
       transferMode: 'ReturnAsStream',
     })
   }
+  if (cpuProfileEnabled) {
+    await client.send('Profiler.enable')
+    await client.send('Profiler.start')
+  }
   const before = await getMetrics(client)
   const result = await page.evaluate(options => window.__runBenchmark(options), {
     chunks,
@@ -435,6 +466,9 @@ async function runOnce(browser, port, rendererConfig, chunks, caseId) {
     stableFrames,
   })
   const after = await getMetrics(client)
+  const cpuProfile = cpuProfileEnabled
+    ? summarizeCpuProfile((await client.send('Profiler.stop')).profile)
+    : undefined
   const trace = traceEnabled ? await stopTracing(client) : {}
   const correctness = await page.evaluate(options => window.__verifyBenchmarkResult(options), {
     expectedContent,
@@ -485,6 +519,7 @@ async function runOnce(browser, port, rendererConfig, chunks, caseId) {
     jsHeapUsedMB: after.JSHeapUsedSize / 1024 / 1024,
     jsHeapDeltaMB: (after.JSHeapUsedSize - before.JSHeapUsedSize) / 1024 / 1024,
     ...trace,
+    cpuProfile,
     correctness,
   }
 }
@@ -803,6 +838,7 @@ async function main() {
         smoothMaxCommitFps,
         skipConfigProbe,
         traceEnabled,
+        cpuProfileEnabled,
         sourceRoot,
         renderers: primaryRenderers.map(renderer => renderer.id),
       },

--- a/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
+++ b/src/components/MarkstreamVirtualTimeline/MarkstreamVirtualTimeline.vue
@@ -30,7 +30,7 @@ import MarkdownRender from '../NodeRenderer'
 defineOptions({ name: 'MarkstreamVirtualTimeline' })
 
 const props = withDefaults(defineProps<MarkstreamVirtualTimelineProps<any>>(), {
-  overscan: 4,
+  overscan: 1,
   overscanPx: 1200,
   stickToBottom: 'auto',
   markdownFade: false,
@@ -622,7 +622,7 @@ function lowerBoundRecordByOffset(offset: number, mode: 'gte' | 'gt' = 'gte') {
 }
 
 const effectiveOverscanItems = computed(() => {
-  const value = Math.max(0, props.overscan ?? 4)
+  const value = Math.max(0, props.overscan ?? 1)
   return value
 })
 

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -868,7 +868,7 @@ const deferNodesDomRequired = computed(() => {
 })
 // Provide viewport-priority registrar so heavy nodes can defer work until visible
 const registerNodeVisibility = provideViewportPriority(
-  target => resolveViewportRoot(target ?? containerRef.value ?? null),
+  target => resolveViewportRoot(target?.parentElement ?? containerRef.value ?? null),
   heavyViewportPriorityEnabled,
 )
 const {

--- a/test/html-block-streaming-dom-stability.test.ts
+++ b/test/html-block-streaming-dom-stability.test.ts
@@ -3,7 +3,7 @@
  */
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import HtmlBlockNode from '../src/components/HtmlBlockNode/HtmlBlockNode.vue'
 
@@ -33,6 +33,7 @@ describe('htmlBlockNode streaming DOM stability', () => {
       }
     }
     await new Promise(resolve => setTimeout(resolve, 0))
+    vi.unstubAllGlobals()
   })
 
   function trackMount(component: any, options: Record<string, unknown>) {
@@ -128,5 +129,55 @@ describe('htmlBlockNode streaming DOM stability', () => {
 
     expect(wrapper.text()).toContain('fresh final content')
     expect(wrapper.text()).not.toContain('stale intermediate parse')
+  })
+
+  it('keeps the measured streaming height until the settled DOM commits', async () => {
+    const resizeCallbacks: ResizeObserverCallback[] = []
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+      }
+
+      observe() {}
+      disconnect() {}
+    })
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    }))
+
+    const loadingNode = {
+      type: 'html_block',
+      tag: 'div',
+      raw: '<div><p>streaming card</p>',
+      content: '<div><p>streaming card</p></div>',
+      loading: true,
+    }
+    const wrapper = trackMount(HtmlBlockNode, { props: { node: loadingNode as any } })
+    await nextTick()
+
+    resizeCallbacks[0]!([{
+      borderBoxSize: [{ blockSize: 240 }],
+      contentRect: { height: 240 },
+    } as unknown as ResizeObserverEntry], {} as ResizeObserver)
+    await nextTick()
+
+    expect((wrapper.element as HTMLElement).style.minHeight).toBe('240px')
+
+    await wrapper.setProps({
+      node: {
+        ...loadingNode,
+        raw: '<div><p>streaming card</p></div>',
+        loading: false,
+      } as any,
+    })
+    await nextTick()
+
+    expect((wrapper.element as HTMLElement).style.minHeight).toBe('240px')
+    expect(frames).toHaveLength(1)
+    frames.shift()!(0)
+    await nextTick()
+    expect((wrapper.element as HTMLElement).style.minHeight).toBe('')
   })
 })

--- a/test/virtual-timeline.test.ts
+++ b/test/virtual-timeline.test.ts
@@ -869,6 +869,40 @@ describe('virtual timeline API', () => {
     wrapper.unmount()
   })
 
+  it('defaults to one item beyond the pixel overscan window', async () => {
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100)
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(800)
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function () {
+      return Number.parseFloat((this as HTMLElement).style.minHeight || '0') || 1000
+    })
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+
+    const items = Array.from({ length: 10 }, (_, index) => ({
+      id: `item-${index}`,
+      kind: 'user-message',
+      text: `Item ${index}`,
+    }))
+    const wrapper = mount(MarkstreamVirtualTimeline, {
+      attachTo: document.body,
+      props: {
+        items,
+        threadKey: 'default-overscan',
+        stickToBottom: false,
+        estimateItemHeight: () => 1000,
+      },
+    })
+    await flushAll()
+
+    expect((wrapper.vm as any).getVisibleRange()).toEqual({ start: 0, end: 3 })
+    expect(wrapper.findAll('[data-markstream-item-key]')).toHaveLength(3)
+
+    wrapper.unmount()
+  })
+
   it('drops the previous key when an incremental rebuild replaces an item', async () => {
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(300)
     vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(800)


### PR DESCRIPTION
## Summary

- Reuse the exact linkify demotion context at the stable top-level boundary instead of replaying every reused prefix string on each streaming append.
- Process only the dirty HTML tail after an identity-preserving pass, with a conservative full-pass fallback for cross-node merges, resets, missing source ranges, and other unsafe cases.
- Start viewport-root resolution at the observed node's parent to avoid redundant style and geometry work during large restores.
- Reduce the virtual timeline's default item overscan from 4 to 1 while retaining the existing 1200 px overscan window.
- Add optional CDP CPU profiles and configurable chat-restore overscan to the performance benchmark harnesses.

## Performance

### Streaming parser

10,000 independent HTML blocks followed by 100 streaming appends:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Append wall time | 2316.2 ms | 156.1 ms | 14.8x faster |
| Parser total | 2293.2 ms | 135.8 ms | 94.1% lower |
| HTML passes | 576.9 ms | 19.2 ms | 96.7% lower |
| Token-to-node processing | 1590.4 ms | 1.6 ms | 99.9% lower |

### Full history restore

Real-document chat restore, three-run median with 4x CPU throttling:

| Metric | Overscan 4 | Overscan 1 | Change |
| --- | ---: | ---: | ---: |
| Total restore | 1137.6 ms | 426.2 ms | 2.67x faster |
| Maximum long task | 909 ms | 283 ms | 68.9% lower |
| DOM elements | 3616 | 989 | 72.6% lower |
| Parser time | 74.0 ms | 16.5 ms | 77.7% lower |
| Mounted items | 7 | 4 | 42.9% lower |

The restored logical height remained 173,740 px. Visible drift, hidden drift, and CLS remained 0. For reference, mounting the complete thread took 2840.8 ms and created 7015 DOM elements.

## Correctness and risk controls

- Dirty-tail HTML processing falls back to the full parser whenever incremental reuse cannot be proven safe.
- The timeline still keeps a 1200 px pixel overscan window in addition to the single extra item.
- Added regression coverage for the new default mounted range.
- More aggressive streaming backpressure, serialized history ASTs, transition removal, and highlight-result caching were evaluated but not included because they either changed behavior, introduced invalidation risk, or did not justify their cost.

## Validation

- `pnpm release:verify`
  - Parser: 62 files / 577 tests
  - Repository: 345 files / 3055 tests
  - Fixed-seed streaming/cold differential fixtures
  - Real-document structured-reuse corpora with 0 mismatches
  - Lint, typecheck, builds, strict public API checks, peer-dependency checks, and package smokes
- Virtual timeline browser E2E passed.
- Real-document restore height, drift, CLS, DOM, and mounted-range checks passed.
- Fine-grained generic HTML differential matrix passed at every character boundary.
- macOS, Ubuntu, and Windows CI passed.
