### PR TITLE
fix: preserve streamed footnotes and image placeholders

### DIFF
--- a/scripts/e2e-main-playground-performance.mjs
+++ b/scripts/e2e-main-playground-performance.mjs
@@ -486,15 +486,8 @@ async function collectMetrics(page) {
   fullScroll.layoutReads = normalizeLayoutReadPerformance(fullScroll.layoutReads)
   fullScroll.scrollDriftPx = scrollMetrics.maxScrollDriftPx
 
-  const replayButton = page.locator('button.nav-btn--stream')
+  const replayButton = page.locator('button.nav-btn--retry')
   await replayButton.waitFor({ state: 'visible', timeout: 5000 })
-  if ((await replayButton.textContent())?.includes('Pause')) {
-    await replayButton.click()
-    await page.waitForFunction(() => {
-      const button = document.querySelector('button.nav-btn--stream')
-      return button?.textContent?.includes('Resume')
-    }, null, { timeout: 5000 })
-  }
   const replayParsePerformanceBaseline = await page.evaluate(() => {
     const state = window.__mainPlaygroundPerf
     if (!state)
@@ -510,7 +503,13 @@ async function collectMetrics(page) {
     return state.replayParsePerformanceBaseline
   })
   await resetLayoutReadPerformance(page)
-  await page.locator('button.nav-btn--stream').click()
+  await replayButton.click()
+  await page.waitForFunction((baseline) => {
+    const stream = window.__mainPlaygroundPerf.parsePerformance.stream
+    const previous = baseline.stream
+    return stream.appendHits + stream.tailHits + stream.cacheHits
+      > previous.appendHits + previous.tailHits + previous.cacheHits
+  }, replayParsePerformanceBaseline, { timeout: 5000 })
   await waitForVisibleBlocksReady(page, rootSelector)
   await page.waitForTimeout(250)
 

--- a/src/components/ImageNode/ImageNode.vue
+++ b/src/components/ImageNode/ImageNode.vue
@@ -18,6 +18,7 @@ const emit = defineEmits<{ (e: 'load', src: string): void, (e: 'error', src: str
 const IMAGE_LIFECYCLE_PENDING_TIMEOUT_MS = 8000
 
 const imageLoaded = ref(false)
+const streamingPlaceholder = ref(false)
 const hasError = ref(false)
 const activeSrc = ref('')
 const imageStage = ref<'primary' | 'fallback' | 'failed'>('primary')
@@ -57,10 +58,11 @@ const viewportRootMargin = computed(() => viewportPriorityOptions?.value.heavyBl
 const showImage = computed(() => !props.node.loading && imageStage.value !== 'failed' && activeSrc.value.length > 0)
 const showError = computed(() => imageStage.value === 'failed')
 
-// Shimmer overlay while waiting to enter viewport or finish downloading.
+// Keep the placeholder through viewport deferral and downloading.
 const showShimmer = computed(() => (
-  !useEagerImagePath.value
-  || (shouldDeferImageRequest.value && !viewportReady.value)
+  streamingPlaceholder.value
+  || !useEagerImagePath.value
+  || shouldDeferImageRequest.value
 ) && !imageLoaded.value && !hasError.value && imageStage.value !== 'failed' && activeSrc.value.length > 0)
 const lifecycleIndexKey = computed(() => {
   return resolveLifecycleIndexKey(props, attrs)
@@ -158,6 +160,7 @@ function handleImageError() {
 
 function handleImageLoad() {
   imageLoaded.value = true
+  streamingPlaceholder.value = false
   hasError.value = false
   emit('load', displaySrc.value)
   scheduleLifecycleHeightReport()
@@ -179,6 +182,7 @@ watch(
     hasError.value = false
 
     if (props.node.loading) {
+      streamingPlaceholder.value = true
       activeSrc.value = safeNodeSrc.value
       imageStage.value = 'primary'
       return
@@ -290,6 +294,7 @@ onBeforeUnmount(() => {
       :title="String(props.node.title ?? props.node.alt ?? '')"
       class="image-node__img"
       :class="{
+        'has-placeholder': node.loading || showShimmer,
         'is-loading': !useEagerImagePath && !imageLoaded,
         'is-loaded': useEagerImagePath || imageLoaded,
         'has-natural-size': imageLoaded,
@@ -306,22 +311,8 @@ onBeforeUnmount(() => {
     >
 
     <span
-      v-if="node.loading && !hasError"
+      v-if="(node.loading || showShimmer) && !hasError"
       class="image-placeholder"
-    >
-      <template v-if="props.usePlaceholder">
-        <slot name="placeholder" :node="props.node" :display-src="displaySrc" :image-loaded="imageLoaded" :has-error="hasError" :fallback-src="props.fallbackSrc" :lazy="props.lazy">
-          <span class="image-shimmer" />
-        </slot>
-      </template>
-      <template v-else>
-        <span class="image-node__raw-text">{{ node.raw }}</span>
-      </template>
-    </span>
-
-    <span
-      v-if="showShimmer && !node.loading"
-      class="image-shimmer-overlay"
     >
       <template v-if="props.usePlaceholder">
         <slot name="placeholder" :node="props.node" :display-src="displaySrc" :image-loaded="imageLoaded" :has-error="hasError" :fallback-src="props.fallbackSrc" :lazy="props.lazy">
@@ -386,19 +377,10 @@ onBeforeUnmount(() => {
   vertical-align: middle;
 }
 
-.image-shimmer-overlay {
+.image-node__img.has-placeholder {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: hsl(var(--ms-muted));
-  overflow: hidden;
-}
-
-.image-shimmer-overlay .image-shimmer {
-  width: 100%;
-  height: 100%;
+  opacity: 0;
 }
 
 .image-shimmer {

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -5809,6 +5809,20 @@ function buildRenderedItemSignature(node: ParsedNode, index: number, globalSigna
   return [index, (node as { loading?: unknown }).loading, estimatedHeight, globalSignature]
 }
 
+const footnoteOccurrences = computed(() => {
+  const counts = new Map<string, number>()
+  const occurrences = new Map<number, number>()
+  parsedNodes.value.forEach((node, index) => {
+    if (node.type !== 'footnote')
+      return
+    const id = (node as FootnoteNodeData).id
+    const occurrence = counts.get(id) ?? 0
+    occurrences.set(index, occurrence)
+    counts.set(id, occurrence + 1)
+  })
+  return occurrences
+})
+
 /**
  * Build (or reuse from the WeakMap cache) the render item for one node.
  * The per-node signature tracks index, loading, estimated height and the
@@ -5940,9 +5954,7 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }, globalSign
   let nodeIdentity: string | number = item.index
   if (node.type === 'footnote' && component === FootnoteNode) {
     const id = (node as FootnoteNodeData).id
-    const occurrence = parsedNodes.value.slice(0, item.index)
-      .filter(previous => previous.type === 'footnote' && (previous as FootnoteNodeData).id === id)
-      .length
+    const occurrence = footnoteOccurrences.value.get(item.index)!
     nodeIdentity = `footnote-${id}-${occurrence}`
   }
   const indexKey = `${indexPrefix.value}-${nodeIdentity}`

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ParsedNode } from 'stream-markdown-parser'
+import type { FootnoteNode as FootnoteNodeData, ParsedNode } from 'stream-markdown-parser'
 import type { EstimatedNodeHeight } from '../../internal/heightEstimationExperiment'
 import type { CustomComponents } from '../../types'
 import type { CodeBlockPreviewPayload } from '../../types/component-props'
@@ -5928,7 +5928,11 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }, globalSign
     ? getCustomNodeAttrs(node as any, resolvedHtmlPolicy.value)
     : undefined
   const loading = (node as unknown as { loading?: unknown }).loading
-  const indexKey = `${indexPrefix.value}-${item.index}`
+  // Footnotes move as body blocks arrive; inline footnotes can share parser ids.
+  const nodeIdentity = node.type === 'footnote' && component === FootnoteNode
+    ? `footnote-${(node as FootnoteNodeData).id}-${parsedNodes.value.slice(0, item.index).filter(node => node.type === 'footnote').length}`
+    : item.index
+  const indexKey = `${indexPrefix.value}-${nodeIdentity}`
   const baseNodeProps = {
     node,
     loading,
@@ -5982,7 +5986,7 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }, globalSign
     slotContent: String((node as any).content ?? ''),
     isCodeBlock: node.type === 'code_block',
     indexKey,
-    vnodeKey: `${rendererSessionIdentity.value}\u0000${item.index}\u0000${node.type}`,
+    vnodeKey: `${rendererSessionIdentity.value}\u0000${nodeIdentity}\u0000${node.type}`,
   }
   renderedItemCache.set(item.node, { signature: cacheSignature, item: renderedItem })
   return renderedItem

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -481,11 +481,11 @@ watch(
 )
 
 watch(
-  [renderContent, () => props.nodes, requestedFinal],
-  ([content, nodes, finalRequested]) => {
+  [renderContent, () => props.nodes, effectiveFinal],
+  ([content, nodes, finalRendered]) => {
     const nextContent = content ?? ''
 
-    if (nodes?.length || finalRequested === true) {
+    if (nodes?.length || finalRendered === true) {
       clearContentStreamingTailActive()
       continuousStreamingObserved.value = false
       previousContentStreamValue = nextContent
@@ -4487,7 +4487,15 @@ function scheduleFinalHeightConvergence() {
   }
 }
 
-function setNodeContentRef(index: number, el: HTMLElement | null) {
+// Deferral controls initial mounting; moving a mounted key must not hide it again.
+const mountedNodeKeys = new Set<string>()
+
+function setNodeContentRef(index: number, key: string, el: HTMLElement | null) {
+  if (el)
+    mountedNodeKeys.add(key)
+  else
+    mountedNodeKeys.delete(key)
+
   if (el) {
     const node = parsedNodes.value[index]
     const registered = nodeContentRegistration.get(index)
@@ -5929,9 +5937,14 @@ function buildRenderedItem(item: { node: ParsedNode, index: number }, globalSign
     : undefined
   const loading = (node as unknown as { loading?: unknown }).loading
   // Footnotes move as body blocks arrive; inline footnotes can share parser ids.
-  const nodeIdentity = node.type === 'footnote' && component === FootnoteNode
-    ? `footnote-${(node as FootnoteNodeData).id}-${parsedNodes.value.slice(0, item.index).filter(node => node.type === 'footnote').length}`
-    : item.index
+  let nodeIdentity: string | number = item.index
+  if (node.type === 'footnote' && component === FootnoteNode) {
+    const id = (node as FootnoteNodeData).id
+    const occurrence = parsedNodes.value.slice(0, item.index)
+      .filter(previous => previous.type === 'footnote' && (previous as FootnoteNodeData).id === id)
+      .length
+    nodeIdentity = `footnote-${id}-${occurrence}`
+  }
   const indexKey = `${indexPrefix.value}-${nodeIdentity}`
   const baseNodeProps = {
     node,
@@ -6800,8 +6813,8 @@ onBeforeUnmount(() => {
           :data-node-type="item.node.type"
         >
           <div
-            v-if="shouldRenderNode(item.index)"
-            :ref="el => setNodeContentRef(item.index, el as HTMLElement | null)"
+            v-if="mountedNodeKeys.has(item.vnodeKey) || shouldRenderNode(item.index)"
+            :ref="el => setNodeContentRef(item.index, item.vnodeKey, el as HTMLElement | null)"
             class="node-content"
           >
             <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->

--- a/test/benchmark-runner-partial.test.ts
+++ b/test/benchmark-runner-partial.test.ts
@@ -69,7 +69,8 @@ describe('benchmark 1.0 runner partial reports', () => {
           MARKSTREAM_BENCHMARK_SAMPLES: 'truncated,ok',
           MARKSTREAM_BENCHMARK_SKIP_BUILD: '1',
           NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${hookPath}`].filter(Boolean).join(' '),
-          PLAYWRIGHT_CHROME_PATH: join(tmpRoot, 'missing-chrome'),
+          // Probe a deterministic executable instead of the host's Chrome install.
+          PLAYWRIGHT_CHROME_PATH: process.execPath,
         },
       })
 
@@ -78,6 +79,10 @@ describe('benchmark 1.0 runner partial reports', () => {
       const partialJson = readdirSync(outputDir).find(file => file.endsWith('.partial.json'))
       expect(partialJson).toBeTruthy()
       const report = JSON.parse(readFileSync(join(outputDir, partialJson!), 'utf8'))
+      expect(report.environment.browser).toEqual({
+        executablePath: process.execPath,
+        version: process.version,
+      })
 
       expect(report.scenarios.map((scenario: any) => scenario.id)).toEqual([
         'diagnostic-truncated',
@@ -119,7 +124,7 @@ describe('benchmark 1.0 runner partial reports', () => {
           MARKSTREAM_BENCHMARK_SKIP_BUILD: '1',
           MARKSTREAM_TEST_WEB_VITALS_PARTIAL: '1',
           NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${hookPath}`].filter(Boolean).join(' '),
-          PLAYWRIGHT_CHROME_PATH: join(tmpRoot, 'missing-chrome'),
+          PLAYWRIGHT_CHROME_PATH: process.execPath,
         },
       })
 

--- a/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
+++ b/test/e2e/__snapshots__/node-renderer.e2e.test.ts.snap
@@ -305,8 +305,8 @@ exports[`markdownRender node e2e coverage > renders footnote nodes 1`] = `
                 <div data-v-8dfe8a80="" class="node-content">
                   <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
                   <transition-stub data-v-8dfe8a80="" name="fade" appear="true" persisted="false" css="true">
-                    <p data-v-93ee5c2d="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="footnote-markdown-renderer-1-0-0"><span data-v-a84b8095="">Footnote explanation</span><span data-v-a84b8095=""></span>
-                      <!--v-if--></span><a data-v-31914872="" data-v-93ee5c2d="" class="footnote-anchor text-sm hover:underline cursor-pointer" href="#fnref-1" title="返回引用 1" index-key="footnote-markdown-renderer-1-0-1"> ↩︎ </a>
+                    <p data-v-93ee5c2d="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-a84b8095="" data-v-93ee5c2d="" class="text-node" index-key="footnote-markdown-renderer-footnote-1-0-0-0"><span data-v-a84b8095="">Footnote explanation</span><span data-v-a84b8095=""></span>
+                      <!--v-if--></span><a data-v-31914872="" data-v-93ee5c2d="" class="footnote-anchor text-sm hover:underline cursor-pointer" href="#fnref-1" title="返回引用 1" index-key="footnote-markdown-renderer-footnote-1-0-0-1"> ↩︎ </a>
                     </p>
                   </transition-stub>
                 </div>
@@ -402,7 +402,11 @@ exports[`markdownRender node e2e coverage > renders image links with relative ta
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
-      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://www.npmjs.com/package/markstream-vue" title="" aria-label="Link: https://www.npmjs.com/package/markstream-vue" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-4ff2ac62="" data-v-994bfd08="" class="image-node-container" index-key="markdown-renderer-0-0-0"><img data-v-4ff2ac62="" alt="NPM version" title="NPM version" class="image-node__img is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="NPM version" src="https://img.shields.io/npm/v/markstream-vue?color=a1b858&amp;label="><!--v-if--><!--v-if--><!--v-if--></span></a> <a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="README.zh-CN.md" title="" aria-label="Link: README.zh-CN.md" aria-hidden="false" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-4ff2ac62="" data-v-994bfd08="" class="image-node-container" index-key="markdown-renderer-0-2-0"><img data-v-4ff2ac62="" alt="中文版" title="中文版" class="image-node__img is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="中文版" src="https://img.shields.io/badge/docs-%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3-blue"><!--v-if--><!--v-if--><!--v-if--></span></a></p>
+      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="https://www.npmjs.com/package/markstream-vue" title="" aria-label="Link: https://www.npmjs.com/package/markstream-vue" aria-hidden="false" target="_blank" rel="noopener noreferrer" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-4ff2ac62="" data-v-994bfd08="" class="image-node-container" index-key="markdown-renderer-0-0-0"><img data-v-4ff2ac62="" alt="NPM version" title="NPM version" class="image-node__img has-placeholder is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="NPM version" src="https://img.shields.io/npm/v/markstream-vue?color=a1b858&amp;label="><span data-v-4ff2ac62="" class="image-placeholder"><span data-v-4ff2ac62="" class="image-shimmer"></span></span>
+          <!--v-if--></span>
+        </a> <a data-v-994bfd08="" data-v-93ee5c2d="" class="link-node" href="README.zh-CN.md" title="" aria-label="Link: README.zh-CN.md" aria-hidden="false" style="--underline-height: 2px; --underline-bottom: -3px; --underline-opacity: 0.35; --underline-rest-opacity: 0.175; --underline-duration: 1.6s; --underline-timing: ease-in-out; --underline-iteration: infinite;"><span data-v-4ff2ac62="" data-v-994bfd08="" class="image-node-container" index-key="markdown-renderer-0-2-0"><img data-v-4ff2ac62="" alt="中文版" title="中文版" class="image-node__img has-placeholder is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="中文版" src="https://img.shields.io/badge/docs-%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3-blue"><span data-v-4ff2ac62="" class="image-placeholder"><span data-v-4ff2ac62="" class="image-shimmer"></span></span>
+          <!--v-if--></span>
+        </a></p>
     </div>
   </div>
   <!--v-if-->
@@ -416,7 +420,9 @@ exports[`markdownRender node e2e coverage > renders image node 1`] = `
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
-      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-4ff2ac62="" data-v-93ee5c2d="" class="image-node-container" index-key="markdown-renderer-0-0"><img data-v-4ff2ac62="" alt="Vue Logo" title="Vue Logo" class="image-node__img is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="Vue Logo" src="https://example.com/vue.png"><!--v-if--><!--v-if--><!--v-if--></span></p>
+      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-4ff2ac62="" data-v-93ee5c2d="" class="image-node-container" index-key="markdown-renderer-0-0"><img data-v-4ff2ac62="" alt="Vue Logo" title="Vue Logo" class="image-node__img has-placeholder is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="Vue Logo" src="https://example.com/vue.png"><span data-v-4ff2ac62="" class="image-placeholder"><span data-v-4ff2ac62="" class="image-shimmer"></span></span>
+        <!--v-if--></span>
+      </p>
     </div>
   </div>
   <!--v-if-->
@@ -575,7 +581,9 @@ exports[`markdownRender node e2e coverage > renders single badge image with trai
   <div data-v-8dfe8a80="" class="node-slot" data-node-index="0" data-node-type="paragraph">
     <div data-v-8dfe8a80="" class="node-content">
       <!-- Skip wrapping code_block nodes in transitions to avoid touching stream-diffs internals -->
-      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-4ff2ac62="" data-v-93ee5c2d="" class="image-node-container" index-key="markdown-renderer-0-0"><img data-v-4ff2ac62="" alt="License" title="License" class="image-node__img is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="License" src="https://img.shields.io/npm/l/markstream-vue"><!--v-if--><!--v-if--><!--v-if--></span></p>
+      <p data-v-93ee5c2d="" data-v-8dfe8a80="" dir="auto" class="paragraph-node" typewriter="false" fade="true" is-dark="false"><span data-v-4ff2ac62="" data-v-93ee5c2d="" class="image-node-container" index-key="markdown-renderer-0-0"><img data-v-4ff2ac62="" alt="License" title="License" class="image-node__img has-placeholder is-loaded" fetchpriority="high" decoding="sync" tabindex="-1" aria-label="License" src="https://img.shields.io/npm/l/markstream-vue"><span data-v-4ff2ac62="" class="image-placeholder"><span data-v-4ff2ac62="" class="image-shimmer"></span></span>
+        <!--v-if--></span>
+      </p>
     </div>
   </div>
   <!--v-if-->

--- a/test/footnote-streaming-dom-stability.test.ts
+++ b/test/footnote-streaming-dom-stability.test.ts
@@ -1,9 +1,78 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { streamContent } from '../playground/src/const/markdown'
 import NodeRenderer from '../src/components/NodeRenderer'
 
 describe('streaming footnotes', () => {
+  it.each([
+    { name: 'a final heading', count: 1, tail: '## Image' },
+    { name: 'a final image', count: 3, tail: '## Image\n\n![Main image](https://example.com/main.png)' },
+    { name: 'nested blocks and images', count: 3, tail: '\n\n::: note\nNested **content**.\n\n> Quoted text.\n:::\n\n## Image\n\n![Main image](https://example.com/main.png)\n\n## Next\n\nMore text.'.repeat(3) },
+  ].flatMap(testCase => [true, false].map(smoothStreaming => ({ ...testCase, smoothStreaming }))))('keeps $count footnotes mounted through $name (smooth=$smoothStreaming)', async ({ count, tail, smoothStreaming }) => {
+    vi.useFakeTimers()
+    const visibleCallbacks: Array<() => void> = []
+    vi.stubGlobal('IntersectionObserver', class {
+      constructor(private callback: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        visibleCallbacks.push(() => this.callback([{ target, isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry], this as unknown as IntersectionObserver))
+      }
+
+      unobserve() {}
+      disconnect() {}
+    })
+    const prefix = Array.from({ length: 45 }, (_, index) => `Paragraph ${index}.`).join('\n\n')
+    const references = Array.from({ length: count }, (_, index) => `Reference[^${index}].`).join(' ')
+    const definitions = Array.from({ length: count }, (_, index) => `[^${index}]: Note **${index}** with [a link](https://example.com) and **[![image](https://example.com/note.png)](https://example.com)**.\n\n    Second paragraph with *emphasis*.`).join('\n\n')
+    const seed = `${prefix}\n\n${references}\n\n${definitions}\n\n`
+    const wrapper = mount(NodeRenderer, {
+      props: { content: seed, final: false, smoothStreaming, parseCoalesceMs: 0 },
+    })
+    try {
+      for (let frame = 0; frame < 80; frame++) {
+        visibleCallbacks.splice(0).forEach(notify => notify())
+        await vi.advanceTimersByTimeAsync(16)
+      }
+      const footnotes = wrapper.findAll('.footnote-node').map(node => node.element)
+      expect(footnotes).toHaveLength(count)
+      const images = wrapper.findAll('.footnote-node img').map(node => node.element)
+      expect(images).toHaveLength(count)
+      await wrapper.setProps({ content: seed + tail, final: true })
+      for (let frame = 0; frame < 100; frame++) {
+        await vi.advanceTimersByTimeAsync(16)
+        const current = wrapper.findAll('.footnote-node')
+        expect(current, `frame ${frame}`).toHaveLength(count)
+        current.forEach((node, index) => expect(node.element, `frame ${frame}, footnote ${index}`).toBe(footnotes[index]))
+        const currentImages = wrapper.findAll('.footnote-node img')
+        expect(currentImages).toHaveLength(count)
+        currentImages.forEach((node, index) => expect(node.element).toBe(images[index]))
+      }
+      expect(wrapper.vm.$.setupState.effectiveFinal).toBe(true)
+    }
+    finally {
+      wrapper.unmount()
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('preserves an existing footnote when an earlier reference gets its definition later', async () => {
+    const content = 'Earlier[^late], existing[^known], repeated[^known].\n\n[^known]: Existing **note**.'
+    const wrapper = mount(NodeRenderer, {
+      props: { content, final: false, smoothStreaming: false, parseCoalesceMs: 0 },
+    })
+    try {
+      const existing = wrapper.get('.footnote-node').element
+      await wrapper.setProps({ content: `${content}\n\n[^late]: Arrived later.\n\n## Next`, final: true })
+      const footnotes = wrapper.findAll('.footnote-node')
+      expect(footnotes).toHaveLength(2)
+      expect(footnotes[0].text()).toContain('Arrived later')
+      expect(footnotes[1].element).toBe(existing)
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
   it('keeps inline footnotes with repeated parser ids distinct when blocks are inserted', async () => {
     const content = 'Text ^[First inline note] and ^[Second inline note]'
     const wrapper = mount(NodeRenderer, {
@@ -33,7 +102,7 @@ describe('streaming footnotes', () => {
   it('keeps the footnote mounted as following blocks are inserted before it', async () => {
     const start = streamContent.indexOf('## Footnotes')
     const firstEnd = streamContent.indexOf('This is a note admonition', start) + 'This i'.length
-    const lastEnd = streamContent.indexOf('## Image', firstEnd)
+    const lastEnd = streamContent.length
     const wrapper = mount(NodeRenderer, {
       props: {
         content: streamContent.slice(start, firstEnd),
@@ -54,6 +123,8 @@ describe('streaming footnotes', () => {
         expect(footnote.textContent).toContain('complete token specification')
         expect(wrapper.get('.footnote-node p').element).toBe(paragraph)
       }
+      await wrapper.setProps({ final: true })
+      expect(wrapper.get('.footnote-node').element).toBe(footnote)
     }
     finally {
       wrapper.unmount()

--- a/test/footnote-streaming-dom-stability.test.ts
+++ b/test/footnote-streaming-dom-stability.test.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { streamContent } from '../playground/src/const/markdown'
+import NodeRenderer from '../src/components/NodeRenderer'
+
+describe('streaming footnotes', () => {
+  it('keeps inline footnotes with repeated parser ids distinct when blocks are inserted', async () => {
+    const content = 'Text ^[First inline note] and ^[Second inline note]'
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content,
+        final: false,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+        parseCoalesceMs: 0,
+      },
+    })
+    try {
+      const footnotes = wrapper.findAll('.footnote-node').map(node => node.element)
+      expect(footnotes).toHaveLength(2)
+      await wrapper.setProps({ content: `${content} and ^[Third inline note]\n\n## Next\n\nMore content.` })
+      expect(wrapper.findAll('.footnote-node')).toHaveLength(3)
+      expect(wrapper.findAll('.footnote-node')[0].element).toBe(footnotes[0])
+      expect(wrapper.findAll('.footnote-node')[1].element).toBe(footnotes[1])
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps the footnote mounted as following blocks are inserted before it', async () => {
+    const start = streamContent.indexOf('## Footnotes')
+    const firstEnd = streamContent.indexOf('This is a note admonition', start) + 'This i'.length
+    const lastEnd = streamContent.indexOf('## Image', firstEnd)
+    const wrapper = mount(NodeRenderer, {
+      props: {
+        content: streamContent.slice(start, firstEnd),
+        final: false,
+        smoothStreaming: false,
+        batchRendering: false,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+        parseCoalesceMs: 0,
+      },
+    })
+    try {
+      const footnote = wrapper.get('.footnote-node').element
+      const paragraph = wrapper.get('.footnote-node p').element
+      for (let end = firstEnd + 1; end <= lastEnd; end++) {
+        await wrapper.setProps({ content: streamContent.slice(start, end) })
+        expect(wrapper.get('.footnote-node').element, `prefix ${end}`).toBe(footnote)
+        expect(footnote.textContent).toContain('complete token specification')
+        expect(wrapper.get('.footnote-node p').element).toBe(paragraph)
+      }
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/test/heavy-node-final-restore-defer.test.ts
+++ b/test/heavy-node-final-restore-defer.test.ts
@@ -161,7 +161,7 @@ describe('final restore heavy-node deferral', () => {
       expect(target.exists()).toBe(true)
       expect(countImageRequests()).toBe(0)
       expect(image.attributes('src')).toBeUndefined()
-      expect(wrapper.find('.image-shimmer-overlay').exists()).toBe(true)
+      expect(wrapper.find('.image-placeholder').exists()).toBe(true)
       expect(target.attributes('data-markstream-viewport-pending')).toBe('true')
 
       await drainIdleCallbacks()
@@ -174,6 +174,7 @@ describe('final restore heavy-node deferral', () => {
 
       expect(countImageRequests()).toBe(1)
       expect(image.attributes('src')).toBe('https://example.com/history.png')
+      expect(wrapper.find('.image-placeholder').exists()).toBe(true)
       expect(target.attributes('data-markstream-viewport-pending')).toBeUndefined()
     }
     finally {

--- a/test/image-node-performance.test.ts
+++ b/test/image-node-performance.test.ts
@@ -73,6 +73,29 @@ describe('image node performance defaults', () => {
     expect(wrapper.get('img').classes()).not.toContain('has-natural-size')
   })
 
+  it.each([false, true])('keeps the streaming placeholder until the image loads (lazy=%s)', async (lazy) => {
+    const node = {
+      type: 'image' as const,
+      src: 'https://example.com/hero.png',
+      alt: 'Hero',
+      raw: '![Hero](https://example.com/hero.png)',
+      loading: true,
+    }
+    const wrapper = mount(ImageNode, { props: { node, lazy } })
+    try {
+      const placeholder = wrapper.get('.image-placeholder').element
+      await wrapper.setProps({ node: { ...node, loading: false } })
+      expect(wrapper.get('img').attributes('src')).toBe(node.src)
+      expect(wrapper.find('.image-placeholder').element).toBe(placeholder)
+      await wrapper.get('img').trigger('load')
+      expect(wrapper.find('.image-placeholder').exists()).toBe(false)
+      expect(wrapper.get('img').classes()).toContain('has-natural-size')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+
   it('reports image load lifecycle for virtual-scroll settling', async () => {
     const markPending = vi.fn()
     const reportHeight = vi.fn()

--- a/test/node-renderer-measurement-performance.test.ts
+++ b/test/node-renderer-measurement-performance.test.ts
@@ -555,9 +555,9 @@ describe('node renderer measurement performance', () => {
     const baselineHeight = state.getFallbackNodeHeight(0)
 
     platform.heights.set(element, 100)
-    state.setNodeContentRef(0, element)
+    state.setNodeContentRef(0, state.renderedItems[0].vnodeKey, element)
     await Promise.resolve()
-    state.setNodeContentRef(0, null)
+    state.setNodeContentRef(0, state.renderedItems[0].vnodeKey, null)
     platform.flushFrames()
 
     expect(state.getFallbackNodeHeight(0)).toBe(baselineHeight)
@@ -800,8 +800,8 @@ describe('node renderer measurement performance', () => {
     // rendered node on every streaming commit), so simulate a real remount
     // with a null pass to force the measurement/observer re-registration.
     platform.heights.set(element, 40)
-    state.setNodeContentRef(0, null)
-    state.setNodeContentRef(0, element)
+    state.setNodeContentRef(0, state.renderedItems[0].vnodeKey, null)
+    state.setNodeContentRef(0, state.renderedItems[0].vnodeKey, element)
     await Promise.resolve()
     platform.flushFrames()
     expect(state.getFallbackNodeHeight(0)).toBe(40)

--- a/test/node-renderer-virtual-scroll.test.ts
+++ b/test/node-renderer-virtual-scroll.test.ts
@@ -1578,7 +1578,7 @@ describe('node renderer virtual-scroll coordination', () => {
     wrapper.unmount()
   })
 
-  it('keeps virtual metrics unsettled until an async custom node reports settled', async () => {
+  it.each(['async_node', 'footnote'])('keeps virtual metrics unsettled until a custom %s reports settled', async (nodeType) => {
     let finishAsyncNode: ((height: number) => void) | null = null
     const AsyncNode = defineComponent({
       props: {
@@ -1599,7 +1599,7 @@ describe('node renderer virtual-scroll coordination', () => {
     })
 
     setCustomComponents('virtual-lifecycle-test', {
-      async_node: AsyncNode as any,
+      [nodeType]: AsyncNode as any,
     })
 
     const NodeRenderer = (await import('../src/components/NodeRenderer')).default
@@ -1608,7 +1608,8 @@ describe('node renderer virtual-scroll coordination', () => {
         customId: 'virtual-lifecycle-test',
         nodes: [
           {
-            type: 'async_node',
+            type: nodeType,
+            id: 'custom-note',
             raw: '<async-node />',
             content: '',
           },

--- a/test/security/link-image-url-policy.test.ts
+++ b/test/security/link-image-url-policy.test.ts
@@ -349,7 +349,7 @@ describe('link and image URL policy', () => {
     await nextTick()
 
     expect(wrapper.find('img').exists()).toBe(false)
-    expect(wrapper.find('.image-shimmer-overlay').exists()).toBe(false)
+    expect(wrapper.find('.image-placeholder').exists()).toBe(false)
     expect(wrapper.find('.image-error').exists()).toBe(true)
   })
 


### PR DESCRIPTION
## Summary

Appending body blocks moves footnotes to new array indices. Their keys and deferred-mount state depended on those positions, so an already visible footnote could remount or become a placeholder. Source completion also cleared the streaming-tail state before smooth rendering caught up. Image placeholders disappeared after Markdown parsing completed, leaving a blank, shorter box until the image downloaded.

Keep built-in footnotes mounted and preserve the same image placeholder through loading. Also isolate the benchmark report test from host Chrome discovery, addressing the Ubuntu test timeout on main.

## Changes

- Use a stable identity for built-in footnotes and their nested renderers. Count occurrences only among equal IDs to distinguish inline footnotes without changing existing keys when another definition arrives earlier in the footnote list. Compute the occurrence lookup once per parsed-node pass instead of scanning the prefix for every footnote. Custom component position keys retain their existing behavior.
- Keep streaming-tail rendering active until the visible stream finishes. Track mounted vnode keys until their content unmounts, so moving an existing node cannot send it back through deferred mounting; virtual-window removal still unmounts normally.
- Keep the image placeholder in normal flow until load or terminal failure; deferred and lazy requests use the same placeholder.
- Check DOM identity frame by frame across final headings, images, nested admonitions/quotes, multiple footnotes, multi-paragraph definitions, and images nested inside bold links, with smooth streaming on and off. Also cover late definitions, repeated references, duplicate inline IDs, custom-footnote virtual height reporting, and eager/lazy image handoff.
- Fix the main playground benchmark to use Retry rather than Pause/Resume and wait for incremental parse metrics before sampling. The existing 5-second replay budget and parser-hit assertion stay in place; a fixed 250ms sample could contain only full parses with random chunks.
- Use the Node executable for the report test's version probe. Main's [failed run](https://github.com/Simon-He95/markstream-vue/actions/runs/34231294848) passed lint but timed out in `benchmark-runner-partial.test.ts` after 12.9 seconds; the missing Chrome path allowed discovery of a real host browser.

## Screenshots / Demo

[Open the streaming reproduction](https://markstream-vue.simonhe.me/test#data=MTAEDEHtIFwO1gUwM4ChUBUAWjQBMUBLAczlBkgGtEzkBPZGRAWwG0A9ARgF1QaBDAEYAbFKABmAV2HDyOZrgDGkxpGaEAXvxiFIcAHToOPAFygAyolwADAshJwA9PwBOirISaKYkl4n3MeNYSkC5ySmoADqJM5FQ0oMiRiIqE4oSK2roG6CZ5oAhMmB7IoISl-AVIoPx4zHqe2SFhtXiNevyyinpMAB4whnkmufl4-HDEiC7F5WUV+OOTLXUNOnrNoIoujZmyAO6ucIQTyIN56CCgAJLM-JPoAISsAGqSuAAykMSQ3AAUWDAYJFkCZHI4AG5vABWp1CxEchFuk2QjmEX0g+kiEwAlKggA) and replay it with network throttling for the final image. The hosted page reflects its deployed version until this change ships.

Chromium checks on the updated playground source cover the full automatic replay, including source completion while smooth rendering catches up, as well as incremental appends. Both eager and lazy images retained a 128 × 128 placeholder throughout a delayed response, then switched directly to their 256 × 192 natural size.

## Checklist

- [x] Lint: `pnpm lint` and `pnpm exec eslint . --no-cache`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test --run --exclude '**/.tmp/**'` (354 files / 3,131 tests; exclude local historical checkout copies)
- [x] Build: `pnpm build`
- [x] Playground browser verification
