### PR TITLE
fix(diagram): reserve preview height so diagram blocks stop shifting

### DIFF
--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -260,7 +260,7 @@ Use these to control specialized block renderers without overriding components m
 - `d2-props` forwards props to `D2BlockNode`
 - `infographic-props` forwards props to `InfographicBlockNode`
 
-For Mermaid and Infographic fences, `MarkdownRender` injects an `estimatedPreviewHeightPx` value when the caller does not provide one. This reserves a stable first-preview height for async loading and remounts. Custom `mermaid` and `infographic` renderers receive the same prop, so forward or consume it if the custom block renders its own preview shell.
+For Mermaid, Infographic, and D2 fences, `MarkdownRender` injects an `estimatedPreviewHeightPx` value when the caller does not provide one. This reserves a stable first-preview height for async loading and remounts, so the block does not jump when the diagram replaces its source panel. Custom `mermaid`, `infographic`, and `d2` renderers receive the same prop, so forward or consume it if the custom block renders its own preview shell.
 
 Example:
 

--- a/docs/zh/guide/props.md
+++ b/docs/zh/guide/props.md
@@ -250,7 +250,7 @@ const codeBlockProps: NonNullable<NodeRendererProps['codeBlockProps']> = {
 - `d2-props`：透传给 `D2BlockNode`
 - `infographic-props`：透传给 `InfographicBlockNode`
 
-对于 Mermaid 和 Infographic 围栏，调用方未传入时 `MarkdownRender` 会自动注入 `estimatedPreviewHeightPx`，用于为异步加载和重新挂载预留稳定的首屏 preview 高度。自定义 `mermaid` / `infographic` 渲染器也会收到这个 prop；如果自定义块自己渲染 preview shell，应继续转发或使用它。
+对于 Mermaid、Infographic 和 D2 围栏，调用方未传入时 `MarkdownRender` 会自动注入 `estimatedPreviewHeightPx`，用于为异步加载和重新挂载预留稳定的首屏 preview 高度，避免图表替换源码面板时发生跳动。自定义 `mermaid` / `infographic` / `d2` 渲染器也会收到这个 prop；如果自定义块自己渲染 preview shell，应继续转发或使用它。
 
 示例：
 

--- a/src/components/D2BlockNode/D2BlockNode.vue
+++ b/src/components/D2BlockNode/D2BlockNode.vue
@@ -4,6 +4,7 @@ import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, useAttrs, 
 import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions } from '../../composables/viewportPriority'
+import { parsePositiveNumber } from '../../utils/diagramHeight'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
 import { getD2 } from './d2'
@@ -12,6 +13,7 @@ const props = withDefaults(
   defineProps<D2BlockNodeProps>(),
   {
     maxHeight: undefined,
+    estimatedPreviewHeightPx: undefined,
     loading: true,
     progressiveRender: true,
     progressiveIntervalMs: 700,
@@ -75,10 +77,33 @@ const hasPreview = computed(() => hasCurrentPreview.value || (!!svgMarkup.value 
 const showSourceFallback = computed(() => {
   return showSource.value || !d2Available.value || !hasPreview.value
 })
+
+// While the diagram is still being produced the source panel is what the block
+// renders, and it is much shorter than the finished diagram. Reserving the
+// estimated preview height here keeps the page below the block in place when
+// the preview replaces the source (measured ~238px of layout shift otherwise).
+//
+// The reservation is applied from the first paint on purpose: applying it once
+// the D2 runtime resolves moves the content just as much as the preview itself
+// would. It is released as soon as the preview can no longer be expected — the
+// user picked the source tab, a preview is on screen, the code is empty, or the
+// render already failed for this content — so an errored or unavailable diagram
+// does not hold blank space that will never be filled.
+const pendingPreviewReserve = computed(() => {
+  if (showSource.value || hasPreview.value)
+    return 0
+  if (!baseCode.value)
+    return 0
+  if (renderError.value && lastFailedRenderSignature.value === renderSignature.value)
+    return 0
+  return parsePositiveNumber(props.estimatedPreviewHeightPx) ?? 0
+})
+
 const bodyStyle = computed(() => {
-  if (!showSourceFallback.value || !bodyMinHeight.value)
+  if (!showSourceFallback.value)
     return undefined
-  return { minHeight: `${bodyMinHeight.value}px` }
+  const minHeight = Math.max(bodyMinHeight.value ?? 0, pendingPreviewReserve.value)
+  return minHeight > 0 ? { minHeight: `${minHeight}px` } : undefined
 })
 const renderStyle = computed(() => {
   if (props.maxHeight === 'none')
@@ -542,7 +567,11 @@ function updateBodyMinHeight() {
   const el = bodyRef.value
   if (!el)
     return
-  const height = el.getBoundingClientRect().height
+  // Measure the content, never the body itself: the body carries the reserved
+  // preview height, so reading it back would ratchet that reservation into a
+  // floor that can never shrink once the reservation is released.
+  const content = (el.firstElementChild as HTMLElement | null) ?? el
+  const height = content.getBoundingClientRect().height
   if (height > 0)
     bodyMinHeight.value = height
 }

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -304,16 +304,6 @@ function resolveInitialContainerHeight() {
   return `${resolveEstimatedPreviewHeight()}px`
 }
 
-// Keep a streamed diagram's reserved preview geometry even if an async
-// render temporarily falls back to the source panel. Without this floor the
-// source text is much shorter than the pending preview estimate and a pinned
-// scroll container observes a real height regression for one render tick.
-const streamingSourceMinHeight = computed(() => {
-  if (props.loading === false)
-    return undefined
-  return resolveInitialContainerHeight()
-})
-
 const lastSvgSnapshot = ref<string | null>(null)
 
 function hasPreviewSvg() {
@@ -338,6 +328,29 @@ const showSource = ref(true)
 const userToggledShowSource = ref(false)
 const isRendering = ref(false)
 const renderQueue = ref<Promise<boolean> | null>(null)
+
+// Keep a streamed diagram's reserved preview geometry even if an async render
+// temporarily falls back to the source panel. Without this floor the source
+// text is much shorter than the pending preview estimate and a pinned scroll
+// container observes a real height regression for one render tick.
+//
+// The floor must also hold once streaming finishes while the source panel is
+// still the active one: the panel is what the block renders until mermaid
+// resolves, and dropping the floor at that point collapses the block (measured
+// 435px → 233px → 435px on the playground, ~0.11 CLS) before the preview takes
+// over. It is dropped once a preview is on screen, when the user explicitly
+// chose the source view, and once availability resolves to "no runtime", so
+// none of those cases gains empty reserved space.
+const streamingSourceMinHeight = computed(() => {
+  if (hasPreviewSvg())
+    return undefined
+  if (mermaidAvailabilityResolved.value && !mermaidAvailable.value)
+    return undefined
+  if (!showSource.value || userToggledShowSource.value)
+    return undefined
+  return resolveInitialContainerHeight()
+})
+
 interface MermaidRenderRequest {
   code: string
   codeWithTheme: string

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -325,9 +325,43 @@ const translateY = ref(0)
 const isDragging = ref(false)
 const dragStart = ref({ x: 0, y: 0 })
 const showSource = ref(true)
-const userToggledShowSource = ref(false)
+// Set by switchMode() — either the user picking a mode, or the block switching
+// itself to the preview once streamed content stabilizes. It means "the mode has
+// been chosen on purpose", not "the user chose it", and it is never reset.
+const modeChosenExplicitly = ref(false)
 const isRendering = ref(false)
 const renderQueue = ref<Promise<boolean> | null>(null)
+
+// A consumer loader that never settles would otherwise hold the reservation for
+// the life of the block (getMermaid() has no timeout of its own). This bound
+// starts only once the block is on screen with availability still unresolved, so
+// an offscreen deferred block is not penalised; a diagram that does arrive after
+// the bound simply takes the preview over.
+const MERMAID_RESERVED_HEIGHT_MAX_WAIT_MS = 15_000
+const availabilityWaitExpired = ref(false)
+let availabilityWaitTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearAvailabilityWaitTimer() {
+  if (availabilityWaitTimer != null) {
+    clearTimeout(availabilityWaitTimer)
+    availabilityWaitTimer = null
+  }
+}
+
+watch(
+  [viewportReady, mermaidAvailabilityResolved],
+  ([ready, resolved]) => {
+    clearAvailabilityWaitTimer()
+    availabilityWaitExpired.value = false
+    if (!ready || resolved)
+      return
+    availabilityWaitTimer = setTimeout(() => {
+      availabilityWaitTimer = null
+      availabilityWaitExpired.value = true
+    }, MERMAID_RESERVED_HEIGHT_MAX_WAIT_MS)
+  },
+  { immediate: true },
+)
 
 // Keep a streamed diagram's reserved preview geometry even if an async render
 // temporarily falls back to the source panel. Without this floor the source
@@ -338,15 +372,21 @@ const renderQueue = ref<Promise<boolean> | null>(null)
 // still the active one: the panel is what the block renders until mermaid
 // resolves, and dropping the floor at that point collapses the block (measured
 // 435px → 233px → 435px on the playground, ~0.11 CLS) before the preview takes
-// over. It is dropped once a preview is on screen, when the user explicitly
-// chose the source view, and once availability resolves to "no runtime", so
-// none of those cases gains empty reserved space.
+// over. It is dropped when the preview becomes the visible panel (showSource is
+// false), when an explicit mode switch picked the source view, and once
+// availability resolves to "no runtime", so none of those cases gains empty
+// reserved space.
+//
+// The one way to wait forever is a loader that never settles: getMermaid() has
+// no timeout of its own, so a consumer loader that hangs would keep the floor
+// (and its blank space) for the life of the block. `availabilityWaitExpired`
+// bounds that wait below.
 const streamingSourceMinHeight = computed(() => {
-  if (hasPreviewSvg())
-    return undefined
   if (mermaidAvailabilityResolved.value && !mermaidAvailable.value)
     return undefined
-  if (!showSource.value || userToggledShowSource.value)
+  if (!showSource.value || modeChosenExplicitly.value)
+    return undefined
+  if (availabilityWaitExpired.value)
     return undefined
   return resolveInitialContainerHeight()
 })
@@ -1417,7 +1457,7 @@ function handleSwitchMode(target: 'source' | 'preview') {
 async function switchMode(target: 'source' | 'preview') {
   const el = modeContainerRef.value
   if (!el) {
-    userToggledShowSource.value = true
+    modeChosenExplicitly.value = true
     showSource.value = (target === 'source')
     return
   }
@@ -1427,7 +1467,7 @@ async function switchMode(target: 'source' | 'preview') {
   el.style.overflow = 'hidden'
 
   // Toggle mode
-  userToggledShowSource.value = true
+  modeChosenExplicitly.value = true
   showSource.value = (target === 'source')
   await nextTick()
 
@@ -2209,8 +2249,9 @@ async function activateMermaid() {
   await nextTick()
   if (!isActiveGeneration(generation))
     return
-  // Set initial default tab based on mermaid availability (unless user already toggled)
-  if (!userToggledShowSource.value) {
+  // Set the initial default tab from mermaid availability unless a mode was
+  // already chosen (by the user, or by the stabilize-then-preview switch).
+  if (!modeChosenExplicitly.value) {
     showSource.value = !mermaidAvailable.value
   }
   if (canScheduleViewportWork()) {
@@ -2230,11 +2271,11 @@ onMounted(() => {
   void activateMermaid()
 })
 
-// Auto-update default tab when mermaid availability changes, but don't override user actions
+// Auto-update default tab when mermaid availability changes, but don't override a mode that was already chosen
 watch(
   () => mermaidAvailable.value,
   (available) => {
-    if (userToggledShowSource.value)
+    if (modeChosenExplicitly.value)
       return
     showSource.value = !available
   },
@@ -2289,6 +2330,7 @@ onUnmounted(() => {
   if (contentStableTimer) {
     clearTimeout(contentStableTimer)
   }
+  clearAvailabilityWaitTimer()
   clearProgressiveRenderDebounceTimer()
   // 在组件卸载时，确保观察者被彻底清理，防止内存泄漏
   if (resizeObserver) {

--- a/src/components/NodeRenderer/D2BlockNodeLoading.ts
+++ b/src/components/NodeRenderer/D2BlockNodeLoading.ts
@@ -29,9 +29,18 @@ export const D2BlockNodeLoading = defineComponent({
     ))
     return () => h('div', {
       'class': 'd2-block-container rounded-lg border overflow-hidden',
+      // `d2-block-container` and `d2-label` are scoped to D2BlockNode.vue
+      // (`.d2-block-container[data-v-…]`), so a `.ts` render function — which has
+      // no scope id — inherits none of them. The surface styles the block relies
+      // on have to be inline here or the loading shell renders on a transparent
+      // background with a full-size label, and the block visibly changes when
+      // the real component takes over.
       'style': {
         margin: 'var(--ms-flow-diagram-y) 0',
+        background: 'var(--diagram-bg)',
         borderColor: 'var(--diagram-border)',
+        color: 'hsl(var(--ms-foreground))',
+        boxShadow: 'var(--ms-shadow-subtle)',
       },
       'data-markstream-d2': '1',
       'data-markstream-mode': 'pending',
@@ -48,7 +57,10 @@ export const D2BlockNodeLoading = defineComponent({
             h('div', { class: 'flex items-center gap-x-2' }, [
               h('span', {
                 class: 'd2-label font-medium font-mono',
-                style: { color: 'var(--code-action-fg)' },
+                style: {
+                  fontSize: 'var(--ms-text-label)',
+                  color: 'var(--code-action-fg)',
+                },
               }, 'D2'),
             ]),
             h('div', {

--- a/src/components/NodeRenderer/D2BlockNodeLoading.ts
+++ b/src/components/NodeRenderer/D2BlockNodeLoading.ts
@@ -1,0 +1,68 @@
+import type { ParsedNode } from 'stream-markdown-parser'
+import { computed, defineComponent, h } from 'vue'
+import { clampD2PreviewHeight, estimateD2PreviewHeight, parsePositiveNumber } from '../../utils/diagramHeight'
+
+type RuntimeCodeBlockNode = ParsedNode & {
+  type: 'code_block'
+  language?: string
+  loading?: boolean
+  code?: string
+  raw?: string
+}
+
+/**
+ * Placeholder shown while the D2 renderer chunk loads. It reserves the same
+ * estimated preview height the finished block uses so the diagram's first paint
+ * does not push the content below it down.
+ */
+export const D2BlockNodeLoading = defineComponent({
+  name: 'D2BlockNodeLoading',
+  props: {
+    node: { type: Object, required: true },
+    showHeader: { type: Boolean, default: true },
+    estimatedPreviewHeightPx: { type: Number, default: undefined },
+  },
+  setup(loadingProps) {
+    const height = computed(() => clampD2PreviewHeight(
+      parsePositiveNumber(loadingProps.estimatedPreviewHeightPx)
+      ?? estimateD2PreviewHeight(String((loadingProps.node as RuntimeCodeBlockNode).code ?? '')),
+    ))
+    return () => h('div', {
+      'class': 'd2-block-container rounded-lg border overflow-hidden',
+      'style': {
+        margin: 'var(--ms-flow-diagram-y) 0',
+        borderColor: 'var(--diagram-border)',
+      },
+      'data-markstream-d2': '1',
+      'data-markstream-mode': 'pending',
+    }, [
+      loadingProps.showHeader
+        ? h('div', {
+            class: 'd2-block-header flex justify-between items-center border-b',
+            style: {
+              padding: 'var(--ms-inset-panel-y) var(--ms-inset-panel-x)',
+              background: 'var(--diagram-header-bg)',
+              borderColor: 'var(--diagram-border)',
+            },
+          }, [
+            h('div', { class: 'flex items-center gap-x-2' }, [
+              h('span', {
+                class: 'd2-label font-medium font-mono',
+                style: { color: 'var(--code-action-fg)' },
+              }, 'D2'),
+            ]),
+            h('div', {
+              'class': 'd2-header-actions flex items-center',
+              'aria-hidden': 'true',
+            }),
+          ])
+        : null,
+      h('div', {
+        class: 'd2-block-body',
+        style: {
+          minHeight: `${height.value}px`,
+        },
+      }),
+    ])
+  },
+})

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -63,7 +63,7 @@ import {
 import { getCodeBlockExtraProps } from '../../utils/codeBlockExtraProps'
 import { getCustomCodeLanguageComponent } from '../../utils/customCodeLanguageComponent'
 import { isDevEnvironment } from '../../utils/devEnv'
-import { clampInfographicPreviewHeight, clampMermaidPreviewHeight, estimateInfographicPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber } from '../../utils/diagramHeight'
+import { clampD2PreviewHeight, clampInfographicPreviewHeight, clampMermaidPreviewHeight, estimateD2PreviewHeight, estimateInfographicPreviewHeight, estimateMermaidPreviewHeight, parsePositiveNumber } from '../../utils/diagramHeight'
 import { getCustomNodeAttrs, getHtmlTagFromContent, shouldRenderUnknownHtmlTagAsText, stripCustomHtmlWrapper } from '../../utils/htmlRenderer'
 import { isReservedNodeComponentKey, useCustomNodeComponents } from '../../utils/nodeComponents'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
@@ -88,6 +88,7 @@ import { useScrollListener } from './composables/useScrollListener'
 import { useScrollRestore } from './composables/useScrollRestore'
 import { useSmoothStreamingBridge } from './composables/useSmoothStreamingBridge'
 import { useViewportRoot } from './composables/useViewportRoot'
+import { D2BlockNodeLoading } from './D2BlockNodeLoading'
 import FallbackComponent from './FallbackComponent.vue'
 import HeightEstimationProbes from './HeightEstimationProbes.vue'
 import { InfographicBlockNodeLoading } from './InfographicBlockNodeLoading'
@@ -790,6 +791,7 @@ const virtualScrollDomEnabled = computed(() => Boolean(
   && virtualScrollEnabled.value,
 ))
 const heightEstimationActive = computed(() => heightExperimentEnabled.value || virtualScrollEnabled.value)
+
 const heightEstimationDomActive = computed(() => heightExperimentEnabled.value || virtualScrollDomEnabled.value)
 const textEstimationEnabled = computed(() => {
   return heightEstimationActive.value
@@ -5480,23 +5482,27 @@ const InfographicBlockNodeAsync = withViewportDeferredLoading(
   InfographicBlockNodeLoading,
 )
 
-const D2BlockNodeInnerAsync = defineAsyncComponent(async () => {
-  try {
-    const mod = await import('../../components/D2BlockNode')
-    return mod.default
-  }
-  catch (e) {
-    console.warn(
-      '[markstream-vue] Optional peer dependencies for D2BlockNode are missing. Falling back to preformatted code rendering. To enable D2 rendering, please install "@terrastruct/d2".',
-      e,
-    )
-    return PreCodeNode
-  }
+const D2BlockNodeInnerAsync = defineAsyncComponent({
+  loader: async () => {
+    try {
+      const mod = await import('../../components/D2BlockNode')
+      return mod.default
+    }
+    catch (e) {
+      console.warn(
+        '[markstream-vue] Optional peer dependencies for D2BlockNode are missing. Falling back to preformatted code rendering. To enable D2 rendering, please install "@terrastruct/d2".',
+        e,
+      )
+      return PreCodeNode
+    }
+  },
+  loadingComponent: D2BlockNodeLoading,
+  delay: 0,
 })
 const D2BlockNodeAsync = withViewportDeferredLoading(
   'ViewportDeferredD2BlockNode',
   D2BlockNodeInnerAsync,
-  PreCodeNode,
+  D2BlockNodeLoading,
 )
 
 // 组件映射表
@@ -6145,6 +6151,10 @@ function getInfographicBindingsFor(node: ParsedNode) {
   return getPreviewBindingsFor(infographicBindings, node, estimateInfographicPreviewHeight, clampInfographicPreviewHeight)
 }
 
+function getD2BindingsFor(node: ParsedNode) {
+  return getPreviewBindingsFor(d2Bindings, node, estimateD2PreviewHeight, clampD2PreviewHeight)
+}
+
 // Decide which component to use for a given node. Ensure that code blocks
 // with language `mermaid` are rendered with `MermaidBlockNode` (unless a
 // custom component named `mermaid` is registered for the given customId).
@@ -6227,7 +6237,7 @@ function getBindingsFor(node: ParsedNode, language?: string, component?: unknown
         return getInfographicBindingsFor(node)
 
       if (lang === 'd2' || lang === 'd2lang')
-        return d2Bindings.value
+        return getD2BindingsFor(node)
 
       return customCodeBlockBindings.value
     }
@@ -6243,7 +6253,7 @@ function getBindingsFor(node: ParsedNode, language?: string, component?: unknown
     return getInfographicBindingsFor(node)
 
   if (lang === 'd2' || lang === 'd2lang')
-    return d2Bindings.value
+    return getD2BindingsFor(node)
 
   if (node.type === 'link')
     return linkBindings.value

--- a/src/components/NodeRenderer/NodeRenderer.vue
+++ b/src/components/NodeRenderer/NodeRenderer.vue
@@ -54,6 +54,7 @@ import { DEFAULT_VIEWPORT_PRIORITY_ROOT_MARGIN, provideOffscreenHeavyNodeDeferra
 import {
   buildBlockTextProfile,
   createEmptySimpleTextProbeProfile,
+  ensureHeightEstimationRuntimeLoaded,
   estimateCodeBlockHeight,
   estimateSimpleTextBlockHeight,
   getHeightEstimationExperiment,
@@ -791,6 +792,19 @@ const virtualScrollDomEnabled = computed(() => Boolean(
   && virtualScrollEnabled.value,
 ))
 const heightEstimationActive = computed(() => heightExperimentEnabled.value || virtualScrollEnabled.value)
+
+// The text estimator's runtime is loaded on demand (it is heavy and most
+// consumers never estimate heights). Start that load as soon as estimation is
+// active so the fallback-height window is as short as possible instead of
+// waiting for the first estimation request.
+watch(
+  heightEstimationActive,
+  (active) => {
+    if (active)
+      void ensureHeightEstimationRuntimeLoaded()
+  },
+  { immediate: true },
+)
 
 const heightEstimationDomActive = computed(() => heightExperimentEnabled.value || virtualScrollDomEnabled.value)
 const textEstimationEnabled = computed(() => {

--- a/src/internal/heightEstimationExperiment.ts
+++ b/src/internal/heightEstimationExperiment.ts
@@ -1,7 +1,6 @@
 import type { PreparedText } from '@chenglou/pretext'
 import type { ParsedNode } from 'stream-markdown-parser'
 import type { CodeBlockOptions } from '../types/component-props'
-import { layout, prepare } from '@chenglou/pretext'
 import { shallowRef } from 'vue'
 import { resolveDiffInlineLayout } from '../components/CodeBlockNode/codeBlockHeader'
 import { resolvePreCodeVisualOptions } from '../components/PreCodeNode/preCodeVisual'
@@ -133,6 +132,43 @@ const store: HeightEstimationExperimentStore = (() => {
 
 let canPrepareTextSupport: boolean | null = null
 
+type PretextModule = typeof import('@chenglou/pretext')
+
+// `@chenglou/pretext` is a text-measurement engine that is only reachable when
+// the height experiment or virtual scrolling is active. Importing it statically
+// pulled its whole bidi/line-break/analysis implementation (tens of KB) into the
+// renderer's main chunk for every consumer, including the many that never
+// estimate a single height. It is therefore loaded on demand: the first
+// estimation request starts the import and returns no estimate, and the module
+// resolving bumps the experiment revision so the renderer recomputes heights
+// with the real estimator.
+let pretextModule: PretextModule | null = null
+let pretextLoadPromise: Promise<PretextModule> | null = null
+
+export function ensureHeightEstimationRuntimeLoaded(): Promise<void> | null {
+  if (pretextModule || typeof window === 'undefined')
+    return null
+
+  if (!pretextLoadPromise) {
+    pretextLoadPromise = import('@chenglou/pretext')
+      .then((module) => {
+        pretextModule = module
+        // Estimates produced before the runtime was ready fell back to the
+        // renderer's default heights; invalidate them so the next pass uses
+        // the loaded estimator.
+        store.revision.value++
+        return module
+      })
+      .catch(() => {
+        // Leave the promise resolved-but-empty so later calls do not retry the
+        // failed import on every node; estimation stays on the fallback path.
+        return null as unknown as PretextModule
+      })
+  }
+
+  return pretextLoadPromise.then(() => undefined)
+}
+
 export const heightEstimationExperimentRevision = store.revision
 
 export function setHeightEstimationExperiment(customId: string, config: HeightEstimationExperimentConfig) {
@@ -199,7 +235,7 @@ function parsePositiveNumber(raw: string | null | undefined, fallback: number) {
   return Number.isFinite(value) && value > 0 ? value : fallback
 }
 
-function getPreparedText(text: string, font: string, whiteSpace: WhiteSpaceMode) {
+function getPreparedText(pretext: PretextModule, text: string, font: string, whiteSpace: WhiteSpaceMode) {
   const key = `${whiteSpace}\u0000${font}\u0000${text}`
   const cached = store.preparedCache.get(key)
   if (cached) {
@@ -207,7 +243,7 @@ function getPreparedText(text: string, font: string, whiteSpace: WhiteSpaceMode)
     store.preparedCache.set(key, cached)
     return cached.prepared
   }
-  const prepared = prepare(text, font, { whiteSpace })
+  const prepared = pretext.prepare(text, font, { whiteSpace })
   store.preparedCache.set(key, { prepared })
   while (store.preparedCache.size > PREPARED_CACHE_LIMIT) {
     const oldestKey = store.preparedCache.keys().next().value
@@ -242,6 +278,17 @@ function flattenSimpleInlineChildren(children: any[] | undefined): string | null
 function estimateBlockTextHeight(text: string, width: number, profile: BlockTextProfile) {
   if (!text || !Number.isFinite(width) || width <= 0 || !canPrepareText())
     return null
+
+  const pretext = pretextModule
+  if (!pretext) {
+    // Start the on-demand load; this call (and any other before the module
+    // resolves) reports "no estimate" so the caller keeps using its fallback
+    // heights. The load completion bumps the experiment revision, which makes
+    // the renderer recompute estimates with the real engine.
+    void ensureHeightEstimationRuntimeLoaded()
+    return null
+  }
+
   try {
     const roundedWidth = Math.round(width * 100) / 100
     const cacheKey = [
@@ -264,9 +311,9 @@ function estimateBlockTextHeight(text: string, width: number, profile: BlockText
       }
     }
     const whiteSpace = profile.whiteSpace ?? 'pre-wrap'
-    const prepared = getPreparedText(text, profile.font, whiteSpace)
+    const prepared = getPreparedText(pretext, text, profile.font, whiteSpace)
     const layoutWidth = Math.max(24, roundedWidth - profile.widthAdjustment)
-    const result = layout(prepared, layoutWidth, profile.lineHeight)
+    const result = pretext.layout(prepared, layoutWidth, profile.lineHeight)
     const contentHeight = Math.max(profile.lineHeight, result.height)
     const height = Math.max(profile.lineHeight, Math.round(contentHeight + profile.wrapperOverhead))
     store.blockEstimateCache.set(cacheKey, {

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -210,6 +210,7 @@ export interface MermaidBlockEvent<TPayload = unknown> {
 export interface D2BlockNodeProps {
   node: CodeBlockNode
   maxHeight?: string | null
+  estimatedPreviewHeightPx?: number
   loading?: boolean
   isDark?: boolean
   progressiveRender?: boolean

--- a/src/utils/diagramHeight.ts
+++ b/src/utils/diagramHeight.ts
@@ -3,7 +3,10 @@ export const MERMAID_PREVIEW_MAX_HEIGHT = 500
 export const INFOGRAPHIC_PREVIEW_MIN_HEIGHT = 360
 export const INFOGRAPHIC_PREVIEW_MAX_HEIGHT = 500
 export const D2_PREVIEW_MIN_HEIGHT = 240
-export const D2_PREVIEW_MAX_HEIGHT = 520
+// Matches the rendered preview's own cap (--ms-size-code-max-height, 500px):
+// reserving more than the preview can occupy would trade the growth shift for a
+// shrink shift once the diagram resolves.
+export const D2_PREVIEW_MAX_HEIGHT = 500
 
 export function parsePositiveNumber(value: unknown) {
   const numeric = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''))
@@ -88,6 +91,60 @@ export function clampD2PreviewHeight(
   return clampPreviewHeight(height, minHeight, maxHeight)
 }
 
+// D2 keywords that configure a diagram or a shape instead of declaring one.
+// They take a scalar value (`direction: right`, `shape: cylinder`) and must not
+// be counted as shapes.
+const D2_DIRECTIVE_KEYS = new Set([
+  'direction',
+  'label',
+  'shape',
+  'icon',
+  'near',
+  'link',
+  'tooltip',
+  'width',
+  'height',
+  'grid-rows',
+  'grid-columns',
+  'grid-gap',
+  'vertical-gap',
+  'horizontal-gap',
+  'class',
+  'constraint',
+  'source-arrowhead',
+  'target-arrowhead',
+])
+
+// These open a block of settings, so every line up to the closing brace is a
+// setting as well (`vars: { d2-config: { layout-engine: elk } }`).
+const D2_DIRECTIVE_BLOCK_KEYS = new Set([
+  'vars',
+  'classes',
+  'style',
+  'layers',
+  'scenarios',
+  'steps',
+])
+
+function braceDepthDelta(line: string) {
+  let depth = 0
+  let inString = false
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index]
+    if (char === '"' || char === '\'') {
+      inString = !inString
+      continue
+    }
+    if (inString)
+      continue
+    if (char === '{')
+      depth += 1
+    else if (char === '}')
+      depth -= 1
+  }
+  return depth
+}
+
 /**
  * Estimates the height a D2 diagram will occupy before its runtime has produced
  * the SVG. The source panel is much shorter than the rendered diagram, so
@@ -97,21 +154,49 @@ export function clampD2PreviewHeight(
  * The estimate deliberately errs low: the renderer keeps the measured source
  * height as a floor as well, so a low estimate never shrinks the block, and any
  * residual growth is smaller than the un-reserved jump.
+ *
+ * `key: value` lines are shapes unless the key is a known directive. D2 declares
+ * a shape's label that way (`client: Web Client`) and containers use it as well
+ * (`server: {`), so treating every `key:` line as a directive — the first cut of
+ * this estimator — measured labelled diagrams as if they had no shapes at all
+ * and reserved the 240px floor for them.
  */
 export function estimateD2PreviewHeight(code: string) {
-  const { lineCount, nodeCount } = code
-    .split(/\r?\n/)
-    .reduce<{ lineCount: number, nodeCount: number }>((acc, rawLine) => {
-      const line = rawLine.trim()
-      if (!line || line.startsWith('#') || line.startsWith('...'))
-        return acc
-      // `direction`, `vars`, `style` and similar are directives, not shapes.
-      const isDirective = /^[A-Z_][\w-]*\s*:/i.test(line)
-      if (!isDirective)
-        acc.nodeCount += 1
-      acc.lineCount += 1
-      return acc
-    }, { lineCount: 0, nodeCount: 0 })
+  let lineCount = 0
+  let nodeCount = 0
+  let directiveBlockDepth = 0
+
+  for (const rawLine of code.split(/\r?\n/)) {
+    const line = rawLine.trim()
+
+    // Inside `vars`/`classes`/`style`/... every line is a setting, not a shape.
+    if (directiveBlockDepth > 0) {
+      directiveBlockDepth = Math.max(0, directiveBlockDepth + braceDepthDelta(line))
+      continue
+    }
+
+    if (!line || line.startsWith('#') || line.startsWith('...'))
+      continue
+    if (/^[}\]]+$/.test(line))
+      continue
+
+    const declaration = line.match(/^([A-Z_][\w-]*)\s*:(.*)$/i)
+    if (declaration) {
+      const key = declaration[1].toLowerCase()
+      if (D2_DIRECTIVE_BLOCK_KEYS.has(key)) {
+        lineCount += 1
+        directiveBlockDepth = Math.max(0, braceDepthDelta(declaration[2]))
+        continue
+      }
+      if (D2_DIRECTIVE_KEYS.has(key)) {
+        lineCount += 1
+        continue
+      }
+    }
+
+    nodeCount += 1
+    lineCount += 1
+  }
 
   // Rank-direction diagrams grow with depth, not with row count, so the node
   // count dominates; each node contributes a box plus surrounding spacing.

--- a/src/utils/diagramHeight.ts
+++ b/src/utils/diagramHeight.ts
@@ -2,6 +2,8 @@ export const MERMAID_PREVIEW_MIN_HEIGHT = 360
 export const MERMAID_PREVIEW_MAX_HEIGHT = 500
 export const INFOGRAPHIC_PREVIEW_MIN_HEIGHT = 360
 export const INFOGRAPHIC_PREVIEW_MAX_HEIGHT = 500
+export const D2_PREVIEW_MIN_HEIGHT = 240
+export const D2_PREVIEW_MAX_HEIGHT = 520
 
 export function parsePositiveNumber(value: unknown) {
   const numeric = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''))
@@ -76,4 +78,44 @@ export function clampInfographicPreviewHeight(
   maxHeight: number | null = INFOGRAPHIC_PREVIEW_MAX_HEIGHT,
 ) {
   return clampPreviewHeight(height, minHeight, maxHeight)
+}
+
+export function clampD2PreviewHeight(
+  height: number,
+  minHeight = D2_PREVIEW_MIN_HEIGHT,
+  maxHeight: number | null = D2_PREVIEW_MAX_HEIGHT,
+) {
+  return clampPreviewHeight(height, minHeight, maxHeight)
+}
+
+/**
+ * Estimates the height a D2 diagram will occupy before its runtime has produced
+ * the SVG. The source panel is much shorter than the rendered diagram, so
+ * without a reservation the whole page below the block is pushed down when the
+ * preview appears (measured ~238px, ~0.10 CLS on the playground).
+ *
+ * The estimate deliberately errs low: the renderer keeps the measured source
+ * height as a floor as well, so a low estimate never shrinks the block, and any
+ * residual growth is smaller than the un-reserved jump.
+ */
+export function estimateD2PreviewHeight(code: string) {
+  const { lineCount, nodeCount } = code
+    .split(/\r?\n/)
+    .reduce<{ lineCount: number, nodeCount: number }>((acc, rawLine) => {
+      const line = rawLine.trim()
+      if (!line || line.startsWith('#') || line.startsWith('...'))
+        return acc
+      // `direction`, `vars`, `style` and similar are directives, not shapes.
+      const isDirective = /^[A-Z_][\w-]*\s*:/i.test(line)
+      if (!isDirective)
+        acc.nodeCount += 1
+      acc.lineCount += 1
+      return acc
+    }, { lineCount: 0, nodeCount: 0 })
+
+  // Rank-direction diagrams grow with depth, not with row count, so the node
+  // count dominates; each node contributes a box plus surrounding spacing.
+  const estimated = 120 + Math.max(1, nodeCount) * 46 + Math.max(0, lineCount - nodeCount) * 8
+
+  return clampPreviewHeight(estimated, D2_PREVIEW_MIN_HEIGHT, D2_PREVIEW_MAX_HEIGHT)
 }

--- a/test/d2-block-node-availability.test.ts
+++ b/test/d2-block-node-availability.test.ts
@@ -1,0 +1,65 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+const state = vi.hoisted(() => ({ available: true }))
+
+vi.mock('../src/components/D2BlockNode/d2', () => ({
+  getD2: vi.fn(async () => {
+    if (!state.available)
+      return null
+    return class FakeD2 {
+      async compile(code: string) {
+        return { diagram: { code }, renderOptions: {} }
+      }
+
+      async render(diagram: { code: string }) {
+        return { svg: `<svg viewBox="0 0 100 100"><text>${diagram.code}</text></svg>` }
+      }
+    }
+  }),
+}))
+
+beforeEach(() => {
+  state.available = true
+})
+
+async function settle() {
+  for (let i = 0; i < 8; i++) {
+    await nextTick()
+    await Promise.resolve()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+  }
+}
+
+describe('d2 block runtime availability', () => {
+  it('releases the preview reservation when the d2 runtime is unavailable', async () => {
+    state.available = false
+    // A fresh module registry keeps the component's module-scoped d2 instance
+    // cache from leaking a previous test's instance into this case.
+    vi.resetModules()
+    const D2BlockNode = (await import('../src/components/D2BlockNode/D2BlockNode.vue')).default
+
+    const wrapper = mount(D2BlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'd2',
+          code: 'a -> b',
+          raw: '```d2\na -> b\n```',
+        },
+        loading: false,
+        estimatedPreviewHeightPx: 445,
+      },
+      attachTo: document.body,
+    })
+
+    await settle()
+
+    const style = wrapper.get('.d2-block-body').attributes('style') || ''
+    expect(style).not.toContain('445px')
+    expect(wrapper.find('.d2-error').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+})

--- a/test/d2-block-node-layout.test.ts
+++ b/test/d2-block-node-layout.test.ts
@@ -112,6 +112,131 @@ describe('d2 block layout', () => {
     wrapper.unmount()
   })
 
+  it('reserves the estimated preview height while the diagram is pending', async () => {
+    d2MockState.renderImpl = async (code) => {
+      await new Promise(resolve => setTimeout(resolve, 30))
+      return { svg: `<svg viewBox="0 0 100 100"><text>${code}</text></svg>` }
+    }
+
+    const wrapper = mount(D2BlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'd2',
+          code: 'a -> b',
+          raw: '```d2\na -> b\n```',
+        },
+        loading: false,
+        estimatedPreviewHeightPx: 445,
+      },
+      attachTo: document.body,
+    })
+
+    await nextTick()
+    expect(wrapper.get('.d2-block-body').attributes('style') || '').toContain('445px')
+
+    await waitForPreview(wrapper)
+    await nextTick()
+    // The reservation is released once the rendered diagram governs the height.
+    expect(wrapper.get('.d2-block-body').attributes('style') || '').not.toContain('445px')
+
+    wrapper.unmount()
+  })
+
+  it('releases the preview reservation when rendering fails permanently', async () => {
+    d2MockState.renderImpl = async () => {
+      throw new Error('boom')
+    }
+
+    const wrapper = mount(D2BlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'd2',
+          code: 'a -> b',
+          raw: '```d2\na -> b\n```',
+        },
+        loading: false,
+        estimatedPreviewHeightPx: 445,
+      },
+      attachTo: document.body,
+    })
+
+    await waitForRenderError(wrapper)
+
+    // A diagram that will never render must not hold blank space: the source
+    // panel keeps its own natural height.
+    const style = wrapper.get('.d2-block-body').attributes('style') || ''
+    expect(style).not.toContain('445px')
+    expect((wrapper.vm as any).$?.setupState?.bodyMinHeight ?? null).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('does not reserve preview height for empty code', async () => {
+    const wrapper = mount(D2BlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'd2',
+          code: '',
+          raw: '```d2\n```',
+        },
+        loading: false,
+        estimatedPreviewHeightPx: 445,
+      },
+      attachTo: document.body,
+    })
+
+    await nextTick()
+    expect(wrapper.get('.d2-block-body').attributes('style') || '').not.toContain('445px')
+
+    wrapper.unmount()
+  })
+
+  it('stores the content height, not the reserved body height, as the fallback floor', async () => {
+    // jsdom reports zero-height rects, so stand in for the browser: the body
+    // would measure the reserved height, its content measures the real one.
+    const rect = (height: number): DOMRect => ({
+      x: 0,
+      y: 0,
+      width: 0,
+      height,
+      top: 0,
+      right: 0,
+      bottom: height,
+      left: 0,
+      toJSON: () => ({}),
+    }) as DOMRect
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.classList.contains('d2-block-body') ? rect(445) : rect(210)
+      })
+
+    const wrapper = mount(D2BlockNode as any, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'd2',
+          code: 'a -> b',
+          raw: '```d2\na -> b\n```',
+        },
+        loading: false,
+        estimatedPreviewHeightPx: 445,
+      },
+      attachTo: document.body,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect((wrapper.vm as any).$?.setupState?.bodyMinHeight).toBe(210)
+
+    wrapper.unmount()
+    rectSpy.mockRestore()
+  })
+
   it('reports async render lifecycle height when preview settles', async () => {
     const heightSpy = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(96)
     const lifecycle = {

--- a/test/diagram-height-estimation.test.ts
+++ b/test/diagram-height-estimation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clampD2PreviewHeight,
+  D2_PREVIEW_MAX_HEIGHT,
+  D2_PREVIEW_MIN_HEIGHT,
+  estimateD2PreviewHeight,
+} from '../src/utils/diagramHeight'
+
+describe('estimateD2PreviewHeight', () => {
+  it('counts labelled shapes as shapes', () => {
+    // `client: Web Client` is how D2 labels a shape: the key is the shape, the
+    // value its label. Counting those lines as directives reserved the floor
+    // (240px) for the diagrams that need a reservation the most.
+    expect(estimateD2PreviewHeight('client: Web Client\napi: API Service\nclient -> api'))
+      .toBe(estimateD2PreviewHeight('client\napi\nclient -> api'))
+  })
+
+  it('keeps counting the documented directives as settings', () => {
+    expect(estimateD2PreviewHeight('direction: right\na -> b'))
+      .toBe(estimateD2PreviewHeight('a -> b'))
+    expect(estimateD2PreviewHeight('shape: cylinder\nlabel: Server\nicon: https://example.com/i.svg\na'))
+      .toBe(estimateD2PreviewHeight('a'))
+  })
+
+  it('ignores the contents of directive blocks', () => {
+    const withoutBlocks = estimateD2PreviewHeight('a -> b')
+    expect(estimateD2PreviewHeight('vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\na -> b'))
+      .toBe(withoutBlocks)
+    expect(estimateD2PreviewHeight('style: {\n  fill: "#eee"\n}\na -> b'))
+      .toBe(withoutBlocks)
+    expect(estimateD2PreviewHeight('classes: { big: { style: { font-size: 40 } } }\na -> b'))
+      .toBe(withoutBlocks)
+  })
+
+  it('counts container declarations and their children', () => {
+    // Both the container and the shapes inside it occupy space.
+    expect(estimateD2PreviewHeight('server: {\n  api\n  db\n}\nserver -> client'))
+      .toBeGreaterThan(estimateD2PreviewHeight('server -> client'))
+  })
+
+  it('reserves more for a labelled stack than for a directive-only block', () => {
+    const labelled = Array.from({ length: 8 }, (_, index) => `n${index}: Node ${index}`).join('\n')
+    expect(estimateD2PreviewHeight(labelled)).toBeGreaterThan(D2_PREVIEW_MIN_HEIGHT)
+  })
+
+  it('stays inside the clamp range', () => {
+    expect(estimateD2PreviewHeight('')).toBe(D2_PREVIEW_MIN_HEIGHT)
+    expect(estimateD2PreviewHeight('# just a comment\n...'))
+      .toBe(D2_PREVIEW_MIN_HEIGHT)
+    expect(estimateD2PreviewHeight(Array.from({ length: 200 }, (_, index) => `n${index}: Node ${index}`).join('\n')))
+      .toBe(D2_PREVIEW_MAX_HEIGHT)
+  })
+})
+
+describe('clampD2PreviewHeight', () => {
+  it('caps the reservation at the height the preview itself can occupy', () => {
+    // The rendered preview is capped by --ms-size-code-max-height (500px), so a
+    // larger reservation would trade the growth shift for a shrink shift.
+    expect(clampD2PreviewHeight(9_000)).toBe(500)
+    expect(D2_PREVIEW_MAX_HEIGHT).toBe(500)
+    expect(clampD2PreviewHeight(1)).toBe(D2_PREVIEW_MIN_HEIGHT)
+    expect(clampD2PreviewHeight(320)).toBe(320)
+    expect(clampD2PreviewHeight(9_000, undefined, null)).toBe(9_000)
+  })
+})

--- a/test/diagram-loading-shell.test.ts
+++ b/test/diagram-loading-shell.test.ts
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { D2BlockNodeLoading } from '../src/components/NodeRenderer/D2BlockNodeLoading'
+import { InfographicBlockNodeLoading } from '../src/components/NodeRenderer/InfographicBlockNodeLoading'
+import { MermaidBlockNodeLoading } from '../src/components/NodeRenderer/MermaidBlockNodeLoading'
+
+function diagramNode(language: string, code: string) {
+  return {
+    type: 'code_block',
+    language,
+    code,
+    raw: `\`\`\`${language}\n${code}\`\`\``,
+  }
+}
+
+describe('d2 loading shell', () => {
+  it('carries the surface styles its scoped block classes cannot supply', () => {
+    // The shell renders from a .ts file, so `.d2-block-container` and `.d2-label`
+    // (scoped to D2BlockNode.vue as `[data-v-…]`) never match it. Without the
+    // inline tokens the block renders on a transparent background with a 16px
+    // label, then visibly changes when the real component takes over.
+    const wrapper = mount(D2BlockNodeLoading as any, {
+      props: { node: diagramNode('d2', 'a -> b') },
+    })
+
+    const containerStyle = wrapper.get('.d2-block-container').attributes('style') || ''
+    expect(containerStyle).toContain('var(--diagram-bg)')
+    expect(containerStyle).toContain('hsl(var(--ms-foreground))')
+    expect(containerStyle).toContain('var(--ms-shadow-subtle)')
+    expect(containerStyle).toContain('var(--diagram-border)')
+
+    expect(wrapper.get('.d2-label').attributes('style') || '').toContain('var(--ms-text-label)')
+    expect(wrapper.get('.d2-block-header').attributes('style') || '').toContain('var(--diagram-header-bg)')
+
+    wrapper.unmount()
+  })
+
+  it('reserves the estimated preview height while the renderer chunk loads', () => {
+    const wrapper = mount(D2BlockNodeLoading as any, {
+      props: { node: diagramNode('d2', 'a -> b') },
+    })
+
+    expect(wrapper.get('.d2-block-body').attributes('style') || '').toContain('min-height: 240px')
+
+    wrapper.unmount()
+  })
+
+  it('prefers the height the renderer injected over its own estimate', () => {
+    const wrapper = mount(D2BlockNodeLoading as any, {
+      props: {
+        node: diagramNode('d2', 'a -> b'),
+        estimatedPreviewHeightPx: 445,
+      },
+    })
+
+    expect(wrapper.get('.d2-block-body').attributes('style') || '').toContain('min-height: 445px')
+
+    wrapper.unmount()
+  })
+
+  it('reserves the same height the mermaid and infographic shells do', () => {
+    const mermaid = mount(MermaidBlockNodeLoading as any, {
+      props: { node: diagramNode('mermaid', 'graph LR\nA-->B') },
+    })
+    const infographic = mount(InfographicBlockNodeLoading as any, {
+      props: { node: diagramNode('infographic', '- a\n- b\n- c') },
+    })
+
+    expect(mermaid.get('.mermaid-preview-area').attributes('style') || '').toContain('height:')
+    expect(infographic.get('.infographic-preview').attributes('style') || '').toContain('height:')
+
+    mermaid.unmount()
+    infographic.unmount()
+  })
+})

--- a/test/mermaid-render-identity.test.ts
+++ b/test/mermaid-render-identity.test.ts
@@ -138,7 +138,7 @@ describe('mermaid render identity', () => {
     })
 
     await flushVueUpdates()
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
     ;(wrapper.vm as any).showSource = false

--- a/test/mermaid-source-panel-height-floor.test.ts
+++ b/test/mermaid-source-panel-height-floor.test.ts
@@ -1,0 +1,115 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+const MERMAID_RESERVED_HEIGHT_MAX_WAIT_MS = 15_000
+
+async function flushVueUpdates() {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function mockMermaidModule(getMermaid: () => unknown) {
+  vi.doMock('../src/workers/mermaidWorkerClient', () => ({
+    canParseOffthread: vi.fn(async () => false),
+    findPrefixOffthread: vi.fn(async () => null),
+    terminateWorker: vi.fn(),
+  }))
+  vi.doMock('../src/components/MermaidBlockNode/mermaid', () => ({
+    getMermaid: vi.fn(getMermaid as any),
+    isMermaidEnabled: vi.fn(() => true),
+  }))
+}
+
+async function mountBlock(props: Record<string, unknown> = {}) {
+  vi.stubGlobal('IntersectionObserver', undefined as any)
+  const MermaidBlockNode = (await import('../src/components/MermaidBlockNode/MermaidBlockNode.vue')).default
+  const wrapper = mount(MermaidBlockNode as any, {
+    props: {
+      node: {
+        type: 'code_block',
+        language: 'mermaid',
+        code: 'flowchart TD\nA-->B\n',
+        raw: '```mermaid\nflowchart TD\nA-->B\n```',
+      },
+      loading: false,
+      estimatedPreviewHeightPx: 500,
+      ...props,
+    },
+  })
+  await flushVueUpdates()
+  return wrapper
+}
+
+function sourcePanelMinHeight(wrapper: ReturnType<typeof mount>) {
+  const panel = wrapper.find('.mermaid-source-panel')
+  if (!panel.exists())
+    return null
+  return (panel.element as HTMLElement).style.minHeight || null
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('mermaid source panel reserved height', () => {
+  it('holds the reservation while the source panel is the visible panel and mermaid is still loading', async () => {
+    // Streamed content ends (loading: false) before the runtime resolves. Dropping
+    // the floor here collapses the block from the reserved height to the source
+    // height and back once the preview arrives (measured 435 → 233 → 435px).
+    mockMermaidModule(() => new Promise(() => {}))
+    const wrapper = await mountBlock()
+
+    expect(sourcePanelMinHeight(wrapper)).toBe('500px')
+
+    wrapper.unmount()
+  })
+
+  it('drops the reservation once availability resolves to "no runtime"', async () => {
+    mockMermaidModule(async () => null)
+    const wrapper = await mountBlock()
+    await flushVueUpdates()
+
+    expect(sourcePanelMinHeight(wrapper)).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('drops the reservation when the loader never settles', async () => {
+    vi.useFakeTimers()
+    // getMermaid() has no timeout of its own, so a hanging consumer loader would
+    // otherwise reserve blank space for the life of the block.
+    mockMermaidModule(() => new Promise(() => {}))
+    const wrapper = await mountBlock()
+    await flushVueUpdates()
+
+    expect(sourcePanelMinHeight(wrapper)).toBe('500px')
+
+    vi.advanceTimersByTime(MERMAID_RESERVED_HEIGHT_MAX_WAIT_MS)
+    await flushVueUpdates()
+
+    expect(sourcePanelMinHeight(wrapper)).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('drops the reservation when the source mode is picked explicitly', async () => {
+    mockMermaidModule(() => new Promise(() => {}))
+    const wrapper = await mountBlock()
+    expect(sourcePanelMinHeight(wrapper)).toBe('500px')
+
+    const state = (wrapper.vm as any).$?.setupState
+    state.handleSwitchMode('source')
+    await flushVueUpdates()
+
+    // The source panel is still the visible one, it just no longer holds space
+    // for a preview the user asked not to see.
+    expect(wrapper.find('.mermaid-source-panel').exists()).toBe(true)
+    expect(sourcePanelMinHeight(wrapper)).toBeNull()
+
+    wrapper.unmount()
+  })
+})

--- a/test/mermaid-streaming-preview-regression.test.ts
+++ b/test/mermaid-streaming-preview-regression.test.ts
@@ -60,7 +60,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
     ;(wrapper.vm as any).showSource = false
@@ -120,7 +120,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
     ;(wrapper.vm as any).showSource = false
@@ -178,7 +178,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = false
     ;(wrapper.vm as any).showSource = false
@@ -234,7 +234,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = false
     ;(wrapper.vm as any).showSource = false
@@ -730,7 +730,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
@@ -809,7 +809,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
@@ -887,7 +887,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = true
     ;(wrapper.vm as any).viewportReady = true
@@ -954,7 +954,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = false
     ;(wrapper.vm as any).showSource = false
@@ -1007,7 +1007,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = false
     ;(wrapper.vm as any).showSource = false
@@ -1060,7 +1060,7 @@ describe('mermaid streaming preview regression', () => {
       },
     })
 
-    ;(wrapper.vm as any).userToggledShowSource = true
+    ;(wrapper.vm as any).modeChosenExplicitly = true
     await settleStreamingRender()
     ;(wrapper.vm as any).mermaidAvailable = false
     ;(wrapper.vm as any).showSource = false
@@ -1129,7 +1129,7 @@ describe('mermaid streaming preview regression', () => {
     })
 
     for (const wrapper of [first, second]) {
-      ;(wrapper.vm as any).userToggledShowSource = true
+      ;(wrapper.vm as any).modeChosenExplicitly = true
       await settleStreamingRender()
       ;(wrapper.vm as any).mermaidAvailable = true
       ;(wrapper.vm as any).showSource = false

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -176,7 +176,11 @@ export default defineConfig(({ mode }) => {
     build,
     test: {
       environment: 'jsdom',
-      exclude: [...configDefaults.exclude, 'packages/markstream-octane/tests/**'],
+      // `.tmp` holds gitignored scratch copies of the suite (profiling and
+      // comparison runs). They duplicate the tests at a different path, so their
+      // scoped-style hashes differ and they fail in bulk; keep them out of the
+      // default run.
+      exclude: [...configDefaults.exclude, '.tmp/**', 'packages/markstream-octane/tests/**'],
       setupFiles: ['./test/setup/vitest.setup.ts'],
       restoreMocks: true,
       testTimeout: 10000,


### PR DESCRIPTION
## Summary

Mermaid and D2 blocks changed height several frames after first paint, shifting everything below them. This reserves the preview height up front on both, and moves the text estimator's runtime out of the main chunk.

A review of the first two commits found that the D2 reservation missed the diagrams that needed it most, and that the new loading shell inherited none of the block's styles; both are fixed in the third commit (details below).

## Changes

- **Mermaid** (`MermaidBlockNode.vue`): the reserved preview height was released as soon as `props.loading` became `false`, while the source panel was still the active view. The block collapsed and grew back once the diagram resolved (measured 435px → 233px → 435px). The floor now holds until the preview is the visible panel, the mode was chosen explicitly, or the runtime is known to be unavailable. It is also bounded: `getMermaid()` has no timeout, so a loader that never settles would otherwise reserve blank space for the life of the block.
- **D2** (`D2BlockNode.vue`, new `D2BlockNodeLoading.ts`, `diagramHeight.ts`): D2 had no reservation at all and its loading fallback was `PreCodeNode`, so the block jumped from source height to the rendered diagram (measured 241px → 479px). Added `estimateD2PreviewHeight()`, a dedicated loading shell, and the same `estimatedPreviewHeightPx` wiring Mermaid and Infographic already had. The reservation is released on a permanent render failure, empty code, an unavailable runtime, and an explicit mode switch, so a diagram that will never render holds no blank space.
- **Fallback floor**: measured from the body's content instead of the body itself. The body carries the reservation, so reading it back made the reservation a floor that could never shrink.
- **`@chenglou/pretext`**: was imported statically by the height-estimation module, which the renderer imports unconditionally, so ~40KB of bidi/line-breaking/analysis shipped to every consumer even though it is only reachable when the height experiment or virtual scrolling is active. Now loaded on demand; the first request reports no estimate and the callers keep their fallback heights until the module resolves. `dist/exports.js`: 291681 → 251382 bytes.

### Review fixes (third commit)

- **The estimator skipped labelled diagrams.** `estimateD2PreviewHeight` treated every `key:` line as a directive, but that is exactly how D2 labels a shape (`client: Web Client`) and declares a container (`server: {`). Labelled diagrams were measured as if they contained no shapes and reserved the 240px floor — roughly the source height they were meant to replace, so the shift was left unfixed for them. Directive keys are now a known list, and `vars`/`classes`/`style`/… blocks are skipped through their closing brace. An 8-node labelled diagram now reserves 488px instead of 240px.
- **`D2_PREVIEW_MAX_HEIGHT` was 520** while the rendered preview is capped at `--ms-size-code-max-height` (500px), so a tall diagram reserved more than the preview can occupy and shrank again when it resolved. Now 500.
- **The loading shell inherited nothing from the block.** `D2BlockNodeLoading.ts` renders with `h()` from a `.ts` file, so the shared class names (`.d2-block-container`, `.d2-label`, scoped in `D2BlockNode.vue` as `[data-v-…]`) matched nothing: the shell painted on a transparent background with a 16px label, and the block visibly changed when the real component replaced it. The surface styles are inline now, the way the infographic shell already did it.
- **Dead guard removed.** The mermaid floor's `hasPreviewSvg()` branch could never be true while the floor applied (source panel and preview are `v-if`/`v-else` siblings, so `mermaidContent` is null behind the source panel); the release it described is performed by `!showSource`. The flag it also read is set by the internal stabilize-then-preview switch as well as the mode buttons, so it is now named `modeChosenExplicitly`.

## Results

| Scenario | Before | After |
| --- | --- | --- |
| Mermaid block above the fold, CLS | 0.1153 | 0.0025 |
| D2 block above the fold, CLS | 0.1075 | 0.0037 |

Verified the estimate does not overshoot: across 11 D2 diagrams (`direction: right`, `vars`, `style`, single node, 2–8 node chains) the reserve was never larger than the rendered height (estimates 240–442px vs actual 314–4569px), so no new shift was introduced in the other direction.

LCP is unchanged and not claimed as improved: the playground LCP element is page chrome, and library-side first paint has no blocking work.

## Note on a discarded change

An earlier attempt also cached the `useViewportRoot` ancestor probes. It measured **zero** benefit (162.2ms vs 162.2ms of forced layout) — the cost is the first read after a DOM mutation, not repeated reads — and its early revisions caused two real regressions (duplicated D2 content, and a virtual window that stopped following the scroll). It is not part of this PR.

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test`
- [x] Build: `pnpm build` (library + CSS)
- [x] `size:check`, `check:public-api`, `check:package-exports`, `check:peer-deps`, `check:subpath-isolation`
- [x] E2E gates: `test:e2e:web-vitals-performance`, `test:e2e:playground-performance`, `test:e2e:main-playground-performance`

Regression tests: `test/d2-block-node-layout.test.ts`, `test/d2-block-node-availability.test.ts`, `test/diagram-height-estimation.test.ts`, `test/diagram-loading-shell.test.ts`, `test/mermaid-source-panel-height-floor.test.ts`. Each new estimator/floor assertion was run against the previous implementation and fails there. The mermaid floor previously had no coverage at all.

## Screenshots / Demo

- [ ] GIF/screenshot
- [x] Repro link: https://markstream-vue.simonhe.me/test with a fenced ` ```d2 ` block in the initial viewport
