### PR TITLE
perf(code-block): drop redundant single-editor host pin before reveal

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -885,24 +885,19 @@ async function revealEditorDisplay() {
   if (!isDiff.value) {
     if (whenRuntimeVisualReady && !await whenRuntimeVisualReady())
       return false
-    // Hold the grid row at the fallback <pre>'s full height (content + vertical
-    // padding) while the stream-diffs surface is revealed, then settle on a
-    // later frame. Without this pin, removing the fallback collapses the row by
-    // its padding and any content-estimation delta in the same patch the surface
-    // mounts, producing a CLS. Mirror the diff handoff below.
-    syncEditorHostToFallbackHeight()
-    layoutEditorToHost(true)
+    // The enhanced surface and the fallback <pre> share one grid cell and are
+    // driven by the same line metrics: `syncEditorCssVars()` feeds the
+    // fallback's font-size/line-height into `--diffs-font-size` /
+    // `--diffs-line-height`, so both surfaces resolve the same line box height
+    // and the grid track keeps its height when the fallback is removed. No host
+    // pin is required here (unlike the diff handoff below, whose fallback uses a
+    // different row model). Move the host into its final cell while the
+    // fallback is still visible, lay the runtime out against that box, reveal.
     editorHandoffPrepared.value = true
     await nextTick()
-    syncEditorHostToFallbackHeight()
-    layoutEditorToHost(true)
-    await waitForAnimationFrame()
-    syncEditorHostToFallbackHeight()
     layoutEditorToHost(true)
     editorDisplayReady.value = true
     await nextTick()
-    // Keep the removal frame at the pinned fallback height; schedule the settle
-    // on a subsequent frame instead of collapsing synchronously.
     scheduleEditorHeightSync()
     return true
   }


### PR DESCRIPTION
## What

Removes the three-round host pin (and its two animation-frame waits) from the single-editor branch of `revealEditorDisplay()` in `src/components/CodeBlockNode/CodeBlockNode.vue`.

The branch keeps everything it actually needs: move the host into its final grid cell, lay the runtime out against that box, reveal.

## Context

The pin came from `53b5b36e2` ("fix: pin editor host to fallback height before stream-diffs reveal"), which measured a CLS regression against the Web Vitals gate of that time. Five days later `58cc63462` ("unify pre fallback visual contract") made both surfaces share one line-metric contract: `syncEditorCssVars()` feeds the fallback's `font-size`/`line-height` into `--diffs-font-size` / `--diffs-line-height`, and both surfaces resolve the same 12px/18px line box. Once the two surfaces agree on line metrics, the grid track no longer changes height when the fallback is removed.

## Why the remaining pin is redundant

The host does not depend on this pin for its height. `runEditorCreation()` calls `syncDiffRevealHostHeight()` before revealing, and for a single editor that function takes its early branch (`CodeBlockNode.vue:1055-1087`), measures the rendered enhanced surface and writes it as the host's inline height. So by the time the deleted pin runs, the host already carries the authoritative height — the enhanced surface's own measurement.

A frame-by-frame trace of the reveal confirms both builds write the same number:

| frame | pinned build | unpinned build |
| --- | --- | --- |
| before reveal | `height: 250px`, `min-height: 0px` | `height: 250px`, `min-height: 0px` |
| reveal frame | `height: 250px`, `min-height: 250px` | — |
| container height | 293px throughout | 293px throughout |

The deleted pin re-measured the *fallback* to the same 250px, added a `min-height`, and cost one extra frame before the reveal. Identical geometry, one fewer frame.

## It is not a metric-drift safety net either

To test whether the pin protects against the two surfaces' metrics diverging, I injected a document-start stylesheet that makes the fallback's line boxes 60px (fallback 500px vs enhanced 250px) and traced both builds:

| frame | pinned build | unpinned build |
| --- | --- | --- |
| pin applied | `height: 500px`, `min-height: 500px` | `height: 250px`, `min-height: 0px` |
| reveal frame | container holds 543px | container drops 543px → 293px |
| next frame | container drops 543px → 293px | 293px |

The pin does take effect — it writes the fallback's 500px — but it cannot prevent the collapse, because the enhanced surface's real height is 250px and the track must end there. It only moves the 250px collapse one frame later. So removing it does not give up any protection in the scenario it was written for.

## Evidence

Block-level geometry sampling (every animation frame across the handoff) on `/diff-handoff-check`:

| build | ordinary | unified (1 col) | split (2 col) |
| --- | --- | --- | --- |
| metrics aligned, pin removed | 0 | 0 | 0 |
| metrics aligned, pin present | 0 | 0 | 0 |

- Zero shift holds across a 541-543 frame sample in both `wrap` and `scroll` overflow modes.
- Probe sensitivity was calibrated by breaking metric alignment, which the same probe reports as a 250px / 392px jump — so the zero is a measured zero, not an insensitive probe.

Note on the Web Vitals gate: the codeblock scenario CLS budgets are 0.15 / 0.8, recalibrated from 0.05 in `168e04f8b` against the measured ~0.09 / ~0.75 of the 2.0 stream-diffs mounts. Passing that gate therefore does not by itself prove the absence of a 0.09-class regression. The stronger measurement is the gate's own output on this branch: all 12 phases report `phaseCls: 0`, in addition to the block-level sampling above.

Diff scenarios are unaffected: the change is guarded by `if (!isDiff.value)`, and the diff handoff keeps its own `stabilizeDiffHandoffHeight()` path. `pnpm run test:e2e:diff-handoff-check` reports the same 8 pre-existing `unified`/`split` `wrap` failures before and after this change, with no new failures. Those failures are not part of any CI workflow.

## Checks run

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- unit tests — 355 files / 3144 tests pass
- `pnpm run build` — pass
- `pnpm size:check` — pass (dist 920.2 KB, tarball 267.9 KB)
- `check:ssr` — pass
- `pnpm run test:e2e:web-vitals-performance` — exit 0, zero warnings, 12/12 phases `phaseCls: 0`, LCP 576ms / 720ms
- CI on this PR — all jobs green (ubuntu / macos / windows, benchmark report, docs, dts)

## Notes

Layout passes during the codeblock handoff drop from 32 to 26. Long-task duration is unchanged within noise — the remaining cost is the single full-document layout of the enhanced surface, not this handoff. This PR is a correctness/cleanup change, not a speed win.

Unrelated observation while verifying: `scripts/e2e-line-number-handoff-playgrounds.mjs` fails on its light-theme assertion (`light pre/highlight background mismatch`) in every framework. Its dark-mode handoff assertions — the ones that actually measure the pre → enhanced height invariant at 1% / 2px tolerance — pass. The script is not wired into CI, so this has gone unnoticed. Worth fixing separately so it can serve as a real gate for this file.
