### PR TITLE
fix: forward reference id in click event

### DIFF
--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -195,7 +195,7 @@ Use `html-policy="escape"` when you want literal HTML text to stay visible inste
 | `copy` | `string` | A code block copy button copies code. |
 | `copy-code` | `string` | Same as `copy` (kebab-case alias kept for the public event contract). |
 | `handle-artifact-click` | `CodeBlockPreviewPayload` | A code-block HTML preview artifact is clicked. |
-| `click` | `MouseEvent` | A click bubbles up from renderer content. |
+| `click` | `(event: MouseEvent, referenceId?: string)` | A click bubbles up from renderer content. `referenceId` is present when a reference node was clicked. |
 | `mouseover` | `MouseEvent` | Mouse enters renderer content. |
 | `mouseout` | `MouseEvent` | Mouse leaves renderer content. |
 | `height-change` | `MarkstreamVirtualMetrics` | Logical height metrics are emitted (host virtual-scroll coordination; throttled to the configured `emitIntervalMs`). |

--- a/docs/zh/guide/props.md
+++ b/docs/zh/guide/props.md
@@ -185,7 +185,7 @@ flowchart TD
 | `copy` | `string` | 代码块复制按钮复制了代码。 |
 | `copy-code` | `string` | 与 `copy` 相同（保留的 kebab-case 别名，属于公开事件契约）。 |
 | `handle-artifact-click` | `CodeBlockPreviewPayload` | 点击了代码块 HTML 预览产物。 |
-| `click` | `MouseEvent` | 渲染内容中的点击事件冒泡。 |
+| `click` | `(event: MouseEvent, referenceId?: string)` | 渲染内容中的点击事件冒泡；点击引用节点时会提供 `referenceId`。 |
 | `mouseover` | `MouseEvent` | 鼠标进入渲染内容。 |
 | `mouseout` | `MouseEvent` | 鼠标离开渲染内容。 |
 | `height-change` | `MarkstreamVirtualMetrics` | 发起逻辑高度指标（外部虚拟滚动协调；按 `emitIntervalMs` 节流）。 |

--- a/src/components/NodeChildRenderer/NodeChildRenderer.vue
+++ b/src/components/NodeChildRenderer/NodeChildRenderer.vue
@@ -60,6 +60,7 @@ const fallbackText = computed(() => String((props.node as any).content ?? props.
     :index-key="indexKey"
     :custom-id="customId"
     :is-dark="nestedRendererProps.isDark"
+    :data-markstream-reference-id="node.type === 'reference' ? String(node.id) : undefined"
   >
     <StructuredNodeRenderer
       v-if="hasSlotChildren"
@@ -88,6 +89,7 @@ const fallbackText = computed(() => String((props.node as any).content ?? props.
     :node="node"
     :custom-id="customId"
     :index-key="indexKey"
+    :data-markstream-reference-id="node.type === 'reference' ? String(node.id) : undefined"
   />
   <span v-else-if="fallbackToText">{{ fallbackText }}</span>
 </template>

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -133,7 +133,7 @@ const emit = defineEmits<{
   (e: 'copy', code: string): void
   (e: 'copy-code', code: string): void
   (e: 'handleArtifactClick', payload: CodeBlockPreviewPayload): void
-  (e: 'click', event: MouseEvent): void
+  (e: 'click', event: MouseEvent, referenceId?: string): void
   (e: 'mouseover', event: MouseEvent): void
   (e: 'mouseout', event: MouseEvent): void
   (e: 'virtual-state-change', payload: MarkstreamVirtualState): void
@@ -6197,7 +6197,8 @@ function getBindingsFor(node: ParsedNode, language?: string, component?: unknown
 }
 
 function handleContainerClick(event: MouseEvent) {
-  emit('click', event)
+  const target = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-reference-id]')
+  emit('click', event, target?.dataset.referenceId)
 }
 
 function handleContainerMouseover(event: MouseEvent) {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5899,6 +5899,9 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }, globalSign
     node,
     loading,
     'index-key': indexKey,
+    ...(node.type === 'reference'
+      ? { 'data-markstream-reference-id': String((node as any).id) }
+      : {}),
   }
   const globalNodeProps = {
     'custom-id': rendererProps.customId,
@@ -6197,8 +6200,14 @@ function getBindingsFor(node: ParsedNode, language?: string, component?: unknown
 }
 
 function handleContainerClick(event: MouseEvent) {
-  const target = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-reference-id]')
-  emit('click', event, target?.dataset.referenceId)
+  const target = event.target instanceof Element
+    ? event.target.closest<HTMLElement>('[data-markstream-reference-id]')
+    : null
+  const boundary = event.currentTarget
+  const referenceId = target && boundary instanceof Element && boundary.contains(target)
+    ? target.dataset.markstreamReferenceId
+    : undefined
+  emit('click', event, referenceId)
 }
 
 function handleContainerMouseover(event: MouseEvent) {

--- a/src/components/ParagraphNode/ParagraphNode.vue
+++ b/src/components/ParagraphNode/ParagraphNode.vue
@@ -145,6 +145,9 @@ function getChildProps(child: NodeChild, index: number) {
     'index-key': `${props.indexKey}-${index}`,
     'custom-id': props.customId,
     'custom-html-tags': resolvedCustomHtmlTags.value,
+    ...(child.type === 'reference'
+      ? { 'data-markstream-reference-id': String(child.id) }
+      : {}),
   }
 }
 

--- a/src/components/ReferenceNode/ReferenceNode.vue
+++ b/src/components/ReferenceNode/ReferenceNode.vue
@@ -17,6 +17,7 @@ defineEmits(['click', 'mouseEnter', 'mouseLeave'])
     role="button"
     tabindex="0"
     :data-reference-id="node.id"
+    :data-markstream-reference-id="node.id"
     @click="$emit('click', $event, node.id, messageId, threadId)"
     @mouseenter="$emit('mouseEnter', $event, node.id, messageId, threadId)"
     @mouseleave="$emit('mouseLeave', $event, node.id, messageId, threadId)"

--- a/src/components/ReferenceNode/ReferenceNode.vue
+++ b/src/components/ReferenceNode/ReferenceNode.vue
@@ -16,6 +16,7 @@ defineEmits(['click', 'mouseEnter', 'mouseLeave'])
     class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5"
     role="button"
     tabindex="0"
+    :data-reference-id="node.id"
     @click="$emit('click', $event, node.id, messageId, threadId)"
     @mouseenter="$emit('mouseEnter', $event, node.id, messageId, threadId)"
     @mouseleave="$emit('mouseLeave', $event, node.id, messageId, threadId)"

--- a/src/components/VmrContainerNode/VmrContainerNode.vue
+++ b/src/components/VmrContainerNode/VmrContainerNode.vue
@@ -78,6 +78,7 @@ function getNodeComponent(type: string) {
       :index-key="`${indexKey || 'vmr-container'}-${index}`"
       :typewriter="props.typewriter"
       :fade="props.fade"
+      :data-markstream-reference-id="child.type === 'reference' ? String((child as any).id) : undefined"
     />
   </div>
 </template>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -558,7 +558,7 @@ exports[`markdownRender node e2e coverage > renders reference node 1`] = `
       <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span><span data-v-a84b8095=""></span>
-          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" data-reference-id="1" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" data-reference-id="1" data-markstream-reference-id="1" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -558,7 +558,7 @@ exports[`markdownRender node e2e coverage > renders reference node 1`] = `
       <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
       <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
         <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-0"><span data-v-a84b8095="">Cite research </span><span data-v-a84b8095=""></span>
-          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span><span data-v-a84b8095=""></span>
+          <!--v-if--></span><span data-v-7c86ecd2="" data-v-93ee5c2d="" class="reference-node cursor-pointer text-xs rounded-md px-1.5 mx-0.5" role="button" tabindex="0" data-reference-id="1" index-key="markdown-renderer-0-1">1</span><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="markdown-renderer-0-2"><span data-v-a84b8095=""> for details.</span><span data-v-a84b8095=""></span>
           <!--v-if--></span>
         </p>
       </transition-stub>

--- a/test/reference-node-click.test.ts
+++ b/test/reference-node-click.test.ts
@@ -3,8 +3,10 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
 import MarkdownRender from '../src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../src/utils/nodeComponents'
 import { flushAll } from './setup/flush-all'
 
 function paragraphWithReference(reference: Record<string, unknown>) {
@@ -16,6 +18,8 @@ function paragraphWithReference(reference: Record<string, unknown>) {
 }
 
 describe('reference node click', () => {
+  afterEach(() => removeCustomComponents('reference-click-test'))
+
   it.each([
     ['paragraph', { type: 'reference', id: '741', raw: '[741]' }],
     [
@@ -62,5 +66,75 @@ describe('reference node click', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
     expect(onClick.mock.calls[0]?.[0]).toBeInstanceOf(MouseEvent)
     expect(onClick.mock.calls[0]?.[1]).toBeUndefined()
+  })
+
+  it('does not read a reference id outside the renderer boundary', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(defineComponent({
+      setup: () => () => h('div', { 'data-markstream-reference-id': 'outside' }, [
+        h(MarkdownRender, {
+          nodes: [{
+            type: 'paragraph',
+            raw: 'text',
+            children: [{ type: 'text', content: 'text', raw: 'text' }],
+          }] as any,
+          onClick,
+        }),
+      ]),
+    }))
+    await flushAll()
+
+    await wrapper.get('.paragraph-node').trigger('click')
+
+    expect(onClick.mock.calls[0]?.[1]).toBeUndefined()
+  })
+
+  it('does not treat user-authored data-reference-id HTML as a reference node', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        content: '<span data-reference-id="user-data">text</span>',
+        onClick,
+      },
+    })
+    await flushAll()
+
+    await wrapper.get('[data-reference-id="user-data"]').trigger('click')
+
+    expect(onClick.mock.calls[0]?.[1]).toBeUndefined()
+  })
+
+  it.each([
+    ['paragraph', { type: 'reference', id: '741', raw: '[741]' }],
+    [
+      'nested inline node',
+      {
+        type: 'strong',
+        raw: '**[741]**',
+        children: [{ type: 'reference', id: '741', raw: '[741]' }],
+      },
+    ],
+  ])('forwards the id from a custom reference renderer in a %s', async (_name, reference) => {
+    const onClick = vi.fn()
+    setCustomComponents('reference-click-test', {
+      reference: defineComponent({
+        props: ['node'],
+        setup(props) {
+          return () => h('button', { class: 'custom-reference' }, (props.node as any).id)
+        },
+      }),
+    })
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        customId: 'reference-click-test',
+        nodes: [paragraphWithReference(reference)] as any,
+        onClick,
+      },
+    })
+    await flushAll()
+
+    await wrapper.get('.custom-reference').trigger('click')
+
+    expect(onClick.mock.calls[0]?.[1]).toBe('741')
   })
 })

--- a/test/reference-node-click.test.ts
+++ b/test/reference-node-click.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownRender from '../src/components/NodeRenderer'
+import { flushAll } from './setup/flush-all'
+
+function paragraphWithReference(reference: Record<string, unknown>) {
+  return {
+    type: 'paragraph',
+    raw: '[741]',
+    children: [reference],
+  }
+}
+
+describe('reference node click', () => {
+  it.each([
+    ['paragraph', { type: 'reference', id: '741', raw: '[741]' }],
+    [
+      'nested inline node',
+      {
+        type: 'strong',
+        raw: '**[741]**',
+        children: [{ type: 'reference', id: '741', raw: '[741]' }],
+      },
+    ],
+  ])('forwards the reference id from a %s', async (_name, reference) => {
+    const onClick = vi.fn()
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        nodes: [paragraphWithReference(reference)] as any,
+        onClick,
+      },
+    })
+    await flushAll()
+
+    await wrapper.get('.reference-node').trigger('click')
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick.mock.calls[0]?.[0]).toBeInstanceOf(MouseEvent)
+    expect(onClick.mock.calls[0]?.[1]).toBe('741')
+  })
+
+  it('keeps emitting ordinary clicks without a reference id', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(MarkdownRender, {
+      props: {
+        nodes: [{
+          type: 'paragraph',
+          raw: 'text',
+          children: [{ type: 'text', content: 'text', raw: 'text' }],
+        }] as any,
+        onClick,
+      },
+    })
+    await flushAll()
+
+    await wrapper.get('.paragraph-node').trigger('click')
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick.mock.calls[0]?.[0]).toBeInstanceOf(MouseEvent)
+    expect(onClick.mock.calls[0]?.[1]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- expose the clicked reference ID as the optional second argument of the MarkdownRender click event
- add a stable data-reference-id attribute for delegated click handling
- cover paragraph, nested inline, and ordinary click behavior

Closes #741

## Verification

- pnpm exec vitest run test/reference-node-click.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test -- --run (346 files, 3060 tests)