### PR TITLE
fix(mermaid): fit the preview box to the rendered diagram

### DIFF
--- a/docs/guide/mermaid-block-node.md
+++ b/docs/guide/mermaid-block-node.md
@@ -17,6 +17,7 @@ keywords:
 - `loading?: boolean` — initial loading placeholder
 - `maxHeight?: string | null` — maximum height
 - `estimatedPreviewHeightPx?: number` — first-preview height reserved before Mermaid finishes rendering; `MarkdownRender` fills this automatically for Mermaid fences
+- `fitPreviewHeight?: boolean` — defaults to `false`; once the diagram has resolved and the render is at rest, drop the pre-render reservation and fit the box to the rendered diagram (clamped to a 120px floor and `maxHeight`). Without it, wide/flat diagrams (gantt, sequence, …) keep the reserved height — e.g. 500px reserved around a 77px diagram in a 506px-wide column. Enabling it makes the block shrink once, which reflows the content below it; streaming renders keep the reservation either way.
 - `isStrict?: boolean` — defaults to `true`; runs Mermaid in `securityLevel: 'strict'` with DOMPurify + HTML-label hardening. Set `false` only for trusted diagrams that need Mermaid's loose parse/render config. The rendered SVG is still sanitized before mounting and export.
 - `enableMermaidInteractions?: boolean` — defaults to `false`; enables Mermaid-generated click bindings after sanitized SVG mount. Use only for trusted diagrams.
 - `onRenderError?: (error: unknown, code: string, container: HTMLElement) => boolean | void` — custom error handler called when mermaid rendering fails. Return `true` to prevent the default error display. Receives the error, the raw mermaid source code, and the container DOM element so you can render custom content.

--- a/docs/zh/guide/mermaid-block-node.md
+++ b/docs/zh/guide/mermaid-block-node.md
@@ -17,6 +17,7 @@ keywords:
 - `loading?: boolean` — 初始加载占位
 - `maxHeight?: string | null` — 最大高度
 - `estimatedPreviewHeightPx?: number` — Mermaid 完成渲染前预留的首屏 preview 高度；通过 `MarkdownRender` 渲染 Mermaid 围栏时会自动填入
+- `fitPreviewHeight?: boolean` — 默认 `false`；图渲染完成且渲染静止后丢弃渲染前的预留高度，让容器贴合实际图高（下界 120px、上界 `maxHeight`）。不开启时，宽扁图（甘特／时序等）会一直保持预留高度（实测：506px 宽列中预留 500px，实际图高仅 77px）。开启后图块会收缩一次，下方内容随之回流；流式渲染期间无论开关都保持预留。
 - `isStrict?: boolean` — 默认 `true`；开启 `securityLevel: 'strict'` + DOMPurify，并禁用 HTML labels。只有可信图表确实需要 Mermaid loose 解析/渲染配置时才设为 `false`；最终 SVG 挂载和导出前仍会清理。
 - `enableMermaidInteractions?: boolean` — 默认 `false`；在清理后的 SVG 挂载后启用 Mermaid 生成的点击绑定。只建议用于可信图表。
 - Header/按钮控制（全部可选，默认 `true`）:

--- a/src/components/MermaidBlockNode/MermaidBlockNode.vue
+++ b/src/components/MermaidBlockNode/MermaidBlockNode.vue
@@ -6,7 +6,7 @@ import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useOffscreenHeavyNodeDeferral, useViewportPriority, useViewportPriorityOptions } from '../../composables/viewportPriority'
 import mermaidIcon from '../../icon/mermaid.svg?raw'
-import { clampMermaidPreviewHeight, estimateMermaidPreviewHeight, getMermaidDiagramKind, parsePositiveNumber } from '../../utils/diagramHeight'
+import { clampFittedMermaidPreviewHeight, clampMermaidPreviewHeight, estimateMermaidPreviewHeight, getMermaidDiagramKind, MERMAID_FITTED_PREVIEW_MIN_HEIGHT, parsePositiveNumber } from '../../utils/diagramHeight'
 import { resolveLifecycleIndexKey } from '../../utils/lifecycleIndexKey'
 import { escapeSequenceTextSemicolons } from '../../utils/mermaidSequenceSemicolons'
 import { MARKSTREAM_NODE_LIFECYCLE_KEY } from '../../utils/nodeLifecycle'
@@ -43,6 +43,7 @@ const props = withDefaults(
     isStrict: true,
     enableMermaidInteractions: false,
     showTooltips: true,
+    fitPreviewHeight: false,
   },
 )
 
@@ -1098,8 +1099,21 @@ function updateContainerHeight(newContainerWidth?: number, options?: { force?: b
     const maxHeight = resolveMaxContainerHeight()
     const newHeight = effectiveWidth * aspectRatio
     const resolvedHeight = maxHeight == null ? newHeight : Math.min(newHeight, maxHeight)
-    const previewHeight = Math.max(resolvedHeight, resolveEstimatedPreviewHeight())
-    if (!freezePreviewHeight && !hasExternalPreviewHeightEstimate())
+    // The estimate is a reservation: it keeps the block from collapsing while
+    // the diagram is still resolving, and it carries the streaming floor. It is
+    // also what leaves wide/flat diagrams (gantt, sequence, …) inside a box
+    // several times their rendered height — e.g. 500px reserved against a 77px
+    // diagram in a 506px-wide chat column, so ~80% of the block is blank.
+    // With `fitPreviewHeight` the reservation is dropped once the diagram has
+    // resolved and the render is at rest, and the box ends up the size of the
+    // diagram (clamped to the fitted floor). It also covers the host-supplied
+    // estimate, which is the worst case: the host can only guess before the
+    // render, while the block reports its real height through the node
+    // lifecycle once it has one.
+    const previewHeight = props.fitPreviewHeight
+      ? clampFittedMermaidPreviewHeight(resolvedHeight, MERMAID_FITTED_PREVIEW_MIN_HEIGHT, maxHeight)
+      : Math.max(resolvedHeight, resolveEstimatedPreviewHeight())
+    if (!freezePreviewHeight && (props.fitPreviewHeight || !hasExternalPreviewHeightEstimate()))
       containerHeight.value = `${previewHeight}px`
     contentHeight.value = containerHeight.value
   }

--- a/src/types/component-props.ts
+++ b/src/types/component-props.ts
@@ -186,6 +186,10 @@ export interface MermaidBlockNodeProps {
   // Defaults to false. Set true only for trusted diagrams that need Mermaid-generated click bindings after sanitized SVG mount.
   enableMermaidInteractions?: boolean
   showTooltips?: boolean
+  // Fit the preview box to the rendered diagram once the render is at rest,
+  // instead of holding the pre-render reservation. Opt-in: the block shrinks
+  // once, which reflows the content below it.
+  fitPreviewHeight?: boolean
   // Custom error handler called when mermaid rendering fails.
   // Receives the error, the raw mermaid code, and the container element.
   // Return true to prevent the default error display.

--- a/src/utils/diagramHeight.ts
+++ b/src/utils/diagramHeight.ts
@@ -1,5 +1,11 @@
 export const MERMAID_PREVIEW_MIN_HEIGHT = 360
 export const MERMAID_PREVIEW_MAX_HEIGHT = 500
+// Floor for the *fitted* preview height (MermaidBlockNode's `fitPreviewHeight`).
+// MERMAID_PREVIEW_MIN_HEIGHT above is a pre-render reservation and also backs
+// --ms-size-diagram-min-height, so reusing it after the diagram has resolved
+// would keep the blank space that fitting exists to remove; a 0 floor would let
+// a one-line diagram collapse into a sliver.
+export const MERMAID_FITTED_PREVIEW_MIN_HEIGHT = 120
 export const INFOGRAPHIC_PREVIEW_MIN_HEIGHT = 360
 export const INFOGRAPHIC_PREVIEW_MAX_HEIGHT = 500
 export const D2_PREVIEW_MIN_HEIGHT = 240
@@ -70,6 +76,19 @@ export function clampPreviewHeight(
 export function clampMermaidPreviewHeight(
   height: number,
   minHeight = MERMAID_PREVIEW_MIN_HEIGHT,
+  maxHeight: number | null = MERMAID_PREVIEW_MAX_HEIGHT,
+) {
+  return clampPreviewHeight(height, minHeight, maxHeight)
+}
+
+/**
+ * Clamps a height measured from the rendered diagram to the fitted range: the
+ * max still caps the preview at what it can occupy, the floor is the fitted
+ * floor rather than the pre-render reservation.
+ */
+export function clampFittedMermaidPreviewHeight(
+  height: number,
+  minHeight = MERMAID_FITTED_PREVIEW_MIN_HEIGHT,
   maxHeight: number | null = MERMAID_PREVIEW_MAX_HEIGHT,
 ) {
   return clampPreviewHeight(height, minHeight, maxHeight)

--- a/test/mermaid-fit-rendered-height.test.ts
+++ b/test/mermaid-fit-rendered-height.test.ts
@@ -1,0 +1,118 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import MermaidBlockNode from '../src/components/MermaidBlockNode/MermaidBlockNode.vue'
+
+const mounted: Array<ReturnType<typeof mount>> = []
+
+/**
+ * Mounts a block whose render is already at rest (`loading: false`) and whose
+ * host reserved `estimatedPreviewHeightPx` — the virtual-list case, where the
+ * host can only guess the height before the diagram resolves.
+ */
+async function mountBlock(props: Record<string, unknown> = {}) {
+  const wrapper = mount(MermaidBlockNode as any, {
+    props: {
+      node: {
+        type: 'code_block',
+        language: 'mermaid',
+        code: 'gantt\n  title timeline\n  section A\n  phase :a1, 0, 5\n',
+        raw: '',
+      },
+      loading: false,
+      estimatedPreviewHeightPx: 500,
+      ...props,
+    },
+    attachTo: document.body,
+  })
+  mounted.push(wrapper)
+
+  // Switch the block to its preview panel: the source panel is what renders
+  // until the runtime resolves.
+  ;(wrapper.vm as any).mermaidAvailable = true
+  ;(wrapper.vm as any).showSource = false
+  await nextTick()
+  return wrapper
+}
+
+// A 1440×220 viewBox laid out at 506px wide renders 77px tall: a wide/flat gantt.
+const FLAT_DIAGRAM = '0 0 1440 220'
+const CONTAINER_WIDTH = 506
+
+/**
+ * Commits a rendered diagram into the block and re-runs the height pass.
+ * jsdom has no layout, so the measured width falls back to the container width —
+ * the block derives the height from the viewBox ratio and that width.
+ */
+async function commitDiagram(wrapper: ReturnType<typeof mount>, viewBox: string) {
+  const content = wrapper.get('div._mermaid').element as HTMLElement
+  content.innerHTML = `<svg viewBox="${viewBox}"></svg>`
+
+  const container = (wrapper.get('[data-mermaid-wrapper]').element as HTMLElement).parentElement as HTMLElement
+  Object.defineProperty(container, 'clientWidth', { configurable: true, value: CONTAINER_WIDTH })
+
+  const setupState = (wrapper.vm as any).$?.setupState
+  setupState.updateContainerHeight()
+  await nextTick()
+  return container
+}
+
+afterEach(() => {
+  while (mounted.length)
+    mounted.pop()?.unmount()
+})
+
+describe('mermaid fitted preview height', () => {
+  it('holds the host reservation by default', async () => {
+    const wrapper = await mountBlock()
+    const container = await commitDiagram(wrapper, FLAT_DIAGRAM)
+
+    // The host reserved 500px and the block keeps honouring it, so the 77px
+    // diagram sits in a box ~6.5× its height — the blank space reported by
+    // consumers of the virtual list.
+    expect(container.style.height).toBe('500px')
+  })
+
+  it('fits the box to the rendered diagram when fitPreviewHeight is on', async () => {
+    const wrapper = await mountBlock({ fitPreviewHeight: true })
+    const container = await commitDiagram(wrapper, FLAT_DIAGRAM)
+
+    // Below the fitted floor, so the box lands on the floor instead of holding
+    // the reservation — and it overrides the host estimate, which is the case
+    // that reserves the most empty space.
+    expect(container.style.height).toBe('120px')
+  })
+
+  it('fits a mid-size diagram to its measured height', async () => {
+    const wrapper = await mountBlock({ fitPreviewHeight: true })
+    const container = await commitDiagram(wrapper, '0 0 850 507')
+
+    // 506 × (507 / 850) ≈ 301.8px: above the fitted floor, below the cap.
+    expect(Number.parseFloat(container.style.height)).toBeCloseTo(301.8, 1)
+  })
+
+  it('still caps the fitted height at the preview max height', async () => {
+    const wrapper = await mountBlock({ fitPreviewHeight: true })
+    const container = await commitDiagram(wrapper, '0 0 200 2000')
+
+    expect(container.style.height).toBe('500px')
+  })
+
+  it('keeps the reservation while streaming, even with fitPreviewHeight on', async () => {
+    const wrapper = await mountBlock({ fitPreviewHeight: true, loading: true })
+    const container = await commitDiagram(wrapper, FLAT_DIAGRAM)
+
+    // A streamed diagram keeps its reserved geometry: shrinking mid-stream would
+    // reflow the content below on every render pass.
+    expect(container.style.height).toBe('500px')
+  })
+
+  it('fits an estimate-only block (no host reservation) too', async () => {
+    const wrapper = await mountBlock({ fitPreviewHeight: true, estimatedPreviewHeightPx: undefined })
+    const container = await commitDiagram(wrapper, FLAT_DIAGRAM)
+
+    // Without the flag the estimate itself (clamped to the 360px reservation
+    // floor) would keep the box at 360px.
+    expect(container.style.height).toBe('120px')
+  })
+})


### PR DESCRIPTION
The block reserves the pre-render height (a host estimatedPreviewHeightPx, or the code-line estimate) so a streaming diagram does not shift while it resolves, and it keeps that reservation once the diagram has resolved: the container height is max(renderedHeight, clamp(estimate, 360, 500)). For wide/flat diagrams (gantt, sequence) the box ends up several times the diagram - measured 500px reserved around a 77px diagram in a 506px-wide chat column, so roughly 80 percent of the block is blank. A host-supplied estimate is kept as-is outright, which is the case that reserves the most empty space.

Add an opt-in fitPreviewHeight prop: once the diagram has resolved and the render is at rest, drop the reservation and fit the box to the rendered height, clamped to a new 120px fitted floor and the existing max height. Streaming renders keep the reservation either way, and a host estimate no longer pins the box open when the flag is on.

Opt-in because the block shrinks once, which reflows the content below it; consumers that need the current geometry can leave it off. Covered by test/mermaid-fit-rendered-height.test.ts (3 of its 6 cases fail without the change).

## Summary

A resolved mermaid block keeps its pre-render height reservation (`max(renderedHeight, clamp(estimate, 360, 500))`), so wide/flat diagrams sit in a box several times their height — measured 500px reserved around a 77px gantt in a 506px chat column, ~80% of the block blank. This adds an opt-in `fitPreviewHeight` prop that drops the reservation once the render is at rest and fits the box to the rendered height (new 120px fitted floor, existing max height), while streaming renders keep the reservation.

## Changes

- [x] `src/components/MermaidBlockNode/MermaidBlockNode.vue` — `fitPreviewHeight` prop; on the at-rest path the height becomes the fitted height, and a host estimate no longer pins the box open when the flag is on
- [x] `src/utils/diagramHeight.ts` — `MERMAID_FITTED_PREVIEW_MIN_HEIGHT` (120px) + `clampFittedMermaidPreviewHeight()`
- [x] `src/types/component-props.ts` — prop type
- [x] `test/mermaid-fit-rendered-height.test.ts` — 6 cases, 3 of them fail without the change
- [x] `docs/guide/mermaid-block-node.md`, `docs/zh/guide/mermaid-block-node.md` — document the prop

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test — not attached: the case needs a host that supplies `estimatedPreviewHeightPx` (virtual list), which the demo page does not exercise

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)

> Note on lint: in my working copy `pnpm lint` also reports errors from untracked scratch files (1304 errors across 32 files, none of them tracked by the repository); the six files changed here are eslint-clean.
