### PR TITLE
fix: keep code block overflow menu above sibling blocks

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockShell.vue
+++ b/src/components/CodeBlockNode/CodeBlockShell.vue
@@ -283,6 +283,12 @@ const fontIncreaseDisabled = computed(() =>
   box-shadow: var(--ms-shadow-subtle);
 }
 
+/* Raise the containing stacking context so sibling code blocks cannot cover the menu. */
+.code-block-container:has(.code-more-menu) {
+  position: relative;
+  z-index: 1;
+}
+
 /* ── Header layout ── */
 .code-block-header {
   position: relative;


### PR DESCRIPTION
## Summary

When adjacent code blocks are collapsed, the lower block covers the upper block's overflow menu. Raise the code block's stacking context only while its menu is present, so every menu item stays visible and clickable without changing its position.

Closes #744.

## Changes

- [x] Add a scoped-to-container CSS rule for code blocks with an open overflow menu; restore normal stacking when the menu closes.

## Screenshots / Demo

[Original reproduction](https://markstream-vue.simonhe.me/test#data=br:GzwNACwO7IbPG-qJhLBnhppaZyfI0XlCoUQJ4HfbRw3OC7le0G5d6nT3Mn1UVBDklmegTaG3_QZMog_QsI29NoiCSt8GYdnp6X_t98sf616zWKiE-Pbes2-_C2rRdAW3UIkkhiY2nZyIiWN0_tzgrnOagFLeJ2vIh-ipkvjoB6EK-LUdTMck9virD_lJH-_l6NGSMY-_tjCU7vKD4DsiiSWewUos0oWhvokFNj5GXVbhqkC0O0Qve-2t1E8IIQG76n-vE9b8gK3H8rzIapSXMswpOvLUnHIVh8KKZL3awYBersjn_RH4opXGffdy7SOqIk0hxpUXS0B0EElY7mvkIMoLa1_TIqe734dbUcaU3ypHmUPo_mn9b7h4kdsi5vvkKSnDejhaAKDRePwSKt2-B8FKijO4M0nff0dXi6hVGZOKgiz73gH13_tPJ008gIFS9IZ15kYyxATaIWHEhuTPljRWg0iO_FyYfSEa3kdJskjWHBDrHGZSYnDtFVZ2OMxmG84sZNLOL_WZwk-hMWVisDLDMSH29Ik7ayUFCFZnolV8JNIUIJCLTaKZsR1FRBqnLTZyi9flRAzVGvuMPEDdX3-dzT64N1Wx_0i3675huNYbBgKf1q2Z-aOt-i-HMAs6ob0F8hO51eekcQNJVcbCt5jgNSgDIp7-aPvq1M526OQPcad-iHvkh5jalJ1YoDV6HiHtpa72algpz1-AYSYyp2UJto5vVU-0pqK_rSWG2qo_hK6DxQSP6Gji3tXhNUDaYXenhqbnABW8cIEOLdHs4j_1gRiqW9T9bfMfvo2ubWcKJQAuLODzO84Ezpx_W_KHOtNtMee8Ws8UCCojl5QT2k-lCNSVcnIMlSmDwTArA5q6NizTmGx33LN4sWx33FYtZp_BOAMf2_y-yMB3FFeMnEecxjyy-Df8TkKxLg6i2vMnOrvnZ_sOkFn10KP3IvHnu1pLPKeRS6IaPR8DUjrNiM_CwnEiMooW77Jwtkq4RYhO0ske1wGl5byI94p4ckvqlTF9HJQO0QI8r9XudHtCNcBlz-zeM6vGLCerWhcD2oHmN9BxG0EUJjNcqCr4Na1FQvuWyHE0bpi8FyQbh_NkQmfSEKvq6hndqmpXdRL0pb7qPMAFAEW1H9-7FZEn5EQRJi5Sc9YiYd2uJ88mMgNwbxy2c5XefYAb4LqDnvN9PCoq8l3CjqVFcJtcQCxTyXLgl_Cgg0yjYQPRs9TkWP-TRl3quC_3NtrcV9omEzb2CS6QoiaxCilzhk7UB1yQm8xtHLlJDB_v1NujMFoJq3xi2CqQvqVcdHwgyXlLJ4doKL99jI7LDrYPM1yMKRIb0-QmhaEdQ9yxIe58Exvy8Hm4p2sAw3Z8AU7MttV8mk884GIK6OWYo8J0NQM): collapse both code blocks, then open the first block's overflow menu.

<details>
<summary>Before: the lower code block covers the menu (issue screenshot)</summary>

![Menu covered by the next collapsed code block](https://github.com/user-attachments/assets/95a73844-3276-4833-a412-37273a8ec8ee)

</details>

Verified the fix in Chrome with light and dark themes: all menu items receive clicks, anchor alignment is unchanged, font controls and expansion work, and normal stacking returns after closing the menu.

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test --run` — 349 files, 3,077 tests passed
- [x] Build: `pnpm build`
