### PR TITLE
perf(parser): skip link-free inline candidates

### DIFF
--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -38,7 +38,7 @@ const LINKIFY_SEED_RE = /[@:]|\/\/|\.\S/
 interface LinkifyLike {
   test: (text: string) => boolean
   match?: unknown
-  re?: { cache: object, opts: { schema_names?: string[], tlds?: string[] } }
+  re?: { cache: { link_fuzzy_search?: RegExp }, opts: { schema_names?: string[], tlds?: string[] } }
 }
 
 interface CoreRuleRecord {
@@ -54,6 +54,7 @@ interface CoreRulerWithNamedRules {
 interface CoreStateLike {
   md?: MarkdownItInstance & { linkify?: LinkifyLike }
   tokens?: Token[]
+  env?: { __markstreamFinal?: boolean }
 }
 
 interface InlineRuleRecord {
@@ -143,7 +144,9 @@ function applyLinkifyCandidateFilter(md: MarkdownItInstance) {
       seedSafe = schemas.every(name => name === '//' || name.endsWith(':'))
         && tlds.every(tld => /^[\p{L}\p{N}-]+$/u.test(tld))
     }
+    // Keep cold streaming initialization spread across frames as in the native path.
     let canScreen = !!nativeMethods && !!nativeBuilder && seedSafe
+      && (state.env?.__markstreamFinal !== false || !!re?.cache.link_fuzzy_search)
     const candidates = tokens.filter((token: Token) => {
       if (canScreen && token?.type === 'inline') {
         const children = token.children

--- a/packages/markdown-parser/src/factory.ts
+++ b/packages/markdown-parser/src/factory.ts
@@ -33,9 +33,12 @@ export interface FactoryOptions extends Record<string, unknown> {
 
 const HTML_LINK_OPEN_RE = /^<a[>\s]/i
 const HTML_LINK_CLOSE_RE = /^<\/a\s*>/i
+const LINKIFY_SEED_RE = /[@:]|\/\/|\.\S/
 
 interface LinkifyLike {
   test: (text: string) => boolean
+  match?: unknown
+  re?: { cache: object, opts: { schema_names?: string[], tlds?: string[] } }
 }
 
 interface CoreRuleRecord {
@@ -110,6 +113,13 @@ function applyLinkifyCandidateFilter(md: MarkdownItInstance) {
   if (typeof original !== 'function')
     return
 
+  const nativeLinkify = md.options.linkify ? md.linkify as LinkifyLike : undefined
+  const nativeTest = nativeLinkify?.test
+  const nativeMatch = nativeLinkify?.match
+  const nativeBuilderPrototype = nativeLinkify?.re && Object.getPrototypeOf(nativeLinkify.re)
+  let screenedCache: object | undefined
+  let seedSafe = false
+
   ruler.at('linkify', (state: CoreStateLike) => {
     if (!state.md?.options?.linkify)
       return
@@ -119,7 +129,36 @@ function applyLinkifyCandidateFilter(md: MarkdownItInstance) {
     if (!linkify)
       return
 
-    const candidates = tokens.filter((token: Token) => inlineTokenMayNeedLinkify(token, linkify))
+    if (!tokens.some(token => token?.type === 'inline'))
+      return
+
+    const re = linkify.re
+    const nativeBuilder = re && Object.getPrototypeOf(re) === nativeBuilderPrototype
+      && !Object.values(re).some(value => typeof value === 'function')
+    const nativeMethods = linkify.test === nativeTest && linkify.match === nativeMatch
+    if (nativeMethods && nativeBuilder && screenedCache !== re.cache) {
+      // Configuration methods replace this cache; screening must not compile regexes.
+      screenedCache = re.cache
+      const { schema_names: schemas = [], tlds = [] } = re.opts
+      seedSafe = schemas.every(name => name === '//' || name.endsWith(':'))
+        && tlds.every(tld => /^[\p{L}\p{N}-]+$/u.test(tld))
+    }
+    let canScreen = !!nativeMethods && !!nativeBuilder && seedSafe
+    const candidates = tokens.filter((token: Token) => {
+      if (canScreen && token?.type === 'inline') {
+        const children = token.children
+        if (Array.isArray(children) && children.length > 0) {
+          if (!children.some(child => child?.type === 'text' && LINKIFY_SEED_RE.test(String(child.content ?? ''))))
+            return false
+        }
+        else if (!LINKIFY_SEED_RE.test(String(token.content ?? ''))) {
+          return false
+        }
+        // Native validators can change schemas or methods during this rule run.
+        canScreen = false
+      }
+      return inlineTokenMayNeedLinkify(token, linkify)
+    })
     if (!candidates.length)
       return
 

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -22,6 +22,17 @@ function links(input: string) {
 }
 
 describe('linkify candidate filter', () => {
+  it('keeps native initialization on the first streaming frame and after reconfiguration', () => {
+    const md = getMarkdown('stream-linkify-initialization')
+    const linkify = md.linkify as any
+    parseMarkdownToStructure('## Heading\n\nPlain text.', md, { final: false })
+    expect(linkify.re.cache.link_fuzzy_search).toBeDefined()
+    linkify.set({ fuzzyLink: true })
+    expect(linkify.re.cache.link_fuzzy_search).toBeUndefined()
+    parseMarkdownToStructure('## Heading\n\nPlain text. More text.', md, { final: false })
+    expect(linkify.re.cache.link_fuzzy_search).toBeDefined()
+  })
+
   it('skips native regex construction for prose and leaves public methods unchanged', () => {
     const md = getMarkdown('plain-screen')
     const linkify = md.linkify as any

--- a/packages/markdown-parser/test/linkify-candidate-filter.test.ts
+++ b/packages/markdown-parser/test/linkify-candidate-filter.test.ts
@@ -22,6 +22,125 @@ function links(input: string) {
 }
 
 describe('linkify candidate filter', () => {
+  it('skips native regex construction for prose and leaves public methods unchanged', () => {
+    const md = getMarkdown('plain-screen')
+    const linkify = md.linkify as any
+    const test = linkify.test
+    parseMarkdownToStructure('A sentence. Another sentence.\nNext line.', md, { final: true })
+    expect(linkify.re.cache.link_fuzzy_search).toBeUndefined()
+    expect(linkify.re.cache.schema_search).toBeUndefined()
+    expect(linkify.test).toBe(test)
+  })
+
+  it('preserves replaced test callbacks on seed-free text', () => {
+    const md = getMarkdown('custom-test')
+    const linkify = md.linkify as any
+    let calls = 0
+    linkify.test = () => {
+      calls++
+      return false
+    }
+    parseMarkdownToStructure('Plain text.', md, { final: true })
+    expect(calls).toBe(1)
+  })
+
+  it('bypasses screening when the matcher is replaced', () => {
+    const md = getMarkdown('custom-match')
+    const linkify = md.linkify as any
+    linkify.match = linkify.match.bind(linkify)
+    parseMarkdownToStructure('Plain text.', md, { final: true })
+    expect(linkify.re.cache.link_fuzzy_search).toBeDefined()
+  })
+
+  it('preserves linkify being enabled after factory construction', () => {
+    const md = getMarkdown('disabled-linkify', { markdownItOptions: { linkify: false } })
+    expect(flatten(parseMarkdownToStructure('example.com', md, { final: true })).filter(node => node.type === 'link')).toHaveLength(0)
+    md.options.linkify = true
+    const found = flatten(parseMarkdownToStructure('example.com', md, { final: true })).filter(node => node.type === 'link')
+    expect(found.map(node => node.href)).toEqual(['http://example.com'])
+  })
+
+  it('matches the native filter on every streaming prefix and final commit', () => {
+    const fixtures = [
+      'A sentence. Another sentence.\n\n**Bold** and `code`.',
+      '//localhost/path and user@example.com, example.com.',
+      '中文.example.com，文件 README.md 和 https://例子.测试/a。',
+      '[example.com](https://target.test) and <a href="https://target.test">example.com</a> then example.org',
+      '| name | value |\n| - | - |\n| text. | 12 |\n| next | https://example.com |',
+      'Before.\r\n\r\n$$\nx+y\n$$\n\n::: warning\nNo links.\n:::',
+      '[label][ref]\n\n[ref]: https://example.com\n',
+    ]
+    for (const source of fixtures) {
+      const optimized = getMarkdown('screened')
+      const native = getMarkdown('native')
+      const linkify = native.linkify as any
+      const test = linkify.test
+      // A replaced test method retains the original candidate-filter path.
+      linkify.test = (text: string) => test.call(linkify, text)
+      for (let end = 1; end <= source.length; end++) {
+        expect(parseMarkdownToStructure(source.slice(0, end), optimized, { final: false }))
+          .toEqual(parseMarkdownToStructure(source.slice(0, end), native, { final: false }))
+      }
+      expect(parseMarkdownToStructure(source, optimized, { final: true }))
+        .toEqual(parseMarkdownToStructure(source, native, { final: true }))
+    }
+  })
+
+  it('invalidates the screen after schema, TLD, option and builder changes', () => {
+    const configure = [
+      (linkify: any) => linkify.add('issue', { validate: (text: string, pos: number) => /^\d+/.exec(text.slice(pos))?.[0].length ?? 0 }),
+      (linkify: any) => linkify.tlds(['$']),
+      (linkify: any) => linkify.set({ tlds: ['$'] }),
+      (linkify: any) => { linkify.re.get_fuzzy_link_search = () => /(^| )(magic)/gi },
+      (linkify: any) => {
+        const Builder = Object.getPrototypeOf(linkify.re).constructor
+        class CustomBuilder extends Builder {
+          get_fuzzy_link_search() { return /(^| )(magic)/gi }
+        }
+        linkify.re = new CustomBuilder(linkify.re.opts)
+      },
+    ]
+    for (const change of configure) {
+      const optimized = getMarkdown('configured-screen')
+      const native = getMarkdown('configured-native')
+      const nativeLinkify = native.linkify as any
+      const test = nativeLinkify.test
+      nativeLinkify.test = (text: string) => test.call(nativeLinkify, text)
+      for (const md of [optimized, native]) {
+        parseMarkdownToStructure('Plain text.', md, { final: true })
+        change(md.linkify)
+      }
+      for (const source of ['issue123', 'foo.', 'magic', '//localhost/path']) {
+        expect(parseMarkdownToStructure(source, optimized, { final: true }))
+          .toEqual(parseMarkdownToStructure(source, native, { final: true }))
+      }
+    }
+  })
+
+  it('preserves configuration changes made by a validator within the same rule run', () => {
+    const optimized = getMarkdown('mutating-validator')
+    const native = getMarkdown('native-mutating-validator')
+    const nativeLinkify = native.linkify as any
+    const test = nativeLinkify.test
+    nativeLinkify.test = (text: string) => test.call(nativeLinkify, text)
+    for (const md of [optimized, native]) {
+      const linkify = md.linkify as any
+      linkify.add('trigger:', {
+        validate: () => {
+          linkify.add('issue', {
+            validate: () => 3,
+            normalize: (match: any) => { match.url = 'https://example.com/issue123' },
+          })
+          return 0
+        },
+      })
+    }
+    const source = 'trigger:noop\n\nissue123'
+    const expected = parseMarkdownToStructure(source, native, { final: true })
+    expect(flatten(expected).some(node => node.href === 'https://example.com/issue123')).toBe(true)
+    expect(parseMarkdownToStructure(source, optimized, { final: true })).toEqual(expected)
+  })
+
   it('linkifies ordinary bare links', () => {
     const found = links('Visit example.com now.')
 


### PR DESCRIPTION
Skip link-free inline groups before the existing candidate filter to reduce repeated native linkify work and first-time history parsing cost. Public `test`/`match` methods and the existing handling of candidate groups remain unchanged.

Screening checks native methods, builder identity and schema/TLD configuration, and stops after any group that can invoke a validator. Custom methods/builders, colonless schemas and regex TLDs use the original path. Cold streaming frames also use the original path until the native fuzzy-link regex exists; final history restores can still skip unnecessary regex initialization.

The initial implementation reduced total time but deferred generic regex initialization until the same frame as HTTP validator initialization. CI consistently measured a ~6.3 → 11.1 ms peak frame and correctly failed. Commit `447940331` preserves the original cold streaming initialization timing, including after reconfiguration. The new regression test failed before the fix and passes afterward. No CI thresholds or baselines were loosened. The online Playground Performance Report now passes on this commit.

Re-measured after the fix: 61 consumer scenarios, five independent-process rounds, two warmups, frozen README and the same unchanged markdown-it-ts build on both sides. All per-frame output digests match.

| Scenario | Baseline wall → fixed | CPU reduction |
|---|---:|---:|
| Long-paragraph streaming | 88.2 → 61.5 ms | 20.2% |
| 100 mixed history messages | 238.3 → 193.7 ms | 14.3% |
| 100 table history messages | 212.5 → 175.3 ms | 9.4% |
| Long-paragraph history restore | 101.6 → 55.8 ms | 36.0% |

These are parser measurements, not UI speedup claims. The full matrix is not uniformly faster: the table/strikethrough streaming family has +12.8% CPU, and table chunks of 512 characters have +14.7% CPU despite slightly lower wall time. All negative samples are preserved. Benefits remain concentrated in restoration and long link-free paragraphs.

[CI diagnosis and full revised results](https://github.com/Simon-He95/markdown-it-ts/blob/de0406801e2b17481bd763b9aa6a6eb8a99a8dd8/docs/perf-stream-history-ci-followup.md) · [Raw data](https://github.com/Simon-He95/markdown-it-ts/blob/de0406801e2b17481bd763b9aa6a6eb8a99a8dd8/docs/perf-stream-history-ci-followup.json) · [Earlier experiments and reproduction](https://github.com/Simon-He95/markdown-it-ts/blob/de0406801e2b17481bd763b9aa6a6eb8a99a8dd8/docs/perf-stream-history-2026-09-07.md)

Validation:

- 21 focused tests, including per-character prefixes, final output, custom extensions, validator-side configuration changes and cold streaming initialization after reconfiguration.
- Lint, root/parser typechecks and parser production build passed.
- Original CI deep time/heap gate rerun locally: seven samples after two warmups, six scenarios; all absolute and same-runner checks passed. Peak frames match the baseline (~8 ms for prose-code-math locally).
- The online Playground Performance Report passed on `447940331`; it includes rich playground rendering and the same-runner parser gate.
- All 61 re-measured benchmark output digests match.

Final verification: the local full suite passed. Online Linux/Node 20 peak frames for prose-code-math are now 6.352 → 6.387 ms (1x), 6.246 → 6.295 ms (2x), and 6.097 → 6.148 ms (4x). [Passing performance run and artifacts](https://github.com/Simon-He95/markstream-vue/actions/runs/34103969706).
