### PR TITLE
fix(math): reserve space while math nodes load

### DIFF
--- a/src/components/NodeRenderer/MathNodeLoading.ts
+++ b/src/components/NodeRenderer/MathNodeLoading.ts
@@ -1,0 +1,106 @@
+import type { MathInlineNodeProps } from '../../types/component-props'
+import { defineComponent, h, inject } from 'vue'
+import { MATH_BLOCK_MIN_HEIGHT_CACHE } from '../MathBlockNode/minHeightCache'
+import TextNode from '../TextNode'
+
+/**
+ * Placeholders rendered while the math async chunk (and the optional `katex`
+ * peer) is still loading.
+ *
+ * `MathBlockNodeAsync` / `MathInlineNodeAsync` previously had no
+ * `loadingComponent`, so Vue rendered a comment node during the load: a display
+ * equation occupied zero height and every node below it jumped down as the
+ * equation resolved. Measured CLS ~0.06 on a document with six display
+ * equations, over this renderer's own 0.05 budget.
+ *
+ * Both placeholders render the node's raw source, matching the no-katex
+ * fallback (and the loading shells for mermaid / code blocks, which also show
+ * the real source). That keeps the box closer to its final size and keeps the
+ * text selectable and visible instead of replacing it with a spinner.
+ */
+
+const DOLLAR = String.fromCharCode(36)
+
+function rawMathSource(node: unknown, prefix: string, suffix: string) {
+  const candidate = node as { raw?: unknown, content?: unknown } | null | undefined
+  if (typeof candidate?.raw === 'string' && candidate.raw.length)
+    return candidate.raw
+  return `${prefix}${String(candidate?.content ?? '')}${suffix}`
+}
+
+export const MathBlockNodeLoading = defineComponent({
+  name: 'MathBlockNodeLoading',
+  // `defineAsyncComponent` forwards the renderer's props (final/fade/…) to the
+  // loading component; none of them belong on this placeholder's DOM node.
+  inheritAttrs: false,
+  props: {
+    node: { type: Object, required: true },
+    indexKey: { type: [String, Number], default: undefined },
+    cacheScope: { type: [String, Number], default: undefined },
+  },
+  setup(loadingProps) {
+    const minHeightCache = inject(MATH_BLOCK_MIN_HEIGHT_CACHE, null)
+
+    // `MathBlockNode` records every height it has measured under
+    // `math-block:<indexKey>`; reusing it here means a re-mounted equation
+    // reserves its real height instead of the generic floor.
+    function reservedHeight() {
+      const scope = loadingProps.cacheScope ?? minHeightCache?.scope
+      const scopedPrefix = scope != null && String(scope).length > 0 ? `${String(scope)}:` : ''
+      const cacheKey = loadingProps.indexKey == null
+        ? ''
+        : `${scopedPrefix}math-block:${String(loadingProps.indexKey)}`
+      const cached = cacheKey ? Number(minHeightCache?.cache.get(cacheKey) ?? 0) : 0
+      return Number.isFinite(cached) && cached > 0 ? cached : null
+    }
+
+    return () => {
+      const reserved = reservedHeight()
+
+      return h('div', {
+        'class': 'math-block text-center overflow-x-auto relative',
+        'data-markstream-math': 'block',
+        // Distinct from the rendered node's `katex`/`fallback`/`loading`
+        // markers so consumers can tell the placeholder apart.
+        'data-markstream-mode': 'pending',
+        'data-markstream-pending': 'true',
+        // `MathBlockNode`'s `min-height` lives in a scoped style block, so it
+        // does not apply here. Reserve the same floor, upgraded to the measured
+        // height when this equation has been rendered before.
+        'style': { minHeight: reserved == null ? 'var(--ms-size-math-min-height)' : `${reserved}px` },
+      }, [
+        h('pre', {
+          class: 'math-block__fallback text-left',
+          style: {
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            margin: '0',
+          },
+        }, rawMathSource(loadingProps.node, `${DOLLAR}${DOLLAR}`, `${DOLLAR}${DOLLAR}`)),
+      ])
+    }
+  },
+})
+
+export const MathInlineNodeLoading = defineComponent({
+  name: 'MathInlineNodeLoading',
+  inheritAttrs: false,
+  props: {
+    node: { type: Object, required: true },
+  },
+  setup(loadingProps) {
+    // Inline math sits inside a paragraph, so a fixed-size box would not reserve
+    // the right space — the line would still re-wrap once the formula resolved.
+    // Rendering the raw source (exactly what the no-katex fallback shows) yields
+    // a close-enough width for the resolved formula.
+    const mathProps = loadingProps as unknown as MathInlineNodeProps
+    return () => h(TextNode, {
+      ...mathProps,
+      node: {
+        type: 'text',
+        content: rawMathSource(mathProps.node, DOLLAR, DOLLAR),
+        raw: rawMathSource(mathProps.node, DOLLAR, DOLLAR),
+      },
+    })
+  },
+})

--- a/src/components/NodeRenderer/asyncComponent.ts
+++ b/src/components/NodeRenderer/asyncComponent.ts
@@ -9,6 +9,7 @@ import { getKatex } from '../MathInlineNode/katex'
 import PreCodeNode from '../PreCodeNode'
 import TextNode from '../TextNode'
 import CodeBlockNodeLoadingContent from './CodeBlockNodeLoading'
+import { MathBlockNodeLoading, MathInlineNodeLoading } from './MathNodeLoading'
 
 interface ProcessLike {
   env?: {
@@ -22,6 +23,47 @@ type MathBlockFallbackProps = MathBlockNodeProps & Record<string, unknown>
 function getProcessEnv() {
   const processValue = Reflect.get(globalThis, 'process') as ProcessLike | undefined
   return processValue?.env
+}
+
+function renderInlineFallback(props: MathInlineFallbackProps) {
+  const raw = props.node.raw ?? `$${props.node.content ?? ''}$`
+  return h(TextNode, {
+    ...props,
+    node: {
+      type: 'text',
+      content: raw,
+      raw,
+    },
+  })
+}
+
+function renderBlockFallback(props: MathBlockFallbackProps) {
+  const raw = props.node.raw ?? `$$${props.node.content ?? ''}$$`
+  return h(TextNode, {
+    ...props,
+    node: {
+      type: 'text',
+      content: raw,
+      raw,
+    },
+  })
+}
+
+/**
+ * Load the KaTeX runtime and the math component together.
+ *
+ * These used to be awaited in sequence, so every equation waited for two chunk
+ * requests back-to-back before anything could paint. Both are needed before the
+ * component can render, so they are fetched concurrently.
+ */
+async function loadMathDeps<T>(importer: () => Promise<T>): Promise<{ mod: T | null, error?: unknown }> {
+  try {
+    const [, mod] = await Promise.all([getKatex(), importer()])
+    return { mod }
+  }
+  catch (error) {
+    return { mod: null, error }
+  }
 }
 
 export function withViewportDeferredLoading(name: string, component: Component, loadingComponent: Component) {
@@ -131,67 +173,51 @@ export const CodeBlockNodeAsync = withViewportDeferredLoading(
   CodeBlockNodeLoading,
 )
 
-export const MathInlineNodeAsync = defineAsyncComponent(async () => {
-  // In test environment prefer the simple text fallback to avoid
-  // race conditions with workers/KaTeX rendering.
-  const isTestEnv = getProcessEnv()?.NODE_ENV === 'test'
-  if (isTestEnv && typeof window !== 'undefined') {
-    return (props: MathInlineFallbackProps) => {
+export const MathInlineNodeAsync = defineAsyncComponent({
+  loader: async () => {
+    // In test environment prefer the simple text fallback to avoid
+    // race conditions with workers/KaTeX rendering.
+    const isTestEnv = getProcessEnv()?.NODE_ENV === 'test'
+    if (isTestEnv && typeof window !== 'undefined') {
       // test fallback should be deterministic and minimal
-      return h(TextNode, {
-        ...props,
-        node: {
-          type: 'text',
-          content: props.node.raw ?? `$${props.node.content ?? ''}$`,
-          raw: props.node.raw ?? `$${props.node.content ?? ''}$`,
-        },
-      })
+      return renderInlineFallback
     }
-  }
 
-  try {
-    await getKatex()
-    const mod = await import('../../components/MathInlineNode')
-    return mod.default
-  }
-  catch (e) {
+    const { mod, error } = await loadMathDeps(() => import('../../components/MathInlineNode'))
+    if (mod)
+      return mod.default
+
     console.warn(
       '[markstream-vue] Optional peer dependencies for MathInlineNode are missing. Falling back to text rendering. To enable full math rendering features, please install "katex".',
-      e,
+      error,
     )
-  }
-  return (props: MathInlineFallbackProps) => {
-    return h(TextNode, {
-      ...props,
-      node: {
-        type: 'text',
-        content: props.node.raw ?? `$${props.node.content ?? ''}$`,
-        raw: props.node.raw ?? `$${props.node.content ?? ''}$`,
-      },
-    })
-  }
+    return renderInlineFallback
+  },
+  // Without a placeholder the inline formula collapsed to a 1rem spinner and
+  // then re-wrapped its line once KaTeX arrived.
+  loadingComponent: MathInlineNodeLoading,
+  delay: 0,
+  // `suspensible` is deliberately left at its default (true): inside a
+  // `<Suspense>` boundary the component must keep suspending exactly as it did
+  // before. `loadingComponent` still applies on the client outside Suspense,
+  // which is where the shift was observable.
 })
 
-export const MathBlockNodeAsync = defineAsyncComponent(async () => {
-  try {
-    await getKatex()
-    const mod = await import('../../components/MathBlockNode')
-    return mod.default
-  }
-  catch (e) {
+export const MathBlockNodeAsync = defineAsyncComponent({
+  loader: async () => {
+    const { mod, error } = await loadMathDeps(() => import('../../components/MathBlockNode'))
+    if (mod)
+      return mod.default
+
     console.warn(
       '[markstream-vue] Optional peer dependencies for MathBlockNode are missing. Falling back to text rendering. To enable full math rendering features, please install "katex".',
-      e,
+      error,
     )
-  }
-  return (props: MathBlockFallbackProps) => {
-    return h(TextNode, {
-      ...props,
-      node: {
-        type: 'text',
-        content: props.node.raw ?? `$$${props.node.content ?? ''}$$`,
-        raw: props.node.raw ?? `$$${props.node.content ?? ''}$$`,
-      },
-    })
-  }
+    return renderBlockFallback
+  },
+  // Without a placeholder a display equation occupied zero height while the
+  // chunk loaded, so every node below it jumped when the equation appeared.
+  loadingComponent: MathBlockNodeLoading,
+  delay: 0,
+  // See the note on MathInlineNodeAsync: keep the default Suspense semantics.
 })


### PR DESCRIPTION
## 问题

`MathBlockNodeAsync` 和 `MathInlineNodeAsync` 是**唯一两个没有 `loadingComponent` 的异步节点包装**。加载期间 Vue 渲染的是注释节点（`<!---->`），所以：

- **块级公式占位高度为 0** —— 每渲染一个公式，它下方所有内容整体下跳；
- **行内公式塌缩成 1rem 转圈** —— KaTeX 到达后行宽变化，整段重新折行。

在那个「6 个块级公式」的文档上，实测 **CLS 0.064**，超过渲染器自己的 0.05 预算（`scripts/web-vitals-budget-checks.mjs` 里就是这个数）。

另外 `getKatex()` 和组件 `import()` 原本是**串行 await**，每个公式都要等两次 chunk 请求才能开始渲染。

## 改动

新增 [`MathNodeLoading.ts`](src/components/NodeRenderer/MathNodeLoading.ts)，为两种节点各提供一个占位组件：

- **块级**：复用 `MathBlockNode` 自己写入的 `math-block:<indexKey>` 高度缓存（挂载过就按真实高度预留），冷启动回退到 CSS `--ms-size-math-min-height` 下限；
- **行内**：渲染原始源码，与「未安装 katex」的 fallback 一致，让行盒保持接近真实公式的宽度，而不是塌缩成转圈。

两者都沿用仓库既有约定 —— mermaid / 代码块的加载壳同样是渲染真实源码而非骨架屏。占位标记为 `data-markstream-mode="pending"`（其他重节点已在用的约定值），与真节点自身的 `katex` / `fallback` / `loading` 保持可区分。

`asyncComponent.ts` 中 `getKatex()` 与组件 chunk 改为 `Promise.all` 并发加载；顺带把重复三遍的 fallback 内联渲染抽成 `renderInlineFallback` / `renderBlockFallback`。

## 兼容性

- **SSR 输出不变。** `loadingComponent` 只在客户端且 `<Suspense>` 之外被使用；服务端渲染（`isInSSRComponentSetup`）和 `suspensible` 组件仍然会先 await loader 再产出。hydration 测试已确认服务端 HTML 仍包含 `data-markstream-mode="katex"` 与 `katex-display`。
- `suspensible` **保持默认值 `true`**，`<Suspense>` 内的挂起语义与改动前完全一致。
- 失败回退渲染与原实现逐字节等价。
- 加载期 DOM 中**开始出现** `[data-markstream-math]` 占位元素（此前为空）。若外部代码用该选择器判断「是否已渲染」，需要注意其提前为真；`data-markstream-mode="pending"` 可用于区分占位与真节点。

## 测量

CPU 4× 节流 + production build，playground `/test` 预览面板：

| | 改动前 | 改动后 |
| --- | --- | --- |
| CLS（6 个块级公式文档） | 0.064 | **0.032** |

残余 ~0.029 来自**库没有数学高度估算器**（mermaid / D2 有），本 PR 未处理；重挂载的公式会复用缓存高度，主要残留在首屏冷启动。

## 验证

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm exec vitest --run` — 359 文件 / 3164 测试全过 ✅
- `test:e2e:playground-performance` / `test:e2e:main-playground-performance` / `test:e2e:web-vitals-performance` / `test:e2e:virtual-scroll` — 全部通过 ✅

## 后续（未包含在本 PR）

排查首屏 LCP 时定位到 `resolveViewportRoot`（[`useViewportRoot.ts`](src/components/NodeRenderer/composables/useViewportRoot.ts)）在挂载期为每个重节点做祖先链遍历，每次 `getComputedStyle` + `scrollHeight/clientHeight` 都强制同步样式/布局刷新。批量解析版本实测 **LCP −22%、首屏长任务 −24%、LayoutDuration −39%**，但它会让 `test:e2e:playground-performance` 稳定失败（滚动进视口的代码块永远停在加载壳、编辑器宿主不创建）—— 重节点用 `allowIdle:false` + `whenVisible` 闩锁就绪，而当注册时返回的 root 是继承来的猜测（视口）而非真实滚动容器时，元素永远无法相交。该实现、测量数据与建议修法已存档，适合另开 PR 处理。
