### PR TITLE
docs: add GitHub Sponsors entry alongside payment QR codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,9 @@ Parse hooks example (match server + client):
 
 ## Support the project
 
-If markstream-vue helps your work, you can support ongoing maintenance with one of these QR codes.
+If markstream-vue helps your work, you can support ongoing maintenance via [GitHub Sponsors](https://github.com/sponsors/Simon-He95) or one of these QR codes.
+
+[![Sponsor on GitHub](https://img.shields.io/badge/-Sponsor-db61a2?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Simon-He95)
 
 | Alipay | WeChat Pay |
 | --- | --- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,7 +175,9 @@ npx skills add git@github.com:Simon-He95/markstream-vue.git
 
 ## 支持项目
 
-如果 markstream-vue 对你的工作有帮助，欢迎通过下面的收款码支持项目的持续维护。
+如果 markstream-vue 对你的工作有帮助，欢迎通过 [GitHub Sponsors](https://github.com/sponsors/Simon-He95) 或下面的收款码支持项目的持续维护。
+
+[![在 GitHub 上赞助](https://img.shields.io/badge/-Sponsor-db61a2?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Simon-He95)
 
 | 支付宝 | 微信收款 |
 | --- | --- |

--- a/docs/.vitepress/theme/SupportQRCodes.vue
+++ b/docs/.vitepress/theme/SupportQRCodes.vue
@@ -5,11 +5,15 @@ interface Props {
   title: string
   description: string
   note?: string
+  sponsorUrl?: string
+  sponsorLabel?: string
   alipayLabel?: string
   wechatLabel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  sponsorUrl: 'https://github.com/sponsors/Simon-He95',
+  sponsorLabel: 'Sponsor on GitHub',
   alipayLabel: 'Alipay',
   wechatLabel: 'WeChat Pay',
 })
@@ -27,6 +31,25 @@ const wechatSrc = withBase('/sponsor/weixin.jpg')
       <p class="support-qrs__description">
         {{ props.description }}
       </p>
+
+      <a
+        class="support-qrs__sponsor-btn"
+        :href="props.sponsorUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <svg
+          class="support-qrs__sponsor-icon"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 14.25l.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 15.848 15.848 0 0 1-1.794-1.238C4.005 11.81 2 9.983 2 7.5 2 5.088 3.827 3 6.25 3c.72 0 1.393.2 1.975.545.582-.345 1.255-.545 1.975-.545C12.673 3 14.5 5.088 14.5 7.5c0 2.483-2.005 4.317-3.515 5.494a15.848 15.848 0 0 1-1.794 1.238 7.152 7.152 0 0 1-.31.17l-.018.01-.008.004Z"
+            fill="currentColor"
+          />
+        </svg>
+        {{ props.sponsorLabel }}
+      </a>
     </div>
 
     <div class="support-qrs__grid">
@@ -93,6 +116,35 @@ const wechatSrc = withBase('/sponsor/weixin.jpg')
   line-height: 1.7;
 }
 
+.support-qrs__sponsor-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1.15rem;
+  padding: 0.55rem 1.35rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #ea4aaa, #db61a2);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(219, 97, 162, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.support-qrs__sponsor-btn:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(219, 97, 162, 0.42);
+}
+
+.support-qrs__sponsor-icon {
+  width: 1.05em;
+  height: 1.05em;
+  flex-shrink: 0;
+}
+
 .support-qrs__grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -157,6 +209,10 @@ const wechatSrc = withBase('/sponsor/weixin.jpg')
 .dark .support-qrs__card {
   background: rgba(15, 23, 42, 0.78);
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+}
+
+.dark .support-qrs__sponsor-btn {
+  box-shadow: 0 10px 28px rgba(219, 97, 162, 0.4);
 }
 
 .dark .support-qrs__image-frame {

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,8 +48,9 @@ The showcase cards below replay their markdown as a live token stream through `m
 
 <SupportQRCodes
   title="Support Markstream"
-  description="If Markstream helps your work, you can support ongoing maintenance with Alipay or WeChat Pay."
+  description="If Markstream helps your work, you can support ongoing maintenance on GitHub Sponsors, or with Alipay / WeChat Pay."
   note="Thank you for helping keep the docs, demos, and package maintenance moving."
+  sponsor-label="Sponsor on GitHub"
   alipay-label="Alipay"
   wechat-label="WeChat Pay"
 />

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -48,8 +48,9 @@ hero:
 
 <SupportQRCodes
   title="支持 Markstream"
-  description="如果 Markstream 对你的工作有帮助，欢迎通过支付宝或微信支持项目的持续维护。"
+  description="如果 Markstream 对你的工作有帮助，欢迎通过 GitHub Sponsors、支付宝或微信支持项目的持续维护。"
   note="感谢你的支持，这会帮助文档、演示和包维护持续迭代。"
+  sponsor-label="在 GitHub 上赞助"
   alipay-label="支付宝"
   wechat-label="微信收款"
 />


### PR DESCRIPTION
## Summary

GitHub Sponsors is now live at https://github.com/sponsors/Simon-He95 — this PR adds it as a sponsorship entry while keeping the existing Alipay / WeChat Pay QR codes untouched.

## Changes

- **README.md / README.zh-CN.md**: the "Support the project / 支持项目" sections now link GitHub Sponsors (badge + inline link) above the QR table; the QR table itself is unchanged.
- **Docs home (EN + ZH)**: the `SupportQRCodes` component gains a pink "Sponsor on GitHub" button below the description.
  - New optional props: `sponsorUrl` (default `https://github.com/sponsors/Simon-He95`) and `sponsorLabel` (default `Sponsor on GitHub`, ZH home passes `在 GitHub 上赞助`).
  - Includes hover states and dark-mode styling.
- `.github/FUNDING.yml` already carries both entries (`github: Simon-He95` + `custom:` sponsor repo), so it needed no change — the repo header "Sponsor" button activates automatically now that Sponsors is live.

## Verification

- [x] `pnpm docs:build` passes (no errors)
- [x] ESLint clean on all changed files
- [x] Manually verified docs home in light + dark mode, EN + ZH — button label, link target, and layout all correct
