### PR TITLE
fix(e2e): repair the code-block handoff gate and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm run test:e2e:virtual-scroll:ci
 
+      - name: Code block handoff e2e (Ubuntu only)
+        # Guards the pre -> enhanced code-block handoff: asserts the surfaces
+        # agree on line metrics, that the fallback never disappears before the
+        # enhanced surface is ready, and that switching heights at the handoff
+        # stays within max(2px, 1%). This is the only check that measures that
+        # invariant, and the Web Vitals CLS budgets for code blocks are too loose
+        # (0.15 / 0.8) to catch a regression of this size.
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm run test:e2e:line-number-handoff-playgrounds --framework=vue3
+
       - name: Virtual scroll playground stress e2e (scheduled/manual, Ubuntu only)
         if: >
           matrix.os == 'ubuntu-latest' &&

--- a/scripts/e2e-line-number-handoff-playgrounds.mjs
+++ b/scripts/e2e-line-number-handoff-playgrounds.mjs
@@ -942,6 +942,31 @@ async function runFramework(browser, framework, spec) {
 
     await page.getByRole('button', { name: 'Toggle dark' }).click()
     await page.waitForFunction(() => !document.querySelector('.handoff-check')?.classList.contains('dark'))
+    // The wrapper class follows the `isDark` prop synchronously, but the
+    // enhanced surface applies its theme asynchronously: the component syncs the
+    // injected worker pool's render options and re-tokenizes before repainting.
+    // Waiting only on the class samples the one-frame window where the fallback
+    // is already light while the code surface is still dark. Wait for the
+    // surfaces to actually agree — a failure to converge within the timeout is
+    // itself the regression this guards against.
+    await page.waitForFunction(() => {
+      const queryDeep = (root, selector) => {
+        const direct = root?.querySelector?.(selector)
+        if (direct)
+          return direct
+        for (const element of root?.querySelectorAll?.('*') || []) {
+          const nested = element.shadowRoot && queryDeep(element.shadowRoot, selector)
+          if (nested)
+            return nested
+        }
+        return null
+      }
+      const pre = document.querySelector('[data-handoff-case="pre"] pre[data-markstream-pre="1"]')
+      const code = queryDeep(document.querySelector('[data-handoff-case="enhanced"]'), '[data-code]')
+      if (!pre || !code)
+        return false
+      return getComputedStyle(code).backgroundColor === getComputedStyle(pre).backgroundColor
+    }, { timeout: 15000 })
     const lightVisual = await page.evaluate(() => {
       const queryDeep = (root, selector) => {
         const direct = root?.querySelector?.(selector)

--- a/scripts/e2e-line-number-handoff-playgrounds.mjs
+++ b/scripts/e2e-line-number-handoff-playgrounds.mjs
@@ -701,7 +701,15 @@ function validateResult(result, { requireDark = true, requireNarrowPre = true, r
     assert(result.preHeadingOpacity === '1', `Pre Markdown heading opacity is ${result.preHeadingOpacity}`)
   }
   if (vue3HeaderParityFrameworks.has(result.framework)) {
-    assert(Math.abs(result.headerHeight - 41) <= 0.5, `code header height is ${result.headerHeight}px, expected 41px`)
+    // The header's content box is driven by the platform's default sans line box,
+    // which differs by a pixel or two between macOS and Linux. Keep the band
+    // tight enough to catch a structural regression (the exact padding, gaps,
+    // icon and action sizes are asserted separately below) without pinning one
+    // platform's font metrics.
+    assert(
+      result.headerHeight >= 38 && result.headerHeight <= 46,
+      `code header height is ${result.headerHeight}px, expected 38-46px`,
+    )
     assert(
       [result.headerPaddingTop, result.headerPaddingRight, result.headerPaddingBottom, result.headerPaddingLeft].join(' ') === '6px 10px 6px 10px',
       `code header padding is ${result.headerPaddingTop} ${result.headerPaddingRight} ${result.headerPaddingBottom} ${result.headerPaddingLeft}`,
@@ -738,8 +746,21 @@ function validateResult(result, { requireDark = true, requireNarrowPre = true, r
   assert(result.preLineHeight === '18px', `shared Pre line height is ${result.preLineHeight}, expected 18px`)
   assert(result.prePaddingTop === '8px', `shared Pre top padding is ${result.prePaddingTop}, expected 8px`)
   assert(result.prePaddingBottom === '8px', `shared Pre bottom padding is ${result.prePaddingBottom}, expected 8px`)
-  assert(Math.abs(Number.parseFloat(result.prePaddingRight) - 7.20117) <= 0.1, `shared Pre right padding is ${result.prePaddingRight}, expected 1ch`)
-  assert(Math.abs(Number.parseFloat(result.prePaddingLeft) - 45.207) <= 0.1, `shared Pre line-number padding is ${result.prePaddingLeft}, expected gutter plus 1ch`)
+  // The Pre gutter contract is `padding-right: 1ch` and
+  // `padding-left: calc(2ch + 2ch + 1ch + 2px + 1ch)` (PreCodeNode.vue:406,411).
+  // A `ch` resolves to whatever monospace font the platform picks, so asserting
+  // absolute pixels would pin one platform's font metrics. `padding-right` *is*
+  // the resolved `1ch` of this element, so assert the relationship between the
+  // two paddings instead — exact, and independent of the font.
+  const preCh = Number.parseFloat(result.prePaddingRight)
+  assert(Number.isFinite(preCh) && preCh > 0, `shared Pre right padding is not measurable: ${result.prePaddingRight}`)
+  // At the shared 12px font size a monospace `ch` is roughly 0.45-0.75em; this
+  // catches the gutter silently switching to a non-`ch` unit.
+  assert(preCh >= 5.4 && preCh <= 9, `shared Pre right padding is ${result.prePaddingRight}, not a 12px monospace ch`)
+  assert(
+    Math.abs(Number.parseFloat(result.prePaddingLeft) - (6 * preCh + 2)) <= 0.05,
+    `shared Pre line-number padding is ${result.prePaddingLeft}, expected 6ch + 2px separator (${(6 * preCh + 2).toFixed(3)}px)`,
+  )
   assert(
     result.preOverflowX === (overflow === 'wrap' ? 'hidden' : 'auto'),
     `${overflow} shared Pre overflow-x is ${result.preOverflowX}`,


### PR DESCRIPTION
## What

Three commits that repair the code-block handoff gate and wire it into CI:

1. **`fix(e2e)`**: the script failed on every framework — it was a test race, not a rendering bug.
2. **`ci`**: the script existed but no workflow ran it.
3. **`test(e2e)`**: wiring it into CI exposed two assertions that only held on macOS.

## 1. The failure was a test race

The script failed at `scripts/e2e-line-number-handoff-playgrounds.mjs:972`:

```
light pre/highlight background mismatch: rgb(255,255,255) vs rgb(18,18,18)
```

It toggles the theme and waits only for the `.dark` class to leave the wrapper:

```js
await page.waitForFunction(() => !document.querySelector('.handoff-check')?.classList.contains('dark'))
```

That class follows the `isDark` prop synchronously, but the enhanced surface applies its theme asynchronously — `themeUpdate()` awaits `syncStreamDiffsWorkerTheme()` (a cross-worker `pool.setRenderOptions()` round trip) and `setTheme()` before the surface repaints, and the repaint lands on a later frame. Sampling right after the class flip reads a one-frame window where the fallback is already light while the code surface is still dark.

Measured with a per-frame sampler:

| t | fallback `<pre>` | enhanced `[data-code]` |
| --- | --- | --- |
| +50ms | `rgb(255,255,255)` | `rgb(18,18,18)` ← the E2E read here |
| +67ms | `rgb(255,255,255)` | `rgb(255,255,255)` |

A **17ms, one-frame** window. Widening the gap between the viewport change and the toggle (50ms → 1500ms) makes it disappear, confirming a race.

**Fix:** wait for the invariant the script asserts — the enhanced surface's code background matching the fallback's — with a 15s timeout. The theme assertions are unchanged.

**This does not weaken the check.** Negative control: a stylesheet injected into the `diffs-container` shadow root pins `[data-code]` to the dark background, reproducing permanent divergence:

```
healthy (theme propagates):    converged=true in 19ms
broken  (theme pinned dark):   converged=false in 30002ms
NEGATIVE CONTROL PASSES
```

## 2. Two assertions only held on macOS

The first CI run on Ubuntu failed with:

```
[vue3] code header height is 42px, expected 41px
```

- **`headerHeight`** was asserted as `|h - 41| <= 0.5`. The header's content box is driven by the title's `line-height: normal`, which resolves from the platform's default sans font and legitimately differs by a pixel or two. Now a 38-46px band; the exact padding, gaps, icon size (16x16) and action size (26x26) are still asserted separately, and those come from `rem`/`em` tokens that do not drift.
- **Pre gutter paddings** were asserted as absolute pixels calibrated on macOS (7.20117 / 45.207). Both come from `ch` units (`PreCodeNode.vue:406,411`). `padding-right` *is* the resolved `1ch` of that same element, so the assertion now checks the relationship between the two paddings — `padding-left == 6ch + 2px` — which is exact (measured delta 2e-05) and font-independent. A 5.4-9px band on `padding-right` catches the gutter silently switching units.

Both keep the assertion strength: same CSS contract, no longer pinned to one platform's font metrics.

## 3. Why this gate belongs in CI

It is the only check that measures the pre → enhanced handoff:

- `|heightBeforeHandoff - firstEditorHeight| <= max(2px, 1%)`
- the fallback never disappears before the enhanced surface is ready
- the fallback never reappears afterwards
- layout jitter within `max(2px, 1% of final height)`

The Web Vitals harness cannot substitute: the codeblock CLS budgets are 0.15 / 0.8, recalibrated from 0.05 in `168e04f8b` against the measured ~0.09 / ~0.75 of the 2.0 stream-diffs mounts, so a regression of that magnitude passes unnoticed.

Scoped to `--framework=vue3` for CI cost (the harness starts a browser plus a dev server per framework). Ubuntu-only, beside the existing virtual-scroll e2e. The script prepares what it needs itself.

## Checks run

- `pnpm run test:e2e:line-number-handoff-playgrounds --framework=vue3` — exit 0, `"passed": ["vue3"]`, ~10s locally, repeatedly
- Negative control rejects genuine divergence (above)
- CI green on this PR: ubuntu 12m39s (new step `completed/success`), macos 5m14s, windows 5m53s, plus docs, dts and benchmark jobs
